### PR TITLE
Addweightbalance1

### DIFF
--- a/src/components/TweakBrush.cpp
+++ b/src/components/TweakBrush.cpp
@@ -1062,8 +1062,11 @@ void TB_Weight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* p
 			if (bw.find(i) != bw.end())
 				totW += bw[i].endVal;
 		}
-		if (totW - 1.0 > -EPSILON) totW = 1.0;
 		float sw = ts.boneWeights[0].weights[i].endVal;
+		bool solo = false;
+		if (totW - sw <= EPSILON) solo = true;
+		if (solo) totW = 1.0;
+		if (totW - 1.0 > -EPSILON) totW = 1.0;
 		float ew = bFixedWeight ? strength * 10.0f - sw : strength;
 		ew *= getFalloff(pickInfo.origin.DistanceTo(refmesh->verts[i]));
 		ew *= 1.0f - refmesh->vcolors[i].x;
@@ -1072,7 +1075,7 @@ void TB_Weight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* p
 		if (fw > totW) fw = totW;
 		if (fw - 1.0 > -EPSILON) fw = 1.0;
 		ts.boneWeights[0].weights[i].endVal = refmesh->vcolors[i].y = fw;
-		float redFac = totW - sw > EPSILON ? (totW - fw) / (totW - sw) : 0.0;
+		float redFac = solo ? 0.0 : (totW - fw) / (totW - sw);
 		for (unsigned int bi = 1; bi < nBones; ++bi) {
 			auto owi = ts.boneWeights[bi].weights.find(i);
 			if (owi == ts.boneWeights[bi].weights.end()) continue;
@@ -1132,8 +1135,11 @@ void TB_Unweight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int*
 			if (bw.find(i) != bw.end())
 				totW += bw[i].endVal;
 		}
-		if (totW - 1.0 > -EPSILON) totW = 1.0;
 		float sw = ts.boneWeights[0].weights[i].endVal;
+		bool solo = false;
+		if (totW - sw <= EPSILON) solo = true;
+		if (solo) totW = 1.0;
+		if (totW - 1.0 > -EPSILON) totW = 1.0;
 		float ew = strength;
 		ew *= getFalloff(pickInfo.origin.DistanceTo(refmesh->verts[i]));
 		ew *= 1.0f - refmesh->vcolors[i].x;
@@ -1142,7 +1148,7 @@ void TB_Unweight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int*
 		if (fw > totW) fw = totW;
 		if (fw - 1.0 > -EPSILON) fw = 1.0;
 		ts.boneWeights[0].weights[i].endVal = refmesh->vcolors[i].y = fw;
-		float redFac = totW - sw > EPSILON ? (totW - fw) / (totW - sw) : 0.0;
+		float redFac = solo ? 0.0 : (totW - fw) / (totW - sw);
 		for (unsigned int bi = 1; bi < nBones; ++bi) {
 			auto owi = ts.boneWeights[bi].weights.find(i);
 			if (owi == ts.boneWeights[bi].weights.end()) continue;
@@ -1285,6 +1291,10 @@ void TB_SmoothWeight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const 
 				totW += bw[i].endVal;
 		}
 		float sw = ts.boneWeights[0].weights[i].endVal;
+		bool solo = false;
+		if (totW - sw <= EPSILON) solo = true;
+		if (solo) totW = 1.0;
+		if (totW - 1.0 > -EPSILON) totW = 1.0;
 		float ew = wv[i] - sw;
 		ew *= getFalloff(pickInfo.origin.DistanceTo(refmesh->verts[i]));
 		ew *= 1.0f - refmesh->vcolors[i].x;
@@ -1293,7 +1303,7 @@ void TB_SmoothWeight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const 
 		if (fw - 1.0 > -EPSILON) fw = 1.0;
 		if (fw > totW) fw = totW;
 		ts.boneWeights[0].weights[i].endVal = refmesh->vcolors[i].y = fw;
