### PR TITLE
Minor housekeeping

### DIFF
--- a/src/components/SliderData.cpp
+++ b/src/components/SliderData.cpp
@@ -9,8 +9,8 @@ See the included LICENSE file
 #include <wx/dir.h>
 #include <wx/tokenzr.h>
 
-SliderData::SliderData(const std::string& inName) {
-	name = inName;
+SliderData::SliderData(std::string inName)
+	: name(std::move(inName)) {
 }
 
 SliderData::~SliderData() {

--- a/src/components/SliderData.h
+++ b/src/components/SliderData.h
@@ -38,7 +38,7 @@ public:
 
 	std::vector<DiffInfo> dataFiles;
 
-	SliderData(const std::string& inName = "");
+	SliderData(std::string inName = "");
 	~SliderData();
 
 	// Gets the slider's data record name for the specified target.

--- a/src/components/TweakBrush.cpp
+++ b/src/components/TweakBrush.cpp
@@ -382,6 +382,8 @@ bool TweakBrush::queryPoints(mesh *refmesh, TweakPickInfo& pickInfo, int* result
 		return false;
 
 	bool* pointVisit = (bool*)calloc(refmesh->nVerts, sizeof(bool));
+	if (!pointVisit)
+		return false;
 
 	if (bConnected && !IResults.empty()) {
 		int pickFacet = IResults[0].HitFacet;
@@ -840,10 +842,16 @@ bool TB_Move::strokeInit(const std::vector<mesh*>& refMeshes, TweakPickInfo& pic
 		meshCache->nCachedPointsM = 0;
 		meshCache->cachedPoints = (int*)malloc(m->nVerts * sizeof(int));
 
+		if (!meshCache->cachedPoints)
+			continue;
+
 		if (bMirror) {
 			meshCache->cachedPointsM = (int*)malloc(m->nVerts * sizeof(int));
 			meshCache->cachedFacetsM.clear();
 			meshCache->cachedNodesM.clear();
+
+			if (!meshCache->cachedPointsM)
+				continue;
 		}
 
 		if (!TweakBrush::queryPoints(m, pick, meshCache->cachedPoints, meshCache->nCachedPoints, meshCache->cachedFacets, meshCache->cachedNodes))

--- a/src/files/ObjFile.cpp
+++ b/src/files/ObjFile.cpp
@@ -113,7 +113,7 @@ int ObjFile::LoadForNif(std::fstream& base, const ObjOptionsImport& options) {
 				else {
 					// Don't keep empty group
 					data.erase(current->name);
-					current->name = "";
+					current->name.clear();
 				}
 			}
 

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -881,8 +881,8 @@ void BodySlideApp::InitPreview() {
 		sliderManager.FlagReload(false);
 	}
 
-	previewBaseName = inputFileName;
-	previewSetName = inputSetName;
+	previewBaseName = std::move(inputFileName);
+	previewSetName = std::move(inputSetName);
 	
 	preview->ShowWeight(activeSet.GenWeights());
 
@@ -2044,8 +2044,8 @@ int BodySlideApp::BuildListBodies(std::vector<std::string>& outfitList, std::map
 			zapIdxAll.emplace(it->first, std::vector<ushort>());
 
 			for (int s = 0; s < currentSet.size(); s++) {
-				std::string dn = currentSet[s].TargetDataName(it->second.targetShape);
 				std::string target = it->second.targetShape;
+				std::string dn = currentSet[s].TargetDataName(target);
 				if (dn.empty())
 					continue;
 
@@ -2357,7 +2357,7 @@ BodySlideFrame::BodySlideFrame(BodySlideApp* a, const wxSize &size) : delayLoad(
 		return;
 	}
 
-	xrc->LoadFrame(this, GetParent(), "bodySlideFrame");
+	loaded = xrc->LoadFrame(this, GetParent(), "bodySlideFrame");
 	if (!loaded) {
 		wxMessageBox(_("Failed to load BodySlide frame!"), _("Error"), wxICON_ERROR);
 		Close(true);

--- a/src/program/GroupManager.cpp
+++ b/src/program/GroupManager.cpp
@@ -21,7 +21,8 @@ wxBEGIN_EVENT_TABLE(GroupManager, wxDialog)
 	EVT_CLOSE(GroupManager::OnClose)
 wxEND_EVENT_TABLE()
 
-GroupManager::GroupManager(wxWindow* parent, std::vector<std::string> outfits) {
+GroupManager::GroupManager(wxWindow* parent, std::vector<std::string> outfits)
+	: allOutfits(std::move(outfits)) {
 	wxXmlResource *xrc = wxXmlResource::Get();
 	xrc->Load("res\\xrc\\GroupManager.xrc");
 	xrc->LoadDialog(this, parent, "dlgGroupManager");
@@ -42,7 +43,6 @@ GroupManager::GroupManager(wxWindow* parent, std::vector<std::string> outfits) {
 	listMembers = XRCCTRL(*this, "listMembers", wxListBox);
 	listOutfits = XRCCTRL(*this, "listOutfits", wxListBox);
 
-	allOutfits = outfits;
 	RefreshUI();
 }
 

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -1685,7 +1685,7 @@ int OutfitProject::LoadReferenceNif(const std::string& fileName, const std::stri
 		if (IsBaseShape(s)) {
 			std::string newName = s + "_ref";
 			refNif.RenameShape(s, newName);
-			baseShape = newName;
+			baseShape = std::move(newName);
 			break;
 		}
 	}
@@ -1771,7 +1771,7 @@ int OutfitProject::LoadReference(const std::string& fileName, const std::string&
 		if (s == shape) {
 			std::string newName = s + "_ref";
 			refNif.RenameShape(s, newName);
-			shape = newName;
+			shape = std::move(newName);
 			break;
 		}
 	}
@@ -1807,7 +1807,7 @@ int OutfitProject::LoadReference(const std::string& fileName, const std::string&
 				DeleteShape(s);
 	}
 
-	baseShape = shape;
+	baseShape = std::move(shape);
 
 	if (mergeSliders)
 		activeSet.LoadSetDiffData(baseDiffData, baseShape);
@@ -1862,7 +1862,7 @@ int OutfitProject::OutfitFromSliderSet(const std::string& fileName, const std::s
 		if (shape) {
 			NiShader* shader = workNif.GetShader(shape);
 			if (shader && shader->IsSkinTinted()) {
-				newBaseShape = shapeName;
+				newBaseShape = std::move(shapeName);
 				break;
 			}
 		}
@@ -1884,7 +1884,7 @@ int OutfitProject::OutfitFromSliderSet(const std::string& fileName, const std::s
 
 	// Prevent duplication if valid reference was found
 	DeleteShape(newBaseShape);
-	baseShape = newBaseShape;
+	baseShape = std::move(newBaseShape);
 
 	owner->UpdateProgress(90, _("Updating slider data..."));
 	morpher.LoadResultDiffs(activeSet);

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -5511,7 +5511,7 @@ void OutfitStudioFrame::OnSliderProperties(wxCommandEvent& WXUNUSED(event)) {
 				d->sliderNameCheck->SetName(sn + "|check");
 				d->sliderReadout->SetName(sn + "|readout");
 				d->sliderName->SetLabel(sn);
-				activeSlider = sliderName;
+				activeSlider = std::move(sliderName);
 			}
 		}
 	}
@@ -5543,7 +5543,7 @@ void OutfitStudioFrame::OnSliderConformAll(wxCommandEvent& event) {
 		pos++;
 	}
 
-	selectedItems = selectedItemsSave;
+	selectedItems = std::move(selectedItemsSave);
 
 	if (statusBar)
 		statusBar->SetStatusText(_("All shapes conformed."));
@@ -5616,7 +5616,7 @@ void OutfitStudioFrame::OnRenameShape(wxCommandEvent& WXUNUSED(event)) {
 		if (result.empty())
 			return;
 
-		newShapeName = result;
+		newShapeName = std::move(result);
 	} while (project->IsValidShape(newShapeName));
 
 	wxLogMessage("Renaming shape '%s' to '%s'.", activeItem->shapeName, newShapeName);
@@ -6214,7 +6214,7 @@ void OutfitStudioFrame::OnSeparateVerts(wxCommandEvent& WXUNUSED(event)) {
 		if (result.empty())
 			return;
 
-		newShapeName = result;
+		newShapeName = std::move(result);
 	} while (project->IsValidShape(newShapeName));
 
 	project->DuplicateShape(activeItem->shapeName, newShapeName);
@@ -6254,7 +6254,7 @@ void OutfitStudioFrame::OnDupeShape(wxCommandEvent& WXUNUSED(event)) {
 			if (result.empty())
 				return;
 
-			newName = result;
+			newName = std::move(result);
 		} while (project->IsValidShape(newName));
 
 		wxLogMessage("Duplicating shape '%s' as '%s'.", activeItem->shapeName, newName);

--- a/src/program/PresetSaveDialog.cpp
+++ b/src/program/PresetSaveDialog.cpp
@@ -55,7 +55,7 @@ void PresetSaveDialog::FilterGroups(const std::string& filter) {
 					filteredGroups.push_back(group);
 			}
 		}
-		catch (std::regex_error) {
+		catch (std::regex_error&) {
 			for (auto &group : allGroupNames)
 				filteredGroups.push_back(group);
 		}

--- a/src/render/GLMaterial.cpp
+++ b/src/render/GLMaterial.cpp
@@ -25,9 +25,9 @@ GLMaterial::GLMaterial(ResourceLoader* resLoader, std::string texName, const std
 	shader = GLShader(vertShaderProg, fragShaderProg);
 }
 
-GLMaterial::GLMaterial(ResourceLoader* resLoader, std::vector<std::string> inTexNames, const std::string& vertShaderProg, const std::string& fragShaderProg) {
+GLMaterial::GLMaterial(ResourceLoader* resLoader, std::vector<std::string> inTexNames, const std::string& vertShaderProg, const std::string& fragShaderProg)
+	: texNames(inTexNames) {
 	resLoaderRef = resLoader;
-	texNames = inTexNames;
 	resLoader->CacheStamp(cacheTime);
 	texCache.resize(inTexNames.size(), 0);
 	for (int i = 0; i < inTexNames.size(); i++)

--- a/src/utils/ConfigurationManager.h
+++ b/src/utils/ConfigurationManager.h
@@ -28,13 +28,13 @@ public:
 		isDefault = false;
 		SettingFromXML(srcElement);
 	}
-	ConfigurationItem(const std::string& text, ConfigurationItem* inParent = nullptr, int inLevel = 0) {
+	ConfigurationItem(std::string text, ConfigurationItem* inParent = nullptr, int inLevel = 0)
+		: value(std::move(text)) {
 		parent = inParent;
 		level = inLevel;
 		isProp = false;
 		isComment = true;
 		isDefault = false;
-		value = text;
 	}
 	~ConfigurationItem();
 


### PR DESCRIPTION
* Fix never showing error dialog (result not assigned to bool variable)
* Add `nullptr` checks to `malloc` & `calloc` calls
* Fix `std::string` -> `char*` -> `std::string` conversions
* Add `std::move` to reduce data copying
* Catch C++ exception by reference