### PR TITLE
:2924 add wxSTAY_ON_TOP for the message.

### DIFF
--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -2921,7 +2921,7 @@ void BodySlideFrame::OnBatchBuild(wxCommandEvent& WXUNUSED(event)) {
 
 	if (ret == 0) {
 		wxLogMessage("All sets processed successfully!");
-		wxMessageBox(_("All sets processed successfully!"), _("Complete"), wxICON_INFORMATION);
+		wxMessageBox(_("All sets processed successfully!"), _("Complete"), wxICON_INFORMATION | wxSTAY_ON_TOP );
 	}
 	else if (ret == 3) {
 		wxArrayString errlist;


### PR DESCRIPTION
If the application is maximized, finish message hides behind the frame occasionally. wxSTAY_ON_TOP to say on top to avoid this situation.