### PR TITLE
Split GameDataPath onto input and output

### DIFF
--- a/Config.xml
+++ b/Config.xml
@@ -3,7 +3,7 @@
     <TargetGame>-1</TargetGame>
     <WarnMissingGamePath>true</WarnMissingGamePath>
     <BSATextureScan>true</BSATextureScan>
-	<!-- Archives black list -->
+    <!-- Archives black list -->
     <GameDataFiles>
         <Fallout3>Anchorage - Sounds.bsa; BrokenSteel - Sounds.bsa; Fallout - MenuVoices.bsa; Fallout - Meshes.bsa; Fallout - Misc.bsa; Fallout - Sounds.bsa; Fallout - Voices.bsa; PointLookout - Sounds.bsa; ThePitt - Sounds.bsa; Zeta - Sounds.bsa</Fallout3>
         <FalloutNewVegas>DeadMoney - Sounds.bsa; Fallout - Meshes.bsa; Fallout - Misc.bsa; Fallout - Sound.bsa; Fallout - Voices1.bsa; GunRunnersArsenal - Sounds.bsa; HonestHearts - Sounds.bsa; LonesomeRoad - Sounds.bsa; OldWorldBlues - Sounds.bsa</FalloutNewVegas>
@@ -21,6 +21,7 @@
         <Fallout4VR></Fallout4VR>
         <SkyrimVR></SkyrimVR></GameDataPaths>
     <GameDataPath></GameDataPath>
+    <OutputDataPath></OutputDataPath>
     <GameRegKey></GameRegKey>
     <GameRegVal></GameRegVal>
     <LogLevel>3</LogLevel>

--- a/res/xrc/Settings.xrc
+++ b/res/xrc/Settings.xrc
@@ -73,7 +73,36 @@
 									<value>,90,90,-1,70,0</value>
 									<message>Select the data path of the game...</message>
 									<style>wxDIRP_DEFAULT_STYLE</style>
-									<tooltip>Data path to load textures from and build files to.</tooltip>
+									<tooltip>Data path to load textures from.</tooltip>
+								</object>
+							</object>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxEXPAND|wxLEFT|wxRIGHT</flag>
+						<border>5</border>
+						<object class="wxBoxSizer">
+							<orient>wxHORIZONTAL</orient>
+							<object class="sizeritem">
+								<option>0</option>
+								<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
+								<border>5</border>
+								<object class="wxStaticText" name="lbOutputPath">
+									<size>100,-1</size>
+									<label>Output Path</label>
+									<wrap>-1</wrap>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>3</option>
+								<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
+								<border>5</border>
+								<object class="wxDirPickerCtrl" name="dpOutputPath">
+									<value></value>
+									<message>Select the output path...</message>
+									<style>wxDIRP_DEFAULT_STYLE</style>
+									<tooltip>Data path to build files to. If empty, Game Data Path will be used instead.</tooltip>
 								</object>
 							</object>
 						</object>

--- a/src/program/BodySlideApp.h
+++ b/src/program/BodySlideApp.h
@@ -95,6 +95,8 @@ class BodySlideApp : public wxApp {
 
 	int CreateSetSliders(const std::string& outfit);
 
+	std::string GetOutputDataPath() const;
+
 public:
 	virtual ~BodySlideApp();
 	virtual bool OnInit();

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -965,6 +965,10 @@ void OutfitStudioFrame::OnSettings(wxCommandEvent& WXUNUSED(event)) {
 		wxString gameDataPath = Config["GameDataPath"];
 		dpGameDataPath->SetPath(gameDataPath);
 
+		wxDirPickerCtrl* dpOutputPath = XRCCTRL(*settings, "dpOutputPath", wxDirPickerCtrl);
+		wxString outputPath = Config["OutputDataPath"];
+		dpOutputPath->SetPath(outputPath);
+
 		wxCheckBox* cbBBOverrideWarn = XRCCTRL(*settings, "cbBBOverrideWarn", wxCheckBox);
 		cbBBOverrideWarn->SetValue(Config["WarnBatchBuildOverride"] != "false");
 
@@ -1009,6 +1013,10 @@ void OutfitStudioFrame::OnSettings(wxCommandEvent& WXUNUSED(event)) {
 				Config.SetValue("GameDataPath", gameDataDir.GetFullPath().ToStdString());
 				Config.SetValue("GameDataPaths/" + TargetGames[targ].ToStdString(), gameDataDir.GetFullPath().ToStdString());
 			}
+
+			// set OutputDataPath even if it is empty
+			wxFileName outputDataDir = dpOutputPath->GetDirName();
+			Config.SetValue("OutputDataPath", outputDataDir.GetFullPath().ToStdString());
 
 			wxArrayInt items;
 			wxString selectedfiles;


### PR DESCRIPTION
Setting independent output directory makes sense
when using Mod Organizer 2 and allows to keep
generated meshes in their own mods.