### PR TITLE
Made weight copy auto-normalize

### DIFF
--- a/src/components/TweakBrush.cpp
+++ b/src/components/TweakBrush.cpp
@@ -910,7 +910,7 @@ TB_Weight::~TB_Weight() {
 
 void TB_Weight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape &uss) {
 	BoneWeightAutoNormalizer nzer;
-	nzer.SetUp(&uss, animInfo, refmesh->shapeName, boneNames, lockedBoneNames, bSpreadWeight);
+	nzer.SetUp(&uss, animInfo, refmesh->shapeName, boneNames, lockedBoneNames, 1, bSpreadWeight);
 	nzer.GrabStartingWeights(points, nPoints);
 	for (int pi = 0; pi < nPoints; pi++) {
 		int i = points[pi];
@@ -919,7 +919,7 @@ void TB_Weight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* p
 		ew *= getFalloff(pickInfo.origin.DistanceTo(refmesh->verts[i]));
 		ew *= 1.0f - refmesh->vcolors[i].x;
 		float fw = sw + ew;
-		fw = nzer.SetWeight(0, i, fw);
+		fw = nzer.SetWeight(i, fw);
 		refmesh->vcolors[i].y = fw;
 	}
 	refmesh->QueueUpdate(mesh::UpdateType::VertexColors);
@@ -938,7 +938,7 @@ TB_Unweight::~TB_Unweight() {
 
 void TB_Unweight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape &uss) {
 	BoneWeightAutoNormalizer nzer;
-	nzer.SetUp(&uss, animInfo, refmesh->shapeName, boneNames, lockedBoneNames, bSpreadWeight);
+	nzer.SetUp(&uss, animInfo, refmesh->shapeName, boneNames, lockedBoneNames, 1, bSpreadWeight);
 	nzer.GrabStartingWeights(points, nPoints);
 	for (int pi = 0; pi < nPoints; pi++) {
 		int i = points[pi];
@@ -947,7 +947,7 @@ void TB_Unweight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int*
 		ew *= getFalloff(pickInfo.origin.DistanceTo(refmesh->verts[i]));
 		ew *= 1.0f - refmesh->vcolors[i].x;
 		float fw = sw + ew;
-		fw = nzer.SetWeight(0, i, fw);
+		fw = nzer.SetWeight(i, fw);
 		refmesh->vcolors[i].y = fw;
 	}
 	refmesh->QueueUpdate(mesh::UpdateType::VertexColors);
@@ -1036,7 +1036,7 @@ void TB_SmoothWeight::hclapFilter(mesh* refmesh, const int* points, int nPoints,
 
 void TB_SmoothWeight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape &uss) {
 	BoneWeightAutoNormalizer nzer;
-	nzer.SetUp(&uss, animInfo, refmesh->shapeName, boneNames, lockedBoneNames, bSpreadWeight);
+	nzer.SetUp(&uss, animInfo, refmesh->shapeName, boneNames, lockedBoneNames, 1, bSpreadWeight);
 	nzer.GrabStartingWeights(points, nPoints);
 
 	// Copy previous iteration's results into wv
@@ -1058,7 +1058,7 @@ void TB_SmoothWeight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const 
 		ew *= getFalloff(pickInfo.origin.DistanceTo(refmesh->verts[i]));
 		ew *= 1.0f - refmesh->vcolors[i].x;
 		float fw = sw + ew;
-		fw = nzer.SetWeight(0, i, fw);
+		fw = nzer.SetWeight(i, fw);
 		refmesh->vcolors[i].y = fw;
 	}
 	refmesh->QueueUpdate(mesh::UpdateType::VertexColors);

--- a/src/components/WeightNorm.h
+++ b/src/components/WeightNorm.h
@@ -9,9 +9,9 @@ See the included LICENSE file
 
 class AnimInfo;
 
-/* BoneWeightAutoNormalizer: this class has the algorithm for automatic
-normalization of bone weights.  The algorithm itself is in SetWeight.
-The rest is setup.
+/* BoneWeightAutoNormalizer: this class has the algorithm for
+automatic normalization of bone weights.  The algorithm itself is
+in AdjustWeights.  The rest is setup.
 
 The algorithm adjusts the weights of the normalize bones to follow the
 following rules, from highest to lowest priority:
@@ -19,9 +19,11 @@ following rules, from highest to lowest priority:
 in uss->boneWeights).
 2.  All weights must be between zero and one.
 4.  The sum of the weights is no more than one.
-5.  The specified weight is set.
+5.  The specified weights are set.
 6.  If not bSpreadWeight, zero weights are not changed.
 7.  The sum of the weights is at least one.
+8.  Weights are multiplied by a scale factor if nonzero; an amount
+is added to each if zero.
 
 Note that, while uss->boneWeights is the main output, it can also be
 a source of input, containing the results of previous changes.
@@ -30,24 +32,40 @@ class BoneWeightAutoNormalizer {
 	static constexpr double WEIGHT_EPSILON = .001;
 	UndoStateShape *uss;
 	std::vector<std::unordered_map<ushort, float>*> wPtrs, lWPtrs;
+	int nMBones;
 	bool bSpreadWeight;
 public:
 	/* SetUp: fills in the class's private data.  ussi->boneWeights
 	must either already match boneNames or be empty, in which case
-	it is initialized.  boneNames and lockedBoneNames must not have any
-	common names, and together they must include all bones with non-zero
-	weights for the shape.  boneNames is the "normalize bones", the bones
-	whose weights can be adjusted, and must include the bone whose weights
-	will actually be modified.  */
-	void SetUp(UndoStateShape *ussi, AnimInfo *animInfo, const std::string &shapeName, const std::vector<std::string> &boneNames, const std::vector<std::string> &lockedBoneNames, bool bSprWt);
+	it is initialized.  boneNames and lockedBoneNames must not have
+	any common names, and together they must include all bones with
+	non-zero weights for the shape.  boneNames is the "normalize
+	bones", the bones whose weights can be adjusted, and must start
+	with the bones whose weights will actually be modified; the number
+	of these modified bones is nMBones.  */
+	void SetUp(UndoStateShape *ussi, AnimInfo *animInfo, const std::string &shapeName, const std::vector<std::string> &boneNames, const std::vector<std::string> &lockedBoneNames, int nMBones, bool bSprWt);
 
-	/* GrabStartingWeights: initializes missing startVal and endVal
-	in uss->boneWeights for normalize bones for the vertices with
-	the given indices by copying weights from animInfo. */
+	/* GrabOneVertexStartingWeights: initializes missing startVal
+	and endVal in uss->boneweights for normalize bones for the vertex
+	with the given index by copying weights from animInfo.  For
+	bones with index >= nMBones, only nonzero weights are copied. */
+	void GrabOneVertexStartingWeights(int ptInd);
+
+	/* GrabStartingWeights: calls GrabOneVertexStartingWeights for
+	the given vertex indices. */
 	void GrabStartingWeights(const int *points, int nPoints);
 
-	/* SetWeight:  sets the weight for the vertex with the given index
-	for the given bone (indexed into boneNames or uss->boneWeights)
-	and normalizes the weights for the vertex.  */
-	float SetWeight(int bonInd, int ptInd, float w);
+	/* AdjustWeights: normalizes the weights for the vertex, preferring
+	to adjust weights for bones with index >= nMBones (the unmodified
+	but normalizable bones) before those with index < nBones (the
+	modified bones).  Note that only weight data in uss is accessed
+	for unlocked bones, so you must ensure that all necessary data
+	is grabbed first. */
+	void AdjustWeights(int ptInd);
+
+	/* SetWeight: sets the weight for the vertex with the given
+	index for bone 0 (indexed into boneNames or uss->boneWeights) and
+	normalizes the weights for the vertex (by calling AdjustWeights).
+	Returns the adjusted w. */
+	float SetWeight(int ptInd, float w);
 };

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -13,7 +13,7 @@ See the included LICENSE file
 #include <wx/arrstr.h>
 
 class OutfitStudioFrame;
-class UndoStateShape;
+struct UndoStateShape;
 
 class OutfitProject {
 	OutfitStudioFrame* owner = nullptr;

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -13,6 +13,7 @@ See the included LICENSE file
 #include <wx/arrstr.h>
 
 class OutfitStudioFrame;
+class UndoStateShape;
 
 class OutfitProject {
 	OutfitStudioFrame* owner = nullptr;
@@ -158,11 +159,12 @@ public:
 	void ScaleShape(NiShape* shape, const Vector3& scale, std::unordered_map<ushort, float>* mask = nullptr);
 	void RotateShape(NiShape* shape, const Vector3& angle, std::unordered_map<ushort, float>* mask = nullptr);
 
+	bool AddShapeBoneAndXForm(const std::string &shapeName, const std::string &boneName);
 	// Uses the AutoMorph class to generate proximity values for bone weights.
 	// This is done by creating several virtual sliders that contain weight offsets for each vertex per bone.
 	// These data sets are then temporarily linked to the AutoMorph class and result 'diffs' are generated.
 	// The resulting data is then written back to the outfit shape as the green color channel.
-	void CopyBoneWeights(NiShape* shape, const float proximityRadius, const int maxResults, std::unordered_map<ushort, float>* mask = nullptr, std::vector<std::string>* inBoneList = nullptr);
+	void CopyBoneWeights(NiShape* shape, const float proximityRadius, const int maxResults, std::unordered_map<ushort, float>& mask, const std::vector<std::string>& boneList, int nCopyBones, const std::vector<std::string> &lockedBones, UndoStateShape &uss, bool bSpreadWeight);
 	// Transfers the weights of the selected bones from reference to chosen shape 1:1. Requires same vertex count and order.
 	void TransferSelectedWeights(NiShape* shape, std::unordered_map<ushort, float>* mask = nullptr, std::vector<std::string>* inBoneList = nullptr);
 	bool HasUnweighted(std::vector<std::string>* shapeNames = nullptr);

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -2066,6 +2066,7 @@ void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject *usp, bool bIsUndo)
 				mesh *m = mit.first;
 				for (auto &bw : mit.second.boneWeights) {
 					if (bw.weights.empty()) continue;
+					project->AddShapeBoneAndXForm(m->shapeName, bw.boneName);
 					auto weights = project->GetWorkAnim()->GetWeightsPtr(m->shapeName, bw.boneName);
 					if (!weights) continue;
 					for (auto &p : bw.weights) {
@@ -7808,18 +7809,32 @@ void OutfitStudioFrame::OnCopyBoneWeight(wxCommandEvent& WXUNUSED(event)) {
 	if (ShowWeightCopy(options)) {
 		StartProgress(_("Copying bone weights..."));
 
+		UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+		usp->undoType = UT_WEIGHT;
+		std::vector<std::string> baseBones = project->GetWorkAnim()->shapeBones[project->GetBaseShape()->GetName()];
+		std::sort(baseBones.begin(), baseBones.end());
 		std::unordered_map<ushort, float> mask;
 		for (int i = 0; i < selectedItems.size(); i++) {
-			if (!project->IsBaseShape(selectedItems[i]->GetShape())) {
-				wxLogMessage("Copying bone weights to '%s'...", selectedItems[i]->GetShape()->GetName());
+			NiShape *shape = selectedItems[i]->GetShape();
+			mesh *m = glView->GetMesh(shape->GetName());
+			if (!m) continue;
+			if (!project->IsBaseShape(shape)) {
+				wxLogMessage("Copying bone weights to '%s'...", shape->GetName());
 				mask.clear();
-				glView->GetShapeMask(mask, selectedItems[i]->GetShape()->GetName());
-				project->CopyBoneWeights(selectedItems[i]->GetShape(), options.proximityRadius, options.maxResults, &mask);
+				glView->GetShapeMask(mask, shape->GetName());
+				std::vector<std::string> bones = project->GetWorkAnim()->shapeBones[shape->GetName()];
+				std::vector<std::string> mergedBones = baseBones;
+				for (auto b : bones)
+					if (!std::binary_search(baseBones.begin(), baseBones.end(), b))
+						mergedBones.push_back(b);
+				std::vector<std::string> lockedBones;
+				project->CopyBoneWeights(shape, options.proximityRadius, options.maxResults, mask, mergedBones, baseBones.size(), lockedBones, usp->usss[m], false);
 			}
 			else
 				wxMessageBox(_("Sorry, you can't copy weights from the reference shape to itself. Skipping this shape."), _("Can't copy weights"), wxICON_WARNING);
 		}
 
+		ActiveShapesUpdated(usp, false);
 		project->morpher.ClearProximityCache();
 		ReselectBone();
 
@@ -7844,7 +7859,7 @@ void OutfitStudioFrame::OnCopySelectedWeight(wxCommandEvent& WXUNUSED(event)) {
 		return;
 	}
 
-	std::vector<std::string> selectedBones;
+	std::vector<std::string> boneList;
 	wxArrayTreeItemIds selItems;
 	outfitBones->GetSelections(selItems);
 	if (selItems.size() < 1)
@@ -7854,25 +7869,49 @@ void OutfitStudioFrame::OnCopySelectedWeight(wxCommandEvent& WXUNUSED(event)) {
 	for (int i = 0; i < selItems.size(); i++) {
 		std::string boneName = outfitBones->GetItemText(selItems[i]).ToStdString();
 		bonesString += "'" + boneName + "' ";
-		selectedBones.push_back(boneName);
+		boneList.push_back(boneName);
+	}
+	std::sort(boneList.begin(), boneList.end());
+	int nSelBones = boneList.size();
+	std::vector<std::string> normBones, notNormBones, lockedBones;
+	GetNormalizeBones(&normBones, &notNormBones);
+	for (auto &bone : normBones)
+		if (!std::binary_search(boneList.begin(), boneList.begin() + nSelBones, bone))
+			boneList.push_back(bone);
+	bool bHasNormBones = static_cast<int>(boneList.size()) > nSelBones;
+	if (bHasNormBones) {
+		for (auto &bone : notNormBones)
+			if (!std::binary_search(boneList.begin(), boneList.begin() + nSelBones, bone))
+				lockedBones.push_back(bone);
+	}
+	else {
+		for (auto &bone : notNormBones)
+			if (!std::binary_search(boneList.begin(), boneList.begin() + nSelBones, bone))
+				boneList.push_back(bone);
 	}
 
 	WeightCopyOptions options;
 	if (ShowWeightCopy(options)) {
 		StartProgress(_("Copying selected bone weights..."));
 
+		UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+		usp->undoType = UT_WEIGHT;
 		std::unordered_map<ushort, float> mask;
 		for (int i = 0; i < selectedItems.size(); i++) {
-			if (!project->IsBaseShape(selectedItems[i]->GetShape())) {
-				wxLogMessage("Copying selected bone weights to '%s' for %s...", selectedItems[i]->GetShape()->GetName(), bonesString);
+			NiShape *shape = selectedItems[i]->GetShape();
+			mesh *m = glView->GetMesh(shape->GetName());
+			if (!m) continue;
+			if (!project->IsBaseShape(shape)) {
+				wxLogMessage("Copying selected bone weights to '%s' for %s...", shape->GetName(), bonesString);
 				mask.clear();
-				glView->GetShapeMask(mask, selectedItems[i]->GetShape()->GetName());
-				project->CopyBoneWeights(selectedItems[i]->GetShape(), options.proximityRadius, options.maxResults, &mask, &selectedBones);
+				glView->GetShapeMask(mask, shape->GetName());
+				project->CopyBoneWeights(shape, options.proximityRadius, options.maxResults, mask, boneList, nSelBones, lockedBones, usp->usss[m], bHasNormBones);
 			}
 			else
 				wxMessageBox(_("Sorry, you can't copy weights from the reference shape to itself. Skipping this shape."), _("Can't copy weights"), wxICON_WARNING);
 		}
 
+		ActiveShapesUpdated(usp, false);
 		project->morpher.ClearProximityCache();
 		ReselectBone();
 


### PR DESCRIPTION
I changed OutfitProject::CopyBoneWeights and the functions that call it
so that bone weights are normalized after being copied.  This affects
the commands "Copy Bone Weights" and "Copy Selected Weights" in the UI.