### PR TITLE
Bug fix: slider scale doubled on unset reference

### DIFF
--- a/src/components/Automorph.cpp
+++ b/src/components/Automorph.cpp
@@ -315,7 +315,7 @@ void Automorph::SetResultDiff(const std::string& shapeName, const std::string& s
 		resultDiffData.AddEmptySet(setName, shapeName);
 
 	for (auto &i : diff)
-		resultDiffData.SumDiff(setName, shapeName, i.first, i.second);
+		resultDiffData.UpdateDiff(setName, shapeName, i.first, i.second);
 }
 
 void Automorph::UpdateResultDiff(const std::string& shapeName, const std::string& sliderName, std::unordered_map<ushort, Vector3>& diff) {


### PR DESCRIPTION
When a shape was unset as a reference, all of its slider diffs were
being doubled.