### PR TITLE
Fixed three bugs in move brush

### DIFF
--- a/src/components/TweakBrush.cpp
+++ b/src/components/TweakBrush.cpp
@@ -850,6 +850,8 @@ void TB_Move::brushAction(mesh* m, TweakPickInfo& pickInfo, const int*, int, Twe
 		for (int p = 0; p < meshCache->nCachedPointsM; p++) {
 			int i = meshCache->cachedPointsM[p];
 			vs = startState[i];
+			if (mpick.origin.DistanceTo(vs) > pick.origin.DistanceTo(vs))
+				continue;
 			ve = xformMirror * vs;
 			ve -= vs;
 			applyFalloff(ve, mpick.origin.DistanceTo(vs));
@@ -866,6 +868,8 @@ void TB_Move::brushAction(mesh* m, TweakPickInfo& pickInfo, const int*, int, Twe
 	for (int p = 0; p < meshCache->nCachedPoints; p++) {
 		int i = meshCache->cachedPoints[p];
 		vs = startState[i];
+		if (bMirror && pick.origin.DistanceTo(vs) > mpick.origin.DistanceTo(vs))
+			continue;
 		ve = xform * vs;
 		ve -= vs;
 		applyFalloff(ve, pick.origin.DistanceTo(vs));

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -2030,11 +2030,14 @@ void OutfitStudioFrame::ActiveShapesUpdated(TweakStateHolder *tsh, bool bIsUndo)
 			mesh *m = mit.first;
 			std::unordered_map<ushort, Vector3> strokeDiff;
 
-			for (auto &p : mit.second.pointStartState) {
+			for (auto &ps : mit.second.pointStartState) {
+				auto pe = mit.second.pointEndState.find(ps.first);
+				if (pe == mit.second.pointEndState.end())
+					continue;
 				if (bIsUndo)
-					strokeDiff[p.first] = (p.second - mit.second.pointEndState[p.first]) * sliderscale;
+					strokeDiff[ps.first] = (ps.second - pe->second) * sliderscale;
 				else
-					strokeDiff[p.first] = (mit.second.pointEndState[p.first] - p.second) * sliderscale;
+					strokeDiff[ps.first] = (pe->second - ps.second) * sliderscale;
 			}
 			auto shape = project->GetWorkNif()->FindBlockByName<NiShape>(m->shapeName);
 			if (shape)
@@ -8598,17 +8601,17 @@ bool wxGLPanel::StartTransform(const wxPoint& screenPos) {
 		translateBrush.SetXFormType(1);
 		switch (mname[0]) {
 		case 'X':
-			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(1.0f, 0.0f, 0.0f), -tpi.center.x);
+			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(1.0f, 0.0f, 0.0f), tpi.center.x);
 			//tpi.view = Vector3(0.0f, 1.0f, 0.0f);
 			tpi.normal = Vector3(1.0f, 0.0f, 0.0f);
 			break;
 		case 'Y':
-			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(0.0f, 1.0f, 0.0f), -tpi.center.y);
+			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(0.0f, 1.0f, 0.0f), tpi.center.y);
 			//tpi.view = Vector3(-1.0f, 0.0f, 0.0f);
 			tpi.normal = Vector3(0.0f, 1.0f, 0.0f);
 			break;
 		case 'Z':
-			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(0.0f, 0.0f, 1.0f), -tpi.center.z);
+			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(0.0f, 0.0f, 1.0f), tpi.center.z);
 			//tpi.view = Vector3(-1.0f, 0.0f, 0.0f);
 			tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
 			break;
@@ -8634,9 +8637,9 @@ bool wxGLPanel::StartTransform(const wxPoint& screenPos) {
 		}
 		else {
 			translateBrush.SetXFormType(3);
-			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(1.0f, 0.0f, 0.0f), -tpi.center.x);
-			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(0.0f, 1.0f, 0.0f), -tpi.center.y);
-			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(0.0f, 0.0f, 1.0f), -tpi.center.z);
+			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(1.0f, 0.0f, 0.0f), tpi.center.x);
+			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(0.0f, 1.0f, 0.0f), tpi.center.y);
+			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(0.0f, 0.0f, 1.0f), tpi.center.z);
 			tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
 		}
 	}
@@ -8667,7 +8670,7 @@ void wxGLPanel::UpdateTransform(const wxPoint& screenPos) {
 	float pd;
 
 	translateBrush.GetWorkingPlane(pn, pd);
-	gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, pn, -pd);
+	gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, pn, pd);
 
 	activeStroke->updateStroke(tpi);
 
@@ -8737,7 +8740,7 @@ void wxGLPanel::UpdatePivotPosition(const wxPoint& screenPos) {
 	float pd;
 
 	translateBrush.GetWorkingPlane(pn, pd);
-	gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, pn, -pd);
+	gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, pn, pd);
 
 	activeStroke->updateStroke(tpi);
 }

--- a/src/render/GLSurface.cpp
+++ b/src/render/GLSurface.cpp
@@ -479,7 +479,7 @@ bool GLSurface::CollidePlane(int ScreenX, int ScreenY, Vector3& outOrigin, const
 	if (fabs(den) < .00001)
 		return false;
 
-	float t = -(inPlaneNormal.dot(o) + inPlaneDist) / den;
+	float t = -(inPlaneNormal.dot(o) - inPlaneDist) / den;
 	outOrigin = o + d*t;
 
 	return true;


### PR DESCRIPTION
1.  When the move brush overlapped the centerline and x-mirroring was
on, vertices on the other side of the centerline and inside the brush
radius were not mirror-moving.  I added code to TB_Move::brushAction
to check whether each vertex is closer to the origin or mirror-origin.

2.  Rarely, when using the move brush, pointStartState is set
but pointEndState is not for some vertices.  This resulted in
garbage being sent to the slider diff update when slider editing
was on.  I couldn't figure out how this was happening (it should
be impossible), but I prevented the transfer of garbage by adding a
check to ActiveShapesUpdated.

3.  There was a sign bug in GLSurface::CollidePlane.  This bug
caused the move brush to often move points less than it should,
and sometimes in the opposite direction.  I fixed the sign bug.
Of the many places from which CollidePlane is called, the sign bug
was already compensated for in all places except UpdateBrushStroke
in the TBT_MOVE code, which was why it was leading to problems only
for the move brush.  I removed the sign-error compensation from all
of the other places from which CollidePlane is called.