### PR TITLE
Made changes to compile and run on Linux with gcc.

### DIFF
--- a/BodySlide.vcxproj
+++ b/BodySlide.vcxproj
@@ -769,6 +769,7 @@
     <ClInclude Include="src\utils\ConfigurationManager.h" />
     <ClInclude Include="src\utils\Log.h" />
     <ClInclude Include="src\utils\PlatformUtil.h" />
+    <ClInclude Include="src\utils\StringStuff.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="lib\FSEngine\FSBSA.cpp" />
@@ -830,6 +831,7 @@
     <ClCompile Include="src\utils\ConfigurationManager.cpp" />
     <ClCompile Include="src\utils\Log.cpp" />
     <ClCompile Include="src\utils\PlatformUtil.cpp" />
+    <ClCompile Include="src\utils\StringStuff.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Xml Include="Config.xml" />

--- a/BodySlide.vcxproj.filters
+++ b/BodySlide.vcxproj.filters
@@ -865,6 +865,9 @@
     <ClInclude Include="src\utils\PlatformUtil.h">
       <Filter>Utilities</Filter>
     </ClInclude>
+    <ClInclude Include="src\utils\StringStuff.h">
+      <Filter>Utilities</Filter>
+    </ClInclude>
     <ClInclude Include="lib\NIF\Factory.h">
       <Filter>Libraries\NIF</Filter>
     </ClInclude>
@@ -1930,6 +1933,9 @@
       <Filter>Libraries\NIF</Filter>
     </ClCompile>
     <ClCompile Include="src\utils\PlatformUtil.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
+    <ClCompile Include="src\utils\StringStuff.cpp">
       <Filter>Utilities</Filter>
     </ClCompile>
     <ClCompile Include="lib\NIF\Factory.cpp">

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,113 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(BSOS)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+find_package(wxWidgets REQUIRED gl core base net xrc adv qa html propgrid)
+find_package(OpenGL REQUIRED)
+find_package(GLEW REQUIRED)
+find_library(fbxsdk fbxsdk PATHS ../fbxsdk/lib/gcc/x64/release)
+
+set(commonsources
+	lib/FSEngine/FSBSA.cpp
+	lib/FSEngine/FSEngine.cpp
+	lib/FSEngine/FSManager.cpp
+	lib/gli/glm/detail/glm.cpp
+	lib/LZ4F/lz4.c
+	lib/LZ4F/lz4frame.c
+	lib/LZ4F/lz4hc.c
+	lib/LZ4F/xxhash.c
+	lib/NIF/Animation.cpp
+	lib/NIF/BasicTypes.cpp
+	lib/NIF/bhk.cpp
+	lib/NIF/ExtraData.cpp
+	lib/NIF/Factory.cpp
+	lib/NIF/Geometry.cpp
+	lib/NIF/NifFile.cpp
+	lib/NIF/Nodes.cpp
+	lib/NIF/Objects.cpp
+	lib/NIF/Particles.cpp
+	lib/NIF/Shaders.cpp
+	lib/NIF/Skin.cpp
+	lib/NIF/utils/Object3d.cpp
+	lib/SOIL2/etc1_utils.c
+	lib/SOIL2/image_DXT.c
+	lib/SOIL2/image_helper.c
+	lib/SOIL2/SOIL2.c
+	lib/TinyXML-2/tinyxml2.cpp
+	src/components/Anim.cpp
+	src/components/Automorph.cpp
+	src/components/DiffData.cpp
+	src/components/Mesh.cpp
+	src/components/NormalGenLayers.cpp
+	src/components/SliderCategories.cpp
+	src/components/SliderData.cpp
+	src/components/SliderGroup.cpp
+	src/components/SliderManager.cpp
+	src/components/SliderPresets.cpp
+	src/components/SliderSet.cpp
+	src/files/MaterialFile.cpp
+	src/files/ObjFile.cpp
+	src/files/ResourceLoader.cpp
+	src/files/TriFile.cpp
+	src/program/GroupManager.cpp
+	src/program/PresetSaveDialog.cpp
+	src/render/GLExtensions.cpp
+	src/render/GLMaterial.cpp
+	src/render/GLOffscreenBuffer.cpp
+	src/render/GLShader.cpp
+	src/render/GLSurface.cpp
+	src/ui/wxStateButton.cpp
+	src/utils/AABBTree.cpp
+	src/utils/ConfigurationManager.cpp
+	src/utils/Log.cpp
+	src/utils/PlatformUtil.cpp
+	src/utils/StringStuff.cpp
+	)
+set(OSsources
+	${commonsources}
+	src/components/RefTemplates.cpp
+	src/components/TweakBrush.cpp
+	src/files/FBXWrangler.cpp
+	src/program/EditUV.cpp
+	src/program/FBXImportDialog.cpp
+	src/program/OutfitProject.cpp
+	src/program/OutfitStudio.cpp
+	src/program/ShapeProperties.cpp
+	)
+set(BSsources
+	${commonsources}
+	src/files/wxDDSImage.cpp
+	src/program/BodySlideApp.cpp
+	src/program/NormalsGenDialog.cpp
+	src/program/PreviewWindow.cpp
+	src/ui/wxNormalsGenDlg.cpp
+	)
+
+add_executable(OutfitStudio ${OSsources})
+add_executable(BodySlide ${BSsources})
+
+include(${wxWidgets_USE_FILE})
+target_include_directories(OutfitStudio SYSTEM PRIVATE
+	../fbxsdk/include
+	/usr/include/wine/windows
+	)
+target_include_directories(BodySlide SYSTEM PRIVATE
+	/usr/include/wine/windows
+	)
+target_include_directories(OutfitStudio PUBLIC lib/gli)
+target_include_directories(BodySlide PUBLIC lib/gli)
+
+target_link_libraries(OutfitStudio
+	${wxWidgets_LIBRARIES}
+	${OPENGL_LIBRARIES}
+	${GLEW_LIBRARIES}
+	${fbxsdk}
+	xml2)
+
+target_link_libraries(BodySlide
+	${wxWidgets_LIBRARIES}
+	${OPENGL_LIBRARIES}
+	${GLEW_LIBRARIES}
+	xml2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 find_package(wxWidgets REQUIRED gl core base net xrc adv qa html propgrid)
 find_package(OpenGL REQUIRED)
 find_package(GLEW REQUIRED)
-find_library(fbxsdk fbxsdk PATHS ../fbxsdk/lib/gcc/x64/release)
+set(fbxsdk_dir ../fbxsdk)
+find_library(fbxsdk fbxsdk PATHS ${fbxsdk_dir}/lib/gcc/x64/release)
 
 set(commonsources
 	lib/FSEngine/FSBSA.cpp
@@ -90,7 +91,7 @@ add_executable(BodySlide ${BSsources})
 
 include(${wxWidgets_USE_FILE})
 target_include_directories(OutfitStudio SYSTEM PRIVATE
-	../fbxsdk/include
+	${fbxsdk_dir}/include
 	/usr/include/wine/windows
 	)
 target_include_directories(BodySlide SYSTEM PRIVATE

--- a/OutfitStudio.vcxproj
+++ b/OutfitStudio.vcxproj
@@ -774,6 +774,7 @@
     <ClInclude Include="src\utils\ConfigurationManager.h" />
     <ClInclude Include="src\utils\Log.h" />
     <ClInclude Include="src\utils\PlatformUtil.h" />
+    <ClInclude Include="src\utils\StringStuff.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="lib\FSEngine\FSBSA.cpp" />
@@ -838,6 +839,7 @@
     <ClCompile Include="src\utils\ConfigurationManager.cpp" />
     <ClCompile Include="src\utils\Log.cpp" />
     <ClCompile Include="src\utils\PlatformUtil.cpp" />
+    <ClCompile Include="src\utils\StringStuff.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Xml Include="Config.xml" />

--- a/OutfitStudio.vcxproj.filters
+++ b/OutfitStudio.vcxproj.filters
@@ -871,6 +871,9 @@
     <ClInclude Include="src\utils\PlatformUtil.h">
       <Filter>Utilities</Filter>
     </ClInclude>
+    <ClInclude Include="src\utils\StringStuff.h">
+      <Filter>Utilities</Filter>
+    </ClInclude>
     <ClInclude Include="lib\NIF\Factory.h">
       <Filter>Libraries\NIF</Filter>
     </ClInclude>
@@ -1948,6 +1951,9 @@
       <Filter>Libraries\NIF</Filter>
     </ClCompile>
     <ClCompile Include="src\utils\PlatformUtil.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
+    <ClCompile Include="src\utils\StringStuff.cpp">
       <Filter>Utilities</Filter>
     </ClCompile>
     <ClCompile Include="lib\NIF\Factory.cpp">

--- a/Readme-linux.txt
+++ b/Readme-linux.txt
@@ -1,0 +1,45 @@
+Building BodySlide and Outfit Studio on Linux
+
+There's just one file that specifies the build process: CMakeLists.txt.
+
+Install wxWidgets 3.1.3 or newer.  Use the "--enable-stl" option to
+configure.  If you get errors about an ABI mismatch, that means you
+compiled wxWidgets with a different compiler version than BS&OS (and
+wxWidgets is strangely picky about that).  Either gtk2 or gtk3 works.
+With gtk2, you have more background color problems; with gtk3, many
+widgets are distorted because they don't have enough space.  Note that
+many of wxWidget's configure options (such as --enable-universal)
+result in a broken wxWidgets library, so prefer to use as few options
+as possible.
+
+Install FBX SDK.  Put the path to your FBX SDK installation in the
+fbxsdk_dir variable in CMakeLists.txt.
+
+Make sure GLEW is installed.
+
+Then go to your BodySlide-and-Outfit-Studio directory and do:
+mkdir Release
+cd Release
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make
+
+The possible values for CMAKE_BUILD_TYPE:
+	Release
+	RelWithDebInfo
+	Debug
+	MinSizeRel
+	(nothing)
+
+To specify the compiler, set CC and CXX before running cmake.  The build
+directory must be completely empty, or cmake will ignore CC and CXX and
+use the same compilers as it did last time.
+
+Some useful make options:
+make VERBOSE=1
+make -j 4
+
+If you don't want to copy the executables to the BodySlide
+directory within your game, set WX_BODYSLIDE_DATA_DIR and
+WX_OUTFITSTUDIO_DATA_DIR to the BodySlide directory.  Unfortunately,
+program data such as xrc files and icons also come from the data dir;
+if you make changes to the data files, you'll have to copy them over.

--- a/lib/NIF/BasicTypes.h
+++ b/lib/NIF/BasicTypes.h
@@ -12,6 +12,7 @@ See the included LICENSE file
 #include <string>
 #include <algorithm>
 #include <memory>
+#include <iostream>
 
 enum NiFileVersion : uint {
 	V2_3 = 0x02030000,
@@ -420,6 +421,9 @@ public:
 template <typename T>
 class BlockRefShortArray : public BlockRefArray<T> {
 public:
+	typedef BlockRefArray<T> base;
+	using base::arraySize;
+	using base::refs;
 	virtual void Get(NiStream& stream) override {
 		stream.read((char*)&arraySize, 2);
 		refs.resize(arraySize);
@@ -429,7 +433,7 @@ public:
 	}
 
 	virtual void Put(NiStream& stream) override {
-		CleanInvalidRefs();
+		base::CleanInvalidRefs();
 		stream.write((char*)&arraySize, 2);
 
 		for (auto &r : refs)
@@ -437,7 +441,7 @@ public:
 	}
 	
 	virtual void Put(NiStream& stream, const int forcedSize) override {
-		CleanInvalidRefs();
+		base::CleanInvalidRefs();
 		arraySize = forcedSize;
 		refs.resize(forcedSize);
 

--- a/lib/NIF/Keys.h
+++ b/lib/NIF/Keys.h
@@ -59,6 +59,8 @@ public:
 				case TBC_KEY:
 					stream >> key.tbc;
 					break;
+				default:
+					break;
 				}
 
 				keys[i] = std::move(key);
@@ -83,6 +85,8 @@ public:
 					break;
 				case TBC_KEY:
 					stream << keys[i].tbc;
+					break;
+				default:
 					break;
 				}
 			}

--- a/lib/NIF/NifFile.h
+++ b/lib/NIF/NifFile.h
@@ -69,6 +69,7 @@ public:
 
 	NifFile& operator=(const NifFile& other) {
 		CopyFrom(other);
+		return *this;
 	}
 
 	NiHeader& GetHeader() { return hdr; }

--- a/lib/NIF/VertexData.h
+++ b/lib/NIF/VertexData.h
@@ -81,7 +81,7 @@ public:
 	// Set offset to a specific vertex attribute in the description
 	void SetAttributeOffset(VertexAttribute attr, uint offset) {
 		if (attr != VA_POSITION) {
-			desc = ((uint64_t)offset << (4 * (byte)attr + 2)) | desc & ~(15 << (4 * (byte)attr + 4));
+			desc = ((uint64_t)offset << (4 * (byte)attr + 2)) | (desc & ~(15 << (4 * (byte)attr + 4)));
 		}
 	}
 

--- a/lib/NIF/bhk.cpp
+++ b/lib/NIF/bhk.cpp
@@ -51,6 +51,8 @@ void BoundingVolume::Get(NiStream& stream) {
 	case HALFSPACE_BV:
 		stream >> bvHalfSpace;
 		break;
+	default:
+		break;
 	}
 }
 
@@ -72,6 +74,8 @@ void BoundingVolume::Put(NiStream& stream) {
 		break;
 	case HALFSPACE_BV:
 		stream << bvHalfSpace;
+		break;
+	default:
 		break;
 	}
 }

--- a/lib/NIF/bhk.h
+++ b/lib/NIF/bhk.h
@@ -127,6 +127,8 @@ struct MotorDesc {
 		case MOTOR_SPRING:
 			motorSpringDamper.Get(stream);
 			break;
+		default:
+			break;
 		}
 	}
 
@@ -142,6 +144,8 @@ struct MotorDesc {
 			break;
 		case MOTOR_SPRING:
 			motorSpringDamper.Put(stream);
+			break;
+		default:
 			break;
 		}
 	}

--- a/lib/NIF/utils/Object3d.h
+++ b/lib/NIF/utils/Object3d.h
@@ -7,6 +7,8 @@ See the included LICENSE file
 
 #include <vector>
 #include <algorithm>
+#include <cmath>
+#include <cstring>
 
 #pragma warning (disable : 4018 4244 4267 4389)
 
