### PR TITLE
Bug fix: save-as ShapeDataFile control in open mode, not save

### DIFF
--- a/res/xrc/Project.xrc
+++ b/res/xrc/Project.xrc
@@ -509,7 +509,7 @@
 									<tooltip>The name of the output's base NIF file.</tooltip>
 									<message>Select output NIF file name</message>
 									<wildcard>*.nif</wildcard>
-									<style>wxFLP_DEFAULT_STYLE</style>
+									<style>wxFLP_SAVE|wxFLP_USE_TEXTCTRL</style>
 								</object>
 							</object>
 						</object>


### PR DESCRIPTION
The file-picker control sssShapeDataFile was set to wxFLP_DEFAULT_STYLE,
which means file to open rather than file to save.  In addition, this
style implies no text field on some operating systems.  I changed the
style to wxFLP_SAVE|wxFLP_USE_TEXTCTRL, like sssSliderSetFile.