-		float redFac = totW - sw > 0.0 ? (totW - fw) / (totW - sw) : 0.0;
+		float redFac = solo ? 0.0 : (totW - fw) / (totW - sw);
 		for (unsigned int bi = 1; bi < nBones; ++bi) {
 			auto owi = ts.boneWeights[bi].weights.find(i);
 			if (owi == ts.boneWeights[bi].weights.end()) continue;

--- a/src/components/TweakBrush.cpp
+++ b/src/components/TweakBrush.cpp
@@ -1169,7 +1169,7 @@ TB_SmoothWeight::TB_SmoothWeight() :TweakBrush() {
 TB_SmoothWeight::~TB_SmoothWeight() {
 }
 
-void TB_SmoothWeight::lapFilter(mesh* refmesh, const int* points, int nPoints, std::unordered_map<int, float>& wv, TweakState &ts) {
+void TB_SmoothWeight::lapFilter(mesh* refmesh, const int* points, int nPoints, std::unordered_map<int, float>& wv) {
 	int adjPoints[1000];
 
 	for (int i = 0; i < nPoints; i++) {
@@ -1178,7 +1178,7 @@ void TB_SmoothWeight::lapFilter(mesh* refmesh, const int* points, int nPoints, s
 		// average adjacent points values, using values from last iteration.
 		float d = 0.0;
 		for (int n = 0; n < c; n++)
-			d += ts.boneWeights[0].weights[adjPoints[n]].endVal;
+			d += refmesh->vcolors[adjPoints[n]].y;
 		wv[points[i]] = d / (float)c;
 
 		if (refmesh->weldVerts.find(points[i]) != refmesh->weldVerts.end()) {
@@ -1270,7 +1270,7 @@ void TB_SmoothWeight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const 
 	}
 
 	if (method == 0)		// laplacian smooth
-		lapFilter(refmesh, points, nPoints, wv, ts);
+		lapFilter(refmesh, points, nPoints, wv);
 	else					// HC-laplacian smooth
 		hclapFilter(refmesh, points, nPoints, wv, ts);
 

--- a/src/components/TweakBrush.cpp
+++ b/src/components/TweakBrush.cpp
@@ -1062,16 +1062,17 @@ void TB_Weight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* p
 			if (bw.find(i) != bw.end())
 				totW += bw[i].endVal;
 		}
+		if (totW - 1.0 > -EPSILON) totW = 1.0;
 		float sw = ts.boneWeights[0].weights[i].endVal;
 		float ew = bFixedWeight ? strength * 10.0f - sw : strength;
 		ew *= getFalloff(pickInfo.origin.DistanceTo(refmesh->verts[i]));
 		ew *= 1.0f - refmesh->vcolors[i].x;
 		float fw = sw + ew;
 		if (fw < EPSILON) fw = 0.0;
-		if (fw - 1.0 > -EPSILON) fw = 1.0;
 		if (fw > totW) fw = totW;
+		if (fw - 1.0 > -EPSILON) fw = 1.0;
 		ts.boneWeights[0].weights[i].endVal = refmesh->vcolors[i].y = fw;
-		float redFac = totW - sw > 0.0 ? (totW - fw) / (totW - sw) : 0.0;
+		float redFac = totW - sw > EPSILON ? (totW - fw) / (totW - sw) : 0.0;
 		for (unsigned int bi = 1; bi < nBones; ++bi) {
 			auto owi = ts.boneWeights[bi].weights.find(i);
 			if (owi == ts.boneWeights[bi].weights.end()) continue;
@@ -1131,16 +1132,17 @@ void TB_Unweight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int*
 			if (bw.find(i) != bw.end())
 				totW += bw[i].endVal;
 		}
+		if (totW - 1.0 > -EPSILON) totW = 1.0;
 		float sw = ts.boneWeights[0].weights[i].endVal;
 		float ew = strength;
 		ew *= getFalloff(pickInfo.origin.DistanceTo(refmesh->verts[i]));
 		ew *= 1.0f - refmesh->vcolors[i].x;
 		float fw = sw + ew;
 		if (fw < EPSILON) fw = 0.0;
-		if (fw - 1.0 > -EPSILON) fw = 1.0;
 		if (fw > totW) fw = totW;
+		if (fw - 1.0 > -EPSILON) fw = 1.0;
 		ts.boneWeights[0].weights[i].endVal = refmesh->vcolors[i].y = fw;
-		float redFac = totW - sw > 0.0 ? (totW - fw) / (totW - sw) : 0.0;
+		float redFac = totW - sw > EPSILON ? (totW - fw) / (totW - sw) : 0.0;
 		for (unsigned int bi = 1; bi < nBones; ++bi) {
 			auto owi = ts.boneWeights[bi].weights.find(i);
 			if (owi == ts.boneWeights[bi].weights.end()) continue;

--- a/src/components/TweakBrush.h
+++ b/src/components/TweakBrush.h
@@ -382,7 +382,7 @@ public:
 	float hcAlpha;				// Blending constants.
 	float hcBeta;
 
-	void lapFilter(mesh* refmesh, const int* points, int nPoints, std::unordered_map<int, float>& wv, TweakState &ts);
+	void lapFilter(mesh* refmesh, const int* points, int nPoints, std::unordered_map<int, float>& wv);
 	void hclapFilter(mesh* refmesh, const int* points, int nPoints, std::unordered_map<int, float>& wv, TweakState &ts);
 
 	TB_SmoothWeight();

--- a/src/components/TweakBrush.h
+++ b/src/components/TweakBrush.h
@@ -73,9 +73,19 @@ enum TweakBrushType {
 	TBT_XFORM
 };
 
+struct TweakVertexWeight {
+	float startVal, endVal;
+};
+
+struct TweakBoneWeights {
+	std::string boneName;
+	std::unordered_map<ushort, TweakVertexWeight> weights;
+};
+
 struct TweakState {
 	std::unordered_map<int, Vector3> pointStartState;
 	std::unordered_map<int, Vector3> pointEndState;
+	std::vector<TweakBoneWeights> boneWeights;
 	std::shared_ptr<AABBTree> startBVH;
 	std::shared_ptr<AABBTree> endBVH;
 	std::unordered_set<AABBTree::AABBTreeNode*> affectedNodes;
@@ -196,6 +206,7 @@ public:
 	// Standard falloff function, used by most brushes
 	// y = (cos((pi/2)*x) * sqrt(cos((pi/2)*x))) ^ focus
 	// Focus values between 0 and 1 give a spherical curve, values over 1 give a peaked curve.
+	virtual float getFalloff(float dist);
 	virtual void applyFalloff(Vector3& deltaVec, float dist);
 
 	// Get the list of points, facets and BVH nodes within the brush sphere of influence.
@@ -233,8 +244,6 @@ public:
 
 class TB_SmoothMask : public TweakBrush {
 public:
-	std::string refBone;
-	int iterations;
 	byte method;				// 0 for laplacian, 1 for HC-Smooth.
 	float hcAlpha;				// Blending constants.
 	float hcBeta;
@@ -258,9 +267,7 @@ public:
 
 
 // Smooth brush implementing a laplacian smooth function with HC-Smooth modifier.
-// Default is 2 iterations but can be configured for more or less.
 class TB_Smooth : public TweakBrush {
-	int iterations;
 	byte method;				// 0 for laplacian, 1 for HC-Smooth.
 	float hcAlpha;				// Blending constants.
 	float hcBeta;
@@ -339,10 +346,14 @@ public:
 	}
 };
 
+class AnimInfo;
+
 class TB_Weight : public TweakBrush {
 public:
-	std::string refBone;
 	bool bFixedWeight;
+	AnimInfo *animInfo;
+	// boneNames: first is bone being edited; rest are balance
+	std::vector<std::string> boneNames;
 
 	TB_Weight();
 	virtual ~TB_Weight();
@@ -352,7 +363,9 @@ public:
 
 class TB_Unweight : public TweakBrush {
 public:
-	std::string refBone;
+	AnimInfo *animInfo;
+	// boneNames: first is bone being edited; rest are balance
+	std::vector<std::string> boneNames;
 
 	TB_Unweight();
 	virtual ~TB_Unweight();
@@ -362,14 +375,15 @@ public:
 
 class TB_SmoothWeight : public TweakBrush {
 public:
-	std::string refBone;
-	int iterations;
+	AnimInfo *animInfo;
+	// boneNames: first is bone being edited; rest are balance
+	std::vector<std::string> boneNames;
 	byte method;				// 0 for laplacian, 1 for HC-Smooth.
 	float hcAlpha;				// Blending constants.
 	float hcBeta;
 
-	void lapFilter(mesh* refmesh, const int* points, int nPoints, std::unordered_map<int, Vector3>& wv);
-	void hclapFilter(mesh* refmesh, const int* points, int nPoints, std::unordered_map<int, Vector3>& wv, TweakState &ts);
+	void lapFilter(mesh* refmesh, const int* points, int nPoints, std::unordered_map<int, float>& wv, TweakState &ts);
+	void hclapFilter(mesh* refmesh, const int* points, int nPoints, std::unordered_map<int, float>& wv, TweakState &ts);
 
 	TB_SmoothWeight();
 	virtual ~TB_SmoothWeight();


### PR DESCRIPTION
Added weight-balancing to weight brushes
    
This is the first of a sequence of changes to add automatic weight balancing to Outfit Studio.  This change just affects the three weight brushes.  With this change, the weights for the bones on a vertex will be maintained to have more or less the same sum as they did before.
    
A lot of the changes in this commit are designed to support the next changes, which will add balance-bone selection to the GUI.

Please let me know if you'd prefer that I do one huge pull request for all of the weight-balancing stuff rather than doing it incrementally like this.  I thought you would prefer finer control and feedback as I add features one by one.