### PR TITLE
Split bone weight auto-normalize code out of TweakBrush.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ set(OSsources
 	src/components/RefTemplates.cpp
 	src/components/TweakBrush.cpp
 	src/components/UndoHistory.cpp
+	src/components/WeightNorm.cpp
 	src/files/FBXWrangler.cpp
 	src/program/EditUV.cpp
 	src/program/FBXImportDialog.cpp

--- a/OutfitStudio.vcxproj
+++ b/OutfitStudio.vcxproj
@@ -753,6 +753,7 @@
     <ClInclude Include="src\components\TweakBrush.h" />
     <ClInclude Include="src\components\UndoState.h" />
     <ClInclude Include="src\components\UndoHistory.h" />
+    <ClInclude Include="src\components\WeightNorm.h" />
     <ClInclude Include="src\files\FBXWrangler.h" />
     <ClInclude Include="src\files\MaterialFile.h" />
     <ClInclude Include="src\files\ObjFile.h" />
@@ -820,6 +821,7 @@
     <ClCompile Include="src\components\SliderSet.cpp" />
     <ClCompile Include="src\components\TweakBrush.cpp" />
     <ClCompile Include="src\components\UndoHistory.cpp" />
+    <ClCompile Include="src\components\WeightNorm.cpp" />
     <ClCompile Include="src\files\FBXWrangler.cpp" />
     <ClCompile Include="src\files\MaterialFile.cpp" />
     <ClCompile Include="src\files\ObjFile.cpp" />

--- a/OutfitStudio.vcxproj.filters
+++ b/OutfitStudio.vcxproj.filters
@@ -697,6 +697,9 @@
     <ClInclude Include="src\components\UndoHistory.h">
       <Filter>Components</Filter>
     </ClInclude>
+    <ClInclude Include="src\components\WeightNorm.h">
+      <Filter>Components</Filter>
+    </ClInclude>
     <ClInclude Include="src\components\Automorph.h">
       <Filter>Components</Filter>
     </ClInclude>
@@ -1834,6 +1837,9 @@
       <Filter>Components</Filter>
     </ClCompile>
     <ClCompile Include="src\components\UndoHistory.cpp">
+      <Filter>Components</Filter>
+    </ClCompile>
+    <ClCompile Include="src\components\WeightNorm.cpp">
       <Filter>Components</Filter>
     </ClCompile>
     <ClCompile Include="src\components\Automorph.cpp">

--- a/src/components/WeightNorm.cpp
+++ b/src/components/WeightNorm.cpp
@@ -1,0 +1,104 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#include "WeightNorm.h"
+#include "Anim.h"
+
+void BoneWeightAutoNormalizer::SetUp(UndoStateShape *ussi, AnimInfo *animInfo, const std::string &shapeName, const std::vector<std::string> &boneNames, const std::vector<std::string> &lockedBoneNames, bool bSprWt) {
+	uss = ussi;
+	wPtrs.clear();
+	lWPtrs.clear();
+	bSpreadWeight = bSprWt;
+
+	const unsigned int nBones = boneNames.size();
+	const unsigned int nLBones = lockedBoneNames.size();
+	// Create uss->boneWeights if necessary
+	if (uss->boneWeights.size() != nBones) {
+		uss->boneWeights.resize(nBones);
+		for (unsigned int bi = 0; bi < nBones; ++bi)
+			uss->boneWeights[bi].boneName = boneNames[bi];
+	}
+	// Stash weights pointers so we don't look them up over and over.
+	wPtrs.resize(nBones);
+	lWPtrs.resize(nLBones);
+	for (unsigned int bi = 0; bi < nBones; ++bi)
+		wPtrs[bi] = animInfo->GetWeightsPtr(shapeName, boneNames[bi]);
+	for (unsigned int bi = 0; bi < nLBones; ++bi)
+		lWPtrs[bi] = animInfo->GetWeightsPtr(shapeName, lockedBoneNames[bi]);
+}
+
+void BoneWeightAutoNormalizer::GrabStartingWeights(const int *points, int nPoints) {
+	const unsigned int nBones = wPtrs.size();
+	// Fill in uss start and end values for vertices that don't have them yet
+	for (int pi = 0; pi < nPoints; pi++) {
+		int i = points[pi];
+		for (unsigned int bi = 0; bi < nBones; ++bi) {
+			auto &bw = uss->boneWeights[bi].weights;
+			if (bw.find(i) == bw.end()) {
+				float val = 0.0;
+				if (wPtrs[bi] && wPtrs[bi]->find(i) != wPtrs[bi]->end())
+					val = (*wPtrs[bi])[i];
+				if (val > 0.0 || bi == 0)
+					bw[i].startVal = bw[i].endVal = val;
+			}
+		}
+	}
+}
+
+float BoneWeightAutoNormalizer::SetWeight(int bonInd, int vInd, float w) {
+	const unsigned int nBones = wPtrs.size();
+	const unsigned int nLBones = lWPtrs.size();
+	// Calculate total locked and normalizable weight
+	float totW = 0.0;
+	for (unsigned int bi = 0; bi < nBones; ++bi) {
+		if (bi == bonInd) continue;
+		auto &bw = uss->boneWeights[bi].weights;
+		if (bw.find(vInd) != bw.end())
+			totW += bw[vInd].endVal;
+	}
+	float totLW = 0.0;
+	for (unsigned int bi = 0; bi < nLBones; ++bi) {
+		if (!lWPtrs[bi]) continue;
+		auto wpit = lWPtrs[bi]->find(vInd);
+		if (wpit != lWPtrs[bi]->end())
+			totLW += wpit->second;
+	}
+	// Calculate available weight
+	if (totLW < WEIGHT_EPSILON) totLW = 0.0;
+	float availW = 1.0 - totLW;
+	if (availW < WEIGHT_EPSILON) availW = 0.0;
+	// Limit result
+	if (w < WEIGHT_EPSILON) w = 0.0;
+	if (w > availW) w = availW;
+	if (w - 1.0 > -WEIGHT_EPSILON) w = 1.0;
+	uss->boneWeights[bonInd].weights[vInd].endVal = w;
+	// Normalize
+	float redFac = totW <= WEIGHT_EPSILON ? 0.0 : (availW - w) / totW;
+	totW = 0.0;
+	for (unsigned int bi = 0; bi < nBones; ++bi) {
+		if (bi == bonInd) continue;
+		auto owi = uss->boneWeights[bi].weights.find(vInd);
+		if (owi == uss->boneWeights[bi].weights.end()) continue;
+		float &ow = owi->second.endVal;
+		ow *= redFac;
+		if (ow < WEIGHT_EPSILON) ow = 0.0;
+		if (ow - 1.0 > -WEIGHT_EPSILON) ow = 1.0;
+		totW += ow;
+	}
+	// Check if normalization didn't work; if so, split the missing
+	// weight among the normalize bones.
+	if (1.0 - totW - w - totLW > WEIGHT_EPSILON && nBones >= 2 && bSpreadWeight) {
+		float remainW = (1.0 - totW - w - totLW) / (nBones - 1);
+		for (unsigned int bi = 0; bi < nBones; ++bi) {
+			if (bi == bonInd) continue;
+			auto &bw = uss->boneWeights[bi].weights;
+			auto owi = bw.find(vInd);
+			if (owi == bw.end())
+				bw[vInd].startVal = bw[vInd].endVal = 0.0;
+			bw[vInd].endVal += remainW;
+		}
+	}
+	return w;
+}

--- a/src/components/WeightNorm.h
+++ b/src/components/WeightNorm.h
@@ -1,0 +1,53 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#pragma once
+
+#include "UndoState.h"
+
+class AnimInfo;
+
+/* BoneWeightAutoNormalizer: this class has the algorithm for automatic
+normalization of bone weights.  The algorithm itself is in SetWeight.
+The rest is setup.
+
+The algorithm adjusts the weights of the normalize bones to follow the
+following rules, from highest to lowest priority:
+1.  The locked bones' weights are not changed (and are not even present
+in uss->boneWeights).
+2.  All weights must be between zero and one.
+4.  The sum of the weights is no more than one.
+5.  The specified weight is set.
+6.  If not bSpreadWeight, zero weights are not changed.
+7.  The sum of the weights is at least one.
+
+Note that, while uss->boneWeights is the main output, it can also be
+a source of input, containing the results of previous changes.
+*/
+class BoneWeightAutoNormalizer {
+	static constexpr double WEIGHT_EPSILON = .001;
+	UndoStateShape *uss;
+	std::vector<std::unordered_map<ushort, float>*> wPtrs, lWPtrs;
+	bool bSpreadWeight;
+public:
+	/* SetUp: fills in the class's private data.  ussi->boneWeights
+	must either already match boneNames or be empty, in which case
+	it is initialized.  boneNames and lockedBoneNames must not have any
+	common names, and together they must include all bones with non-zero
+	weights for the shape.  boneNames is the "normalize bones", the bones
+	whose weights can be adjusted, and must include the bone whose weights
+	will actually be modified.  */
+	void SetUp(UndoStateShape *ussi, AnimInfo *animInfo, const std::string &shapeName, const std::vector<std::string> &boneNames, const std::vector<std::string> &lockedBoneNames, bool bSprWt);
+
+	/* GrabStartingWeights: initializes missing startVal and endVal
+	in uss->boneWeights for normalize bones for the vertices with
+	the given indices by copying weights from animInfo. */
+	void GrabStartingWeights(const int *points, int nPoints);
+
+	/* SetWeight:  sets the weight for the vertex with the given index
+	for the given bone (indexed into boneNames or uss->boneWeights)
+	and normalizes the weights for the vertex.  */
+	float SetWeight(int bonInd, int ptInd, float w);
+};


### PR DESCRIPTION
I extracted the code for normalizing weights automatically out of
TweakBrush.cpp into WeightNorm.{h,cpp}.  This has two benefits:
1.  There's only one copy of the code instead of three, making it
easier to maintain.
2.  The code can be re-used in other weight-modifying algorithms.