### PR TITLE
Added x-mirror bone feature

### DIFF
--- a/res/xrc/OutfitStudio.xrc
+++ b/res/xrc/OutfitStudio.xrc
@@ -903,6 +903,32 @@
 														<orient>wxHORIZONTAL</orient>
 														<object class="sizeritem">
 															<option>0</option>
+															<flag>wxALIGN_CENTER</flag>
+															<object class="wxStaticText" name="xMirrorBoneLabel">
+																<fg>#ffffff</fg>
+																<label>X-Mirror Bone: </label>
+																<hidden>1</hidden>
+															</object>
+														</object>
+														<object class="sizeritem">
+															<option>1</option>
+															<flag>wxALL|wxEXPAND</flag>
+															<object class="wxChoice" name="cXMirrorBone">
+																<selection>0</selection>
+																<content />
+																<hidden>1</hidden>
+															</object>
+														</object>
+													</object>
+												</object>
+												<object class="sizeritem">
+													<option>0</option>
+													<flag>wxALL|wxEXPAND</flag>
+													<border>5</border>
+													<object class="wxBoxSizer">
+														<orient>wxHORIZONTAL</orient>
+														<object class="sizeritem">
+															<option>0</option>
 															<object class="wxStaticText" name="boneScaleLabel">
 																<fg>#ffffff</fg>
 																<label>Preview Scaling</label>

--- a/res/xrc/OutfitStudio.xrc
+++ b/res/xrc/OutfitStudio.xrc
@@ -903,10 +903,11 @@
 														<orient>wxHORIZONTAL</orient>
 														<object class="sizeritem">
 															<option>0</option>
-															<flag>wxALIGN_CENTER</flag>
+															<flag>wxRIGHT|wxALIGN_CENTER</flag>
+															<border>15</border>
 															<object class="wxStaticText" name="xMirrorBoneLabel">
 																<fg>#ffffff</fg>
-																<label>X-Mirror Bone: </label>
+																<label>X-Mirror Bone</label>
 																<hidden>1</hidden>
 															</object>
 														</object>
@@ -1070,7 +1071,7 @@
 			<fields>1</fields>
 		</object>
 	</object>
-	
+
 	<object class="wxMenuBar" name="menuBar">
 		<label>Menu</label>
 		<object class="wxMenu" name="menuFile">
@@ -1614,7 +1615,7 @@
 			</object>
 		</object>
 	</object>
-	
+
 	<object class="wxToolBar" name="toolBar">
 		<style>wxTB_HORIZONTAL|wxTB_FLAT</style>
 		<bg>#707070</bg>
@@ -1795,7 +1796,7 @@
 			<bitmap>$(AppDir)\res\images\PayPal.png</bitmap>
 		</object>
 	</object>
-	
+
 	<object class="wxMenu" name="menuMeshContext">
 		<label>Shape</label>
 		<object class="wxMenu" name="menuExportMesh">

--- a/res/xrc/OutfitStudio.xrc
+++ b/res/xrc/OutfitStudio.xrc
@@ -527,7 +527,7 @@
 										<option>0</option>
 										<flag>wxALL|wxEXPAND|wxLEFT</flag>
 										<border>2</border>
-										<object class="wxPanel" name="m_panel6">
+										<object class="wxPanel" name="editPanel">
 											<style>wxTAB_TRAVERSAL</style>
 											<object class="wxBoxSizer">
 												<orient>wxVERTICAL</orient>