@@ -252,7 +254,7 @@ struct Vector3 {
 		else if (dot == 0.0f)
 			return PI / 2.0f;
 
-		return acosf(dot);
+		return acos(dot);
 	}
 
 	void clampEpsilon() {
@@ -495,12 +497,12 @@ public:
 
 	// Set rotation matrix from yaw, pitch and roll
 	static Matrix3 MakeRotation(const float yaw, const float pitch, const float roll) {
-		float ch = std::cosf(yaw);
-		float sh = std::sinf(yaw);
-		float cp = std::cosf(pitch);
-		float sp = std::sinf(pitch);
-		float cb = std::cosf(roll);
-		float sb = std::sinf(roll);
+		float ch = std::cos(yaw);
+		float sh = std::sin(yaw);
+		float cp = std::cos(pitch);
+		float sp = std::sin(pitch);
+		float cb = std::cos(roll);
+		float sb = std::sin(roll);
 
 		Matrix3 rot;
 		rot[0].x = ch * cb + sh * sp * sb;
@@ -751,8 +753,8 @@ public:
 	}
 
 	Matrix4& Rotate(float radAngle, float x, float y, float z) {
-		float c = std::cosf(radAngle);
-		float s = std::sinf(radAngle);
+		float c = std::cos(radAngle);
+		float s = std::sin(radAngle);
 
 		float xx = x*x;
 		float xy = x*y;
@@ -1153,19 +1155,13 @@ struct Edge {
 };
 
 namespace std {
-	template<> struct std::hash < Edge > {
+	template<> struct hash < Edge > {
 		std::size_t operator() (const Edge& t) const {
 			return ((t.p2 << 16) | (t.p1 & 0xFFFF));
 		}
 	};
 
-	template <> struct std::equal_to < Edge > {
-		bool operator() (const Edge& t1, const Edge& t2) const {
-			return ((t1.p1 == t2.p1) && (t1.p2 == t2.p2));
-		}
-	};
-
-	template <> struct std::hash < Triangle > {
+	template <> struct hash < Triangle > {
 		std::size_t operator() (const Triangle& t) const {
 			char* d = (char*)&t;
 			std::size_t len = sizeof(Triangle);
@@ -1181,12 +1177,14 @@ namespace std {
 			return hash;
 		}
 	};
+}
 
-	template <> struct std::equal_to < Triangle > {
-		bool operator() (const Triangle& t1, const Triangle& t2) const {
-			return ((t1.p1 == t2.p1) && (t1.p2 == t2.p2) && (t1.p3 == t2.p3));
-		}
-	};
+inline bool operator== (const Edge& t1, const Edge& t2) {
+	return ((t1.p1 == t2.p1) && (t1.p2 == t2.p2));
+}
+
+inline bool operator== (const Triangle& t1, const Triangle& t2) {
+	return ((t1.p1 == t2.p1) && (t1.p2 == t2.p2) && (t1.p3 == t2.p3));
 }
 
 struct Face {

--- a/src/components/Mesh.h
+++ b/src/components/Mesh.h
@@ -32,7 +32,7 @@ class GLMaterial;
 
 class mesh {
 private:
-	bool queueUpdate[7] = { false };
+	bool queueUpdate[8] = { false };
 
 public:
 	enum UpdateType {

--- a/src/components/RefTemplates.cpp
+++ b/src/components/RefTemplates.cpp
@@ -5,6 +5,7 @@ See the included LICENSE file
 
 #include "RefTemplates.h"
 #include "../utils/PlatformUtil.h"
+#include "../utils/StringStuff.h"
 
 int RefTemplateCollection::Load(const std::string& basePath) {
 	refTemplates.clear();
@@ -44,7 +45,7 @@ int RefTemplate::Load(XMLElement* srcElement) {
 	name = srcElement->GetText();
 
 	if (srcElement->Attribute("sourcefile"))
-		source = srcElement->Attribute("sourcefile");
+		source = ToOSSlashes(srcElement->Attribute("sourcefile"));
 
 	if (srcElement->Attribute("set"))
 		set = srcElement->Attribute("set");

--- a/src/components/RefTemplates.cpp
+++ b/src/components/RefTemplates.cpp
@@ -77,8 +77,10 @@ void RefTemplateFile::Open(const std::string& srcFileName) {
 		return;
 #else
 	fp = fopen(srcFileName.c_str(), "rb");
-	if (!fp)
+	if (!fp) {
+		error = errno;
 		return;
+	}
 #endif
 
 	error = doc.LoadFile(fp);

--- a/src/components/SliderCategories.cpp
+++ b/src/components/SliderCategories.cpp
@@ -192,8 +192,10 @@ void SliderCategoryFile::Open(const std::string& srcFileName) {
 		return;
 #else
 	fp = fopen(srcFileName.c_str(), "rb");
-	if (!fp)
+	if (!fp){
+		error = errno;
 		return;
+	}
 #endif
 
 	error = doc.LoadFile(fp);
@@ -323,8 +325,10 @@ bool SliderCategoryFile::Save() {
 		return false;
 #else
 	fp = fopen(fileName.c_str(), "w");
-	if (!fp)
+	if (!fp){
+		error = errno;
 		return false;
+	}
 #endif
 
 	doc.SetBOM(true);

--- a/src/components/SliderData.cpp
+++ b/src/components/SliderData.cpp
@@ -4,6 +4,7 @@ See the included LICENSE file
 */
 
 #include "SliderData.h"
+#include "../utils/StringStuff.h"
 
 #include <wx/dir.h>
 #include <wx/tokenzr.h>
@@ -28,12 +29,12 @@ int SliderData::LoadSliderData(XMLElement* element, bool genWeights) {
 
 	name = element->Attribute("name");
 	if (element->Attribute("invert"))
-		bInvert = (_strnicmp(element->Attribute("invert"), "true", 4) == 0);
+		bInvert = StringsEqualNInsens(element->Attribute("invert"), "true", 4);
 	else
 		bInvert = false;
 
 	if (element->Attribute("uv"))
-		bUV = (_strnicmp(element->Attribute("uv"), "true", 4) == 0);
+		bUV = StringsEqualNInsens(element->Attribute("uv"), "true", 4);
 	else
 		bUV = false;
 
@@ -50,22 +51,22 @@ int SliderData::LoadSliderData(XMLElement* element, bool genWeights) {
 	}
 
 	if (element->Attribute("hidden"))
-		bHidden = (_strnicmp(element->Attribute("hidden"), "true", 4) == 0);
+		bHidden = StringsEqualNInsens(element->Attribute("hidden"), "true", 4);
 	else
 		bHidden = false;
 
 	if (element->Attribute("zap"))
-		bZap = (_strnicmp(element->Attribute("zap"), "true", 4) == 0);
+		bZap = StringsEqualNInsens(element->Attribute("zap"), "true", 4);
 	else
 		bZap = false;
 
 	if (element->Attribute("uv"))
-		bUV = (_strnicmp(element->Attribute("uv"), "true", 4) == 0);
+		bUV = StringsEqualNInsens(element->Attribute("uv"), "true", 4);
 	else
 		bUV = false;
 
 	if (element->Attribute("clamp"))
-		bClamp = (_strnicmp(element->Attribute("clamp"), "true", 4) == 0);
+		bClamp = StringsEqualNInsens(element->Attribute("clamp"), "true", 4);
 	else
 		bClamp = false;
 
@@ -82,7 +83,7 @@ int SliderData::LoadSliderData(XMLElement* element, bool genWeights) {
 		tmpDataFile.targetName = datafile->Attribute("target");
 
 		if (datafile->Attribute("local"))
-			tmpDataFile.bLocal = (_strnicmp(datafile->Attribute("local"), "true", 4) == 0);
+			tmpDataFile.bLocal = StringsEqualNInsens(datafile->Attribute("local"), "true", 4);
 		else
 			tmpDataFile.bLocal = false;
 

--- a/src/components/SliderData.cpp
+++ b/src/components/SliderData.cpp
@@ -94,7 +94,7 @@ int SliderData::LoadSliderData(XMLElement* element, bool genWeights) {
 
 		const char* dataFileText = datafile->GetText();
 		if (dataFileText)
-			tmpDataFile.fileName = dataFileText;
+			tmpDataFile.fileName = ToOSSlashes(dataFileText);
 
 		dataFiles.push_back(tmpDataFile);
 

--- a/src/components/SliderGroup.cpp
+++ b/src/components/SliderGroup.cpp
@@ -140,8 +140,10 @@ void SliderSetGroupFile::Open(const std::string& srcFileName) {
 		return;
 #else
 	fp = fopen(srcFileName.c_str(), "rb");
-	if (!fp)
+	if (!fp) {
+		error = errno;
 		return;
+	}
 #endif
 
 	error = doc.LoadFile(fp);
@@ -287,8 +289,10 @@ bool SliderSetGroupFile::Save() {
 		return false;
 #else
 	fp = fopen(fileName.c_str(), "w");
-	if (!fp)
+	if (!fp) {
+		error = errno;
 		return false;
+	}
 #endif
 
 	doc.SetBOM(true);

--- a/src/components/SliderPresets.cpp
+++ b/src/components/SliderPresets.cpp
@@ -385,3 +385,4 @@ int PresetCollection::DeletePreset(const std::string& filePath, const std::strin
 
 	return 0;
 }
+

--- a/src/components/SliderPresets.cpp
+++ b/src/components/SliderPresets.cpp
@@ -241,11 +241,11 @@ int PresetCollection::SavePreset(const std::string& filePath, const std::string&
 #endif
 
 	if (loaded) {
-		int ret = outDoc.LoadFile(fp);
+		int retDoc = outDoc.LoadFile(fp);
 		fclose(fp);
 		fp = nullptr;
 
-		if (ret != 0)
+		if (retDoc != 0)
 			loaded = false;
 	}
 

--- a/src/components/SliderPresets.cpp
+++ b/src/components/SliderPresets.cpp
@@ -385,4 +385,3 @@ int PresetCollection::DeletePreset(const std::string& filePath, const std::strin
 
 	return 0;
 }
-

--- a/src/components/SliderPresets.cpp
+++ b/src/components/SliderPresets.cpp
@@ -6,6 +6,7 @@ See the included LICENSE file
 #include "../TinyXML-2/tinyxml2.h"
 #include "SliderPresets.h"
 #include "../utils/PlatformUtil.h"
+#include "../utils/StringStuff.h"
 
 #include <wx/dir.h>
 
@@ -149,10 +150,10 @@ bool PresetCollection::LoadPresets(const std::string& basePath, const std::strin
 			continue;
 #endif
 
-		ret = doc.LoadFile(fp);
+		int ret2 = doc.LoadFile(fp);
 		fclose(fp);
 
-		if (ret)
+		if (ret2)
 			continue;
 
 		root = doc.FirstChildElement("SliderPresets");
@@ -240,7 +241,7 @@ int PresetCollection::SavePreset(const std::string& filePath, const std::string&
 #endif
 
 	if (loaded) {
-		ret = outDoc.LoadFile(fp);
+		int ret = outDoc.LoadFile(fp);
 		fclose(fp);
 		fp = nullptr;
 
@@ -254,7 +255,7 @@ int PresetCollection::SavePreset(const std::string& filePath, const std::string&
 		presetElem = slidersNode->FirstChildElement("Preset");
 		while (presetElem) {
 			// Replace preset if found in file.
-			if (_stricmp(presetElem->Attribute("name"), presetName.c_str()) == 0) {
+			if (StringsEqualInsens(presetElem->Attribute("name"), presetName.c_str())) {
 				XMLElement* tmpElem = presetElem;
 				presetElem = presetElem->NextSiblingElement("Preset");
 				slidersNode->DeleteChild(tmpElem);
@@ -336,18 +337,18 @@ int PresetCollection::DeletePreset(const std::string& filePath, const std::strin
 #endif
 
 	XMLDocument doc;
-	ret = doc.LoadFile(fp);
+	int ret2 = doc.LoadFile(fp);
 	fclose(fp);
 	fp = nullptr;
 
-	if (ret)
+	if (ret2)
 		return -1;
 
 	XMLNode* slidersNode = doc.FirstChildElement("SliderPresets");
 	if (slidersNode) {
 		XMLElement* presetElem = slidersNode->FirstChildElement("Preset");
 		while (presetElem) {
-			if (_stricmp(presetElem->Attribute("name"), presetName.c_str()) == 0) {
+			if (StringsEqualInsens(presetElem->Attribute("name"), presetName.c_str())) {
 				slidersNode->DeleteChild(presetElem);
 				break;
 			}

--- a/src/components/SliderSet.cpp
+++ b/src/components/SliderSet.cpp
@@ -153,11 +153,11 @@ void SliderSet::LoadSetDiffData(DiffDataSets& inDataStorage, const std::string& 
 			if (!forShape.empty() && shapeName != forShape)
 				continue;
 
-			std::string fullFilePath = baseDataPath + "\\";
+			std::string fullFilePath = baseDataPath + "/";
 			if (ddf.bLocal)
-				fullFilePath += datafolder + "\\";
+				fullFilePath += datafolder + "/";
 			else
-				fullFilePath += ShapeToDataFolder(shapeName) + "\\";
+				fullFilePath += ShapeToDataFolder(shapeName) + "/";
 
 			fullFilePath += ddf.fileName;
 
@@ -169,6 +169,8 @@ void SliderSet::LoadSetDiffData(DiffDataSets& inDataStorage, const std::string& 
 			else {
 				// Split file name to get file and data name in it
 				int split = fullFilePath.find_last_of('\\');
+				if (split < 0)
+					split = fullFilePath.find_last_of('/');
 				if (split < 0)
 					continue;
 
@@ -194,11 +196,11 @@ void SliderSet::Merge(SliderSet& mergeSet, DiffDataSets& inDataStorage, DiffData
 			return;
 
 		std::string shapeName = mergeSet.TargetToShape(ddf.targetName);
-		std::string fullFilePath = mergeSet.baseDataPath + "\\";
+		std::string fullFilePath = mergeSet.baseDataPath + "/";
 		if (ddf.bLocal)
-			fullFilePath += mergeSet.datafolder + "\\";
+			fullFilePath += mergeSet.datafolder + "/";
 		else
-			fullFilePath += mergeSet.ShapeToDataFolder(shapeName) + "\\";
+			fullFilePath += mergeSet.ShapeToDataFolder(shapeName) + "/";
 
 		fullFilePath += ddf.fileName;
 
@@ -212,7 +214,7 @@ void SliderSet::Merge(SliderSet& mergeSet, DiffDataSets& inDataStorage, DiffData
 		// OSD format
 		else {
 			// Split file name to get file and data name in it
-			int split = fullFilePath.find_last_of('\\');
+			int split = fullFilePath.find_last_of('/');
 			if (split < 0)
 				return;
 
@@ -372,14 +374,14 @@ void SliderSet::WriteSliderSet(XMLElement* sliderSetElement) {
 
 std::string SliderSet::GetInputFileName() {
 	std::string o;
-	o = baseDataPath + "\\";
-	o += datafolder + "\\";
+	o = baseDataPath + "/";
+	o += datafolder + "/";
 	o += inputfile;
 	return o;
 }
 
 std::string SliderSet::GetOutputFilePath() {
-	return outputpath + "\\" + outputfile;
+	return outputpath + "/" + outputfile;
 }
 
 bool SliderSet::GenWeights() {
@@ -520,7 +522,7 @@ void SliderSetFile::GetSetOutputFilePath(const std::string& setName, std::string
 
 	tmpElement = setPtr->FirstChildElement("OutputFile");
 	if (tmpElement) {
-		outFilePath += "\\";
+		outFilePath += "/";
 		outFilePath += tmpElement->GetText();
 	}
 }

--- a/src/components/SliderSet.cpp
+++ b/src/components/SliderSet.cpp
@@ -154,11 +154,11 @@ void SliderSet::LoadSetDiffData(DiffDataSets& inDataStorage, const std::string& 
 			if (!forShape.empty() && shapeName != forShape)
 				continue;
 
-			std::string fullFilePath = baseDataPath + "/";
+			std::string fullFilePath = baseDataPath + PathSepStr;
 			if (ddf.bLocal)
-				fullFilePath += datafolder + "/";
+				fullFilePath += datafolder + PathSepStr;
 			else
-				fullFilePath += ShapeToDataFolder(shapeName) + "/";
+				fullFilePath += ShapeToDataFolder(shapeName) + PathSepStr;
 
 			fullFilePath += ddf.fileName;
 
@@ -169,11 +169,11 @@ void SliderSet::LoadSetDiffData(DiffDataSets& inDataStorage, const std::string& 
 			// OSD format
 			else {
 				// Split file name to get file and data name in it
-				int split = fullFilePath.find_last_of('\\');
+				int split = fullFilePath.find_last_of('/');
 				if (split < 0)
-					split = fullFilePath.find_last_of('/');
+					split = fullFilePath.find_last_of('\\');
 				if (split < 0)
-					continue;
+					return;
 
 				std::string dataName = fullFilePath.substr(split + 1);
 				std::string fileName = fullFilePath.substr(0, split);
@@ -197,11 +197,11 @@ void SliderSet::Merge(SliderSet& mergeSet, DiffDataSets& inDataStorage, DiffData
 			return;
 
 		std::string shapeName = mergeSet.TargetToShape(ddf.targetName);
-		std::string fullFilePath = mergeSet.baseDataPath + "/";
+		std::string fullFilePath = mergeSet.baseDataPath + PathSepStr;
 		if (ddf.bLocal)
-			fullFilePath += mergeSet.datafolder + "/";
+			fullFilePath += mergeSet.datafolder + PathSepStr;
 		else
-			fullFilePath += mergeSet.ShapeToDataFolder(shapeName) + "/";
+			fullFilePath += mergeSet.ShapeToDataFolder(shapeName) + PathSepStr;
 
 		fullFilePath += ddf.fileName;
 
@@ -382,14 +382,14 @@ void SliderSet::WriteSliderSet(XMLElement* sliderSetElement) {
 
 std::string SliderSet::GetInputFileName() {
 	std::string o;
-	o = baseDataPath + "/";
-	o += datafolder + "/";
+	o = baseDataPath + PathSepStr;
+	o += datafolder + PathSepStr;
 	o += inputfile;
 	return o;
 }
 
 std::string SliderSet::GetOutputFilePath() {
-	return outputpath + "/" + outputfile;
+	return outputpath + PathSepStr + outputfile;
 }
 
 bool SliderSet::GenWeights() {
@@ -532,7 +532,7 @@ void SliderSetFile::GetSetOutputFilePath(const std::string& setName, std::string
 
 	tmpElement = setPtr->FirstChildElement("OutputFile");
 	if (tmpElement) {
-		outFilePath += "/";
+		outFilePath += PathSepStr;
 		outFilePath += tmpElement->GetText();
 	}
 }

--- a/src/components/SliderSet.cpp
+++ b/src/components/SliderSet.cpp
@@ -173,7 +173,7 @@ void SliderSet::LoadSetDiffData(DiffDataSets& inDataStorage, const std::string& 
 				if (split < 0)
 					split = fullFilePath.find_last_of('\\');
 				if (split < 0)
-					return;
+					continue;
 
 				std::string dataName = fullFilePath.substr(split + 1);
 				std::string fileName = fullFilePath.substr(0, split);

--- a/src/components/SliderSet.cpp
+++ b/src/components/SliderSet.cpp
@@ -77,7 +77,7 @@ int SliderSet::LoadSliderSet(XMLElement* element) {
 
 	tmpElement = element->FirstChildElement("OutputPath");
 	if (tmpElement)
-		outputpath = tmpElement->GetText();
+		outputpath = ToOSSlashes(tmpElement->GetText());
 
 	genWeights = true;
 	tmpElement = element->FirstChildElement("OutputFile");
@@ -290,7 +290,8 @@ void SliderSet::WriteSliderSet(XMLElement* sliderSetElement) {
 	sliderSetElement->InsertEndChild(newElement)->ToElement()->InsertEndChild(newText);
 
 	newElement = sliderSetElement->GetDocument()->NewElement("OutputPath");
-	newText = sliderSetElement->GetDocument()->NewText(outputpath.c_str());
+	std::string outputpath_bs = ToBackslashes(outputpath);
+	newText = sliderSetElement->GetDocument()->NewText(outputpath_bs.c_str());
 	sliderSetElement->InsertEndChild(newElement)->ToElement()->InsertEndChild(newText);
 
 	newElement = sliderSetElement->GetDocument()->NewElement("OutputFile");
@@ -411,8 +412,10 @@ void SliderSetFile::Open(const std::string& srcFileName) {
 		return;
 #else
 	fp = fopen(srcFileName.c_str(), "rb");
-	if (!fp)
+	if (!fp) {
+		error = errno;
 		return;
+	}
 #endif
 
 	error = doc.LoadFile(fp);
@@ -525,7 +528,7 @@ void SliderSetFile::GetSetOutputFilePath(const std::string& setName, std::string
 	XMLElement* setPtr = setsInFile[setName];
 	XMLElement* tmpElement = setPtr->FirstChildElement("OutputPath");
 	if (tmpElement)
-		outFilePath += tmpElement->GetText();
+		outFilePath += ToOSSlashes(tmpElement->GetText());
 
 	tmpElement = setPtr->FirstChildElement("OutputFile");
 	if (tmpElement) {
@@ -572,8 +575,10 @@ bool SliderSetFile::Save() {
 		return false;
 #else
 	fp = fopen(fileName.c_str(), "w");
-	if (!fp)
+	if (!fp) {
+		error = errno;
 		return false;
+	}
 #endif
 
 	doc.SetBOM(true);

--- a/src/files/FBXWrangler.h
+++ b/src/files/FBXWrangler.h
@@ -9,8 +9,7 @@ See the included LICENSE file
 #include "../components/Anim.h"
 #include "../program/FBXImportOptions.h"
 #include "../NIF/NifFile.h"
-
-#include <fbxsdk.h>
+#include <memory>
 
 
 class FBXShape {
@@ -49,11 +48,10 @@ public:
 
 class FBXWrangler {
 private:
-	FbxManager* sdkManager = nullptr;
-	FbxScene* scene = nullptr;
+	struct Priv;
+	std::unique_ptr<Priv> priv;
 
 	std::string comName;
-	std::map<std::string, FBXShape> shapes;
 
 public:
 	FBXWrangler();
@@ -62,27 +60,13 @@ public:
 	void NewScene();
 	void CloseScene();
 
-	void GetShapeNames(std::vector<std::string>& outNames) {
-		for (auto &s : shapes)
-			outNames.push_back(s.first);
-	}
-
-	FBXShape* GetShape(const std::string& shapeName) {
-		return &(shapes[shapeName]);
-	}
+	void GetShapeNames(std::vector<std::string>& outNames);
+	FBXShape* GetShape(const std::string& shapeName);
 
 	void AddSkeleton(NifFile* nif, bool onlyNonSkeleton = false);
-
-	// Recursively add bones to the skeleton in a depth-first manner
-	FbxNode* AddLimb(NifFile* nif, NiNode* nifBone);
-	void AddLimbChildren(FbxNode* node, NifFile* nif, NiNode* nifBone);
-
 	void AddNif(NifFile* meshNif, NiShape* shape = nullptr);
 	void AddSkinning(AnimInfo* anim, NiShape* shape = nullptr);
-	void AddGeometry(NiShape* shape, const std::vector<Vector3>* verts, const std::vector<Vector3>* norms, const std::vector<Triangle>* tris, const std::vector<Vector2>* uvs);
 
 	bool ExportScene(const std::string& fileName);
 	bool ImportScene(const std::string& fileName, const FBXImportOptions& options = FBXImportOptions());
-
-	bool LoadMeshes(const FBXImportOptions& options);
 };

--- a/src/files/MaterialFile.cpp
+++ b/src/files/MaterialFile.cpp
@@ -4,6 +4,7 @@ See the included LICENSE file
 */
 
 #include "MaterialFile.h"
+#include "../utils/StringStuff.h"
 
 MaterialFile::MaterialFile(const Type& signature) {
 	this->signature = signature;
@@ -79,41 +80,51 @@ int MaterialFile::Read(std::istream& input) {
 
 	uint length = 0;
 	if (signature == BGSM) {
+		std::string tmp;
 		input.read((char*)&length, 4);
-		diffuseTexture.resize(length);
-		input.read((char*)&diffuseTexture.front(), length);
+		tmp.resize(length);
+		input.read((char*)&tmp.front(), length);
+		diffuseTexture = ToOSSlashes(tmp);
 
 		input.read((char*)&length, 4);
-		normalTexture.resize(length);
-		input.read((char*)&normalTexture.front(), length);
+		tmp.resize(length);
+		input.read((char*)&tmp.front(), length);
+		normalTexture = ToOSSlashes(tmp);
 
 		input.read((char*)&length, 4);
-		smoothSpecTexture.resize(length);
-		input.read((char*)&smoothSpecTexture.front(), length);
+		tmp.resize(length);
+		input.read((char*)&tmp.front(), length);
+		smoothSpecTexture = ToOSSlashes(tmp);
 
 		input.read((char*)&length, 4);
-		greyscaleTexture.resize(length);
-		input.read((char*)&greyscaleTexture.front(), length);
+		tmp.resize(length);
+		input.read((char*)&tmp.front(), length);
+		greyscaleTexture = ToOSSlashes(tmp);
 
 		input.read((char*)&length, 4);
-		envmapTexture.resize(length);
-		input.read((char*)&envmapTexture.front(), length);
+		tmp.resize(length);
+		input.read((char*)&tmp.front(), length);
+		envmapTexture = ToOSSlashes(tmp);
 
 		input.read((char*)&length, 4);
-		glowTexture.resize(length);
-		input.read((char*)&glowTexture.front(), length);
+		tmp.resize(length);
+		input.read((char*)&tmp.front(), length);
+		glowTexture = ToOSSlashes(tmp);
 
 		input.read((char*)&length, 4);
-		innerLayerTexture.resize(length);
-		input.read((char*)&innerLayerTexture.front(), length);
+		tmp.resize(length);
+		input.read((char*)&tmp.front(), length);
+		innerLayerTexture = ToOSSlashes(tmp);
 
 		input.read((char*)&length, 4);
-		wrinklesTexture.resize(length);
-		input.read((char*)&wrinklesTexture.front(), length);
+		tmp.resize(length);
+		input.read((char*)&tmp.front(), length);
+		wrinklesTexture = ToOSSlashes(tmp);
 
 		input.read((char*)&length, 4);
-		displacementTexture.resize(length);
-		input.read((char*)&displacementTexture.front(), length);
+		tmp.resize(length);
+		input.read((char*)&tmp.front(), length);
+		displacementTexture = ToOSSlashes(tmp);
 
 		input.read((char*)&enableEditorAlphaRef, 1);
 		input.read((char*)&rimLighting, 1);
@@ -176,25 +187,31 @@ int MaterialFile::Read(std::istream& input) {
 			input.read((char*)&skewSpecularAlpha, 1);
 	}
 	else if (signature == BGEM) {
+		std::string tmp;
 		input.read((char*)&length, 4);
-		baseTexture.resize(length);
-		input.read((char*)&baseTexture.front(), length);
+		tmp.resize(length);
+		input.read((char*)&tmp.front(), length);
+		baseTexture = ToOSSlashes(tmp);
 
 		input.read((char*)&length, 4);
-		grayscaleTexture.resize(length);
-		input.read((char*)&grayscaleTexture.front(), length);
+		tmp.resize(length);
+		input.read((char*)&tmp.front(), length);
+		grayscaleTexture = ToOSSlashes(tmp);
 
 		input.read((char*)&length, 4);
-		fxEnvmapTexture.resize(length);
-		input.read((char*)&fxEnvmapTexture.front(), length);
+		tmp.resize(length);
+		input.read((char*)&tmp.front(), length);
+		fxEnvmapTexture = ToOSSlashes(tmp);
 
 		input.read((char*)&length, 4);
-		fxNormalTexture.resize(length);
-		input.read((char*)&fxNormalTexture.front(), length);
+		tmp.resize(length);
+		input.read((char*)&tmp.front(), length);
+		fxNormalTexture = ToOSSlashes(tmp);
 
 		input.read((char*)&length, 4);
-		envmapMaskTexture.resize(length);
-		input.read((char*)&envmapMaskTexture.front(), length);
+		tmp.resize(length);
+		input.read((char*)&tmp.front(), length);
+		envmapMaskTexture = ToOSSlashes(tmp);
 
 		input.read((char*)&bloodEnabled, 1);
 		input.read((char*)&effectLightingEnabled, 1);
@@ -260,41 +277,51 @@ int MaterialFile::Write(std::ostream& output) {
 
 	uint length = 0;
 	if (signature == BGSM) {
-		length = diffuseTexture.length();
+		std::string tmp;
+		tmp = ToBackslashes(diffuseTexture);
+		length = tmp.length();
 		output.write((char*)&length, 4);
-		output.write(diffuseTexture.c_str(), length);
+		output.write(tmp.c_str(), length);
 
-		length = normalTexture.length();
+		tmp = ToBackslashes(normalTexture);
+		length = tmp.length();
 		output.write((char*)&length, 4);
-		output.write(normalTexture.c_str(), length);
+		output.write(tmp.c_str(), length);
 
-		length = smoothSpecTexture.length();
+		tmp = ToBackslashes(smoothSpecTexture);
+		length = tmp.length();
 		output.write((char*)&length, 4);
-		output.write(smoothSpecTexture.c_str(), length);
+		output.write(tmp.c_str(), length);
 
-		length = greyscaleTexture.length();
+		tmp = ToBackslashes(greyscaleTexture);
+		length = tmp.length();
 		output.write((char*)&length, 4);
-		output.write(greyscaleTexture.c_str(), length);
+		output.write(tmp.c_str(), length);
 
-		length = envmapTexture.length();
+		tmp = ToBackslashes(envmapTexture);
+		length = tmp.length();
 		output.write((char*)&length, 4);
-		output.write(envmapTexture.c_str(), length);
+		output.write(tmp.c_str(), length);
 
-		length = glowTexture.length();
+		tmp = ToBackslashes(glowTexture);
+		length = tmp.length();
 		output.write((char*)&length, 4);
-		output.write(glowTexture.c_str(), length);
+		output.write(tmp.c_str(), length);
 
-		length = innerLayerTexture.length();
+		tmp = ToBackslashes(innerLayerTexture);
+		length = tmp.length();
 		output.write((char*)&length, 4);
-		output.write(innerLayerTexture.c_str(), length);
+		output.write(tmp.c_str(), length);
 
-		length = wrinklesTexture.length();
+		tmp = ToBackslashes(wrinklesTexture);
+		length = tmp.length();
 		output.write((char*)&length, 4);
-		output.write(wrinklesTexture.c_str(), length);
+		output.write(tmp.c_str(), length);
 
-		length = displacementTexture.length();
+		tmp = ToBackslashes(displacementTexture);
+		length = tmp.length();
 		output.write((char*)&length, 4);
-		output.write(displacementTexture.c_str(), length);
+		output.write(tmp.c_str(), length);
 
 		output.write((char*)&enableEditorAlphaRef, 1);
 		output.write((char*)&rimLighting, 1);
@@ -357,25 +384,31 @@ int MaterialFile::Write(std::ostream& output) {
 			output.write((char*)&skewSpecularAlpha, 1);
 	}
 	else if (signature == BGEM) {
-		length = baseTexture.length();
+		std::string tmp;
+		tmp = ToBackslashes(baseTexture);
+		length = tmp.length();
 		output.write((char*)&length, 4);
-		output.write(baseTexture.c_str(), length);
+		output.write(tmp.c_str(), length);
 
-		length = grayscaleTexture.length();
+		tmp = ToBackslashes(grayscaleTexture);
+		length = tmp.length();
 		output.write((char*)&length, 4);
-		output.write(grayscaleTexture.c_str(), length);
+		output.write(tmp.c_str(), length);
 
-		length = fxEnvmapTexture.length();
+		tmp = ToBackslashes(fxEnvmapTexture);
+		length = tmp.length();
 		output.write((char*)&length, 4);
-		output.write(fxEnvmapTexture.c_str(), length);
+		output.write(tmp.c_str(), length);
 
-		length = fxNormalTexture.length();
+		tmp = ToBackslashes(fxNormalTexture);
+		length = tmp.length();
 		output.write((char*)&length, 4);
-		output.write(fxNormalTexture.c_str(), length);
+		output.write(tmp.c_str(), length);
 
-		length = envmapMaskTexture.length();
+		tmp = ToBackslashes(envmapMaskTexture);
+		length = tmp.length();
 		output.write((char*)&length, 4);
-		output.write(envmapMaskTexture.c_str(), length);
+		output.write(tmp.c_str(), length);
 
 		output.write((char*)&bloodEnabled, 1);
 		output.write((char*)&effectLightingEnabled, 1);

--- a/src/files/ResourceLoader.cpp
+++ b/src/files/ResourceLoader.cpp
@@ -61,7 +61,7 @@ GLuint ResourceLoader::LoadTexture(const std::string& inFileName, bool isCubeMap
 
 		wxMemoryBuffer data;
 		wxString texFile = inFileName;
-		texFile.Replace(wxString(Config["GameDataPath"]).MakeLower(), "");
+		texFile.Replace(wxString(Config["GameDataPath"]), "");
 		texFile.Replace("\\", "/");
 		for (FSArchiveFile *archive : FSManager::archiveList()) {
 			if (archive) {
@@ -309,8 +309,6 @@ GLuint ResourceLoader::GLI_load_texture_from_memory(const char* buffer, size_t s
 
 GLMaterial* ResourceLoader::AddMaterial(const std::vector<std::string>& textureFiles, const std::string& vShaderFile, const std::string& fShaderFile, const bool reloadTextures) {
 	auto texFiles = textureFiles;
-	for (auto &f : texFiles)
-		std::transform(f.begin(), f.end(), f.begin(), ::tolower);
 
 	MaterialKey key(texFiles, vShaderFile, fShaderFile);
 	if (!reloadTextures) {
@@ -338,8 +336,7 @@ GLMaterial* ResourceLoader::AddMaterial(const std::vector<std::string>& textureF
 
 	if (texRefs[0] == 0) {
 		// Load default image
-		std::string defaultTex = Config["AppDir"] + "\\res\\images\\noimg.png";
-		std::transform(defaultTex.begin(), defaultTex.end(), defaultTex.begin(), ::tolower);
+		std::string defaultTex = Config["AppDir"] + "/res/images/NoImg.png";
 
 		texRefs[0] = LoadTexture(defaultTex, false);
 

--- a/src/files/ResourceLoader.cpp
+++ b/src/files/ResourceLoader.cpp
@@ -138,9 +138,6 @@ bool ResourceLoader::RenameTexture(const std::string& texNameSrc, const std::str
 	std::string src = texNameSrc;
 	std::string dst = texNameDest;
 
-	std::transform(src.begin(), src.end(), src.begin(), ::tolower);
-	std::transform(dst.begin(), dst.end(), dst.begin(), ::tolower);
-
 	auto tid = textures.find(dst);
 	if (tid != textures.end()) {
 		if (!overwrite)

--- a/src/files/ResourceLoader.h
+++ b/src/files/ResourceLoader.h
@@ -11,7 +11,7 @@ See the included LICENSE file
 
 #pragma warning (push, 0)
 #include "gli.hpp"
-#include "../SOIL2/SOIL2.h""
+#include "../SOIL2/SOIL2.h"
 #pragma warning (pop)
 
 typedef unsigned int GLuint;

--- a/src/files/ResourceLoader.h
+++ b/src/files/ResourceLoader.h
@@ -8,6 +8,9 @@ See the included LICENSE file
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <map>
+
+#include "../utils/StringStuff.h"
 
 #pragma warning (push, 0)
 #include "gli.hpp"
@@ -80,7 +83,7 @@ private:
 	typedef std::unordered_map<MaterialKey, std::unique_ptr<GLMaterial>, MatKeyHash> MaterialCache;
 	// defining texture cache like this both for consitency, might also make it easier to add features like
 	// reference tracking later.  For now, Textures are only unloaded when ResourceLoader is destroyed.
-	typedef std::unordered_map<std::string, GLuint> TextureCache;
+	typedef std::map<std::string, GLuint, case_insensitive_compare> TextureCache;
 
 	TextureCache textures;
 	MaterialCache materials;

--- a/src/files/TriFile.cpp
+++ b/src/files/TriFile.cpp
@@ -168,12 +168,12 @@ bool TriFile::Write(const std::string& fileName) {
 
 						float mult = 0.0f;
 						for (auto& v : morph->offsets) {
-							if (abs(v.second.x) > mult)
-								mult = abs(v.second.x);
-							if (abs(v.second.y) > mult)
-								mult = abs(v.second.y);
-							if (abs(v.second.z) > mult)
-								mult = abs(v.second.z);
+							if (std::abs(v.second.x) > mult)
+								mult = std::abs(v.second.x);
+							if (std::abs(v.second.y) > mult)
+								mult = std::abs(v.second.y);
+							if (std::abs(v.second.z) > mult)
+								mult = std::abs(v.second.z);
 						}
 
 						mult /= 0x7FFF;
@@ -225,10 +225,10 @@ bool TriFile::Write(const std::string& fileName) {
 
 						float mult = 0.0f;
 						for (auto& v : morph->offsets) {
-							if (abs(v.second.x) > mult)
-								mult = abs(v.second.x);
-							if (abs(v.second.y) > mult)
-								mult = abs(v.second.y);
+							if (std::abs(v.second.x) > mult)
+								mult = std::abs(v.second.x);
+							if (std::abs(v.second.y) > mult)
+								mult = std::abs(v.second.y);
 						}
 
 						mult /= 0x7FFF;

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -1159,7 +1159,7 @@ bool BodySlideApp::SetDefaultConfig() {
 		if (key.Exists()) {
 			wxString installPath;
 			if (key.HasValues() && key.QueryValue(gameValueKey, installPath)) {
-				installPath.Append("Data/");
+				installPath.Append("Data").Append(PathSepChar);
 				Config.SetDefaultValue("GameDataPath", installPath.ToStdString());
 				wxLogMessage("Registry game data path: %s", installPath);
 			}
@@ -1355,7 +1355,7 @@ wxString BodySlideApp::GetGameDataPath(TargetGame targ) {
 		wxRegKey key(wxRegKey::HKLM, Config[gkey], wxRegKey::WOW64ViewMode_32);
 		if (key.Exists()) {
 			if (key.HasValues() && key.QueryValue(Config[gval], dataPath)) {
-				dataPath.Append("Data/");
+				dataPath.Append("Data").Append(PathSepChar);
 			}
 		}
 	}

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -352,7 +352,7 @@ int BodySlideApp::CreateSetSliders(const std::string& outfit) {
 		activeSet.Clear();
 		sliderManager.ClearSliders();
 		if (!sliderDoc.GetSet(outfit, activeSet)) {
-			activeSet.SetBaseDataPath(Config["AppDir"] + "/ShapeData");
+			activeSet.SetBaseDataPath(Config["AppDir"] + PathSepStr + "ShapeData");
 			activeSet.LoadSetDiffData(dataSets);
 
 			sliderManager.AddSlidersInSet(activeSet);
@@ -407,10 +407,8 @@ int BodySlideApp::LoadSliderSets() {
 			outfitNameOrder.push_back(o);
 
 			sliderDoc.GetSetOutputFilePath(o, outFilePath);
-			if (!outFilePath.empty()) {
-				std::transform(outFilePath.begin(), outFilePath.end(), outFilePath.begin(), ::tolower);
+			if (!outFilePath.empty())
 				outFileCount[outFilePath].push_back(o);
-			}
 		}
 	}
 
@@ -1627,7 +1625,7 @@ int BodySlideApp::BuildBodies(bool localPath, bool clean, bool tri) {
 				return 4;
 			}
 
-			response.Append('/');
+			response.Append(PathSepChar);
 			Config.SetValue("GameDataPath", response.ToStdString());
 		}
 
@@ -1749,8 +1747,8 @@ int BodySlideApp::BuildBodies(bool localPath, bool clean, bool tri) {
 	if (tri) {
 		std::string triPath = activeSet.GetOutputFilePath() + ".tri";
 		std::string triPathTrimmed = triPath;
-		triPathTrimmed = std::regex_replace(triPathTrimmed, std::regex("/+|\\\\+"), "/");									// Replace multiple backslashes or forward slashes with one forward slash
-		triPathTrimmed = std::regex_replace(triPathTrimmed, std::regex(".*meshes/", std::regex_constants::icase), "");	// Remove everything before and including the meshes path
+		triPathTrimmed = std::regex_replace(triPathTrimmed, std::regex("/+|\\\\+"), "\\");									// Replace multiple backslashes or forward slashes with one backslash
+		triPathTrimmed = std::regex_replace(triPathTrimmed, std::regex(".*meshes\\\\", std::regex_constants::icase), "");	// Remove everything before and including the meshes path
 
 		if (!WriteMorphTRI(outFileNameBig, activeSet, nifBig, zapIdxAll)) {
 			wxLogError("Failed to write TRI file to '%s'!", triPath);
@@ -1902,7 +1900,7 @@ int BodySlideApp::BuildListBodies(std::vector<std::string>& outfitList, std::map
 				}
 			}
 
-			Config.SetValue("GameDataPath", Config["AppDir"] + "/");
+			Config.SetValue("GameDataPath", Config["AppDir"] + PathSepStr);
 		}
 
 		datapath = GetOutputDataPath();
@@ -2015,7 +2013,7 @@ int BodySlideApp::BuildListBodies(std::vector<std::string>& outfitList, std::map
 			return;
 		}
 
-		currentSet.SetBaseDataPath(Config["AppDir"] + "/ShapeData");
+		currentSet.SetBaseDataPath(Config["AppDir"] + PathSepStr + "ShapeData");
 
 		// ALT key
 		if (clean && custPath.empty()) {
@@ -2197,8 +2195,8 @@ int BodySlideApp::BuildListBodies(std::vector<std::string>& outfitList, std::map
 		if (triEnd) {
 			std::string triPath = currentSet.GetOutputFilePath() + ".tri";
 			std::string triPathTrimmed = triPath;
-			triPathTrimmed = std::regex_replace(triPathTrimmed, std::regex("/+|\\\\+"), "/");									// Replace multiple backslashes or forward slashes with one forward slash
-			triPathTrimmed = std::regex_replace(triPathTrimmed, std::regex(".*meshes/", std::regex_constants::icase), "");	// Remove everything before and including the meshes path
+			triPathTrimmed = std::regex_replace(triPathTrimmed, std::regex("/+|\\\\+"), "\\");									// Replace multiple backslashes or forward slashes with one backslash
+			triPathTrimmed = std::regex_replace(triPathTrimmed, std::regex(".*meshes\\\\", std::regex_constants::icase), "");	// Remove everything before and including the meshes path
 
 			if (!WriteMorphTRI(outFileNameBig, currentSet, nifBig, zapIdxAll))
 				wxLogError("Failed to create TRI file to '%s'!", triPath);
@@ -2348,7 +2346,7 @@ void BodySlideApp::AddTriData(NifFile& nif, const std::string& shapeName, const 
 	if (target) {
 		auto triExtraData = new NiStringExtraData();
 		triExtraData->SetName("BODYTRI");
-		triExtraData->SetStringData(ToBackslashes(triPath));
+		triExtraData->SetStringData(triPath);
 		nif.AssignExtraData(target, triExtraData);
 	}
 }
@@ -3212,7 +3210,7 @@ void BodySlideFrame::OnBatchBuild(wxCommandEvent& WXUNUSED(event)) {
 		if (path.empty())
 			return;
 
-		ret = app->BuildListBodies(toBuild, failedOutfits, false, tri, path + "/");
+		ret = app->BuildListBodies(toBuild, failedOutfits, false, tri, path + PathSepStr);
 	}
 	else if (clean)
 		ret = app->BuildListBodies(toBuild, failedOutfits, true, tri);

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -883,15 +883,10 @@ void BodySlideApp::InitPreview() {
 		previewBaseNif = new NifFile();
 		PreviewMod.Clear();
 
-#ifdef _WINDOWS
 		std::fstream file;
 		PlatformUtil::OpenFileStream(file, inputFileName, std::ios::in | std::ios::binary);
 		if (previewBaseNif->Load(file))
 			return;
-#else
-		if (previewBaseNif->Load(inputFileName))
-			return;
-#endif
 
 		PreviewMod.CopyFrom(*previewBaseNif);
 
@@ -2353,7 +2348,7 @@ void BodySlideApp::AddTriData(NifFile& nif, const std::string& shapeName, const 
 	if (target) {
 		auto triExtraData = new NiStringExtraData();
 		triExtraData->SetName("BODYTRI");
-		triExtraData->SetStringData(triPath);
+		triExtraData->SetStringData(ToBackslashes(triPath));
 		nif.AssignExtraData(target, triExtraData);
 	}
 }

--- a/src/program/BodySlideApp.h
+++ b/src/program/BodySlideApp.h
@@ -137,6 +137,7 @@ public:
 			return;
 		}
 
+#ifdef _WINDOWS
 		std::string stupidkeys = "0123456789-";
 		bool stupidHack = false;
 		if (event.GetKeyCode() < 256 && stupidkeys.find(event.GetKeyCode()) != std::string::npos)
@@ -147,7 +148,9 @@ public:
 			HWND hwndEdit = e->GetHandle();
 			::SendMessage(hwndEdit, WM_CHAR, event.GetKeyCode(), event.GetRawKeyFlags());
 		}
-		else {
+		else
+#endif
+		{
 			event.Skip();
 		}
 	}

--- a/src/program/BodySlideApp.h
+++ b/src/program/BodySlideApp.h
@@ -77,17 +77,17 @@ class BodySlideApp : public wxApp {
 	Log logger;
 
 	/* Data Items */
-	std::map<std::string, std::string> outfitNameSource;		// All currently defined outfits.
-	std::vector<std::string> outfitNameOrder;				// All currently defined outfits, in their order of appearance.
-	std::map<std::string, std::vector<std::string>> groupMembers;	// All currently defined groups.
-	std::map<std::string, std::string> groupAlias;				// Group name aliases.
-	std::vector<std::string> ungroupedOutfits;			// Outfits without a group.
-	std::vector<std::string> filteredOutfits;				// Filtered outfit names.
+	std::map<std::string, std::string, case_insensitive_compare> outfitNameSource;	// All currently defined outfits.
+	std::vector<std::string> outfitNameOrder;										// All currently defined outfits, in their order of appearance.
+	std::map<std::string, std::vector<std::string>> groupMembers;					// All currently defined groups.
+	std::map<std::string, std::string> groupAlias;									// Group name aliases.
+	std::vector<std::string> ungroupedOutfits;										// Outfits without a group.
+	std::vector<std::string> filteredOutfits;										// Filtered outfit names.
 	std::vector<std::string> presetGroups;
 	std::vector<std::string> allGroups;
 	SliderSetGroupCollection gCollection;
 
-	std::map<std::string, std::vector<std::string>> outFileCount;	// Counts how many sets write to the same output file
+	std::map<std::string, std::vector<std::string>, case_insensitive_compare> outFileCount;	// Counts how many sets write to the same output file
 
 	std::string previewBaseName;
 	std::string previewSetName;

--- a/src/program/EditUV.cpp
+++ b/src/program/EditUV.cpp
@@ -112,7 +112,7 @@ wxEND_EVENT_TABLE()
 
 EditUV::EditUV(wxWindow* parent, NifFile* srcNif, NiShape* srcShape, mesh* srcMesh, const std::string& srcSliderName) {
 	wxXmlResource *xrc = wxXmlResource::Get();
-	bool loaded = xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\EditUV.xrc");
+	bool loaded = xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/EditUV.xrc");
 	if (!loaded) {
 		wxMessageBox("Failed to load EditUV.xrc file!", "Error", wxICON_ERROR);
 		return;
@@ -141,7 +141,7 @@ EditUV::EditUV(wxWindow* parent, NifFile* srcNif, NiShape* srcShape, mesh* srcMe
 }
 
 EditUV::~EditUV() {
-	wxXmlResource::Get()->Unload(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\EditUV.xrc");
+	wxXmlResource::Get()->Unload(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/EditUV.xrc");
 }
 
 void EditUV::OnSelectTool(wxCommandEvent& event) {
@@ -407,8 +407,8 @@ void EditUVCanvas::OnMouseMove(wxMouseEvent& event) {
 					lastDirection |= EDITUV_DIRECTION_UP;
 			}
 
-			float angle = std::atan2f(currentCenter.y - current.y, currentCenter.x - current.x) * 180.0f / PI;
-			float angleAbs = std::fabsf(angle);
+			float angle = std::atan2(currentCenter.y - current.y, currentCenter.x - current.x) * 180.0f / PI;
+			float angleAbs = std::fabs(angle);
 
 			// Set cursor depending on the angle to the center
 			if ((angle >= -22.5f && angle < 22.5f) || (angleAbs >= 157.5f && angleAbs <= 180.0f))
@@ -463,10 +463,10 @@ void EditUVCanvas::OnMouseMove(wxMouseEvent& event) {
 			}
 		}
 		else if (activeTool == EditUVTool::Rotate) {
-			float angle = std::atan2f(currentCenter.y - current.y, currentCenter.x - current.x);
+			float angle = std::atan2(currentCenter.y - current.y, currentCenter.x - current.x);
 			float angleDiff = angle - lastAngle;
-			float angleSin = std::sinf(angleDiff);
-			float angleCos = std::cosf(angleDiff);
+			float angleSin = std::sin(angleDiff);
+			float angleCos = std::cos(angleDiff);
 
 			auto curState = editUV->GetHistory().GetCurState();
 			if (curState) {
@@ -549,7 +549,7 @@ void EditUVCanvas::OnLeftDown(wxMouseEvent& event) {
 		else
 			currentCenter.Zero();
 
-		lastAngle = std::atan2f(currentCenter.y - click.y, currentCenter.x - click.x);
+		lastAngle = std::atan2(currentCenter.y - click.y, currentCenter.x - click.x);
 
 		std::unordered_map<int, Vector2> state;
 		state.reserve(uvGridMesh->nVerts);
@@ -702,8 +702,8 @@ void EditUVCanvas::InitMeshes() {
 		texFile = texturesDir + texFile;
 
 		std::vector<std::string> textures(1, texFile);
-		std::string vShader = Config["AppDir"] + "\\res\\shaders\\default.vert";
-		std::string fShader = Config["AppDir"] + "\\res\\shaders\\default.frag";
+		std::string vShader = Config["AppDir"] + "/res/shaders/default.vert";
+		std::string fShader = Config["AppDir"] + "/res/shaders/default.frag";
 		planeMesh->material = uvSurface.GetResourceLoader()->AddMaterial(textures, vShader, fShader);
 		uvSurface.UpdateShaders(planeMesh);
 	}
@@ -748,7 +748,7 @@ void EditUVCanvas::InitMeshes() {
 	uvGridMesh->color = Vector3(1.0f, 0.0f, 0.0f);
 	uvGridMesh->vertexColors = true;
 
-	uvGridMaterial = GLMaterial(Config["AppDir"] + "\\res\\shaders\\primitive.vert", Config["AppDir"] + "\\res\\shaders\\primitive.frag");
+	uvGridMaterial = GLMaterial(Config["AppDir"] + "/res/shaders/primitive.vert", Config["AppDir"] + "/res/shaders/primitive.frag");
 	uvGridMesh->material = &uvGridMaterial;
 	uvGridMesh->shapeName = "UVGrid";
 
@@ -771,7 +771,7 @@ void EditUVCanvas::InitMeshes() {
 	boxSelectMesh->tris[0] = Triangle(0, 1, 2);
 	boxSelectMesh->tris[1] = Triangle(2, 3, 0);
 
-	boxSelectMaterial = GLMaterial(Config["AppDir"] + "\\res\\shaders\\primitive.vert", Config["AppDir"] + "\\res\\shaders\\primitive.frag");
+	boxSelectMaterial = GLMaterial(Config["AppDir"] + "/res/shaders/primitive.vert", Config["AppDir"] + "/res/shaders/primitive.frag");
 	boxSelectMesh->material = &boxSelectMaterial;
 
 	boxSelectMesh->shapeName = "BoxSelect";

--- a/src/program/FBXImportDialog.cpp
+++ b/src/program/FBXImportDialog.cpp
@@ -14,7 +14,7 @@ wxEND_EVENT_TABLE()
 
 FBXImportDialog::FBXImportDialog(wxWindow* parent) {
 	wxXmlResource* xrc = wxXmlResource::Get();
-	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\FBXImport.xrc");
+	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/FBXImport.xrc");
 	xrc->LoadDialog(this, parent, "dlgFBXImport");
 
 	SetDoubleBuffered(true);
@@ -27,7 +27,7 @@ FBXImportDialog::FBXImportDialog(wxWindow* parent) {
 }
 
 FBXImportDialog::~FBXImportDialog() {
-	wxXmlResource::Get()->Unload(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\FBXImport.xrc");
+	wxXmlResource::Get()->Unload(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/FBXImport.xrc");
 }
 
 void FBXImportDialog::OnImport(wxCommandEvent& WXUNUSED(event)) {

--- a/src/program/GroupManager.cpp
+++ b/src/program/GroupManager.cpp
@@ -26,14 +26,14 @@ wxEND_EVENT_TABLE()
 GroupManager::GroupManager(wxWindow* parent, std::vector<std::string> outfits)
 	: allOutfits(std::move(outfits)) {
 	wxXmlResource *xrc = wxXmlResource::Get();
-	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\GroupManager.xrc");
+	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/GroupManager.xrc");
 	xrc->LoadDialog(this, parent, "dlgGroupManager");
 
 	SetSize(800, 500);
 	SetDoubleBuffered(true);
 	CenterOnParent();
 
-	XRCCTRL(*this, "fpGroupXML", wxFilePickerCtrl)->SetInitialDirectory(wxString::FromUTF8(Config["AppDir"]) + "\\SliderGroups");
+	XRCCTRL(*this, "fpGroupXML", wxFilePickerCtrl)->SetInitialDirectory(wxString::FromUTF8(Config["AppDir"]) + "/SliderGroups");
 	listGroups = XRCCTRL(*this, "listGroups", wxListBox);
 	groupName = XRCCTRL(*this, "groupName", wxTextCtrl);
 	btAddGroup = XRCCTRL(*this, "btAddGroup", wxButton);
@@ -49,7 +49,7 @@ GroupManager::GroupManager(wxWindow* parent, std::vector<std::string> outfits)
 }
 
 GroupManager::~GroupManager() {
-	wxXmlResource::Get()->Unload(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\GroupManager.xrc");
+	wxXmlResource::Get()->Unload(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/GroupManager.xrc");
 }
 
 void GroupManager::RefreshUI(const bool clearGroups) {
@@ -108,10 +108,10 @@ void GroupManager::DoRemoveMembers() {
 	listMembers->GetSelections(selections);
 
 	// Find and remove member from selected group
-	std::string selectedGroup = listGroups->GetStringSelection().ToUTF8();
+	std::string selectedGroup{listGroups->GetStringSelection().ToUTF8()};
 	if (!selectedGroup.empty()) {
 		for (auto &sel : selections) {
-			std::string member = listMembers->GetString(sel).ToUTF8();
+			std::string member{listMembers->GetString(sel).ToUTF8()};
 			auto it = find(groupMembers[selectedGroup].begin(), groupMembers[selectedGroup].end(), member);
 			if (it != groupMembers[selectedGroup].end())
 				groupMembers[selectedGroup].erase(it);
@@ -128,10 +128,10 @@ void GroupManager::DoAddMembers() {
 	listOutfits->GetSelections(selections);
 
 	// Add member to selected group
-	std::string selectedGroup = listGroups->GetStringSelection().ToUTF8();
+	std::string selectedGroup{listGroups->GetStringSelection().ToUTF8()};
 	if (!selectedGroup.empty()) {
 		for (auto &sel : selections) {
-			std::string member = listOutfits->GetString(sel).ToUTF8();
+			std::string member{listOutfits->GetString(sel).ToUTF8()};
 			groupMembers[selectedGroup].push_back(member);
 		}
 	}
@@ -173,7 +173,7 @@ void GroupManager::OnSaveGroup(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void GroupManager::OnSaveGroupAs(wxCommandEvent& WXUNUSED(event)) {
-	wxFileDialog file(this, "Saving group XML file...", wxString::FromUTF8(Config["AppDir"]) + "\\SliderGroups", fileName, "Group Files (*.xml)|*.xml", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+	wxFileDialog file(this, "Saving group XML file...", wxString::FromUTF8(Config["AppDir"]) + "/SliderGroups", fileName, "Group Files (*.xml)|*.xml", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
 	if (file.ShowModal() != wxID_OK)
 		return;
 

--- a/src/program/NormalsGenDialog.cpp
+++ b/src/program/NormalsGenDialog.cpp
@@ -131,7 +131,7 @@ void NormalsGenDialog::doMoveUpLayer(wxCommandEvent& WXUNUSED(event))
 	int n = 1;
 	for (auto it = pgLayers->GetIterator(wxPG_ITERATE_CATEGORIES); !it.AtEnd(); ++it) {
 		wxPGProperty* p = it.GetProperty();
-		p->SetClientData((void*)n++);
+		p->SetClientData(reinterpret_cast<void*>(n++));
 		if (p == s) {
 			me = p;
 		}
@@ -144,9 +144,9 @@ void NormalsGenDialog::doMoveUpLayer(wxCommandEvent& WXUNUSED(event))
 	if (!me || !prev)
 		return;
 
-	int t = (int)me->GetClientData();
+	int t = reinterpret_cast<unsigned long>(me->GetClientData());
 	me->SetClientData(prev->GetClientData());
-	prev->SetClientData((void*)t);
+	prev->SetClientData(reinterpret_cast<void*>(t));
 
 	pgLayers->Sort();
 	pgLayers->Refresh();
@@ -224,7 +224,7 @@ void NormalsGenDialog::doLoadPreset(wxCommandEvent& WXUNUSED(event))
 	wxFileName fn(fl.GetPath());
 
 	tinyxml2::XMLDocument doc;
-	doc.LoadFile(fn.GetFullPath());
+	doc.LoadFile(fn.GetFullPath().ToUTF8());
 
 	tinyxml2::XMLElement* root = doc.FirstChildElement("NormalsGeneration");
 	if (root)
@@ -243,13 +243,13 @@ void NormalsGenDialog::doSavePreset(wxCommandEvent& WXUNUSED(event))
 	tinyxml2::XMLElement* root = doc.NewElement("NormalsGeneration");
 
 	wxFileName fn(fs.GetPath());
-	root->SetAttribute("name", fn.GetName());
+	root->SetAttribute("name", fn.GetName().ToUTF8());
 
 	doc.InsertFirstChild(root);
 
 	NormalGenLayer::SaveToXML(root, refNormalGenLayers);
 
-	doc.SaveFile(fn.GetFullPath());
+	doc.SaveFile(fn.GetFullPath().ToUTF8());
 }
 
 wxString NormalsGenDialog::nextLayerName()

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -23,7 +23,7 @@ OutfitProject::OutfitProject(OutfitStudioFrame* inOwner) {
 
 	std::string defSkelFile = Config["Anim/DefaultSkeletonReference"];
 	if (wxFileName(wxString::FromUTF8(defSkelFile)).IsRelative())
-		LoadSkeletonReference(Config["AppDir"] + "\\" + defSkelFile);
+		LoadSkeletonReference(Config["AppDir"] + "/" + defSkelFile);
 	else
 		LoadSkeletonReference(defSkelFile);
 
@@ -48,9 +48,9 @@ std::string OutfitProject::Save(const wxString& strFileName,
 
 	owner->UpdateProgress(1, _("Checking destination..."));
 	std::string errmsg = "";
-	std::string outfit = strOutfitName.ToUTF8();
-	std::string baseFile = strBaseFile.ToUTF8();
-	std::string gameFile = strGameFile.ToUTF8();
+	std::string outfit{strOutfitName.ToUTF8()};
+	std::string baseFile{strBaseFile.ToUTF8()};
+	std::string gameFile{strGameFile.ToUTF8()};
 
 	ReplaceForbidden(outfit);
 	ReplaceForbidden(baseFile);
@@ -65,8 +65,8 @@ std::string OutfitProject::Save(const wxString& strFileName,
 	outSet.SetGenWeights(genWeights);
 
 	wxString ssFileName = strFileName;
-	if (ssFileName.Find("SliderSets\\") == wxNOT_FOUND)
-		ssFileName = ssFileName.Prepend("SliderSets\\");
+	if (ssFileName.Find("SliderSets/") == wxNOT_FOUND)
+		ssFileName = ssFileName.Prepend("SliderSets/");
 
 	mFileName = ssFileName;
 	mOutfitName = wxString::FromUTF8(outfit);
@@ -136,7 +136,7 @@ std::string OutfitProject::Save(const wxString& strFileName,
 				targSlider = activeSet[i].TargetDataName(targ);
 				if (baseDiffData.GetDiffSet(targSlider) && baseDiffData.GetDiffSet(targSlider)->size() > 0) {
 					if (activeSet[i].IsLocalData(targSlider)) {
-						targSliderData = osdFileName + "\\" + targSlider;
+						targSliderData = osdFileName + "/" + targSlider;
 						outSet[id].AddDataFile(targ, targSlider, targSliderData);
 					}
 					else {
@@ -159,7 +159,7 @@ std::string OutfitProject::Save(const wxString& strFileName,
 				if (morpher.GetResultDiffSize(shapeName, activeSet[i].name) > 0) {
 					std::string shapeDataFolder = activeSet.ShapeToDataFolder(shapeName);
 					if (shapeDataFolder == activeSet.GetDefaultDataFolder() || activeSet[i].IsLocalData(targSlider)) {
-						targSliderData = osdFileName + "\\" + targSlider;
+						targSliderData = osdFileName + "/" + targSlider;
 						outSet[i].AddDataFile(targ, targSlider, targSliderData);
 					}
 					else {
@@ -172,16 +172,16 @@ std::string OutfitProject::Save(const wxString& strFileName,
 		}
 	}
 
-	std::string saveDataPath = Config["AppDir"] + "\\ShapeData\\" + mDataDir.ToUTF8().data();
-	SaveSliderData(saveDataPath + "\\" + osdFileName, copyRef);
+	std::string saveDataPath = Config["AppDir"] + "/ShapeData/" + mDataDir.ToUTF8().data();
+	SaveSliderData(saveDataPath + "/" + osdFileName, copyRef);
 	
 	prog = 60;
 	owner->UpdateProgress(prog, _("Creating slider set file..."));
 
 	if (wxFileName(ssFileName).IsRelative())
-		ssFileName = ssFileName.Prepend(wxString::FromUTF8(Config["AppDir"] + "\\"));
+		ssFileName = ssFileName.Prepend(wxString::FromUTF8(Config["AppDir"] + "/"));
 
-	std::string ssUFileName = ssFileName.ToUTF8();
+	std::string ssUFileName{ssFileName.ToUTF8()};
 	SliderSetFile ssf(ssUFileName);
 	if (ssf.fail()) {
 		ssf.New(ssUFileName);
@@ -192,6 +192,8 @@ std::string OutfitProject::Save(const wxString& strFileName,
 	}
 
 	auto it = strFileName.rfind('\\');
+	if (it == std::string::npos)
+		it = strFileName.rfind('/');
 	if (it != std::string::npos) {
 		wxString ssNewFolder(wxString::Format("%s/%s", wxString::FromUTF8(Config["AppDir"]), strFileName.substr(0, it)));
 		wxFileName::Mkdir(ssNewFolder, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
@@ -210,7 +212,7 @@ std::string OutfitProject::Save(const wxString& strFileName,
 
 	owner->UpdateProgress(70, _("Saving NIF file..."));
 
-	std::string saveFileName = saveDataPath + "\\" + baseFile;
+	std::string saveFileName = saveDataPath + "/" + baseFile;
 
 	if (workNif.IsValid()) {
 		workAnim.CleanupBones();
@@ -1915,7 +1917,7 @@ int OutfitProject::LoadReference(const std::string& fileName, const std::string&
 
 	sset.GetSet(setName, activeSet);
 
-	activeSet.SetBaseDataPath(Config["AppDir"] + "\\ShapeData");
+	activeSet.SetBaseDataPath(Config["AppDir"] + "/ShapeData");
 	std::string refFile = activeSet.GetInputFileName();
 
 	std::fstream file;
@@ -2023,7 +2025,7 @@ int OutfitProject::LoadFromSliderSet(const std::string& fileName, const std::str
 		return 3;
 	}
 
-	activeSet.SetBaseDataPath(Config["AppDir"] + "\\ShapeData");
+	activeSet.SetBaseDataPath(Config["AppDir"] + "/ShapeData");
 
 	std::string inputNif = activeSet.GetInputFileName();
 
@@ -2081,7 +2083,7 @@ int OutfitProject::LoadFromSliderSet(const std::string& fileName, const std::str
 	mOutfitName = wxString::FromUTF8(sliderSetName);
 	mDataDir = wxString::FromUTF8(activeSet.GetDefaultDataFolder());
 	mBaseFile = wxString::FromUTF8(activeSet.GetInputFileName());
-	mBaseFile = mBaseFile.AfterLast('\\');
+	mBaseFile = mBaseFile.AfterLast('/');
 
 	mGamePath = wxString::FromUTF8(activeSet.GetOutputPath());
 	mGameFile = wxString::FromUTF8(activeSet.GetOutputFile());
@@ -2108,7 +2110,7 @@ int OutfitProject::AddFromSliderSet(const std::string& fileName, const std::stri
 		return 2;
 	}
 
-	addSet.SetBaseDataPath(Config["AppDir"] + "\\ShapeData");
+	addSet.SetBaseDataPath(Config["AppDir"] + "/ShapeData");
 	std::string inputNif = addSet.GetInputFileName();
 
 	std::map<std::string, std::string> renamedShapes;
@@ -2502,7 +2504,7 @@ void OutfitProject::ChooseClothData(NifFile& nif) {
 
 		wxArrayInt sel = clothDataChoice.GetSelections();
 		for (int i = 0; i < sel.Count(); i++) {
-			std::string selString = clothFileNames[sel[i]].ToUTF8();
+			std::string selString{clothFileNames[sel[i]].ToUTF8()};
 			if (!selString.empty()) {
 				auto clothBlock = clothData[selString]->Clone();
 				int id = nif.GetHeader().AddBlock(clothBlock);

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -136,7 +136,7 @@ std::string OutfitProject::Save(const wxString& strFileName,
 				targSlider = activeSet[i].TargetDataName(targ);
 				if (baseDiffData.GetDiffSet(targSlider) && baseDiffData.GetDiffSet(targSlider)->size() > 0) {
 					if (activeSet[i].IsLocalData(targSlider)) {
-						targSliderData = osdFileName + "/" + targSlider;
+						targSliderData = osdFileName + PathSepStr + targSlider;
 						outSet[id].AddDataFile(targ, targSlider, targSliderData);
 					}
 					else {
@@ -159,7 +159,7 @@ std::string OutfitProject::Save(const wxString& strFileName,
 				if (morpher.GetResultDiffSize(shapeName, activeSet[i].name) > 0) {
 					std::string shapeDataFolder = activeSet.ShapeToDataFolder(shapeName);
 					if (shapeDataFolder == activeSet.GetDefaultDataFolder() || activeSet[i].IsLocalData(targSlider)) {
-						targSliderData = osdFileName + "/" + targSlider;
+						targSliderData = osdFileName + PathSepStr + targSlider;
 						outSet[i].AddDataFile(targ, targSlider, targSliderData);
 					}
 					else {

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -23,7 +23,7 @@ OutfitProject::OutfitProject(OutfitStudioFrame* inOwner) {
 
 	std::string defSkelFile = Config["Anim/DefaultSkeletonReference"];
 	if (wxFileName(wxString::FromUTF8(defSkelFile)).IsRelative())
-		LoadSkeletonReference(Config["AppDir"] + "/" + defSkelFile);
+		LoadSkeletonReference(Config["AppDir"] + PathSepStr + defSkelFile);
 	else
 		LoadSkeletonReference(defSkelFile);
 
@@ -172,14 +172,14 @@ std::string OutfitProject::Save(const wxString& strFileName,
 		}
 	}
 
-	std::string saveDataPath = Config["AppDir"] + "/ShapeData/" + mDataDir.ToUTF8().data();
-	SaveSliderData(saveDataPath + "/" + osdFileName, copyRef);
+	std::string saveDataPath = Config["AppDir"] + PathSepStr + "ShapeData" + PathSepStr + mDataDir.ToUTF8().data();
+	SaveSliderData(saveDataPath + PathSepStr + osdFileName, copyRef);
 	
 	prog = 60;
 	owner->UpdateProgress(prog, _("Creating slider set file..."));
 
 	if (wxFileName(ssFileName).IsRelative())
-		ssFileName = ssFileName.Prepend(wxString::FromUTF8(Config["AppDir"] + "/"));
+		ssFileName = ssFileName.Prepend(wxString::FromUTF8(Config["AppDir"] + PathSepStr));
 
 	std::string ssUFileName{ssFileName.ToUTF8()};
 	SliderSetFile ssf(ssUFileName);
@@ -191,9 +191,9 @@ std::string OutfitProject::Save(const wxString& strFileName,
 		}
 	}
 
-	auto it = strFileName.rfind('\\');
+	auto it = strFileName.rfind('/');
 	if (it == std::string::npos)
-		it = strFileName.rfind('/');
+		it = strFileName.rfind('\\');
 	if (it != std::string::npos) {
 		wxString ssNewFolder(wxString::Format("%s/%s", wxString::FromUTF8(Config["AppDir"]), strFileName.substr(0, it)));
 		wxFileName::Mkdir(ssNewFolder, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
@@ -212,7 +212,7 @@ std::string OutfitProject::Save(const wxString& strFileName,
 
 	owner->UpdateProgress(70, _("Saving NIF file..."));
 
-	std::string saveFileName = saveDataPath + "/" + baseFile;
+	std::string saveFileName = saveDataPath + PathSepStr + baseFile;
 
 	if (workNif.IsValid()) {
 		workAnim.CleanupBones();
@@ -1917,7 +1917,7 @@ int OutfitProject::LoadReference(const std::string& fileName, const std::string&
 
 	sset.GetSet(setName, activeSet);
 
-	activeSet.SetBaseDataPath(Config["AppDir"] + "/ShapeData");
+	activeSet.SetBaseDataPath(Config["AppDir"] + PathSepStr + "ShapeData");
 	std::string refFile = activeSet.GetInputFileName();
 
 	std::fstream file;
@@ -2025,7 +2025,7 @@ int OutfitProject::LoadFromSliderSet(const std::string& fileName, const std::str
 		return 3;
 	}
 
-	activeSet.SetBaseDataPath(Config["AppDir"] + "/ShapeData");
+	activeSet.SetBaseDataPath(Config["AppDir"] + PathSepStr + "ShapeData");
 
 	std::string inputNif = activeSet.GetInputFileName();
 
@@ -2083,7 +2083,7 @@ int OutfitProject::LoadFromSliderSet(const std::string& fileName, const std::str
 	mOutfitName = wxString::FromUTF8(sliderSetName);
 	mDataDir = wxString::FromUTF8(activeSet.GetDefaultDataFolder());
 	mBaseFile = wxString::FromUTF8(activeSet.GetInputFileName());
-	mBaseFile = mBaseFile.AfterLast('/');
+	mBaseFile = mBaseFile.AfterLast('/').AfterLast('\\');
 
 	mGamePath = wxString::FromUTF8(activeSet.GetOutputPath());
 	mGameFile = wxString::FromUTF8(activeSet.GetOutputFile());
@@ -2110,7 +2110,7 @@ int OutfitProject::AddFromSliderSet(const std::string& fileName, const std::stri
 		return 2;
 	}
 
-	addSet.SetBaseDataPath(Config["AppDir"] + "/ShapeData");
+	addSet.SetBaseDataPath(Config["AppDir"] + PathSepStr + "ShapeData");
 	std::string inputNif = addSet.GetInputFileName();
 
 	std::map<std::string, std::string> renamedShapes;

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -1766,7 +1766,7 @@ void OutfitStudioFrame::createSliderGUI(const std::string& name, int id, wxScrol
 
 	auto d = new SliderDisplay();
 	d->sliderPane = new wxPanel(wnd, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSIMPLE_BORDER | wxTAB_TRAVERSAL);
-	d->sliderPane->SetBackgroundColour(wxNullColour);
+	d->sliderPane->SetBackgroundColour(wxColour(64,64,64));
 	d->sliderPane->SetMinSize(wxSize(-1, 25));
 	d->sliderPane->SetMaxSize(wxSize(-1, 25));
 

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -1113,7 +1113,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 								// Split target file name to get OSD file name
 								int split = dataFileName.find_last_of('/');
 								if (split < 0)
-								split = dataFileName.find_last_of('\\');
+									split = dataFileName.find_last_of('\\');
 								if (split < 0)
 									continue;
 
@@ -2309,7 +2309,7 @@ void OutfitStudioFrame::OnNewProject(wxCommandEvent& WXUNUSED(event)) {
 		auto tmpl = find_if(refTemplates.begin(), refTemplates.end(), [&tmplName](const RefTemplate& rt) { return rt.GetName() == tmplName; });
 		if (tmpl != refTemplates.end()) {
 			if (wxFileName(wxString::FromUTF8(tmpl->GetSource())).IsRelative())
-				error = project->LoadReferenceTemplate(Config["AppDir"] + "/" + tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape());
+				error = project->LoadReferenceTemplate(Config["AppDir"] + PathSepStr + tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape());
 			else
 				error = project->LoadReferenceTemplate(tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape());
 		}
@@ -2446,7 +2446,7 @@ void OutfitStudioFrame::OnLoadReference(wxCommandEvent& WXUNUSED(event)) {
 		auto tmpl = find_if(refTemplates.begin(), refTemplates.end(), [&tmplName](const RefTemplate& rt) { return rt.GetName() == tmplName; });
 		if (tmpl != refTemplates.end()) {
 			if (wxFileName(wxString::FromUTF8(tmpl->GetSource())).IsRelative())
-				error = project->LoadReferenceTemplate(Config["AppDir"] + "/" + tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), mergeSliders);
+				error = project->LoadReferenceTemplate(Config["AppDir"] + PathSepStr + tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), mergeSliders);
 			else
 				error = project->LoadReferenceTemplate(tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), mergeSliders);
 		}
@@ -3478,7 +3478,7 @@ void OutfitStudioFrame::OnExportTRIHead(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	for (auto &shape : project->GetWorkNif()->GetShapes()) {
-		std::string fn = dir + "/" + shape->GetName() + ".tri";
+		std::string fn = dir + PathSepStr + shape->GetName() + ".tri";
 
 		wxLogMessage("Exporting TRI (head) morphs of '%s' to '%s'...", shape->GetName(), fn);
 		if (!project->WriteHeadTRI(shape, fn)) {
@@ -6177,7 +6177,7 @@ void OutfitStudioFrame::OnSliderExportBSD(wxCommandEvent& WXUNUSED(event)) {
 			return;
 
 		for (auto &i : selectedItems) {
-			std::string targetFile = std::string(dir.ToUTF8()) + "/" + i->GetShape()->GetName() + "_" + activeSlider + ".bsd";
+			std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + i->GetShape()->GetName() + "_" + activeSlider + ".bsd";
 			wxLogMessage("Exporting BSD slider data of '%s' for shape '%s' to '%s'...", activeSlider, i->GetShape()->GetName(), targetFile);
 			project->SaveSliderBSD(activeSlider, i->GetShape(), targetFile);
 		}
@@ -6210,7 +6210,7 @@ void OutfitStudioFrame::OnSliderExportOBJ(wxCommandEvent& WXUNUSED(event)) {
 			return;
 
 		for (auto &i : selectedItems) {
-			std::string targetFile = std::string(dir.ToUTF8()) + "/" + i->GetShape()->GetName() + "_" + activeSlider + ".obj";
+			std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + i->GetShape()->GetName() + "_" + activeSlider + ".obj";
 			wxLogMessage("Exporting OBJ slider data of '%s' for shape '%s' to '%s'...", activeSlider, i->GetShape()->GetName(), targetFile);
 			project->SaveSliderOBJ(activeSlider, i->GetShape(), targetFile);
 		}
@@ -6282,7 +6282,7 @@ void OutfitStudioFrame::OnSliderExportToOBJs(wxCommandEvent& WXUNUSED(event)) {
 	wxLogMessage("Exporting sliders to OBJ files in '%s'...", dir);
 	for (auto &shape : project->GetWorkNif()->GetShapes()) {
 		for (auto &slider : sliderList) {
-			std::string targetFile = std::string(dir.ToUTF8()) + "/" + shape->GetName() + "_" + slider + ".obj";
+			std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + shape->GetName() + "_" + slider + ".obj";
 			wxLogMessage("Exporting OBJ slider data of '%s' for shape '%s' to '%s'...", slider, shape->GetName(), targetFile);
 			if (project->SaveSliderOBJ(slider, shape, targetFile, true))
 				wxLogError("Failed to export OBJ file '%s'!", targetFile);

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -262,17 +262,17 @@ bool OutfitStudio::OnInit() {
 		return false;
 
 #ifdef _DEBUG
-	std::string dataDir = wxGetCwd().ToUTF8();
+	std::string dataDir{wxGetCwd().ToUTF8()};
 #else
-	std::string dataDir = wxStandardPaths::Get().GetDataDir().ToUTF8();
+	std::string dataDir{wxStandardPaths::Get().GetDataDir().ToUTF8()};
 #endif
 
-	Config.LoadConfig(dataDir + "\\Config.xml");
-	OutfitStudioConfig.LoadConfig(dataDir + "\\OutfitStudio.xml", "OutfitStudioConfig");
+	Config.LoadConfig(dataDir + "/Config.xml");
+	OutfitStudioConfig.LoadConfig(dataDir + "/OutfitStudio.xml", "OutfitStudioConfig");
 
 	Config.SetDefaultValue("AppDir", dataDir);
 
-	logger.Initialize(Config.GetIntValue("LogLevel", -1), dataDir + "\\Log_OS.txt");
+	logger.Initialize(Config.GetIntValue("LogLevel", -1), dataDir + "/Log_OS.txt");
 	wxLogMessage("Initializing Outfit Studio...");
 
 #ifdef NDEBUG
@@ -331,10 +331,10 @@ bool OutfitStudio::OnInit() {
 	if (!cmdFiles.IsEmpty()) {
 		wxFileName loadFile(cmdFiles.Item(0));
 		if (loadFile.FileExists()) {
-			std::string fileName = loadFile.GetFullPath().ToUTF8();
+			std::string fileName{loadFile.GetFullPath().ToUTF8()};
 			wxString fileExt = loadFile.GetExt().MakeLower();
 			if (fileExt == "osp") {
-				std::string projectName = cmdProject.ToUTF8();
+				std::string projectName{cmdProject.ToUTF8()};
 				frame->LoadProject(fileName, projectName);
 			}
 			else if (fileExt == "nif")
@@ -468,11 +468,12 @@ bool OutfitStudio::SetDefaultConfig() {
 	wxString gameValueKey = Config["GameRegVal/" + TargetGames[targetGame]];
 
 	if (Config["GameDataPath"].empty()) {
+#ifdef _WINDOWS
 		wxRegKey key(wxRegKey::HKLM, gameKey, wxRegKey::WOW64ViewMode_32);
 		if (key.Exists()) {
 			wxString installPath;
 			if (key.HasValues() && key.QueryValue(gameValueKey, installPath)) {
-				installPath.Append("Data\\");
+				installPath.Append("Data/");
 				Config.SetDefaultValue("GameDataPath", installPath.ToStdString());
 				wxLogMessage("Registry game data path: %s", installPath);
 			}
@@ -481,7 +482,9 @@ bool OutfitStudio::SetDefaultConfig() {
 				wxMessageBox(_("Failed to find game install path registry value or GameDataPath in the config."), _("Warning"), wxICON_WARNING);
 			}
 		}
-		else if (Config["WarnMissingGamePath"] == "true") {
+		else
+#endif
+		if (Config["WarnMissingGamePath"] == "true") {
 			wxLogWarning("Failed to find game install path registry key or GameDataPath in the config.");
 			wxMessageBox(_("Failed to find game install path registry key or GameDataPath in the config."), _("Warning"), wxICON_WARNING);
 		}
@@ -498,7 +501,7 @@ bool OutfitStudio::SetDefaultConfig() {
 
 bool OutfitStudio::ShowSetup() {
 	wxXmlResource* xrc = wxXmlResource::Get();
-	bool loaded = xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\Setup.xrc");
+	bool loaded = xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/Setup.xrc");
 	if (!loaded) {
 		wxMessageBox("Failed to load Setup.xrc file!", "Error", wxICON_ERROR);
 		return false;
@@ -601,37 +604,37 @@ bool OutfitStudio::ShowSetup() {
 			switch (targ) {
 			case FO3:
 				dataDir = dirFallout3->GetDirName();
-				Config.SetValue("Anim/DefaultSkeletonReference", "res\\skeleton_fo3nv.nif");
+				Config.SetValue("Anim/DefaultSkeletonReference", "res/skeleton_fo3nv.nif");
 				Config.SetValue("Anim/SkeletonRootName", "Bip01");
 				break;
 			case FONV:
 				dataDir = dirFalloutNV->GetDirName();
-				Config.SetValue("Anim/DefaultSkeletonReference", "res\\skeleton_fo3nv.nif");
+				Config.SetValue("Anim/DefaultSkeletonReference", "res/skeleton_fo3nv.nif");
 				Config.SetValue("Anim/SkeletonRootName", "Bip01");
 				break;
 			case SKYRIM:
 				dataDir = dirSkyrim->GetDirName();
-				Config.SetValue("Anim/DefaultSkeletonReference", "res\\skeleton_female_sk.nif");
+				Config.SetValue("Anim/DefaultSkeletonReference", "res/skeleton_female_sk.nif");
 				Config.SetValue("Anim/SkeletonRootName", "NPC Root [Root]");
 				break;
 			case FO4:
 				dataDir = dirFallout4->GetDirName();
-				Config.SetValue("Anim/DefaultSkeletonReference", "res\\skeleton_fo4.nif");
+				Config.SetValue("Anim/DefaultSkeletonReference", "res/skeleton_fo4.nif");
 				Config.SetValue("Anim/SkeletonRootName", "Root");
 				break;
 			case SKYRIMSE:
 				dataDir = dirSkyrimSE->GetDirName();
-				Config.SetValue("Anim/DefaultSkeletonReference", "res\\skeleton_female_sse.nif");
+				Config.SetValue("Anim/DefaultSkeletonReference", "res/skeleton_female_sse.nif");
 				Config.SetValue("Anim/SkeletonRootName", "NPC Root [Root]");
 				break;
 			case FO4VR:
 				dataDir = dirFallout4VR->GetDirName();
-				Config.SetValue("Anim/DefaultSkeletonReference", "res\\skeleton_fo4.nif");
+				Config.SetValue("Anim/DefaultSkeletonReference", "res/skeleton_fo4.nif");
 				Config.SetValue("Anim/SkeletonRootName", "Root");
 				break;
 			case SKYRIMVR:
 				dataDir = dirSkyrimVR->GetDirName();
-				Config.SetValue("Anim/DefaultSkeletonReference", "res\\skeleton_female_sse.nif");
+				Config.SetValue("Anim/DefaultSkeletonReference", "res/skeleton_female_sse.nif");
 				Config.SetValue("Anim/SkeletonRootName", "NPC Root [Root]");
 				break;
 			}
@@ -639,7 +642,7 @@ bool OutfitStudio::ShowSetup() {
 			Config.SetValue("GameDataPath", dataDir.GetFullPath().ToStdString());
 			Config.SetValue("GameDataPaths/" + TargetGames[targ].ToStdString(), dataDir.GetFullPath().ToStdString());
 
-			Config.SaveConfig(Config["AppDir"] + "\\Config.xml");
+			Config.SaveConfig(Config["AppDir"] + "/Config.xml");
 			delete setup;
 		}
 		else {
@@ -661,14 +664,16 @@ wxString OutfitStudio::GetGameDataPath(TargetGame targ) {
 	if (!Config[cust].IsEmpty()) {
 		dataPath = Config[cust];
 	}
+#ifdef _WINDOWS
 	else {
 		wxRegKey key(wxRegKey::HKLM, Config[gkey], wxRegKey::WOW64ViewMode_32);
 		if (key.Exists()) {
 			if (key.HasValues() && key.QueryValue(Config[gval], dataPath)) {
-				dataPath.Append("Data\\");
+				dataPath.Append("Data/");
 			}
 		}
 	}
+#endif
 	return dataPath;
 }
 
@@ -681,7 +686,7 @@ void OutfitStudio::InitLanguage() {
 	// Load language if possible, fall back to English otherwise
 	if (wxLocale::IsAvailable(lang)) {
 		locale = new wxLocale(lang);
-		locale->AddCatalogLookupPathPrefix(wxString::FromUTF8(Config["AppDir"]) + "\\lang");
+		locale->AddCatalogLookupPathPrefix(wxString::FromUTF8(Config["AppDir"]) + "/lang");
 		locale->AddCatalog("BodySlide");
 
 		if (!locale->IsOk()) {
@@ -732,7 +737,7 @@ void OutfitStudio::GetArchiveFiles(std::vector<std::string>& outList) {
 	wxDir::GetAllFiles(dataDir, &files, "*.ba2", wxDIR_FILES);
 	wxDir::GetAllFiles(dataDir, &files, "*.bsa", wxDIR_FILES);
 	for (auto& f : files) {
-		f = f.AfterLast('\\').MakeLower();
+		f = f.AfterLast('/').AfterLast('\\');
 		if (fsearch.find(f) == fsearch.end())
 			outList.push_back((dataDir + f).ToUTF8().data());
 	}
@@ -743,7 +748,7 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 	wxLogMessage("Loading Outfit Studio frame at X:%d Y:%d with W:%d H:%d...", pos.x, pos.y, size.GetWidth(), size.GetHeight());
 
 	wxXmlResource *xrc = wxXmlResource::Get();
-	if (!xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\OutfitStudio.xrc")) {
+	if (!xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/OutfitStudio.xrc")) {
 		wxMessageBox(_("Failed to load OutfitStudio.xrc file!"), _("Error"), wxICON_ERROR);
 		Close(true);
 		return;
@@ -755,13 +760,13 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 		return;
 	}
 
-	SetIcon(wxIcon(wxString::FromUTF8(Config["AppDir"]) + "\\res\\images\\OutfitStudio.png", wxBITMAP_TYPE_PNG));
+	SetIcon(wxIcon(wxString::FromUTF8(Config["AppDir"]) + "/res/images/OutfitStudio.png", wxBITMAP_TYPE_PNG));
 
-	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\Project.xrc");
-	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\Actions.xrc");
-	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\Slider.xrc");
-	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\Skeleton.xrc");
-	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\Settings.xrc");
+	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/Project.xrc");
+	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/Actions.xrc");
+	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/Slider.xrc");
+	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/Skeleton.xrc");
+	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/Settings.xrc");
 
 	int statusWidths[] = { -1, 400, 100 };
 	statusBar = (wxStatusBar*)FindWindowByName("statusBar");
@@ -797,9 +802,9 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 	outfitShapes = (wxTreeCtrl*)FindWindowByName("outfitShapes");
 	if (outfitShapes) {
 		visStateImages = new wxImageList(16, 16, false, 2);
-		wxBitmap visImg(wxString::FromUTF8(Config["AppDir"]) + "\\res\\images\\icoVisible.png", wxBITMAP_TYPE_PNG);
-		wxBitmap invImg(wxString::FromUTF8(Config["AppDir"]) + "\\res\\images\\icoInvisible.png", wxBITMAP_TYPE_PNG);
-		wxBitmap wfImg(wxString::FromUTF8(Config["AppDir"]) + "\\res\\images\\icoWireframe.png", wxBITMAP_TYPE_PNG);
+		wxBitmap visImg(wxString::FromUTF8(Config["AppDir"]) + "/res/images/icoVisible.png", wxBITMAP_TYPE_PNG);
+		wxBitmap invImg(wxString::FromUTF8(Config["AppDir"]) + "/res/images/icoInvisible.png", wxBITMAP_TYPE_PNG);
+		wxBitmap wfImg(wxString::FromUTF8(Config["AppDir"]) + "/res/images/icoWireframe.png", wxBITMAP_TYPE_PNG);
 
 		if (visImg.IsOk())
 			visStateImages->Add(visImg);
@@ -921,7 +926,7 @@ void OutfitStudioFrame::OnClose(wxCloseEvent& WXUNUSED(event)) {
 	if (glView)
 		delete glView;
 
-	int ret = OutfitStudioConfig.SaveConfig(Config["AppDir"] + "\\OutfitStudio.xml", "OutfitStudioConfig");
+	int ret = OutfitStudioConfig.SaveConfig(Config["AppDir"] + "/OutfitStudio.xml", "OutfitStudioConfig");
 	if (ret)
 		wxLogWarning("Failed to save configuration (%d)!", ret);
 
@@ -991,11 +996,11 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 		std::map<std::string, SliderSet> projectSources;
 
 		wxArrayString files;
-		wxDir::GetAllFiles(wxString::FromUTF8(Config["AppDir"]) + "\\SliderSets", &files, "*.osp");
-		wxDir::GetAllFiles(wxString::FromUTF8(Config["AppDir"]) + "\\SliderSets", &files, "*.xml");
+		wxDir::GetAllFiles(wxString::FromUTF8(Config["AppDir"]) + "/SliderSets", &files, "*.osp");
+		wxDir::GetAllFiles(wxString::FromUTF8(Config["AppDir"]) + "/SliderSets", &files, "*.xml");
 
 		for (auto &file : files) {
-			std::string fileName = file.ToUTF8();
+			std::string fileName{file.ToUTF8()};
 
 			SliderSetFile sliderDoc;
 			sliderDoc.Open(fileName);
@@ -1017,7 +1022,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 			}
 		}
 
-		std::string sep = wxString(wxFileName::GetPathSeparator()).ToUTF8();
+		std::string sep{wxString(wxFileName::GetPathSeparator()).ToUTF8()};
 		wxString baseDir = "Tools" + sep + "BodySlide";
 
 		TargetGame targetGame = wxGetApp().targetGame;
@@ -1038,7 +1043,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 		});
 
 		auto groupFile = XRCCTRL(*packProjects, "groupFile", wxFilePickerCtrl);
-		groupFile->SetInitialDirectory(wxString::FromUTF8(Config["AppDir"]) + "\\SliderGroups");
+		groupFile->SetInitialDirectory(wxString::FromUTF8(Config["AppDir"]) + "/SliderGroups");
 
 		auto mergedFileName = XRCCTRL(*packProjects, "mergedFileName", wxTextCtrl);
 		auto packFolder = XRCCTRL(*packProjects, "packFolder", wxButton);
@@ -1057,8 +1062,8 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 			wxLogMessage("Packing project to folder...");
 			StartProgress(_("Packing projects to folder..."));
 
-			std::string mergedFile = wxString(mergedFileName->GetValue() + ".osp").ToUTF8();
-			std::string mergedFilePath = wxFileName::CreateTempFileName("os").ToUTF8();
+			std::string mergedFile{wxString(mergedFileName->GetValue() + ".osp").ToUTF8()};
+			std::string mergedFilePath{wxFileName::CreateTempFileName("os").ToUTF8()};
 			project->ReplaceForbidden(mergedFile);
 
 			SliderSetFile projectFile;
@@ -1068,7 +1073,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 			projectList->GetCheckedItems(checkedItems);
 
 			for (auto &item : checkedItems) {
-				std::string setName = projectList->GetString(item).ToUTF8();
+				std::string setName{projectList->GetString(item).ToUTF8()};
 				if (projectSources.find(setName) == projectSources.end())
 					continue;
 
@@ -1106,7 +1111,9 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 							std::string dataFileName = set[i].DataFileName(targetDataName);
 							if (dataFileName.compare(dataFileName.size() - 4, dataFileName.size(), ".bsd") != 0) {
 								// Split target file name to get OSD file name
-								int split = dataFileName.find_last_of('\\');
+								int split = dataFileName.find_last_of('/');
+								if (split < 0)
+								split = dataFileName.find_last_of('\\');
 								if (split < 0)
 									continue;
 
@@ -1184,7 +1191,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 				}
 
 				// Copy group file to destination folder
-				std::string groupFileName = groupFilePath.AfterLast(wxFileName::GetPathSeparator()).ToUTF8();
+				std::string groupFileName{groupFilePath.AfterLast(wxFileName::GetPathSeparator()).ToUTF8()};
 				wxString groupFileDest = wxString::FromUTF8(dir + sep + baseDir + sep + "SliderGroups" + sep + groupFileName);
 				wxFileName::Mkdir(groupFileDest.BeforeLast(wxFileName::GetPathSeparator()), wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
 
@@ -1207,8 +1214,8 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 			wxLogMessage("Packing project to archive...");
 			StartProgress(_("Packing projects to archive..."));
 
-			std::string mergedFile = wxString(mergedFileName->GetValue() + ".osp").ToUTF8();
-			std::string mergedFilePath = wxFileName::CreateTempFileName("os").ToUTF8();
+			std::string mergedFile{wxString(mergedFileName->GetValue() + ".osp").ToUTF8()};
+			std::string mergedFilePath{wxFileName::CreateTempFileName("os").ToUTF8()};
 			project->ReplaceForbidden(mergedFile);
 
 			SliderSetFile projectFile;
@@ -1221,7 +1228,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 			projectList->GetCheckedItems(checkedItems);
 
 			for (auto &item : checkedItems) {
-				std::string setName = projectList->GetString(item).ToUTF8();
+				std::string setName{projectList->GetString(item).ToUTF8()};
 				if (projectSources.find(setName) == projectSources.end())
 					continue;
 
@@ -1263,7 +1270,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 							std::string dataFileName = set[i].DataFileName(targetDataName);
 							if (dataFileName.compare(dataFileName.size() - 4, dataFileName.size(), ".bsd") != 0) {
 								// Split target file name to get OSD file name
-								int split = dataFileName.find_last_of('\\');
+								int split = dataFileName.find_last_of('/');
 								if (split < 0)
 									continue;
 
@@ -1348,7 +1355,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 					return;
 				}
 
-				std::string groupFileName = groupFilePath.AfterLast(wxFileName::GetPathSeparator()).ToUTF8();
+				std::string groupFileName{groupFilePath.AfterLast(wxFileName::GetPathSeparator()).ToUTF8()};
 				wxString groupFileEntry = wxString::FromUTF8(baseDir + sep + "SliderGroups" + sep + groupFileName);
 				if (!zip.PutNextEntry(groupFileEntry, wxDateTime::Now(), groupFileStream.GetLength())) {
 					wxLogError("Failed to put new entry into archive!");
@@ -1382,22 +1389,22 @@ void OutfitStudioFrame::OnChooseTargetGame(wxCommandEvent& event) {
 	switch (targ) {
 	case FO3:
 	case FONV:
-		fpSkeletonFile->SetPath("res\\skeleton_fo3nv.nif");
+		fpSkeletonFile->SetPath("res/skeleton_fo3nv.nif");
 		choiceSkeletonRoot->SetStringSelection("Bip01");
 		break;
 	case SKYRIM:
-		fpSkeletonFile->SetPath("res\\skeleton_female_sk.nif");
+		fpSkeletonFile->SetPath("res/skeleton_female_sk.nif");
 		choiceSkeletonRoot->SetStringSelection("NPC Root [Root]");
 		break;
 	case SKYRIMSE:
 	case SKYRIMVR:
-		fpSkeletonFile->SetPath("res\\skeleton_female_sse.nif");
+		fpSkeletonFile->SetPath("res/skeleton_female_sse.nif");
 		choiceSkeletonRoot->SetStringSelection("NPC Root [Root]");
 		break;
 	case FO4:
 	case FO4VR:
 	default:
-		fpSkeletonFile->SetPath("res\\skeleton_fo4.nif");
+		fpSkeletonFile->SetPath("res/skeleton_fo4.nif");
 		choiceSkeletonRoot->SetStringSelection("Root");
 		break;
 	}
@@ -1429,7 +1436,7 @@ void OutfitStudioFrame::SettingsFillDataFiles(wxCheckListBox* dataFileList, wxSt
 	wxDir::GetAllFiles(dataDir, &files, "*.ba2", wxDIR_FILES);
 	wxDir::GetAllFiles(dataDir, &files, "*.bsa", wxDIR_FILES);
 	for (auto& file : files) {
-		file = file.AfterLast('\\');
+		file = file.AfterLast('/').AfterLast('\\');;
 		dataFileList->Insert(file, dataFileList->GetCount());
 
 		if (fsearch.find(file.Lower()) == fsearch.end())
@@ -1538,7 +1545,7 @@ void OutfitStudioFrame::OnSettings(wxCommandEvent& WXUNUSED(event)) {
 			Config.SetValue("Anim/DefaultSkeletonReference", skeletonFile.GetFullPath().ToStdString());
 			Config.SetValue("Anim/SkeletonRootName", choiceSkeletonRoot->GetStringSelection().ToStdString());
 
-			Config.SaveConfig(Config["AppDir"] + "\\Config.xml");
+			Config.SaveConfig(Config["AppDir"] + "/Config.xml");
 			wxGetApp().InitArchives();
 		}
 
@@ -1763,8 +1770,8 @@ void OutfitStudioFrame::createSliderGUI(const std::string& name, int id, wxScrol
 
 	d->paneSz = new wxBoxSizer(wxHORIZONTAL);
 
-	d->btnSliderEdit = new wxBitmapButton(d->sliderPane, wxID_ANY, wxBitmap(wxString::FromUTF8(Config["AppDir"]) + "\\res\\images\\EditSmall.png", wxBITMAP_TYPE_ANY), wxDefaultPosition, wxSize(22, 22), wxBU_AUTODRAW, wxDefaultValidator, sn + "|btn");
-	d->btnSliderEdit->SetBitmapDisabled(wxBitmap(wxString::FromUTF8(Config["AppDir"]) + "\\res\\images\\EditSmall_d.png", wxBITMAP_TYPE_ANY));
+	d->btnSliderEdit = new wxBitmapButton(d->sliderPane, wxID_ANY, wxBitmap(wxString::FromUTF8(Config["AppDir"]) + "/res/images/EditSmall.png", wxBITMAP_TYPE_ANY), wxDefaultPosition, wxSize(22, 22), wxBU_AUTODRAW, wxDefaultValidator, sn + "|btn");
+	d->btnSliderEdit->SetBitmapDisabled(wxBitmap(wxString::FromUTF8(Config["AppDir"]) + "/res/images/EditSmall_d.png", wxBITMAP_TYPE_ANY));
 	d->btnSliderEdit->SetToolTip(_("Turn on edit mode for this slider."));
 	d->paneSz->Add(d->btnSliderEdit, 0, wxALIGN_CENTER_VERTICAL | wxALL);
 
@@ -2269,7 +2276,7 @@ void OutfitStudioFrame::OnNewProject(wxCommandEvent& WXUNUSED(event)) {
 
 	GetMenuBar()->Enable(XRCID("fileSave"), false);
 
-	std::string outfitName = XRCCTRL(wiz, "npOutfitName", wxTextCtrl)->GetValue().ToUTF8();
+	std::string outfitName{XRCCTRL(wiz, "npOutfitName", wxTextCtrl)->GetValue().ToUTF8()};
 
 	wxLogMessage("Creating project '%s'...", outfitName);
 	StartProgress(wxString::Format(_("Creating project '%s'..."), outfitName));
@@ -2296,11 +2303,11 @@ void OutfitStudioFrame::OnNewProject(wxCommandEvent& WXUNUSED(event)) {
 		wxString refTemplate = XRCCTRL(wiz, "npTemplateChoice", wxChoice)->GetStringSelection();
 		wxLogMessage("Loading reference template '%s'...", refTemplate);
 
-		std::string tmplName = refTemplate.ToUTF8();
+		std::string tmplName{refTemplate.ToUTF8()};
 		auto tmpl = find_if(refTemplates.begin(), refTemplates.end(), [&tmplName](const RefTemplate& rt) { return rt.GetName() == tmplName; });
 		if (tmpl != refTemplates.end()) {
 			if (wxFileName(wxString::FromUTF8(tmpl->GetSource())).IsRelative())
-				error = project->LoadReferenceTemplate(Config["AppDir"] + "\\" + tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape());
+				error = project->LoadReferenceTemplate(Config["AppDir"] + "/" + tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape());
 			else
 				error = project->LoadReferenceTemplate(tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape());
 		}
@@ -2378,20 +2385,20 @@ void OutfitStudioFrame::OnNewProject(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnLoadProject(wxCommandEvent& WXUNUSED(event)) {
-	wxFileDialog loadProjectDialog(this, _("Select a slider set to load"), wxString::FromUTF8(Config["AppDir"]) + "\\SliderSets", wxEmptyString, "Slider Set Files (*.osp;*.xml)|*.osp;*.xml", wxFD_FILE_MUST_EXIST);
+	wxFileDialog loadProjectDialog(this, _("Select a slider set to load"), wxString::FromUTF8(Config["AppDir"]) + "/SliderSets", wxEmptyString, "Slider Set Files (*.osp;*.xml)|*.osp;*.xml", wxFD_FILE_MUST_EXIST);
 	if (loadProjectDialog.ShowModal() == wxID_CANCEL)
 		return;
 
-	std::string fileName = loadProjectDialog.GetPath().ToUTF8();
+	std::string fileName{loadProjectDialog.GetPath().ToUTF8()};
 	LoadProject(fileName);
 }
 
 void OutfitStudioFrame::OnAddProject(wxCommandEvent& WXUNUSED(event)) {
-	wxFileDialog addProjectDialog(this, _("Select a slider set to add"), wxString::FromUTF8(Config["AppDir"]) + "\\SliderSets", wxEmptyString, "Slider Set Files (*.osp;*.xml)|*.osp;*.xml", wxFD_FILE_MUST_EXIST);
+	wxFileDialog addProjectDialog(this, _("Select a slider set to add"), wxString::FromUTF8(Config["AppDir"]) + "/SliderSets", wxEmptyString, "Slider Set Files (*.osp;*.xml)|*.osp;*.xml", wxFD_FILE_MUST_EXIST);
 	if (addProjectDialog.ShowModal() == wxID_CANCEL)
 		return;
 
-	std::string fileName = addProjectDialog.GetPath().ToUTF8();
+	std::string fileName{addProjectDialog.GetPath().ToUTF8()};
 	LoadProject(fileName, "", false);
 }
 
@@ -2433,11 +2440,11 @@ void OutfitStudioFrame::OnLoadReference(wxCommandEvent& WXUNUSED(event)) {
 		wxString refTemplate = XRCCTRL(dlg, "npTemplateChoice", wxChoice)->GetStringSelection();
 		wxLogMessage("Loading reference template '%s'...", refTemplate);
 
-		std::string tmplName = refTemplate.ToUTF8();
+		std::string tmplName{refTemplate.ToUTF8()};
 		auto tmpl = find_if(refTemplates.begin(), refTemplates.end(), [&tmplName](const RefTemplate& rt) { return rt.GetName() == tmplName; });
 		if (tmpl != refTemplates.end()) {
 			if (wxFileName(wxString::FromUTF8(tmpl->GetSource())).IsRelative())
-				error = project->LoadReferenceTemplate(Config["AppDir"] + "\\" + tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), mergeSliders);
+				error = project->LoadReferenceTemplate(Config["AppDir"] + "/" + tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), mergeSliders);
 			else
 				error = project->LoadReferenceTemplate(tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), mergeSliders);
 		}
@@ -2591,14 +2598,14 @@ void OutfitStudioFrame::OnUnloadProject(wxCommandEvent& WXUNUSED(event)) {
 void OutfitStudioFrame::UpdateReferenceTemplates() {
 	refTemplates.clear();
 
-	std::string fileName = Config["AppDir"] + "\\RefTemplates.xml";
+	std::string fileName = Config["AppDir"] + "/RefTemplates.xml";
 	if (wxFileName::IsFileReadable(fileName)) {
 		RefTemplateFile refTemplateFile(fileName);
 		refTemplateFile.GetAll(refTemplates);
 	}
 
 	RefTemplateCollection refTemplateCol;
-	refTemplateCol.Load(Config["AppDir"] + "\\RefTemplates");
+	refTemplateCol.Load(Config["AppDir"] + "/RefTemplates");
 	refTemplateCol.GetAll(refTemplates);
 }
 
@@ -2757,7 +2764,7 @@ void OutfitStudioFrame::RefreshGUIFromProj() {
 				break;
 			}
 
-			std::string shapeName = outfitShapes->GetItemText(child).ToUTF8();
+			std::string shapeName{outfitShapes->GetItemText(child).ToUTF8()};
 			glView->SetShapeGhostMode(shapeName, ghost);
 			glView->ShowShape(shapeName, vis);
 			child = outfitShapes->GetNextChild(outfitRoot, cookie);
@@ -2848,7 +2855,7 @@ void OutfitStudioFrame::FillVertexColors() {
 
 void OutfitStudioFrame::OnSSSNameCopy(wxCommandEvent& event) {
 	wxWindow* win = ((wxButton*)event.GetEventObject())->GetParent();
-	std::string copyStr = XRCCTRL(*win, "sssName", wxTextCtrl)->GetValue().ToUTF8();
+	std::string copyStr{XRCCTRL(*win, "sssName", wxTextCtrl)->GetValue().ToUTF8()};
 
 	project->ReplaceForbidden(copyStr);
 
@@ -2943,7 +2950,7 @@ void OutfitStudioFrame::OnSaveSliderSetAs(wxCommandEvent& WXUNUSED(event)) {
 		wxString sssName = wxString::FromUTF8(outName);
 
 		XRCCTRL(dlg, "sssName", wxTextCtrl)->SetValue(sssName);
-		XRCCTRL(dlg, "sssSliderSetFile", wxFilePickerCtrl)->SetInitialDirectory(wxString::FromUTF8(Config["AppDir"]) + "\\SliderSets");
+		XRCCTRL(dlg, "sssSliderSetFile", wxFilePickerCtrl)->SetInitialDirectory(wxString::FromUTF8(Config["AppDir"]) + "/SliderSets");
 
 		if (!project->mFileName.empty())
 			XRCCTRL(dlg, "sssSliderSetFile", wxFilePickerCtrl)->SetPath(project->mFileName);
@@ -2963,7 +2970,7 @@ void OutfitStudioFrame::OnSaveSliderSetAs(wxCommandEvent& WXUNUSED(event)) {
 		if (!project->mGamePath.empty())
 			XRCCTRL(dlg, "sssOutputDataPath", wxTextCtrl)->ChangeValue(project->mGamePath);
 		else
-			XRCCTRL(dlg, "sssOutputDataPath", wxTextCtrl)->ChangeValue("meshes\\armor\\" + sssName);
+			XRCCTRL(dlg, "sssOutputDataPath", wxTextCtrl)->ChangeValue("meshes/armor/" + sssName);
 
 		if (!project->mGameFile.empty())
 			XRCCTRL(dlg, "sssOutputFileName", wxTextCtrl)->ChangeValue(project->mGameFile);
@@ -3411,9 +3418,9 @@ void OutfitStudioFrame::OnImportTRIHead(wxCommandEvent& WXUNUSED(event)) {
 			return;
 		}
 
-		std::string shapeName = fileName.GetName().ToUTF8();
+		std::string shapeName{fileName.GetName().ToUTF8()};
 		while (project->IsValidShape(shapeName)) {
-			std::string result = wxGetTextFromUser(_("Please enter a new unique name for the shape."), _("Rename Shape"), shapeName, this).ToUTF8();
+			std::string result{wxGetTextFromUser(_("Please enter a new unique name for the shape."), _("Rename Shape"), shapeName, this).ToUTF8()};
 			if (result.empty())
 				continue;
 
@@ -3532,7 +3539,7 @@ void OutfitStudioFrame::OnExportPhysicsData(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	int sel = physicsDataChoice.GetSelection();
-	std::string selString = fileNames[sel].ToUTF8();
+	std::string selString{fileNames[sel].ToUTF8()};
 
 	if (!selString.empty()) {
 		wxString fileName = wxFileSelector(_("Export physics data"), wxEmptyString, wxEmptyString, ".hkx", "*.hkx", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
@@ -3554,12 +3561,12 @@ void OutfitStudioFrame::OnMakeConvRef(wxCommandEvent& WXUNUSED(event)) {
 
 	std::string namebase = "ConvertToBase";
 	char thename[256];
-	_snprintf_s(thename, 256, 256, "%s", namebase.c_str());
+	snprintf(thename, 256, "%s", namebase.c_str());
 	int count = 1;
 	while (sliderDisplays.find(thename) != sliderDisplays.end())
-		_snprintf_s(thename, 256, 256, "%s%d", namebase.c_str(), count++);
+		snprintf(thename, 256, "%s%d", namebase.c_str(), count++);
 
-	std::string finalName = wxGetTextFromUser(_("Create a conversion slider for the current slider settings with the following name: "), _("Create New Conversion Slider"), thename, this).ToUTF8();
+	std::string finalName{wxGetTextFromUser(_("Create a conversion slider for the current slider settings with the following name: "), _("Create New Conversion Slider"), thename, this).ToUTF8()};
 	if (finalName.empty())
 		return;
 
@@ -3638,7 +3645,7 @@ void OutfitStudioFrame::ToggleVisibility(wxTreeItemId firstItem) {
 			break;
 		}
 
-		std::string shapeName = outfitShapes->GetItemText(firstItem).ToUTF8();
+		std::string shapeName{outfitShapes->GetItemText(firstItem).ToUTF8()};
 		glView->SetShapeGhostMode(shapeName, ghost);
 		glView->ShowShape(shapeName, vis);
 		outfitShapes->SetItemState(firstItem, state);
@@ -3647,7 +3654,7 @@ void OutfitStudioFrame::ToggleVisibility(wxTreeItemId firstItem) {
 	if (selectedItems.size() > 1) {
 		for (auto &i : selectedItems) {
 			if (i->GetId().GetID() != firstItem.GetID()) {
-				std::string shapeName = outfitShapes->GetItemText(i->GetId()).ToUTF8();
+				std::string shapeName{outfitShapes->GetItemText(i->GetId()).ToUTF8()};
 				glView->SetShapeGhostMode(shapeName, ghost);
 				glView->ShowShape(shapeName, vis);
 				outfitShapes->SetItemState(i->GetId(), state);
@@ -5164,7 +5171,7 @@ void OutfitStudioFrame::OnClickSliderButton(wxCommandEvent& event) {
 		return;
 
 	wxString buttonName = btn->GetName();
-	std::string clickedName = buttonName.BeforeLast('|').ToUTF8();
+	std::string clickedName{buttonName.BeforeLast('|').ToUTF8()};
 	if (clickedName.empty()) {
 		event.Skip();
 		return;
@@ -5203,7 +5210,7 @@ void OutfitStudioFrame::OnReadoutChange(wxCommandEvent& event) {
 	if (!sn.EndsWith("|readout", &sn))
 		return;
 
-	std::string sliderName = sn.ToUTF8();
+	std::string sliderName{sn.ToUTF8()};
 
 	double v;
 	wxString val = w->GetValue();
@@ -5772,7 +5779,7 @@ void OutfitStudioFrame::OnSlider(wxScrollEvent& event) {
 		return;
 	}
 
-	std::string sn = sliderName.BeforeLast('|').ToUTF8();
+	std::string sn{sliderName.BeforeLast('|').ToUTF8()};
 	if (sn.empty())
 		return;
 
@@ -5793,7 +5800,7 @@ void OutfitStudioFrame::OnLoadPreset(wxCommandEvent& WXUNUSED(event)) {
 	std::string choice;
 	bool hi = true;
 
-	presets.LoadPresets(Config["AppDir"] + "\\SliderPresets", choice, names, true);
+	presets.LoadPresets(Config["AppDir"] + "/SliderPresets", choice, names, true);
 	presets.GetPresetNames(names);
 
 	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgChoosePreset")) {
@@ -5860,7 +5867,7 @@ void OutfitStudioFrame::OnSavePreset(wxCommandEvent& WXUNUSED(event)) {
 	}
 
 	SliderSetGroupCollection groupCollection;
-	groupCollection.LoadGroups(Config["AppDir"] + "\\SliderGroups");
+	groupCollection.LoadGroups(Config["AppDir"] + "/SliderGroups");
 
 	std::set<std::string> allGroups;
 	groupCollection.GetAllGroups(allGroups);
@@ -6168,7 +6175,7 @@ void OutfitStudioFrame::OnSliderExportBSD(wxCommandEvent& WXUNUSED(event)) {
 			return;
 
 		for (auto &i : selectedItems) {
-			std::string targetFile = std::string(dir.ToUTF8()) + "\\" + i->GetShape()->GetName() + "_" + activeSlider + ".bsd";
+			std::string targetFile = std::string(dir.ToUTF8()) + "/" + i->GetShape()->GetName() + "_" + activeSlider + ".bsd";
 			wxLogMessage("Exporting BSD slider data of '%s' for shape '%s' to '%s'...", activeSlider, i->GetShape()->GetName(), targetFile);
 			project->SaveSliderBSD(activeSlider, i->GetShape(), targetFile);
 		}
@@ -6587,7 +6594,7 @@ void OutfitStudioFrame::OnSliderProperties(wxCommandEvent& WXUNUSED(event)) {
 			project->SetSliderDefault(curSlider, loVal, false);
 			project->SetSliderDefault(curSlider, hiVal, true);
 
-			std::string sliderName = edSliderName->GetValue().ToUTF8();
+			std::string sliderName{edSliderName->GetValue().ToUTF8()};
 			if (activeSlider != sliderName && !project->ValidSlider(sliderName)) {
 				project->SetSliderName(curSlider, sliderName);
 				SliderDisplay* d = sliderDisplays[activeSlider];
@@ -6789,7 +6796,7 @@ void OutfitStudioFrame::OnRenameShape(wxCommandEvent& WXUNUSED(event)) {
 
 	std::string newShapeName;
 	do {
-		std::string result = wxGetTextFromUser(_("Please enter a new unique name for the shape."), _("Rename Shape")).ToUTF8();
+		std::string result{wxGetTextFromUser(_("Please enter a new unique name for the shape."), _("Rename Shape")).ToUTF8()};
 		if (result.empty())
 			return;
 
@@ -7406,7 +7413,7 @@ void OutfitStudioFrame::OnSeparateVerts(wxCommandEvent& WXUNUSED(event)) {
 
 	std::string newShapeName;
 	do {
-		std::string result = wxGetTextFromUser(_("Please enter a unique name for the new separated shape."), _("Separate Vertices...")).ToUTF8();
+		std::string result{wxGetTextFromUser(_("Please enter a unique name for the new separated shape."), _("Separate Vertices...")).ToUTF8()};
 		if (result.empty())
 			return;
 
@@ -7449,7 +7456,7 @@ void OutfitStudioFrame::OnDupeShape(wxCommandEvent& WXUNUSED(event)) {
 		}
 
 		do {
-			std::string result = wxGetTextFromUser(_("Please enter a unique name for the duplicated shape."), _("Duplicate Shape")).ToUTF8();
+			std::string result{wxGetTextFromUser(_("Please enter a unique name for the duplicated shape."), _("Duplicate Shape")).ToUTF8()};
 			if (result.empty())
 				return;
 
@@ -8197,13 +8204,13 @@ void wxGLPanel::SetMeshTextures(const std::string& shapeName, const std::vector<
 	if (!m)
 		return;
 	
-	std::string vShader = Config["AppDir"] + "\\res\\shaders\\default.vert";
-	std::string fShader = Config["AppDir"] + "\\res\\shaders\\default.frag";
+	std::string vShader = Config["AppDir"] + "/res/shaders/default.vert";
+	std::string fShader = Config["AppDir"] + "/res/shaders/default.frag";
 
 	auto targetGame = (TargetGame)Config.GetIntValue("TargetGame");
 	if (targetGame == FO4 || targetGame == FO4VR) {
-		vShader = Config["AppDir"] + "\\res\\shaders\\fo4_default.vert";
-		fShader = Config["AppDir"] + "\\res\\shaders\\fo4_default.frag";
+		vShader = Config["AppDir"] + "/res/shaders/fo4_default.vert";
+		fShader = Config["AppDir"] + "/res/shaders/fo4_default.frag";
 	}
 
 	GLMaterial* mat = gls.AddMaterial(textureFiles, vShader, fShader, reloadTextures);
@@ -9358,7 +9365,7 @@ bool DnDFile::OnDropFiles(wxCoord, wxCoord, const wxArrayString& fileNames) {
 			mergeShape = owner->activeItem->GetShape();
 
 		for (auto &inputFile : fileNames) {
-			wxString dataName = inputFile.AfterLast('\\');
+			wxString dataName = inputFile.AfterLast('/').AfterLast('\\');;
 			dataName = dataName.BeforeLast('.');
 
 			if (inputFile.Lower().EndsWith(".nif")) {
@@ -9412,7 +9419,7 @@ bool DnDSliderFile::OnDropFiles(wxCoord, wxCoord, const wxArrayString& fileNames
 			wxString inputFile;
 			inputFile = fileNames.Item(i);
 
-			wxString dataName = inputFile.AfterLast('\\');
+			wxString dataName = inputFile.AfterLast('/').AfterLast('\\');;
 			dataName = dataName.BeforeLast('.');
 
 			bool isBSD = inputFile.MakeLower().EndsWith(".bsd");

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -1766,7 +1766,7 @@ void OutfitStudioFrame::createSliderGUI(const std::string& name, int id, wxScrol
 
 	auto d = new SliderDisplay();
 	d->sliderPane = new wxPanel(wnd, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSIMPLE_BORDER | wxTAB_TRAVERSAL);
-	d->sliderPane->SetBackgroundColour(wxColour(64,64,64));
+	d->sliderPane->SetBackgroundColour(wxColour(64, 64, 64));
 	d->sliderPane->SetMinSize(wxSize(-1, 25));
 	d->sliderPane->SetMaxSize(wxSize(-1, 25));
 
@@ -5738,7 +5738,7 @@ void OutfitStudioFrame::HighlightSlider(const std::string& name) {
 		}
 		else {
 			d.second->hilite = false;
-			d.second->sliderPane->SetBackgroundColour(wxNullColour);
+			d.second->sliderPane->SetBackgroundColour(wxColour(64, 64, 64));
 			d.second->slider->Disable();
 			d.second->slider->Enable();
 		}

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -473,7 +473,7 @@ bool OutfitStudio::SetDefaultConfig() {
 		if (key.Exists()) {
 			wxString installPath;
 			if (key.HasValues() && key.QueryValue(gameValueKey, installPath)) {
-				installPath.Append("Data/");
+				installPath.Append("Data").Append(PathSepChar);
 				Config.SetDefaultValue("GameDataPath", installPath.ToStdString());
 				wxLogMessage("Registry game data path: %s", installPath);
 			}
@@ -669,7 +669,7 @@ wxString OutfitStudio::GetGameDataPath(TargetGame targ) {
 		wxRegKey key(wxRegKey::HKLM, Config[gkey], wxRegKey::WOW64ViewMode_32);
 		if (key.Exists()) {
 			if (key.HasValues() && key.QueryValue(Config[gval], dataPath)) {
-				dataPath.Append("Data/");
+				dataPath.Append("Data").Append(PathSepChar);
 			}
 		}
 	}
@@ -2972,7 +2972,7 @@ void OutfitStudioFrame::OnSaveSliderSetAs(wxCommandEvent& WXUNUSED(event)) {
 		if (!project->mGamePath.empty())
 			XRCCTRL(dlg, "sssOutputDataPath", wxTextCtrl)->ChangeValue(project->mGamePath);
 		else
-			XRCCTRL(dlg, "sssOutputDataPath", wxTextCtrl)->ChangeValue("meshes/armor/" + sssName);
+			XRCCTRL(dlg, "sssOutputDataPath", wxTextCtrl)->ChangeValue(wxString::Format("meshes%carmor%c%s", PathSepChar, PathSepChar, sssName));
 
 		if (!project->mGameFile.empty())
 			XRCCTRL(dlg, "sssOutputFileName", wxTextCtrl)->ChangeValue(project->mGameFile);

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -1272,6 +1272,8 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 								// Split target file name to get OSD file name
 								int split = dataFileName.find_last_of('/');
 								if (split < 0)
+									split = dataFileName.find_last_of('\\');
+								if (split < 0)
 									continue;
 
 								dataFiles.insert(set.GetDefaultDataFolder() + sep + dataFileName.substr(0, split));

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -42,7 +42,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <wx/tokenzr.h>
 #include <wx/cmdline.h>
 #include <wx/stdpaths.h>
+#ifdef _WINDOWS
 #include <wx/msw/registry.h>
+#endif
 
 enum TargetGame {
 	FO3, FONV, SKYRIM, FO4, SKYRIMSE, FO4VR, SKYRIMVR

--- a/src/program/PresetSaveDialog.cpp
+++ b/src/program/PresetSaveDialog.cpp
@@ -19,7 +19,7 @@ wxEND_EVENT_TABLE()
 
 PresetSaveDialog::PresetSaveDialog(wxWindow* parent) {
 	wxXmlResource* xrc = wxXmlResource::Get();
-	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\SavePreset.xrc");
+	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/SavePreset.xrc");
 	xrc->LoadDialog(this, parent, "dlgSavePreset");
 
 	SetDoubleBuffered(true);
@@ -38,7 +38,7 @@ PresetSaveDialog::PresetSaveDialog(wxWindow* parent) {
 }
 	
 PresetSaveDialog::~PresetSaveDialog() {
-	wxXmlResource::Get()->Unload(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\SavePreset.xrc");
+	wxXmlResource::Get()->Unload(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/SavePreset.xrc");
 }
 
 void PresetSaveDialog::FilterGroups(const std::string& filter) {
@@ -71,7 +71,7 @@ void PresetSaveDialog::FilterGroups(const std::string& filter) {
 }
 
 void PresetSaveDialog::FilterChanged(wxCommandEvent& event) {
-	std::string filter = event.GetString().ToUTF8();
+	std::string filter{event.GetString().ToUTF8()};
 	FilterGroups(filter);
 }
 
@@ -93,7 +93,7 @@ void PresetSaveDialog::OnSave(wxCommandEvent& WXUNUSED(event)) {
 	outPresetName = XRCCTRL((*this), "spPresetName", wxTextCtrl)->GetValue().ToUTF8();
 	std::string presetFile = outPresetName + ".xml";
 
-	wxFileDialog savePresetDialog(this, "Choose a preset file", wxString::FromUTF8(Config["AppDir"]) + "\\SliderPresets", wxString::FromUTF8(presetFile), "Preset Files (*.xml)|*.xml", wxFD_SAVE);
+	wxFileDialog savePresetDialog(this, "Choose a preset file", wxString::FromUTF8(Config["AppDir"]) + "/SliderPresets", wxString::FromUTF8(presetFile), "Preset Files (*.xml)|*.xml", wxFD_SAVE);
 	if (savePresetDialog.ShowModal() == wxID_OK) {
 		outFileName = savePresetDialog.GetPath().ToUTF8();
 		outGroups.assign(selectedGroups.begin(), selectedGroups.end());

--- a/src/program/PreviewWindow.cpp
+++ b/src/program/PreviewWindow.cpp
@@ -24,7 +24,7 @@ PreviewWindow::~PreviewWindow() {
 
 PreviewWindow::PreviewWindow(const wxPoint& pos, const wxSize& size, BodySlideApp* app)
 	: wxFrame(nullptr, wxID_ANY, _("Preview"), pos, size), app(app), refNormalGenLayers(emptyLayers) {
-	SetIcon(wxIcon(wxString::FromUTF8(Config["AppDir"]) + "\\res\\images\\BodySlide.png", wxBITMAP_TYPE_PNG));
+	SetIcon(wxIcon(wxString::FromUTF8(Config["AppDir"]) + "/res/images/BodySlide.png", wxBITMAP_TYPE_PNG));
 
 	wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
 	wxBoxSizer* sizerPanel = new wxBoxSizer(wxHORIZONTAL);
@@ -290,13 +290,13 @@ void PreviewWindow::AddNifShapeTextures(NifFile* fromNif, const std::string& sha
 	//texFiles[1] = "d:\\proj\\FemaleBody_2_msn.dds";
 	//texFiles[1] = "d:\\proj\\TangentNormalsTest.png";
 
-	std::string vShader = Config["AppDir"] + "\\res\\shaders\\default.vert";
-	std::string fShader = Config["AppDir"] + "\\res\\shaders\\default.frag";
+	std::string vShader = Config["AppDir"] + "/res/shaders/default.vert";
+	std::string fShader = Config["AppDir"] + "/res/shaders/default.frag";
 
 	TargetGame targetGame = (TargetGame)Config.GetIntValue("TargetGame");
 	if (targetGame == FO4 || targetGame == FO4VR) {
-		vShader = Config["AppDir"] + "\\res\\shaders\\fo4_default.vert";
-		fShader = Config["AppDir"] + "\\res\\shaders\\fo4_default.frag";
+		vShader = Config["AppDir"] + "/res/shaders/fo4_default.vert";
+		fShader = Config["AppDir"] + "/res/shaders/fo4_default.frag";
 	}
 
 	SetShapeTextures(shapeName, texFiles, vShader, fShader, hasMat, mat);

--- a/src/program/PreviewWindow.h
+++ b/src/program/PreviewWindow.h
@@ -143,11 +143,11 @@ public:
 		//"d:\\proj\\FemaleBodyt_n.dds"
 		//"d:\\proj\\bodyPaintDummy-N_u0_v0.png"
 		//normTextures[20] = "d:\\proj\\masktest.png";
-		GLMaterial* normMat = gls.AddMaterial(normTextures, Config["AppDir"] + "\\res\\shaders\\normalshade.vert", Config["AppDir"] + "\\res\\shaders\\normalshade.frag");
+		GLMaterial* normMat = gls.AddMaterial(normTextures, Config["AppDir"] + "/res/shaders/normalshade.vert", Config["AppDir"] + "/res/shaders/normalshade.frag");
 
 		std::vector<std::string> ppTex;
 		ppTex.push_back("pproc");
-		GLMaterial* ppMat = gls.AddMaterial(ppTex, Config["AppDir"] + "\\res\\shaders\\fullscreentri.vert", Config["AppDir"] + "\\res\\shaders\\fullscreentri.frag");
+		GLMaterial* ppMat = gls.AddMaterial(ppTex, Config["AppDir"] + "/res/shaders/fullscreentri.vert", Config["AppDir"] + "/res/shaders/fullscreentri.frag");
 
 		
 		//texIds.push_back(normMat->GetTexID(0));

--- a/src/program/ShapeProperties.cpp
+++ b/src/program/ShapeProperties.cpp
@@ -340,7 +340,7 @@ void ShapeProperties::OnSetTextures(wxCommandEvent& WXUNUSED(event)) {
 			if (!blockType)
 				continue;
 
-			stTexGrid->SetCellValue(i, 0, texPath);
+			stTexGrid->SetCellValue(i, 0, ToOSSlashes(texPath));
 		}
 
 		// BSEffectShaderProperty
@@ -362,7 +362,8 @@ void ShapeProperties::OnSetTextures(wxCommandEvent& WXUNUSED(event)) {
 			std::vector<std::string> texFiles(10);
 			for (int i = 0; i < 10; i++) {
 				std::string texPath = stTexGrid->GetCellValue(i, 0);
-				nif->SetTextureSlot(shader, texPath, i);
+				std::string texPath_bs = ToBackslashes(texPath);
+				nif->SetTextureSlot(shader, texPath_bs, i);
 
 				if (!texPath.empty())
 					texFiles[i] = dataPath + texPath;

--- a/src/program/ShapeProperties.cpp
+++ b/src/program/ShapeProperties.cpp
@@ -20,7 +20,7 @@ wxEND_EVENT_TABLE()
 
 ShapeProperties::ShapeProperties(wxWindow* parent, NifFile* refNif, NiShape* refShape) {
 	wxXmlResource *xrc = wxXmlResource::Get();
-	bool loaded = xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\ShapeProperties.xrc");
+	bool loaded = xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/ShapeProperties.xrc");
 	if (!loaded) {
 		wxMessageBox("Failed to load ShapeProperties.xrc file!", "Error", wxICON_ERROR);
 		return;
@@ -81,7 +81,7 @@ ShapeProperties::ShapeProperties(wxWindow* parent, NifFile* refNif, NiShape* ref
 }
 
 ShapeProperties::~ShapeProperties() {
-	wxXmlResource::Get()->Unload(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\ShapeProperties.xrc");
+	wxXmlResource::Get()->Unload(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/ShapeProperties.xrc");
 }
 
 void ShapeProperties::GetShader() {
@@ -217,7 +217,7 @@ void ShapeProperties::OnChooseMaterial(wxCommandEvent& WXUNUSED(event)) {
 	if (fileName.empty())
 		return;
 
-	int index = fileName.Lower().Find("\\materials\\");
+	int index = fileName.Lower().Find("/materials/");
 	if (index != wxNOT_FOUND && fileName.length() - 1 > index + 1)
 		fileName = fileName.Mid(index + 1);
 

--- a/src/render/GLExtensions.cpp
+++ b/src/render/GLExtensions.cpp
@@ -10,6 +10,7 @@ bool extInitialized = false;
 bool extSupported = true;
 bool extGLISupported = true;
 
+#ifndef __linux__
 // OpenGL 4.2
 PFNGLTEXSTORAGE1DPROC glTexStorage1D = nullptr;
 PFNGLTEXSTORAGE2DPROC glTexStorage2D = nullptr;
@@ -21,13 +22,13 @@ PFNGLGENVERTEXARRAYSPROC glGenVertexArrays = nullptr;
 PFNGLBINDVERTEXARRAYPROC glBindVertexArray = nullptr;
 PFNGLDELETEVERTEXARRAYSPROC glDeleteVertexArrays = nullptr;
 
-PFNGLGENFRAMEBUFFERSPROC glGenFrameBuffers = nullptr;
-PFNGLDELETEFRAMEBUFFERSPROC glDeleteFrameBuffers = nullptr;
+PFNGLGENFRAMEBUFFERSPROC glGenFramebuffers = nullptr;
+PFNGLDELETEFRAMEBUFFERSPROC glDeleteFramebuffers = nullptr;
 PFNGLBINDFRAMEBUFFERPROC glBindFramebuffer = nullptr;
 PFNGLFRAMEBUFFERTEXTURE2DPROC glFramebufferTexture2D = nullptr;
 PFNGLGENRENDERBUFFERSPROC glGenRenderbuffers = nullptr;
 PFNGLBINDRENDERBUFFERPROC glBindRenderbuffer = nullptr;
-PFNGLRENDERBUFFERSTORAGEPROC glRenderbufferstorage = nullptr;
+PFNGLRENDERBUFFERSTORAGEPROC glRenderbufferStorage = nullptr;
 PFNGLFRAMEBUFFERRENDERBUFFERPROC glFramebufferRenderbuffer = nullptr;
 PFNGLDELETERENDERBUFFERSPROC glDeleteRenderbuffers = nullptr;
 
@@ -87,13 +88,13 @@ void InitExtensions() {
 		glGenVertexArrays = (PFNGLGENVERTEXARRAYSPROC)wglGetProcAddress("glGenVertexArrays");
 		glBindVertexArray = (PFNGLBINDVERTEXARRAYPROC)wglGetProcAddress("glBindVertexArray");
 		glDeleteVertexArrays = (PFNGLDELETEVERTEXARRAYSPROC)wglGetProcAddress("glDeleteVertexArrays");
-		glGenFrameBuffers = (PFNGLGENFRAMEBUFFERSPROC) wglGetProcAddress("glGenFramebuffers");
-		glDeleteFrameBuffers = (PFNGLDELETEFRAMEBUFFERSPROC) wglGetProcAddress("glDeleteFramebuffers");
+		glGenFramebuffers = (PFNGLGENFRAMEBUFFERSPROC) wglGetProcAddress("glGenFramebuffers");
+		glDeleteFramebuffers = (PFNGLDELETEFRAMEBUFFERSPROC) wglGetProcAddress("glDeleteFramebuffers");
 		glBindFramebuffer = (PFNGLBINDFRAMEBUFFERPROC) wglGetProcAddress("glBindFramebuffer");
 		glFramebufferTexture2D = (PFNGLFRAMEBUFFERTEXTURE2DPROC)wglGetProcAddress("glFramebufferTexture2D");
 		glGenRenderbuffers =(PFNGLGENRENDERBUFFERSPROC) wglGetProcAddress("glGenRenderbuffers");
 		glBindRenderbuffer =(PFNGLBINDRENDERBUFFERPROC) wglGetProcAddress("glBindRenderbuffer");
-		glRenderbufferstorage =(PFNGLRENDERBUFFERSTORAGEPROC) wglGetProcAddress("glRenderbufferStorage");
+		glRenderbufferStorage =(PFNGLRENDERBUFFERSTORAGEPROC) wglGetProcAddress("glRenderbufferStorage");
 		glFramebufferRenderbuffer =(PFNGLFRAMEBUFFERRENDERBUFFERPROC) wglGetProcAddress("glFramebufferRenderbuffer");
 		glDeleteRenderbuffers = (PFNGLDELETERENDERBUFFERSPROC) wglGetProcAddress("glDeleteRenderbuffers");
 
@@ -171,3 +172,61 @@ bool IsExtensionSupported(const char* ext) {
 
 	return false;
 }
+
+#else // __linux__
+
+void InitExtensions() {
+	if (extInitialized) return;
+	GLenum err = glewInit();
+	if (err != GLEW_OK) {
+		fprintf(stderr, "Error: %s\n", glewGetErrorString(err));
+		abort();
+	}
+	extGLISupported =
+		glTexStorage1D &&
+		glTexStorage2D &&
+		glTexStorage3D &&
+		glTexSubImage3D &&
+		glCompressedTexSubImage1D &&
+		glCompressedTexSubImage2D &&
+		glCompressedTexSubImage3D;
+	extSupported =
+		glGetStringi &&
+		glGenVertexArrays &&
+		glBindVertexArray &&
+		glDeleteVertexArrays &&
+		glCreateShader &&
+		glShaderSource &&
+		glCompileShader &&
+		glCreateProgram &&
+		glAttachShader &&
+		glLinkProgram &&
+		glUseProgram &&
+		glGetShaderiv &&
+		glGetShaderInfoLog &&
+		glGetProgramiv &&
+		glGetProgramInfoLog &&
+		glDisableVertexAttribArray &&
+		glEnableVertexAttribArray &&
+		glVertexAttribPointer &&
+		glGenBuffers &&
+		glDeleteBuffers &&
+		glBindBuffer &&
+		glBufferData &&
+		glBufferSubData &&
+		glGetAttribLocation &&
+		glGetUniformLocation &&
+		glUniform1f &&
+		glUniform1i &&
+		glUniform2f &&
+		glUniform3f &&
+		glUniformMatrix4fv &&
+		glActiveTexture;
+	extInitialized = true;
+}
+
+bool IsExtensionSupported(const char *ext) {
+	return glewIsSupported(ext);
+}
+
+#endif

--- a/src/render/GLExtensions.h
+++ b/src/render/GLExtensions.h
@@ -5,10 +5,8 @@ See the included LICENSE file
 
 #pragma once
 
-#if defined(_WIN32) || defined(__linux__)
-	#if defined (_WIN32)
-		#include <Windows.h>
-	#endif
+#if defined(_WIN32)
+	#include <Windows.h>
 	#include <GL/gl.h>
 	#include <GL/glu.h>
 	#include <GL/glext.h>
@@ -16,6 +14,8 @@ See the included LICENSE file
 	#include <OpenGL/gl.h>
 	#include <OpenGL/glu.h>
 	#include <OpenGL/glext.h>
+#elif defined(__linux__)
+	#include <GL/glew.h>
 #else
 	#error Platform OpenGL headers not defined yet!
 #endif
@@ -24,6 +24,7 @@ extern bool extInitialized;
 extern bool extSupported;
 extern bool extGLISupported;
 
+#ifndef __linux__
 // OpenGL 4.2
 extern PFNGLTEXSTORAGE1DPROC glTexStorage1D;
 extern PFNGLTEXSTORAGE2DPROC glTexStorage2D;
@@ -35,13 +36,13 @@ extern PFNGLGENVERTEXARRAYSPROC glGenVertexArrays;
 extern PFNGLBINDVERTEXARRAYPROC glBindVertexArray;
 extern PFNGLDELETEVERTEXARRAYSPROC glDeleteVertexArrays;
 
-extern PFNGLGENFRAMEBUFFERSPROC glGenFrameBuffers;
-extern PFNGLDELETEFRAMEBUFFERSPROC glDeleteFrameBuffers;
+extern PFNGLGENFRAMEBUFFERSPROC glGenFramebuffers;
+extern PFNGLDELETEFRAMEBUFFERSPROC glDeleteFramebuffers;
 extern PFNGLBINDFRAMEBUFFERPROC glBindFramebuffer;
 extern PFNGLFRAMEBUFFERTEXTURE2DPROC glFramebufferTexture2D;
 extern PFNGLGENRENDERBUFFERSPROC glGenRenderbuffers;
 extern PFNGLBINDRENDERBUFFERPROC glBindRenderbuffer;
-extern PFNGLRENDERBUFFERSTORAGEPROC glRenderbufferstorage;
+extern PFNGLRENDERBUFFERSTORAGEPROC glRenderbufferStorage;
 extern PFNGLFRAMEBUFFERRENDERBUFFERPROC glFramebufferRenderbuffer;
 extern PFNGLDELETERENDERBUFFERSPROC glDeleteRenderbuffers;
 
@@ -86,6 +87,7 @@ extern PFNGLCOMPRESSEDTEXSUBIMAGE3DPROC glCompressedTexSubImage3D;
 
 // OpenGL 1.2
 extern PFNGLTEXSUBIMAGE3DPROC glTexSubImage3D;
+#endif
 
 extern void InitExtensions();
 extern bool IsExtensionSupported(const char* ext);

--- a/src/render/GLMaterial.h
+++ b/src/render/GLMaterial.h
@@ -3,7 +3,7 @@ BodySlide and Outfit Studio
 See the included LICENSE file
 */
 
-#include "..\files\ResourceLoader.h"
+#include "../files/ResourceLoader.h"
 #include "GLShader.h"
 
 class GLMaterial {

--- a/src/render/GLOffscreenBuffer.cpp
+++ b/src/render/GLOffscreenBuffer.cpp
@@ -31,12 +31,12 @@ GLOffScreenBuffer::GLOffScreenBuffer(GLSurface* gls, int width, int height, unsi
 
 	// Create Texture destination
 	createTextures();
-	glGenFrameBuffers(count, pmfbo);
+	glGenFramebuffers(count, pmfbo);
 
 	// Create a renderbuffer for depth information, and attach it
 	glGenRenderbuffers(1, &mrbo);
 	glBindRenderbuffer(GL_RENDERBUFFER, mrbo);
-	glRenderbufferstorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, w, h);
+	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, w, h);
 
 	for (int i = 0; i < count; i++) {
 		if (texIds.size() > i && texIds[i] != 0) {
@@ -185,7 +185,7 @@ GLOffScreenBuffer::~GLOffScreenBuffer() {
 	deleteTextures();
 	glDeleteRenderbuffers(1, &mrbo);
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-	glDeleteFrameBuffers(numBuffers, pmfbo);
+	glDeleteFramebuffers(numBuffers, pmfbo);
 
 	delete[] pmfbo;
 	delete[] pmtex;

--- a/src/render/GLShader.cpp
+++ b/src/render/GLShader.cpp
@@ -4,6 +4,7 @@ See the included LICENSE file
 */
 
 #include "GLShader.h"
+#include "../utils/PlatformUtil.h"
 #include <fstream>
 #include <sstream>
 
@@ -42,7 +43,8 @@ bool GLShader::CheckExtensions() {
 }
 
 bool GLShader::LoadShaderFile(const std::string& fileName, std::string& text) {
-	std::ifstream file(fileName, std::ios_base::in | std::ios_base::binary);
+	std::fstream file;
+	PlatformUtil::OpenFileStream(file, fileName, std::ios_base::in | std::ios_base::binary);
 	if (!file)
 		return false;
 

--- a/src/render/GLSurface.cpp
+++ b/src/render/GLSurface.cpp
@@ -1759,7 +1759,7 @@ GLMaterial* GLSurface::AddMaterial(const std::vector<std::string>& textureFiles,
 
 GLMaterial* GLSurface::GetPrimitiveMaterial() {
 	if (!primitiveMat) {
-		primitiveMat = new GLMaterial(Config["AppDir"] + "\\res\\shaders\\primitive.vert", Config["AppDir"] + "\\res\\shaders\\primitive.frag");
+		primitiveMat = new GLMaterial(Config["AppDir"] + "/res/shaders/primitive.vert", Config["AppDir"] + "/res/shaders/primitive.frag");
 
 		std::string shaderError;
 		if (primitiveMat->GetShader().GetError(&shaderError)) {

--- a/src/ui/wxNormalsGenDlg.cpp
+++ b/src/ui/wxNormalsGenDlg.cpp
@@ -24,7 +24,7 @@ wxEND_EVENT_TABLE()
 
 wxNormalsGenDlg::wxNormalsGenDlg(wxWindow* parent) {
 	wxXmlResource *xrc = wxXmlResource::Get();
-	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\NormalsGenDlg.xrc");
+	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/NormalsGenDlg.xrc");
 	xrc->LoadDialog(this, parent, "wxNormalsGenDlg");
 
 	bpPreset = XRCCTRL(*this, "bpPreset", wxBitmapButton);
@@ -54,5 +54,5 @@ wxNormalsGenDlg::wxNormalsGenDlg(wxWindow* parent) {
 
 wxNormalsGenDlg::~wxNormalsGenDlg() {
 	delete presetContext;
-	wxXmlResource::Get()->Unload(wxString::FromUTF8(Config["AppDir"]) + "\\res\\xrc\\NormalsGenDlg.xrc");
+	wxXmlResource::Get()->Unload(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/NormalsGenDlg.xrc");
 }

--- a/src/utils/ConfigurationManager.cpp
+++ b/src/utils/ConfigurationManager.cpp
@@ -4,6 +4,7 @@ See the included LICENSE file
 */
 
 #include "ConfigurationManager.h"
+#include "../utils/StringStuff.h"
 
 ConfigurationItem::~ConfigurationItem() {
 	for (auto &it : properties)
@@ -367,9 +368,9 @@ bool ConfigurationManager::GetBoolValue(const std::string& inName, bool def) {
 
 	ConfigurationItem* itemFound = FindCI(inName);
 	if (itemFound) {
-		if (_strnicmp(itemFound->value.c_str(), "true", 4) == 0)
+		if (StringsEqualNInsens(itemFound->value.c_str(), "true", 4))
 			res = true;
-		else if (_strnicmp(itemFound->value.c_str(), "false", 5) == 0)
+		else if (StringsEqualNInsens(itemFound->value.c_str(), "false", 5))
 			res = false;
 	}
 
@@ -450,13 +451,13 @@ void ConfigurationManager::SetValue(const std::string& inName, const std::string
 
 void ConfigurationManager::SetValue(const std::string& inName, int newValue, bool flagDefault) {
 	char intStr[24];
-	_snprintf_s(intStr, 24, 24, "%d", newValue);
+	snprintf(intStr, 24, "%d", newValue);
 	SetValue(inName, std::string(intStr), flagDefault);
 }
 
 void ConfigurationManager::SetValue(const std::string& inName, float newValue, bool flagDefault) {
 	char intStr[24];
-	_snprintf_s(intStr, 24, 24, "%0.5f", newValue);
+	snprintf(intStr, 24, "%0.5f", newValue);
 	SetValue(inName, std::string(intStr), flagDefault);
 }
 
@@ -470,7 +471,7 @@ bool ConfigurationManager::MatchValue(const std::string& inName, const std::stri
 	ConfigurationItem* itemFound = FindCI(inName);
 	if (itemFound) {
 		if (!useCase) {
-			if (!_stricmp(itemFound->value.c_str(), val.c_str()))
+			if (StringsEqualInsens(itemFound->value.c_str(), val.c_str()))
 				return true;
 		}
 		else {

--- a/src/utils/ConfigurationManager.h
+++ b/src/utils/ConfigurationManager.h
@@ -6,6 +6,7 @@ See the included LICENSE file
 #pragma once
 
 #include "../TinyXML-2/tinyxml2.h"
+#include "../utils/StringStuff.h"
 
 #include <vector>
 #include <unordered_map>
@@ -61,7 +62,7 @@ public:
 	ConfigurationItem* FindProperty(const std::string& inName);
 
 	bool Match(const std::string& otherName) {
-		return (!_stricmp(otherName.c_str(), name.c_str()));
+		return StringsEqualInsens(name.c_str(), otherName.c_str());
 	}
 };
 

--- a/src/utils/Log.h
+++ b/src/utils/Log.h
@@ -15,9 +15,13 @@ class LogFormatter : public wxLogFormatter {
 	virtual wxString Format(wxLogLevel level, const wxString& msg, const wxLogRecordInfo& info) const {
 		wxDateTime logTime(info.timestamp);
 		wxString fileName = info.filename;
-		fileName = fileName.AfterLast('\\');
+		fileName = fileName.AfterLast('/').AfterLast('\\');
+		int ihour = logTime.GetHour();
+		int iminute = logTime.GetMinute();
+		int isecond = logTime.GetSecond();
+		int ilevel = level;
 		return wxString::Format("[%02d:%02d:%02d][%d]\t%s(%d): %s",
-			logTime.GetHour(), logTime.GetMinute(), logTime.GetSecond(), level, fileName, info.line, msg);
+			ihour, iminute, isecond, ilevel, fileName, info.line, msg);
 	}
 };
 
@@ -26,8 +30,12 @@ class LogFormatter : public wxLogFormatter {
 class LogFormatterNoFile : public wxLogFormatter {
 	virtual wxString Format(wxLogLevel level, const wxString& msg, const wxLogRecordInfo& info) const {
 		wxDateTime logTime(info.timestamp);
+		int ihour = logTime.GetHour();
+		int iminute = logTime.GetMinute();
+		int isecond = logTime.GetSecond();
+		int ilevel = level;
 		return wxString::Format("[%02d:%02d:%02d][%d]\t%s",
-			logTime.GetHour(), logTime.GetMinute(), logTime.GetSecond(), level, msg);
+			ihour, iminute, isecond, ilevel, msg);
 	}
 };
 

--- a/src/utils/PlatformUtil.cpp
+++ b/src/utils/PlatformUtil.cpp
@@ -5,6 +5,17 @@ See the included LICENSE file
 
 #include "PlatformUtil.h"
 
+namespace {
+std::string backslash_to_slash(const std::string &s) {
+	std::string sc(s);
+	int len = sc.length();
+	for (int i = 0; i < len; ++i)
+		if (sc[i] == '\\')
+			sc[i] = '/';
+	return sc;
+}
+}
+
 namespace PlatformUtil {
 #ifdef _WINDOWS
 	// ACP wide to multibyte
@@ -30,12 +41,13 @@ namespace PlatformUtil {
 	}
 #endif
 
-	void OpenFileStream(std::fstream& file, const std::string& fileName, unsigned int mode) {
+	void OpenFileStream(std::fstream& file, const std::string& fileName, std::ios_base::openmode mode) {
 #ifdef _WINDOWS
 		// Convert to std::wstring on Windows only
 		file.open(MultiByteToWideUTF8(fileName).c_str(), mode);
 #else
-		file.open(fileName.c_str(), mode);
+		std::string fn_nobs = backslash_to_slash(fileName);
+		file.open(fn_nobs.c_str(), mode);
 #endif
 	}
 

--- a/src/utils/PlatformUtil.cpp
+++ b/src/utils/PlatformUtil.cpp
@@ -6,14 +6,14 @@ See the included LICENSE file
 #include "PlatformUtil.h"
 
 namespace {
-std::string backslash_to_slash(const std::string &s) {
-	std::string sc(s);
-	int len = sc.length();
-	for (int i = 0; i < len; ++i)
-		if (sc[i] == '\\')
-			sc[i] = '/';
-	return sc;
-}
+	std::string backslash_to_slash(const std::string &s) {
+		std::string sc(s);
+		size_t len = sc.length();
+		for (size_t i = 0; i < len; ++i)
+			if (sc[i] == '\\')
+				sc[i] = '/';
+		return sc;
+	}
 }
 
 namespace PlatformUtil {

--- a/src/utils/PlatformUtil.cpp
+++ b/src/utils/PlatformUtil.cpp
@@ -58,3 +58,4 @@ namespace PlatformUtil {
 	}
 #endif
 }
+

--- a/src/utils/PlatformUtil.cpp
+++ b/src/utils/PlatformUtil.cpp
@@ -58,4 +58,3 @@ namespace PlatformUtil {
 	}
 #endif
 }
-

--- a/src/utils/PlatformUtil.h
+++ b/src/utils/PlatformUtil.h
@@ -21,7 +21,7 @@ namespace PlatformUtil {
 	std::wstring MultiByteToWideUTF8(const std::string& str);
 #endif
 
-	void OpenFileStream(std::fstream& file, const std::string& fileName, unsigned int mode);
+	void OpenFileStream(std::fstream& file, const std::string& fileName, std::ios_base::openmode mode);
 
 	// Provide std::wstring function for Windows
 #ifdef _WINDOWS

--- a/src/utils/StringStuff.cpp
+++ b/src/utils/StringStuff.cpp
@@ -1,0 +1,21 @@
+#include "StringStuff.h"
+#include <ctype.h>
+
+bool StringsEqualNInsens(const char *a, const char *b, int len)
+{
+	while (len > 0) {
+		if (tolower(*a) != tolower(*b)) return false;
+		if (*a == '\0') return true;
+		++a, ++b, --len;
+	}
+	return true;
+}
+
+bool StringsEqualInsens(const char *a, const char *b)
+{
+	while (true) {
+		if (tolower(*a) != tolower(*b)) return false;
+		if (*a == '\0') return true;
+		++a, ++b;
+	}
+}

--- a/src/utils/StringStuff.cpp
+++ b/src/utils/StringStuff.cpp
@@ -19,3 +19,28 @@ bool StringsEqualInsens(const char *a, const char *b)
 		++a, ++b;
 	}
 }
+
+std::string ToOSSlashes(const std::string &s)
+{
+	std::string d(s);
+	int len = d.length();
+	for (int i = 0; i < len; ++i)
+#ifdef WINDOWS
+		if (d[i] == '/')
+			d[i] = '\\';
+#else
+		if (d[i] == '\\')
+			d[i] = '/';
+#endif
+	return d;
+}
+
+std::string ToBackslashes(const std::string &s)
+{
+	std::string d(s);
+	int len = d.length();
+	for (int i = 0; i < len; ++i)
+		if (d[i] == '/')
+			d[i] = '\\';
+	return d;
+}

--- a/src/utils/StringStuff.cpp
+++ b/src/utils/StringStuff.cpp
@@ -25,7 +25,7 @@ std::string ToOSSlashes(const std::string &s)
 	std::string d(s);
 	size_t len = d.length();
 	for (size_t i = 0; i < len; ++i)
-#ifdef WINDOWS
+#ifdef _WINDOWS
 		if (d[i] == '/')
 			d[i] = '\\';
 #else

--- a/src/utils/StringStuff.cpp
+++ b/src/utils/StringStuff.cpp
@@ -23,8 +23,8 @@ bool StringsEqualInsens(const char *a, const char *b)
 std::string ToOSSlashes(const std::string &s)
 {
 	std::string d(s);
-	int len = d.length();
-	for (int i = 0; i < len; ++i)
+	size_t len = d.length();
+	for (size_t i = 0; i < len; ++i)
 #ifdef WINDOWS
 		if (d[i] == '/')
 			d[i] = '\\';
@@ -38,8 +38,8 @@ std::string ToOSSlashes(const std::string &s)
 std::string ToBackslashes(const std::string &s)
 {
 	std::string d(s);
-	int len = d.length();
-	for (int i = 0; i < len; ++i)
+	size_t len = d.length();
+	for (size_t i = 0; i < len; ++i)
 		if (d[i] == '/')
 			d[i] = '\\';
 	return d;

--- a/src/utils/StringStuff.h
+++ b/src/utils/StringStuff.h
@@ -5,6 +5,8 @@ See the included LICENSE file
 
 #pragma once
 
+#include <string>
+
 /* StringsEqualNInsens: returns true if the first len characters of a
 and b are the same insensitive to case. */
 bool StringsEqualNInsens(const char *a, const char *b, int len);
@@ -12,3 +14,19 @@ bool StringsEqualNInsens(const char *a, const char *b, int len);
 /* StringsEqualInsens: returns true if the strings a and b are the same
 insensitive to case. */
 bool StringsEqualInsens(const char *a, const char *b);
+
+/* ToOSSlash: converts all forward and back slashes in s to the path
+separator character for the operating system and returns the result. */
+std::string ToOSSlashes(const std::string &s);
+
+/* ToBackslashes: converts all forward slashes into backslashes in s
+and returns the result. */
+std::string ToBackslashes(const std::string &s);
+
+#ifdef _WINDOWS
+constexpr char PathSepChar = '\\';
+constexpr const char *PathSepStr = "\\";
+#else
+constexpr char PathSepChar = '/';
+constexpr const char *PathSepStr = "/";
+#endif

--- a/src/utils/StringStuff.h
+++ b/src/utils/StringStuff.h
@@ -1,0 +1,14 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#pragma once
+
+/* StringsEqualNInsens: returns true if the first len characters of a
+and b are the same insensitive to case. */
+bool StringsEqualNInsens(const char *a, const char *b, int len);
+
+/* StringsEqualInsens: returns true if the strings a and b are the same
+insensitive to case. */
+bool StringsEqualInsens(const char *a, const char *b);

--- a/src/utils/StringStuff.h
+++ b/src/utils/StringStuff.h
@@ -23,6 +23,24 @@ std::string ToOSSlashes(const std::string &s);
 and returns the result. */
 std::string ToBackslashes(const std::string &s);
 
+/* case_insensitive_compare: can be used for maps and more */
+struct case_insensitive_compare
+{
+	struct nocase_compare
+	{
+		bool operator() (const unsigned char& c1, const unsigned char& c2) const {
+			return tolower(c1) < tolower(c2);
+		}
+	};
+
+	bool operator() (const std::string & s1, const std::string & s2) const {
+		return std::lexicographical_compare(
+			s1.begin(), s1.end(),
+			s2.begin(), s2.end(),
+			nocase_compare());
+	}
+};
+
 #ifdef _WINDOWS
 constexpr char PathSepChar = '\\';
 constexpr const char *PathSepStr = "\\";


### PR DESCRIPTION
1.  Created CMakeLists.txt to build with CMake on Linux.  It might also
work on other systems.

2.  stricmp and strnicmp were being used; they are missing from
gcc's standard library implementation.  (This is a well-known and
long-standing bug in gcc.)  So I added src/utils/StringStuff.{cpp,h}
with implementations of case-insensitive string compare functions
and changed all instances of stricmp and strnicmp to use them.

3.  Added StringStuff to the VC project files so hopefully it'll still
build on that tool (which I do not have).

4.  Fixed a variety of minor bugs where the code was not standard
C++, but presumably VC was permissive enough that it compiled anyway.
Hopefully VC will accept these changes; I don't have VC.  The most
common bug was assigning a wxString to a std::string in an old-style
initializer; switching to the new initializer style fixed it.

5.  Added a few missing '#include' statements.

6.  Made some no-effect changes to silence compiler warnings, such as
adding "default: break;" to switch statements where some of the values
were not handled.

7.  gcc is missing acosf, cosf, sinf, atan2f, and fabsf.  (This is
a well-known and long-standing bug in gcc.)  Luckily, these are
just alternative names for existing functions, so I switched to the
other names.

8.  There were many locations where BS&OS tried to open files
with filenames where the path separator character was backslash.
I changed them to use forward slash instead.  This shouldn't affect
Windows execution, because Windows accepts either type of slash as a
path separator.  I tried my best to not let the slash style propagate
into data files, but I may not have been successful.

9.  There were a few locations where filenames were being converted to
lowercase before the file was opened.  As Linux is case sensitive, this
didn't work.  So I changed all of these instances so that the filename
is not converted.

10.  On Linux, the wxWidgets headers "#include <X11/X.h>", which is an
ancient legacy header file containing a large number of poorly-named
"#define" statements.  I feel that this is a bug in wxWidgets.  There
was a name clash with a function name in the FBX SDK.  So I moved the
"#include <fbxsdk.h>" line from FBXWrangler.h into FBXWrangler.cpp
so that FBX and wxWidgets headers would never be included by the
same file.  To keep FBXWrangler working, I needed to move more of
the implementation details from the header into the source file.
This necessitated employing the private-implementation idiom.

11.  The C integer-absolute-value function "abs" was being used in
TriFile.cpp on floating point values.  gcc produced a warning, and
I judged this highly likely to be a bug, so I fixed it by replacing
"abs" with "std::abs".

12.  Linux doesn't have a registry, so I used "#ifdef _WINDOWS"
around the handful of blocks of registry code.

13.  In BodySlideApp.h, there was some peculiar code for doing something
with number-key presses and Windows events.  I used "#ifdef _WINDOWS"
to disable this code for linux.

14.  A few files were missing trailing newline characters.
Linux doesn't like that, so I added them.

15.  Switched from old-style cast to "reinterpret_cast" a few places
in NormalsGenDialog to silence compiler complaints.

16.  "_snprintf_s" was used in a few places.  It's a Windows-only
function.  I replaced it with snprintf, which does the same thing
only better.

17.  The extension-loading code in GLExtensions.{h,cpp} used
wglGetProcAddress, which is Windows-specific.  I couldn't figure out
how to convert the code to Linux, so, for Linux, GL extensions are
now loaded by GLEW.  This new code would probably work fine on other
systems too, but it would introduce a dependence on the GLEW library.

18.  Three OpenGL API calls had capitalization errors.  I fixed them.

After all this, BodySlide and Outfit Studio build and run, apparently
correctly, on my Linux system.