### PR TITLE
Renamed and split undo classes from TweakBrush

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(OSsources
 	${commonsources}
 	src/components/RefTemplates.cpp
 	src/components/TweakBrush.cpp
+	src/components/UndoHistory.cpp
 	src/files/FBXWrangler.cpp
 	src/program/EditUV.cpp
 	src/program/FBXImportDialog.cpp

--- a/OutfitStudio.vcxproj
+++ b/OutfitStudio.vcxproj
@@ -751,6 +751,8 @@
     <ClInclude Include="src\components\SliderPresets.h" />
     <ClInclude Include="src\components\SliderSet.h" />
     <ClInclude Include="src\components\TweakBrush.h" />
+    <ClInclude Include="src\components\UndoState.h" />
+    <ClInclude Include="src\components\UndoHistory.h" />
     <ClInclude Include="src\files\FBXWrangler.h" />
     <ClInclude Include="src\files\MaterialFile.h" />
     <ClInclude Include="src\files\ObjFile.h" />
@@ -817,6 +819,7 @@
     <ClCompile Include="src\components\SliderPresets.cpp" />
     <ClCompile Include="src\components\SliderSet.cpp" />
     <ClCompile Include="src\components\TweakBrush.cpp" />
+    <ClCompile Include="src\components\UndoHistory.cpp" />
     <ClCompile Include="src\files\FBXWrangler.cpp" />
     <ClCompile Include="src\files\MaterialFile.cpp" />
     <ClCompile Include="src\files\ObjFile.cpp" />

--- a/OutfitStudio.vcxproj.filters
+++ b/OutfitStudio.vcxproj.filters
@@ -691,6 +691,12 @@
     <ClInclude Include="src\components\TweakBrush.h">
       <Filter>Components</Filter>
     </ClInclude>
+    <ClInclude Include="src\components\UndoState.h">
+      <Filter>Components</Filter>
+    </ClInclude>
+    <ClInclude Include="src\components\UndoHistory.h">
+      <Filter>Components</Filter>
+    </ClInclude>
     <ClInclude Include="src\components\Automorph.h">
       <Filter>Components</Filter>
     </ClInclude>
@@ -1825,6 +1831,9 @@
       <Filter>Components</Filter>
     </ClCompile>
     <ClCompile Include="src\components\TweakBrush.cpp">
+      <Filter>Components</Filter>
+    </ClCompile>
+    <ClCompile Include="src\components\UndoHistory.cpp">
       <Filter>Components</Filter>
     </ClCompile>
     <ClCompile Include="src\components\Automorph.cpp">

--- a/src/components/UndoHistory.cpp
+++ b/src/components/UndoHistory.cpp
@@ -1,0 +1,40 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#include "UndoHistory.h"
+#include "UndoState.h"
+
+void UndoHistory::ClearHistory() {
+	states.clear();
+	curIndex = -1;
+}
+
+UndoStateProject *UndoHistory::PushState(std::unique_ptr<UndoStateProject> uspp) {
+	int nStrokes = states.size();
+	if (curIndex + 1 < nStrokes)
+		states.resize(curIndex + 1);
+	else if (nStrokes == UH_MAX_UNDO)
+		states.erase(states.begin());
+	states.push_back(std::move(uspp));
+	curIndex = states.size() - 1;
+	return states.back().get();
+}
+
+bool UndoHistory::BackStepHistory() {
+	if (curIndex > -1) {
+		curIndex--;
+		return true;
+	}
+	return false;
+}
+
+bool UndoHistory::ForwardStepHistory() {
+	int nStrokes = states.size();
+	if (curIndex < nStrokes - 1) {
+		++curIndex;
+		return true;
+	}
+	return false;
+}

--- a/src/components/UndoHistory.h
+++ b/src/components/UndoHistory.h
@@ -1,0 +1,36 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#pragma once
+
+#include <vector>
+#include <memory>
+
+class UndoStateProject;
+
+class UndoHistory {
+	static constexpr int UH_MAX_UNDO = 40;
+
+	int curIndex = -1;
+	std::vector<std::unique_ptr<UndoStateProject>> states;
+
+public:
+	UndoStateProject *PushState(std::unique_ptr<UndoStateProject> uspp = std::make_unique<UndoStateProject>());
+	bool BackStepHistory();
+	bool ForwardStepHistory();
+	void ClearHistory();
+
+	UndoStateProject *GetCurState() {
+		if (curIndex == -1)
+			return nullptr;
+		return states[curIndex].get();
+	}
+
+	UndoStateProject *GetNextState() {
+		if (curIndex + 1 >= static_cast<int>(states.size()))
+			return nullptr;
+		return states[curIndex + 1].get();
+	}
+};

--- a/src/components/UndoHistory.h
+++ b/src/components/UndoHistory.h
@@ -8,7 +8,7 @@ See the included LICENSE file
 #include <vector>
 #include <memory>
 
-class UndoStateProject;
+struct UndoStateProject;
 
 class UndoHistory {
 	static constexpr int UH_MAX_UNDO = 40;

--- a/src/components/UndoState.h
+++ b/src/components/UndoState.h
@@ -1,0 +1,56 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#pragma once
+
+#include "../utils/AABBTree.h"
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <unordered_set>
+#include <memory>
+
+class mesh;
+
+enum UndoType {
+	UT_VERTPOS,
+	UT_MASK,
+	UT_WEIGHT,
+	UT_COLOR,
+	UT_ALPHA
+};
+
+struct UndoStateVertexWeight {
+	float startVal, endVal;
+};
+
+struct UndoStateBoneWeights {
+	std::string boneName;
+	std::unordered_map<ushort, UndoStateVertexWeight> weights;
+};
+
+struct UndoStateShape {
+	// pointStartState and pointEndState are only meaningful for not UT_WEIGHT.
+	// For UT_MASK and UT_ALPHA, only the x coordinate is meaningful.
+	std::unordered_map<int, Vector3> pointStartState;
+	std::unordered_map<int, Vector3> pointEndState;
+	// boneWeights is only meaningful for UT_WEIGHT.  Index 0 is the selected
+	// bone and all others are normalize bones.
+	std::vector<UndoStateBoneWeights> boneWeights;
+	// startBVH, endBVH, and affectedNodes are only meaningful for UT_VERTPOS
+	std::shared_ptr<AABBTree> startBVH;
+	std::shared_ptr<AABBTree> endBVH;
+	std::unordered_set<AABBTree::AABBTreeNode*> affectedNodes;
+};
+
+struct UndoStateProject {
+	UndoType undoType;
+	std::unordered_map<mesh*, UndoStateShape> usss;
+	// if undoType is UT_VERTPOS and sliderName is not empty, this is
+	// a slider shape edit rather than a base shape edit.
+	std::string sliderName;
+	// sliderscale is only set if this is a slider shape edit.  Non-zero.
+	float sliderscale;
+};

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "../ui/wxStateButton.h"
 #include "../render/GLSurface.h"
 #include "../components/TweakBrush.h"
+#include "../components/UndoHistory.h"
 #include "../components/Automorph.h"
 #include "../components/RefTemplates.h"
 #include "../utils/Log.h"
@@ -149,8 +150,8 @@ public:
 	void SetActiveShapes(const std::vector<std::string>& shapeNames);
 	void SetSelectedShape(const std::string& shapeName);
 
-	TweakUndo* GetStrokeManager() {
-		return &strokeManager;
+	UndoHistory* GetUndoHistory() {
+		return &undoHistory;
 	}
 
 	void SetActiveBrush(int brushID);
@@ -176,7 +177,8 @@ public:
 
 	bool SelectVertex(const wxPoint& screenPos);
 
-	bool RestoreMode(TweakStateHolder *curState);
+	bool RestoreMode(UndoStateProject *usp);
+	void ApplyUndoState(UndoStateProject *usp, bool bUndo);
 	bool UndoStroke();
 	bool RedoStroke();
 
@@ -646,8 +648,8 @@ private:
 	TB_Unalpha unalphaBrush;
 	TB_XForm translateBrush;
 
-	TweakStroke* activeStroke;
-	TweakUndo strokeManager;
+	std::unique_ptr<TweakStroke> activeStroke;
+	UndoHistory undoHistory;
 
 	mesh* XMoveMesh = nullptr;
 	mesh* YMoveMesh = nullptr;
@@ -784,7 +786,7 @@ public:
 
 	void UpdateShapeSource(NiShape* shape);
 
-	void ActiveShapesUpdated(TweakStateHolder *tsh, bool bIsUndo = false);
+	void ActiveShapesUpdated(UndoStateProject *usp, bool bIsUndo = false);
 	void UpdateActiveShapeUI();
 	void HighlightBoneNamesWithWeights();
 	void GetNormalizeBones(std::vector<std::string> *normBones, std::vector<std::string> *notNormBones);


### PR DESCRIPTION
I renamed the following classes:
TweakVertexWeight -> UndoStateVertexWeight
TweakBoneWeights -> UndoStateBoneWeights
TweakState -> UndoStateShape
TweakStateHolder -> UndoStateProject
TweakUndo -> UndoHistory

UndoHistory was moved into UndoHistory.h and UndoHistory.cpp.  The rest were moved into UndoState.h.

I also renamed all of the functions in UndoHistory and most instances of variables of any of these types.

Keeping track of TweakStroke objects was moved from TweakUndo into wxGLPanel.  Now there is only ever one TweakStroke object.  I left the constant re-allocation of this object in place; perhaps it should just be re-initialized instead of re-allocated.

The state-applying functionality of TweakStateHolder::RestoreStartState, TweakStateHolder::RestoreEndState, TweakUndo::backStroke, TweakUndo::forwardStroke, wxGLPanel::UndoStroke, and wxGLPanel::RedoStroke was consolidated into one function, wxGLPanel::ApplyUndoState.  I tried not to change what this code does in any way, but the process was fairly messy, so I could easily have made a mistake.  Hopefully the result is much simpler and more maintainable.  Plus, it may be convenient to call ApplyUndoState from other places in the future.

Probably eventually UndoStateProject should be made polymorphic, but I feel Outfit Studio's project data model should be cleaned up first, probably including major changes to UndoStateProject since its purpose is to record changes to the project data.