--- a/src/components/WeightNorm.h
+++ b/src/components/WeightNorm.h
@@ -58,10 +58,12 @@ public:
 	/* AdjustWeights: normalizes the weights for the vertex, preferring
 	to adjust weights for bones with index >= nMBones (the unmodified
 	but normalizable bones) before those with index < nBones (the
-	modified bones).  Note that only weight data in uss is accessed
-	for unlocked bones, so you must ensure that all necessary data
-	is grabbed first. */
-	void AdjustWeights(int ptInd);
+	modified bones).  If adjFlag is not null, it points to an array
+	of size nMBones, with each array element indicating whether the
+	weight for that bone was adjusted or not.  Note that only weight
+	data in uss is accessed for unlocked bones, so you must ensure
+	that all necessary data is grabbed first. */
+	void AdjustWeights(int ptInd, bool *adjFlag = nullptr);
 
 	/* SetWeight: sets the weight for the vertex with the given
 	index for bone 0 (indexed into boneNames or uss->boneWeights) and

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -2061,7 +2061,7 @@ std::string OutfitStudioFrame::GetXMirrorBone() {
 	else if (xMChoice == 1)
 		return autoXMirrorBone;
 	else
-		return cXMirrorBone->GetString(xMChoice);
+		return cXMirrorBone->GetString(xMChoice).ToStdString();
 }
 
 void OutfitStudioFrame::SelectShape(const std::string& shapeName) {

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -869,7 +869,11 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 		lightDirectional2Slider->SetValue(directional2);
 	}
 
+	wxPanel* m_panel6 = (wxPanel*)FindWindowByName("m_panel6");
+	m_panel6->SetBackgroundColour(wxColour(112, 112, 112));
+
 	boneScale = (wxSlider*)FindWindowByName("boneScale");
+	cXMirrorBone = (wxChoice*)FindWindowByName("cXMirrorBone");
 
 	wxWindow* leftPanel = FindWindowByName("leftSplitPanel");
 	if (leftPanel) {
@@ -2011,6 +2015,55 @@ std::vector<std::string> OutfitStudioFrame::GetSelectedBones() {
 	return boneList;
 }
 
+void OutfitStudioFrame::CalcAutoXMirrorBone() {
+	autoXMirrorBone.clear();
+	const unsigned int abLen = activeBone.length();
+	std::vector<std::string> bones;
+	project->GetActiveBones(bones);
+	int bestFlips = 0;
+	for (const std::string &b : bones) {
+		if (abLen != b.length()) continue;
+		int flips = 0;
+		bool nomatch = false;
+		for (unsigned int i = 0; i < abLen && !nomatch; ++i) {
+			char abc = tolower(activeBone[i]);
+			char bc = tolower(b[i]);
+			if (abc == 'l') {
+				if (bc == 'r')
+					++flips;
+				else if (bc != abc)
+					nomatch = true;
+			}
+			else if (abc == 'r') {
+				if (bc == 'l')
+					++flips;
+				else if (bc != abc)
+					nomatch = true;
+			}
+			else
+				nomatch = bc != abc;
+		}
+		if (nomatch) continue;
+		if (flips <= bestFlips) continue;
+		bestFlips = flips;
+		autoXMirrorBone = b;
+	}
+	if (autoXMirrorBone.empty())
+		cXMirrorBone->SetString(1, "Auto: None");
+	else
+		cXMirrorBone->SetString(1, "Auto: " + autoXMirrorBone);
+}
+
+std::string OutfitStudioFrame::GetXMirrorBone() {
+	int xMChoice = cXMirrorBone->GetSelection();
+	if (xMChoice == 0)
+		return std::string();
+	else if (xMChoice == 1)
+		return autoXMirrorBone;
+	else
+		return cXMirrorBone->GetString(xMChoice);
+}
+
 void OutfitStudioFrame::SelectShape(const std::string& shapeName) {
 	wxTreeItemId item;
 	wxTreeItemId subitem;
@@ -2814,18 +2867,26 @@ void OutfitStudioFrame::RefreshGUIFromProj() {
 }
 
 void OutfitStudioFrame::AnimationGUIFromProj() {
-	// Preserve selected and normalize bones
+	// Preserve selected, normalize, and x-mirror bones
 	std::vector<std::string> selBones = GetSelectedBones();
 	std::vector<std::string> normBones;
 	GetNormalizeBones(&normBones, nullptr);
 	std::unordered_set<std::string> normBonesS{normBones.begin(), normBones.end()};
 	std::unordered_set<std::string> selBonesS{selBones.begin(), selBones.end()};
+	int xMChoice = cXMirrorBone->GetSelection();
+	std::string ManualXMirrorBone;
+	if (xMChoice >= 2)
+		ManualXMirrorBone = cXMirrorBone->GetString(xMChoice);
 
 	// Clear GUI's bone list
 	if (outfitBones->GetChildrenCount(bonesRoot) > 0)
 		outfitBones->DeleteChildren(bonesRoot);
-	if (selBonesS.count(activeBone) != 0)
+	if (selBonesS.count(activeBone) == 0)
 		activeBone.clear();
+	cXMirrorBone->Clear();
+	cXMirrorBone->AppendString("None");
+	cXMirrorBone->AppendString("Auto");
+	cXMirrorBone->SetSelection(xMChoice == 1 ? 1 : 0);
 
 	// Refill GUI's bone list, re-setting normalize flags and re-selecting
 	std::vector<std::string> activeBones;
@@ -2840,8 +2901,12 @@ void OutfitStudioFrame::AnimationGUIFromProj() {
 			if (activeBone.empty())
 				activeBone = bone;
 		}
+		cXMirrorBone->AppendString(bone);
+		if (xMChoice >= 2 && bone == ManualXMirrorBone)
+			cXMirrorBone->SetSelection(cXMirrorBone->GetCount()-1);
 	}
 	recursingUI = saveRUI;
+	CalcAutoXMirrorBone();
 
 	HighlightBoneNamesWithWeights();
 	RefreshGUIWeightColors();
@@ -3896,6 +3961,7 @@ void OutfitStudioFrame::OnBoneSelect(wxTreeEvent& event) {
 		activeBone = outfitBones->GetItemText(item);
 
 	RefreshGUIWeightColors();
+	CalcAutoXMirrorBone();
 }
 
 void OutfitStudioFrame::OnCheckTreeSel(wxTreeEvent& event) {
@@ -5453,12 +5519,15 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 
 	if (id != XRCID("boneTabButton")) {
 		boneScale->Show(false);
+		cXMirrorBone->Show(false);
 
 		wxStaticText* boneScaleLabel = (wxStaticText*)FindWindowByName("boneScaleLabel");
 		wxCheckBox* cbFixedWeight = (wxCheckBox*)FindWindowByName("cbFixedWeight");
+		wxStaticText* xMirrorBoneLabel = (wxStaticText*)FindWindowByName("xMirrorBoneLabel");
 
 		boneScaleLabel->Show(false);
 		cbFixedWeight->Show(false);
+		xMirrorBoneLabel->Show(false);
 
 		project->ClearBoneScale();
 
@@ -5574,12 +5643,15 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 
 		boneScale->SetValue(0);
 		boneScale->Show();
+		cXMirrorBone->Show();
 		
 		wxStaticText* boneScaleLabel = (wxStaticText*)FindWindowByName("boneScaleLabel");
 		wxCheckBox* cbFixedWeight = (wxCheckBox*)FindWindowByName("cbFixedWeight");
+		wxStaticText* xMirrorBoneLabel = (wxStaticText*)FindWindowByName("xMirrorBoneLabel");
 
 		boneScaleLabel->Show();
 		cbFixedWeight->Show();
+		xMirrorBoneLabel->Show();
 		
 		glView->SetTransformMode(false);
 		glView->SetActiveBrush(10);
@@ -7747,6 +7819,7 @@ void OutfitStudioFrame::OnDeleteBone(wxCommandEvent& WXUNUSED(event)) {
 	}
 
 	ReselectBone();
+	CalcAutoXMirrorBone();
 	glView->GetUndoHistory()->ClearHistory();
 }
 
@@ -8564,19 +8637,24 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 		std::vector<std::string> normBones, notNormBones, brushBones, lockedBones;
 		os->GetNormalizeBones(&normBones, &notNormBones);
 		std::string activeBone = os->GetActiveBone();
+		std::string xMirrorBone = os->GetXMirrorBone();
 		brushBones.push_back(activeBone);
+		if (!xMirrorBone.empty())
+			brushBones.push_back(xMirrorBone);
+		bool bHasNormBones = false;
 		for (auto &bone : normBones)
-			if (bone != activeBone)
+			if (bone != activeBone && bone != xMirrorBone) {
 				brushBones.push_back(bone);
-		bool bHasNormBones = brushBones.size() > 1;
+				bHasNormBones = true;
+			}
 		if (bHasNormBones) {
 			for (auto &bone : notNormBones)
-				if (bone != activeBone)
+				if (bone != activeBone && bone != xMirrorBone)
 					lockedBones.push_back(bone);
 		}
 		else {
 			for (auto &bone : notNormBones)
-				if (bone != activeBone)
+				if (bone != activeBone && bone != xMirrorBone)
 					brushBones.push_back(bone);
 		}
 		if (wxGetKeyState(WXK_ALT)) {
@@ -8584,6 +8662,7 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 			unweightBrush.boneNames = brushBones;
 			unweightBrush.lockedBoneNames = lockedBones;
 			unweightBrush.bSpreadWeight = bHasNormBones;
+			unweightBrush.bXMirrorBone = !xMirrorBone.empty();
 			unweightBrush.setStrength(-weightBrush.getStrength());
 			activeBrush = &unweightBrush;
 		}
@@ -8592,6 +8671,7 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 			smoothWeightBrush.boneNames = brushBones;
 			smoothWeightBrush.lockedBoneNames = lockedBones;
 			smoothWeightBrush.bSpreadWeight = bHasNormBones;
+			smoothWeightBrush.bXMirrorBone = !xMirrorBone.empty();
 			smoothWeightBrush.setStrength(weightBrush.getStrength() * 15.0f);
 			activeBrush = &smoothWeightBrush;
 		}
@@ -8600,6 +8680,7 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 			weightBrush.boneNames = brushBones;
 			weightBrush.lockedBoneNames = lockedBones;
 			weightBrush.bSpreadWeight = bHasNormBones;
+			weightBrush.bXMirrorBone = !xMirrorBone.empty();
 		}
 	}
 	else if (wxGetKeyState(WXK_ALT) && !segmentMode) {

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -869,8 +869,9 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 		lightDirectional2Slider->SetValue(directional2);
 	}
 
-	wxPanel* m_panel6 = (wxPanel*)FindWindowByName("m_panel6");
-	m_panel6->SetBackgroundColour(wxColour(112, 112, 112));
+	auto editPanel = (wxPanel*)FindWindowByName("editPanel");
+	if (editPanel)
+		editPanel->SetBackgroundColour(wxColour(112, 112, 112));
 
 	boneScale = (wxSlider*)FindWindowByName("boneScale");
 	cXMirrorBone = (wxChoice*)FindWindowByName("cXMirrorBone");

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -739,6 +739,7 @@ public:
 	wxTreeCtrl* partitionTree;
 	wxPanel* lightSettings;
 	wxSlider* boneScale;
+	wxChoice* cXMirrorBone;
 	wxScrolledWindow* sliderScroll;
 	wxStatusBar* statusBar;
 	wxTreeItemId shapesRoot;
@@ -794,6 +795,8 @@ public:
 	void RefreshGUIWeightColors();
 	void GetNormalizeBones(std::vector<std::string> *normBones, std::vector<std::string> *notNormBones);
 	std::vector<std::string> GetSelectedBones();
+	void CalcAutoXMirrorBone();
+	std::string GetXMirrorBone();
 
 	void ShowSegment(const wxTreeItemId& item = nullptr, bool updateFromMask = false);
 	void UpdateSegmentNames();
@@ -970,6 +973,7 @@ private:
 	std::vector<ShapeItemData*> selectedItems;
 	bool recursingUI = false;
 	std::string activeBone;
+	std::string autoXMirrorBone;
 	wxTreeItemId activeSegment;
 	wxTreeItemId activePartition;
 


### PR DESCRIPTION
Added a GUI element that appears when the bones tab is selected that allows
the user to select an x-mirror bone.  Changes by any of the three brushes
(weight, unweight, smooth weight) are x-mirrored onto the x-mirror bone.
There is also an "Auto" selection for the x-mirror bone.