### PR TITLE
Cleaned up the coordinate-system transform code.

### DIFF
--- a/lib/NIF/NifFile.cpp
+++ b/lib/NIF/NifFile.cpp
@@ -1785,8 +1785,6 @@ int NifFile::GetShapeBoneWeights(NiShape* shape, const int boneIndex, std::unord
 }
 
 bool NifFile::GetShapeTransformGlobalToSkin(NiShape* shape, MatTransform& outTransform) {
-	outTransform = MatTransform();
-
 	if (!shape)
 		return false;
 

--- a/lib/NIF/NifFile.cpp
+++ b/lib/NIF/NifFile.cpp
@@ -435,14 +435,14 @@ bool NifFile::DeleteUnreferencedBlocks() {
 	return hadDeletions;
 }
 
-int NifFile::AddNode(const std::string& nodeName, const MatTransform& xform) {
+int NifFile::AddNode(const std::string& nodeName, const MatTransform& xformToParent) {
 	auto root = GetRootNode();
 	if (!root)
 		return 0xFFFFFFFF;
 
 	auto newNode = new NiNode();
 	newNode->SetName(nodeName);
-	newNode->transform = xform;
+	newNode->SetTransformToParent(xformToParent);
 
 	int newNodeId = hdr.AddBlock(newNode);
 	if (newNodeId != 0xFFFFFFFF)
@@ -774,8 +774,8 @@ NiShape* NifFile::CloneShape(NiShape* srcShape, const std::string& destShapeName
 				// Move existing node to non-root parent
 				auto oldParent = GetParentNode(node);
 				if (oldParent && oldParent != nodeParent && nodeParent != rootNode) {
-					MatTransform xform;
-					srcNif->GetNodeTransform(boneName, xform);
+					MatTransform xformToParent;
+					srcNif->GetNodeTransformToParent(boneName, xformToParent);
 
 					std::set<Ref*> childRefs;
 					oldParent->GetChildRefs(childRefs);
@@ -784,7 +784,7 @@ NiShape* NifFile::CloneShape(NiShape* srcShape, const std::string& destShapeName
 							ref->Clear();
 
 					nodeParent->GetChildren().AddBlockRef(boneID);
-					SetNodeTransform(boneName, xform);
+					SetNodeTransformToParent(boneName, xformToParent);
 				}
 			}
 
@@ -1041,7 +1041,7 @@ OptResult NifFile::OptimizeFor(OptOptions& options) {
 				bsOptShape->GetProperties() = shape->GetProperties();
 				bsOptShape->GetExtraData() = shape->GetExtraData();
 
-				bsOptShape->transform = shape->transform;
+				bsOptShape->SetTransformToParent(shape->GetTransformToParent());
 
 				bsOptShape->Create(vertices, &triangles, uvs, normals);
 				bsOptShape->flags = shape->flags;
@@ -1307,7 +1307,7 @@ OptResult NifFile::OptimizeFor(OptOptions& options) {
 				bsOptShape->GetProperties() = shape->GetProperties();
 				bsOptShape->GetExtraData() = shape->GetExtraData();
 
-				bsOptShape->transform = shape->transform;
+				bsOptShape->SetTransformToParent(shape->GetTransformToParent());
 				bsOptShape->flags = shape->flags;
 
 				// Move segments to new shape
@@ -1597,50 +1597,36 @@ NiNode* NifFile::GetRootNode() {
 	return root;
 }
 
-bool NifFile::GetNodeTransform(const std::string& nodeName, MatTransform& outTransform) {
+bool NifFile::GetNodeTransformToParent(const std::string& nodeName, MatTransform& outTransform) {
 	for (auto& block : blocks) {
 		auto node = dynamic_cast<NiNode*>(block.get());
 		if (node && !node->GetName().compare(nodeName)) {
-			outTransform = node->transform;
+			outTransform = node->GetTransformToParent();
 			return true;
 		}
 	}
 	return false;
 }
 
-bool NifFile::GetAbsoluteNodeTransform(const std::string& nodeName, MatTransform& outTransform) {
-	std::function<void(NiNode*, MatTransform&)> addParents = [&](NiNode* node, MatTransform& xform) -> void {
-		auto parent = GetParentNode(node);
-		if (parent) {
-			Matrix4 rot;
-			rot.SetRow(0, parent->transform.rotation[0]);
-			rot.SetRow(1, parent->transform.rotation[1]);
-			rot.SetRow(2, parent->transform.rotation[2]);
-
-			Matrix4 newRot = rot * xform.ToMatrix();
-			newRot.GetRow(0, xform.rotation[0]);
-			newRot.GetRow(1, xform.rotation[1]);
-			newRot.GetRow(2, xform.rotation[2]);
-
-			xform.translation = parent->transform.translation + (rot * xform.translation);
-			addParents(parent, xform);
-		}
-	};
-
+bool NifFile::GetNodeTransformToGlobal(const std::string& nodeName, MatTransform& outTransform) {
 	for (auto& block : blocks) {
-		auto node = dynamic_cast<NiNode*>(block.get());
-		if (node && node->GetName().compare(nodeName) == 0) {
-			MatTransform xform = node->transform;
-			addParents(node, xform);
-			outTransform = xform;
-			return true;
+		NiNode *node = dynamic_cast<NiNode*>(block.get());
+		if (!node || node->GetName().compare(nodeName) != 0)
+			continue;
+		MatTransform xform = node->GetTransformToParent();
+		NiNode *parent = GetParentNode(node);
+		while (parent) {
+			xform = parent->GetTransformToParent().ComposeTransforms(xform);
+			parent = GetParentNode(parent);
 		}
+		outTransform = xform;
+		return true;
 	}
 
 	return false;
 }
 
-bool NifFile::SetNodeTransform(const std::string& nodeName, MatTransform& inTransform, const bool rootChildrenOnly) {
+bool NifFile::SetNodeTransformToParent(const std::string& nodeName, const MatTransform& inTransform, const bool rootChildrenOnly) {
 	if (rootChildrenOnly) {
 		auto root = GetRootNode();
 		if (root) {
@@ -1648,7 +1634,7 @@ bool NifFile::SetNodeTransform(const std::string& nodeName, MatTransform& inTran
 				auto node = hdr.GetBlock<NiNode>(child.GetIndex());
 				if (node) {
 					if (!node->GetName().compare(nodeName)) {
-						node->transform = inTransform;
+						node->SetTransformToParent(inTransform);
 						return true;
 					}
 				}
@@ -1659,7 +1645,7 @@ bool NifFile::SetNodeTransform(const std::string& nodeName, MatTransform& inTran
 		for (auto& block : blocks) {
 			auto node = dynamic_cast<NiNode*>(block.get());
 			if (node && !node->GetName().compare(nodeName)) {
-				node->transform = inTransform;
+				node->SetTransformToParent(inTransform);
 				return true;
 			}
 		}
@@ -1798,29 +1784,66 @@ int NifFile::GetShapeBoneWeights(NiShape* shape, const int boneIndex, std::unord
 	return outWeights.size();
 }
 
-bool NifFile::GetShapeBoneTransform(NiShape* shape, const std::string& boneName, MatTransform& outTransform) {
+bool NifFile::GetShapeTransformGlobalToSkin(NiShape* shape, MatTransform& outTransform) {
+	outTransform = MatTransform();
+
 	if (!shape)
 		return false;
 
-	int boneIndex = shape->GetBoneID(hdr, boneName);
-	if (boneName.empty())
-		boneIndex = 0xFFFFFFFF;
+	// For FO4 meshes, the skin instance is a BSSkinInstance instead of
+	// an NiSkinInstance, so skinInst will be nullptr.  FO4 meshes do not
+	// have this transform.
+	auto skinInst = hdr.GetBlock<NiSkinInstance>(shape->GetSkinInstanceRef());
+	if (!skinInst)
+		return false;
 
-	return GetShapeBoneTransform(shape, boneIndex, outTransform);
+	auto skinData = hdr.GetBlock<NiSkinData>(skinInst->GetDataRef());
+	if (!skinData)
+		return false;
+
+	outTransform = skinData->skinTransform;
+	return true;
 }
 
-bool NifFile::SetShapeBoneTransform(NiShape* shape, const int boneIndex, MatTransform& inTransform) {
+void NifFile::SetShapeTransformGlobalToSkin(NiShape* shape, const MatTransform& inTransform) {
+	if (!shape)
+		return;
+
+	// For FO4 meshes, the skin instance is a BSSkinInstance instead of
+	// an NiSkinInstance, so skinInst will be nullptr.  FO4 meshes do not
+	// have this transform.
+	auto skinInst = hdr.GetBlock<NiSkinInstance>(shape->GetSkinInstanceRef());
+	if (!skinInst)
+		return;
+
+	auto skinData = hdr.GetBlock<NiSkinData>(skinInst->GetDataRef());
+	if (!skinData)
+		return;
+
+	// Set the overall skin transform
+	skinData->skinTransform = inTransform;
+}
+
+bool NifFile::GetShapeTransformSkinToBone(NiShape* shape, const std::string& boneName, MatTransform& outTransform) {
+	if (!shape)
+		return false;
+	return GetShapeBoneTransform(shape, shape->GetBoneID(hdr, boneName), outTransform);
+}
+
+bool NifFile::GetShapeTransformSkinToBone(NiShape* shape, const int boneIndex, MatTransform& outTransform) {
 	if (!shape)
 		return false;
 
 	auto skinForBoneRef = hdr.GetBlock<BSSkinInstance>(shape->GetSkinInstanceRef());
-	if (skinForBoneRef && boneIndex != 0xFFFFFFFF) {
-		auto bsSkin = hdr.GetBlock<BSSkinBoneData>(skinForBoneRef->GetDataRef());
-		if (!bsSkin)
-			return false;
+	if (skinForBoneRef) {
+		auto boneData = hdr.GetBlock<BSSkinBoneData>(skinForBoneRef->GetDataRef());
+		if (boneData) {
+			if (boneIndex >= boneData->nBones)
+				return false;
 
-		bsSkin->boneXforms[boneIndex].boneTransform = inTransform;
-		return true;
+			outTransform = boneData->boneXforms[boneIndex].boneTransform;
+			return true;
+		}
 	}
 
 	auto skinInst = hdr.GetBlock<NiSkinInstance>(shape->GetSkinInstanceRef());
@@ -1831,17 +1854,64 @@ bool NifFile::SetShapeBoneTransform(NiShape* shape, const int boneIndex, MatTran
 	if (!skinData)
 		return false;
 
-	if (boneIndex == 0xFFFFFFFF) {
-		// Set the overall skin transform
-		skinData->skinTransform = inTransform;
-		return true;
-	}
-
 	if (boneIndex >= skinData->numBones)
 		return false;
 
 	NiSkinData::BoneData* bone = &skinData->bones[boneIndex];
+	outTransform = bone->boneTransform;
+	return true;
+}
+
+void NifFile::SetShapeTransformSkinToBone(NiShape* shape, const int boneIndex, const MatTransform& inTransform) {
+	if (!shape)
+		return;
+
+	auto skinForBoneRef = hdr.GetBlock<BSSkinInstance>(shape->GetSkinInstanceRef());
+	if (skinForBoneRef) {
+		auto bsSkin = hdr.GetBlock<BSSkinBoneData>(skinForBoneRef->GetDataRef());
+		if (!bsSkin)
+			return;
+
+		if (boneIndex >= bsSkin->nBones)
+			return;
+		bsSkin->boneXforms[boneIndex].boneTransform = inTransform;
+		return;
+	}
+
+	auto skinInst = hdr.GetBlock<NiSkinInstance>(shape->GetSkinInstanceRef());
+	if (!skinInst)
+		return;
+
+	auto skinData = hdr.GetBlock<NiSkinData>(skinInst->GetDataRef());
+	if (!skinData)
+		return;
+
+	if (boneIndex >= skinData->numBones)
+		return;
+
+	NiSkinData::BoneData* bone = &skinData->bones[boneIndex];
 	bone->boneTransform = inTransform;
+}
+
+bool NifFile::GetShapeBoneTransform(NiShape* shape, const std::string& boneName, MatTransform& outTransform) {
+	if (boneName.empty())
+		return GetShapeTransformGlobalToSkin(shape, outTransform);
+	else
+		return GetShapeTransformSkinToBone(shape, boneName, outTransform);
+}
+
+bool NifFile::GetShapeBoneTransform(NiShape* shape, const int boneIndex, MatTransform& outTransform) {
+	if (boneIndex == 0xFFFFFFFF)
+		return GetShapeTransformGlobalToSkin(shape, outTransform);
+	else
+		return GetShapeTransformSkinToBone(shape, boneIndex, outTransform);
+}
+
+bool NifFile::SetShapeBoneTransform(NiShape* shape, const int boneIndex, MatTransform& inTransform) {
+	if (boneIndex == 0xFFFFFFFF)
+		SetShapeTransformGlobalToSkin(shape, inTransform);
+	else
+		SetShapeTransformSkinToBone(shape, boneIndex, inTransform);
 	return true;
 }
 
@@ -1873,49 +1943,6 @@ bool NifFile::SetShapeBoneBounds(const std::string& shapeName, const int boneInd
 
 	NiSkinData::BoneData* bone = &skinData->bones[boneIndex];
 	bone->bounds = inBounds;
-	return true;
-}
-
-bool NifFile::GetShapeBoneTransform(NiShape* shape, const int boneIndex, MatTransform& outTransform) {
-	if (!shape)
-		return false;
-
-	auto skinForBoneRef = hdr.GetBlock<BSSkinInstance>(shape->GetSkinInstanceRef());
-	if (skinForBoneRef) {
-		auto boneData = hdr.GetBlock<BSSkinBoneData>(skinForBoneRef->GetDataRef());
-		if (boneData) {
-			if (boneIndex == 0xFFFFFFFF) {
-				// Overall skin transform not found in FO4 meshes :(
-				return false;
-			}
-
-			if (boneIndex >= boneData->nBones)
-				return false;
-
-			outTransform = boneData->boneXforms[boneIndex].boneTransform;
-			return true;
-		}
-	}
-
-	auto skinInst = hdr.GetBlock<NiSkinInstance>(shape->GetSkinInstanceRef());
-	if (!skinInst)
-		return false;
-
-	auto skinData = hdr.GetBlock<NiSkinData>(skinInst->GetDataRef());
-	if (!skinData)
-		return false;
-
-	if (boneIndex == 0xFFFFFFFF) {
-		// Want the overall skin transform
-		outTransform = skinData->skinTransform;
-		return true;
-	}
-
-	if (boneIndex >= skinData->numBones)
-		return false;
-
-	NiSkinData::BoneData* bone = &skinData->bones[boneIndex];
-	outTransform = bone->boneTransform;
 	return true;
 }
 
@@ -2585,7 +2612,7 @@ void NifFile::CalcTangentsForShape(NiShape* shape) {
 void NifFile::GetRootTranslation(Vector3& outVec) {
 	auto root = GetRootNode();
 	if (root)
-		outVec = root->transform.translation;
+		outVec = root->GetTransformToParent().translation;
 	else
 		outVec.Zero();
 }

--- a/lib/NIF/NifFile.h
+++ b/lib/NIF/NifFile.h
@@ -97,7 +97,7 @@ public:
 	void LinkGeomData();
 	void RemoveInvalidTris();
 
-	int AddNode(const std::string& nodeName, const MatTransform& xform);
+	int AddNode(const std::string& nodeName, const MatTransform& xformToParent);
 	void DeleteNode(const std::string& nodeName);
 	bool CanDeleteNode(const std::string& nodeName);
 	std::string GetNodeName(const int blockID);
@@ -142,22 +142,51 @@ public:
 	std::vector<T*> GetChildren(NiNode* parent = nullptr, bool searchExtraData = false);
 
 	NiNode* GetRootNode();
-	bool GetNodeTransform(const std::string& nodeName, MatTransform& outTransform);
-	bool GetAbsoluteNodeTransform(const std::string& nodeName, MatTransform& outTransform);
-	bool SetNodeTransform(const std::string& nodeName, MatTransform& inTransform, const bool rootChildrenOnly = false);
+	bool GetNodeTransformToParent(const std::string& nodeName, MatTransform& outTransform);
+	// GetNodeTransform is deprecated.  Use GetNodeTransformToParent instead.
+	bool GetNodeTransform(const std::string& nodeName, MatTransform& outTransform) {
+		return GetNodeTransformToParent(nodeName, outTransform);
+	}
+	// GetNodeTransformToGlobal calculates the transform from this node's
+	// CS to the global CS by composing transforms up the node tree to the
+	// root node.
+	bool GetNodeTransformToGlobal(const std::string& nodeName, MatTransform& outTransform);
+	// GetAbsoluteNodeTransform is deprecated.  Use GetNodeTransformToGlobal instead.
+	bool GetAbsoluteNodeTransform(const std::string& nodeName, MatTransform& outTransform) {
+		return GetNodeTransformToGlobal(nodeName, outTransform);
+	}
+	bool SetNodeTransformToParent(const std::string& nodeName, const MatTransform& inTransform, const bool rootChildrenOnly = false);
+	// SetNodeTransform is deprecated.  Use SetNodeTransformToParent instead.
+	bool SetNodeTransform(const std::string& nodeName, MatTransform& inTransform, const bool rootChildrenOnly = false) {
+		return SetNodeTransformToParent(nodeName, inTransform, rootChildrenOnly);
+	}
 
 	int GetShapeBoneList(NiShape* shape, std::vector<std::string>& outList);
 	int GetShapeBoneIDList(NiShape* shape, std::vector<int>& outList);
 	void SetShapeBoneIDList(NiShape* shape, std::vector<int>& inList);
 	int GetShapeBoneWeights(NiShape* shape, const int boneIndex, std::unordered_map<ushort, float>& outWeights);
 
+	// Returns false if no such transform exists, in which case outTransform
+	// will be set to the identity transform.
+	bool GetShapeTransformGlobalToSkin(NiShape* shape, MatTransform& outTransform);
+	// Does nothing if the shape has no such transform.
+	void SetShapeTransformGlobalToSkin(NiShape* shape, const MatTransform& inTransform);
+	bool GetShapeTransformSkinToBone(NiShape* shape, const std::string& boneName, MatTransform& outTransform);
+	bool GetShapeTransformSkinToBone(NiShape* shape, int boneIndex, MatTransform& outTransform);
+	void SetShapeTransformSkinToBone(NiShape* shape, int boneIndex, const MatTransform& inTransform);
 	// Empty std::string for the bone name returns the overall skin transform for the shape.
+	// GetShapeBoneTransform is deprecated.  Use GetShapeTransformGlobalToSkin
+	// or GetShapeTransfromSkinToBone instead.
 	bool GetShapeBoneTransform(NiShape* shape, const std::string& boneName, MatTransform& outTransform);
+	// 0xFFFFFFFF on the bone index returns the overall skin transform for the shape.
+	// GetShapeBoneTransform is deprecated.  Use GetShapeTransformGlobalToSkin
+	// or GetShapeTransfromSkinToBone instead.
+	bool GetShapeBoneTransform(NiShape* shape, const int boneIndex, MatTransform& outTransform);
 	// 0xFFFFFFFF for the bone index sets the overall skin transform for the shape.
+	// SetShapeBoneTransform is deprecated.  Use SetShapeTransformGlobalToSkin
+	// or SetShapeTransfromSkinToBone instead.
 	bool SetShapeBoneTransform(NiShape* shape, const int boneIndex, MatTransform& inTransform);
 	bool SetShapeBoneBounds(const std::string& shapeName, const int boneIndex, BoundingSphere& inBounds);
-	// 0xFFFFFFFF on the bone index returns the overall skin transform for the shape.
-	bool GetShapeBoneTransform(NiShape* shape, const int boneIndex, MatTransform& outTransform);
 	bool GetShapeBoneBounds(NiShape* shape, const int boneIndex, BoundingSphere& outBounds);
 	void UpdateShapeBoneID(const std::string& shapeName, const int oldID, const int newID);
 	void SetShapeBoneWeights(const std::string& shapeName, const int boneIndex, std::unordered_map<ushort, float>& inWeights);

--- a/lib/NIF/NifFile.h
+++ b/lib/NIF/NifFile.h
@@ -166,8 +166,10 @@ public:
 	void SetShapeBoneIDList(NiShape* shape, std::vector<int>& inList);
 	int GetShapeBoneWeights(NiShape* shape, const int boneIndex, std::unordered_map<ushort, float>& outWeights);
 
-	// Returns false if no such transform exists, in which case outTransform
-	// will be set to the identity transform.
+	// Returns false if no such transform exists in the file, in which
+	// case outTransform will not be changed.  Note that, even if this
+	// function returns false, you can not assume that the global-to-skin
+	// transform is the identity; it almost never is.
 	bool GetShapeTransformGlobalToSkin(NiShape* shape, MatTransform& outTransform);
 	// Does nothing if the shape has no such transform.
 	void SetShapeTransformGlobalToSkin(NiShape* shape, const MatTransform& inTransform);

--- a/lib/NIF/Objects.h
+++ b/lib/NIF/Objects.h
@@ -44,6 +44,9 @@ protected:
 
 public:
 	uint flags = 524302;
+	/* "transform" is the coordinate system (CS) transform from this
+	object's CS to its parent's CS.
+	Recommendation: rename "transform" to "transformToParent". */
 	MatTransform transform;
 
 	void Get(NiStream& stream);
@@ -54,6 +57,9 @@ public:
 
 	int GetCollisionRef() { return collisionRef.GetIndex(); }
 	void SetCollisionRef(const int colRef) { collisionRef.SetIndex(colRef); }
+
+	const MatTransform &GetTransformToParent() const {return transform;}
+	void SetTransformToParent(const MatTransform &t) {transform = t;}
 };
 
 struct AVObject {

--- a/lib/NIF/Skin.h
+++ b/lib/NIF/Skin.h
@@ -35,12 +35,16 @@ struct BoneIndices {
 class NiSkinData : public NiObject {
 public:
 	struct BoneData {
+		// boneTransform transforms from skin CS to bone CS.
+		// Recommend renaming boneTransform to transformSkinToBone.
 		MatTransform boneTransform;
 		BoundingSphere bounds;
 		ushort numVertices = 0;
 		std::vector<SkinWeight> vertexWeights;
 	};
 
+	// skinTransform transforms from the global CS to the skin CS.
+	// Recommend renaming to "transformGlobalToSkin".
 	MatTransform skinTransform;
 	uint numBones = 0;
 	byte hasVertWeights = 1;
@@ -189,6 +193,9 @@ public:
 
 	struct BoneData {
 		BoundingSphere bounds;
+		// boneTransform transforms from global CS (which is the same as
+		// skin CS for skins with BSSkinBoneData) to bone CS.
+		// Recommend renaming boneTransform to transformGlobalToBone.
 		MatTransform boneTransform;
 	};
 

--- a/lib/NIF/Skin.h
+++ b/lib/NIF/Skin.h
@@ -193,11 +193,14 @@ public:
 
 	struct BoneData {
 		BoundingSphere bounds;
-		// boneTransform transforms from global CS (which is the same as
-		// skin CS for skins with BSSkinBoneData) to bone CS.
-		// Recommend renaming boneTransform to transformGlobalToBone.
+		// boneTransform transforms from skin CS (which is usually not
+		// the same as global CS for skins with BSSkinBoneData) to bone
+		// CS.  Recommend renaming boneTransform to transformSkinToBone.
 		MatTransform boneTransform;
 	};
+	// Note that, unlike for NiSkinData, the global-to-skin transform
+	// "skinTransform" is not given explicitly but implied by the other
+	// transforms.
 
 	std::vector<BoneData> boneXforms;
 

--- a/lib/NIF/utils/Object3d.cpp
+++ b/lib/NIF/utils/Object3d.cpp
@@ -28,3 +28,101 @@ BoundingSphere::BoundingSphere(const std::vector<Vector3>& vertices) {
 
 	radius = sqrt(mb.squared_radius());
 }
+
+float Matrix3::Determinant() const {
+	return
+		rows[0][0]*(rows[1][1]*rows[2][2]-rows[1][2]*rows[2][1]) +
+		rows[0][1]*(rows[1][2]*rows[2][0]-rows[1][0]*rows[2][2]) +
+		rows[0][2]*(rows[1][0]*rows[2][1]-rows[1][1]*rows[2][0]);
+}
+
+bool Matrix3::Invert(Matrix3 *inverse) const {
+	float det = Determinant();
+	if (det == 0.0f) return false;
+	float idet = 1/det;
+	Matrix3 &im = *inverse;
+	im[0][0] = (rows[1][1]*rows[2][2]-rows[1][2]*rows[2][1])*idet;
+	im[1][0] = (rows[1][2]*rows[2][0]-rows[1][0]*rows[2][2])*idet;
+	im[2][0] = (rows[1][0]*rows[2][1]-rows[1][1]*rows[2][0])*idet;
+	im[0][1] = (rows[2][1]*rows[0][2]-rows[2][2]*rows[0][1])*idet;
+	im[1][1] = (rows[2][2]*rows[0][0]-rows[2][0]*rows[0][2])*idet;
+	im[2][1] = (rows[2][0]*rows[0][1]-rows[2][1]*rows[0][0])*idet;
+	im[0][2] = (rows[0][1]*rows[1][2]-rows[0][2]*rows[1][1])*idet;
+	im[1][2] = (rows[0][2]*rows[1][0]-rows[0][0]*rows[1][2])*idet;
+	im[2][2] = (rows[0][0]*rows[1][1]-rows[0][1]*rows[1][0])*idet;
+	return true;
+}
+
+Matrix3 Matrix3::Inverse() const {
+	Matrix3 inv;
+	Invert(&inv);
+	return inv;
+}
+
+Matrix3 Matrix3::MakeRotation(const float yaw, const float pitch, const float roll) {
+	float ch = std::cos(yaw);
+	float sh = std::sin(yaw);
+	float cp = std::cos(pitch);
+	float sp = std::sin(pitch);
+	float cb = std::cos(roll);
+	float sb = std::sin(roll);
+
+	Matrix3 rot;
+	rot[0].x = ch * cb + sh * sp * sb;
+	rot[0].y = sb * cp;
+	rot[0].z = -sh * cb + ch * sp * sb;
+
+	rot[1].x = -ch * sb + sh * sp * cb;
+	rot[1].y = cb * cp;
+	rot[1].z = sb * sh + ch * sp * cb;
+
+	rot[2].x = sh * cp;
+	rot[2].y = -sp;
+	rot[2].z = ch * cp;
+
+	return rot;
+}
+
+bool Matrix3::ToEulerAngles(float &y, float& p, float& r) const {
+	bool canRot = false;
+
+	if (rows[0].z < 1.0f) {
+		if (rows[0].z > -1.0f) {
+			y = atan2(-rows[1].z, rows[2].z);
+			p = asin(rows[0].z);
+			r = atan2(-rows[0].y, rows[0].x);
+			canRot = true;
+		}
+		else {
+			y = -atan2(-rows[1].x, rows[1].y);
+			p = -PI / 2.0f;
+			r = 0.0f;
+		}
+	}
+	else {
+		y = atan2(rows[1].x, rows[1].y);
+		p = PI / 2.0f;
+		r = 0.0f;
+	}
+	return canRot;
+}
+
+Vector3 MatTransform::ApplyTransform(const Vector3 &v) const {
+	return translation + rotation * (v * scale);
+}
+
+MatTransform MatTransform::InverseTransform() const {
+	MatTransform inv;
+	inv.rotation = rotation.Inverse();
+	inv.scale = 1 / scale;
+	inv.translation = - inv.scale * (inv.rotation * translation);
+	return inv;
+}
+
+MatTransform MatTransform::ComposeTransforms(const MatTransform &other) const {
+	MatTransform comp;
+	comp.rotation = rotation * other.rotation;
+	comp.scale = scale * other.scale;
+	comp.translation = translation + rotation * (scale * other.translation);
+	return comp;
+}

--- a/lib/NIF/utils/Object3d.h
+++ b/lib/NIF/utils/Object3d.h
@@ -909,15 +909,15 @@ struct MatTransform {
 	Matrix4 ToMatrix() {
 		Matrix4 mat;
 		mat[0] = rotation[0].x * scale;
-		mat[1] = rotation[0].y;
-		mat[2] = rotation[0].z;
+		mat[1] = rotation[0].y * scale;
+		mat[2] = rotation[0].z * scale;
 		mat[3] = translation.x;
-		mat[4] = rotation[1].x;
+		mat[4] = rotation[1].x * scale;
 		mat[5] = rotation[1].y * scale;
-		mat[6] = rotation[1].z;
+		mat[6] = rotation[1].z * scale;
 		mat[7] = translation.y;
-		mat[8] = rotation[2].x;
-		mat[9] = rotation[2].y;
+		mat[8] = rotation[2].x * scale;
+		mat[9] = rotation[2].y * scale;
 		mat[10] = rotation[2].z * scale;
 		mat[11] = translation.z;
 		return mat;

--- a/lib/NIF/utils/Object3d.h
+++ b/lib/NIF/utils/Object3d.h
@@ -103,6 +103,9 @@ struct Vector3 {
 		z = Z;
 	}
 
+	float &operator[](int ind) {return ind?(ind==2?z:y):x;}
+	const float &operator[](int ind) const {return ind?(ind==2?z:y):x;}
+
 	void Zero() {
 		x = y = z = 0.0f;
 	}
@@ -266,6 +269,10 @@ struct Vector3 {
 			z = 0.0f;
 	}
 };
+
+inline Vector3 operator*(float f, const Vector3 &v) {
+	return Vector3(f*v.x, f*v.y, f*v.z);
+}
 
 struct Vector4 {
 	float x;
@@ -474,50 +481,63 @@ public:
 	}
 
 	Matrix3& operator*=(const Matrix3& other) {
-		Matrix3 res;
-		res[0].x = rows[0].x * other[0].x + rows[1].x * other[0].y + rows[2].x * other[0].z;
-		res[0].y = rows[0].y * other[0].x + rows[1].y * other[0].y + rows[2].y * other[0].z;
-		res[0].z = rows[0].z * other[0].x + rows[1].z * other[0].y + rows[2].z * other[0].z;
-		res[1].x = rows[0].x * other[1].x + rows[1].x * other[1].y + rows[2].x * other[1].z;
-		res[1].y = rows[0].y * other[1].x + rows[1].y * other[1].y + rows[2].y * other[1].z;
-		res[1].z = rows[0].z * other[1].x + rows[1].z * other[1].y + rows[2].z * other[1].z;
-		res[2].x = rows[0].x * other[2].x + rows[1].x * other[2].y + rows[2].x * other[2].z;
-		res[2].y = rows[0].y * other[2].x + rows[1].y * other[2].y + rows[2].y * other[2].z;
-		res[2].z = rows[0].z * other[2].x + rows[1].z * other[2].y + rows[2].z * other[2].z;
-
-		*this = res;
-		return (*this);
+		*this = *this * other;
+		return *this;
 	}
 
-	Matrix3 operator*(const Matrix3& other) {
+	Matrix3 operator*(const Matrix3& o) const {
 		Matrix3 res;
-		res *= other;
+		res[0][0] = rows[0][0] * o[0][0] + rows[0][1] * o[1][0] + rows[0][2] * o[2][0];
+		res[0][1] = rows[0][0] * o[0][1] + rows[0][1] * o[1][1] + rows[0][2] * o[2][1];
+		res[0][2] = rows[0][0] * o[0][2] + rows[0][1] * o[1][2] + rows[0][2] * o[2][2];
+		res[1][0] = rows[1][0] * o[0][0] + rows[1][1] * o[1][0] + rows[1][2] * o[2][0];
+		res[1][1] = rows[1][0] * o[0][1] + rows[1][1] * o[1][1] + rows[1][2] * o[2][1];
+		res[1][2] = rows[1][0] * o[0][2] + rows[1][1] * o[1][2] + rows[1][2] * o[2][2];
+		res[2][0] = rows[2][0] * o[0][0] + rows[2][1] * o[1][0] + rows[2][2] * o[2][0];
+		res[2][1] = rows[2][0] * o[0][1] + rows[2][1] * o[1][1] + rows[2][2] * o[2][1];
+		res[2][2] = rows[2][0] * o[0][2] + rows[2][1] * o[1][2] + rows[2][2] * o[2][2];
 		return res;
 	}
 
-	// Set rotation matrix from yaw, pitch and roll
-	static Matrix3 MakeRotation(const float yaw, const float pitch, const float roll) {
-		float ch = std::cos(yaw);
-		float sh = std::sin(yaw);
-		float cp = std::cos(pitch);
-		float sp = std::sin(pitch);
-		float cb = std::cos(roll);
-		float sb = std::sin(roll);
+	Vector3 operator*(const Vector3& v) const {
+		return Vector3(
+			rows[0][0] * v.x + rows[0][1] * v.y + rows[0][2] * v.z,
+			rows[1][0] * v.x + rows[1][1] * v.y + rows[1][2] * v.z,
+			rows[2][0] * v.x + rows[2][1] * v.y + rows[2][2] * v.z);
+	}
 
-		Matrix3 rot;
-		rot[0].x = ch * cb + sh * sp * sb;
-		rot[0].y = sb * cp;
-		rot[0].z = -sh * cb + ch * sp * sb;
+	float Determinant() const;
 
-		rot[1].x = -ch * sb + sh * sp * cb;
-		rot[1].y = cb * cp;
-		rot[1].z = sb * sh + ch * sp * cb;
+	// Invert attempts to invert this matrix, returning the result in
+	// inverse.  It returns false if the matrix is not invertible, in
+	// which case inverse is not changed.
+	bool Invert(Matrix3 *inverse) const;
 
-		rot[2].x = sh * cp;
-		rot[2].y = -sp;
-		rot[2].z = ch * cp;
+	// Inverse returns the inverse of this matrix if it's invertible.
+	// If this matrix is not invertible, the identity matrix is returned.
+	Matrix3 Inverse() const;
 
-		return rot;
+	// Generate rotation matrix from yaw, pitch and roll (in radians)
+	// This is not the inverse of ToEulerAngles; though both functions
+	// work with Euler angles, there are many conflicting definitions
+	// of "Euler angles" (yaw, pitch, and roll), and these two functions
+	// use different definitions.
+	static Matrix3 MakeRotation(const float yaw, const float pitch, const float roll);
+
+	// Convert rotation to euler degrees (Yaw, Pitch, Roll)
+	// This function assumes that the matrix is a rotation matrix.
+	// ToEulerAngles is not the inverse of MakeRotation; though both
+	// functions work with Euler angles, there are many conflicting
+	// definitions of "Euler angles", and these two functions use
+	// different definitions.
+	// The return result "canRot" apparently means roll is not zero.
+	bool ToEulerAngles(float &y, float& p, float& r) const;
+	bool ToEulerDegrees(float &y, float& p, float& r) const {
+		bool canRot = ToEulerAngles(y, p, r);
+		y *= 180.0f / PI;
+		p *= 180.0f / PI;
+		r *= 180.0f / PI;
+		return canRot;
 	}
 };
 
@@ -548,7 +568,7 @@ public:
 		m[12] = 0;		   m[13] = 0;		  m[14] = 0;	      m[15] = 1;
 	}
 
-	void SetRow(int row, Vector3& inVec) {
+	void SetRow(int row, const Vector3& inVec) {
 		m[row * 4 + 0] = inVec.x;
 		m[row * 4 + 1] = inVec.y;
 		m[row * 4 + 2] = inVec.z;
@@ -865,9 +885,29 @@ struct QuatTransform {
 };
 
 struct MatTransform {
+	/* On MatTransform and coordinate-system (CS) transformations:
+
+	A MatTransform can represent a "similarity transform", where
+	it scales, rotates, and moves geometry; or it can represent a
+	"coordinate-system transform", where the geometry itself does
+	not change, but its representation changes from one CS to another.
+
+	If CS1 is the source CS and CS2 is the target CS, then:
+	ApplyTransform(v) converts a point v represented in CS1 to CS2.
+	translation is CS1's origin represented in CS2.
+	rotation has columns the basis vectors of CS1 represented in CS2.
+	scale gives how much farther apart points appear to be in CS2 than in CS1.
+
+	Note that we do not force "rotation" to actually be a rotation
+	matrix.  A rotation matrix's inverse is its transpose.  Instead,
+	we only assume "rotation" is invertible, which means its inverse
+	must be calculated (using Matrix3::Invert).  Even though we always
+	treat "rotation" as a general invertible matrix and not a rotation
+	matrix, in practice it is always a rotation matrix.
+	*/
 	Vector3 translation;
-	Matrix3 rotation;
-	float scale = 1.0f;
+	Matrix3 rotation; // must be invertible
+	float scale = 1.0f; // must be nonzero
 
 	void Clear() {
 		translation.Zero();
@@ -876,37 +916,12 @@ struct MatTransform {
 	}
 
 	// Rotation in euler degrees (Yaw, Pitch, Roll)
-	bool ToEulerDegrees(float &y, float& p, float& r) {
-		float rx, ry, rz;
-		bool canRot = false;
-
-		if (rotation[0].z < 1.0f) {
-			if (rotation[0].z > -1.0f) {
-				rx = atan2(-rotation[1].z, rotation[2].z);
-				ry = asin(rotation[0].z);
-				rz = atan2(-rotation[0].y, rotation[0].x);
-				canRot = true;
-			}
-			else {
-				rx = -atan2(-rotation[1].x, rotation[1].y);
-				ry = -PI / 2.0f;
-				rz = 0.0f;
-			}
-		}
-		else {
-			rx = atan2(rotation[1].x, rotation[1].y);
-			ry = PI / 2.0f;
-			rz = 0.0f;
-		}
-
-		y = rx * 180.0f / PI;
-		p = ry * 180.0f / PI;
-		r = rz * 180.0f / PI;
-		return canRot;
+	bool ToEulerDegrees(float &y, float& p, float& r) const {
+		return rotation.ToEulerDegrees(y, p, r);
 	}
 
 	// Full matrix of translation, rotation and scale
-	Matrix4 ToMatrix() {
+	Matrix4 ToMatrix() const {
 		Matrix4 mat;
 		mat[0] = rotation[0].x * scale;
 		mat[1] = rotation[0].y * scale;
@@ -922,6 +937,20 @@ struct MatTransform {
 		mat[11] = translation.z;
 		return mat;
 	}
+
+	// ApplyTransform applies this MatTransform to a vector v by first
+	// scaling v, then rotating the result of that, then translating the
+	// result of that.
+	Vector3 ApplyTransform(const Vector3 &v) const;
+
+	// Note that InverseTransform will return garbage if "rotation"
+	// is not invertible or scale is 0.
+	MatTransform InverseTransform() const;
+
+	// ComposeTransforms returns the transform that is the composition
+	// of this and other.  That is, if t3 = t1.ComposeTransforms(t2), then
+	// t3.ApplyTransform(v) == t1.ApplyTransform(t2.ApplyTransform(v)).
+	MatTransform ComposeTransforms(const MatTransform &other) const;
 };
 
 

--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -345,6 +345,7 @@ void AnimInfo::WriteToNif(NifFile* nif, const std::string& shapeException) {
 	}
 
 	bool incomplete = false;
+	bool isFO4 = nif->GetHeader().GetVersion().IsFO4();
 
 	for (auto &shapeBoneList : shapeBones) {
 		if (shapeBoneList.first == shapeException)
@@ -373,7 +374,7 @@ void AnimInfo::WriteToNif(NifFile* nif, const std::string& shapeException) {
 			nif->SetShapeTransformSkinToBone(shape, bid, bw.xformSkinToBone);
 			if (!bptr)
 				incomplete = true;
-			if (!isBSShape)
+			if (!isFO4)
 				nif->SetShapeBoneWeights(shapeBoneList.first, bid, bw.weights);
 
 			if (CalcShapeSkinBounds(shapeBoneList.first, bid))

--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -130,21 +130,22 @@ AnimSkin::AnimSkin(NifFile* loadFromFile, NiShape* shape) {
 	int newID = 0;
 	for (auto &id : idList) {
 		auto node = loadFromFile->GetHeader().GetBlock<NiNode>(id);
-		if (node) {
-			boneWeights[newID] = AnimWeight(loadFromFile, shape, newID);
-			boneNames[node->GetName()] = newID;
-			if (!gotGTS) {
-				// We don't have a global-to-skin transform, probably because
-				// the NIF has BSSkinBoneData instead of NiSkinData (FO4 or
-				// newer).  So calculate by:
-				// Compose: skin -> bone -> global
-				// and inverting.
-				MatTransform xformBoneToGlobal = node->GetTransformToParent();
+		if (!node) continue;
+		boneWeights[newID] = AnimWeight(loadFromFile, shape, newID);
+		boneNames[node->GetName()] = newID;
+		if (!gotGTS) {
+			// We don't have a global-to-skin transform, probably because
+			// the NIF has BSSkinBoneData instead of NiSkinData (FO4 or
+			// newer).  So calculate by:
+			// Compose: skin -> bone -> global
+			// and inverting.
+			MatTransform xformBoneToGlobal;
+			if (AnimSkeleton::getInstance().GetBoneTransformToGlobal(node->GetName(), xformBoneToGlobal)) {
 				xformGlobalToSkin = xformBoneToGlobal.ComposeTransforms(boneWeights[newID].xformSkinToBone).InverseTransform();
 				gotGTS = true;
 			}
-			newID++;
 		}
+		newID++;
 	}
 }
 

--- a/src/components/Anim.h
+++ b/src/components/Anim.h
@@ -61,11 +61,7 @@ public:
 	BoundingSphere bounds;
 
 	AnimWeight() {}
-	AnimWeight(NifFile* loadFromFile, NiShape* shape, const int& index) {
-		loadFromFile->GetShapeBoneWeights(shape, index, weights);
-		loadFromFile->GetShapeTransformSkinToBone(shape, index, xformSkinToBone);
-		loadFromFile->GetShapeBoneBounds(shape, index, bounds);
-	}
+	AnimWeight(NifFile* loadFromFile, NiShape* shape, const int& index);
 };
 
 // Bone to weight list association.
@@ -76,21 +72,7 @@ public:
 	MatTransform xformGlobalToSkin;
 
 	AnimSkin() { }
-	AnimSkin(NifFile* loadFromFile, NiShape* shape) {
-		loadFromFile->GetShapeTransformGlobalToSkin(shape, xformGlobalToSkin);
-		std::vector<int> idList;
-		loadFromFile->GetShapeBoneIDList(shape, idList);
-
-		int newID = 0;
-		for (auto &id : idList) {
-			auto node = loadFromFile->GetHeader().GetBlock<NiNode>(id);
-			if (node) {
-				boneWeights[newID] = AnimWeight(loadFromFile, shape, newID);
-				boneNames[node->GetName()] = newID;
-				newID++;
-			}
-		}
-	}
+	AnimSkin(NifFile* loadFromFile, NiShape* shape);
 
 	void RemoveBone(const std::string& boneName) {
 		auto bone = boneNames.find(boneName);

--- a/src/components/Anim.h
+++ b/src/components/Anim.h
@@ -38,15 +38,13 @@ class AnimBone {
 public:
 	std::string boneName = "bogus";		// bone names are node names in the nif file
 	int boneID = -1;					// block id from the original nif file
-	Matrix4 rot;						// original node rotation value (total rotation, including parents)
-	Vector3 trans;						// original node translation value (total translation, including parents)
-	float scale = 1.0f;					// original node scale value
-
 	bool isValidBone = false;
 	AnimBone* parent = nullptr;
 	std::vector<AnimBone*> children;
-	Matrix4 localRot;					// rotation offset from parent bone.
-	Vector3 localTrans;					// offset from parent bone
+	// xformToGlobal: transforms from this bone's CS to the global CS.
+	MatTransform xformToGlobal;
+	// xformToParent: transforms from this bone's CS to its parent's CS.
+	MatTransform xformToParent;
 
 	int refCount = 0;					// reference count of this bone
 
@@ -55,17 +53,17 @@ public:
 	AnimBone& LoadFromNif(NifFile* skeletonNif, int srcBlock, AnimBone* parent = nullptr);
 };
 
-// Vertex to weight value association. Also keeps track of skin transform and bounding sphere.
+// Vertex to weight value association. Also keeps track of skin-to-bone transform and bounding sphere.
 class AnimWeight {
 public:
 	std::unordered_map<ushort, float> weights;
-	MatTransform xform;
+	MatTransform xformSkinToBone;
 	BoundingSphere bounds;
 
 	AnimWeight() {}
 	AnimWeight(NifFile* loadFromFile, NiShape* shape, const int& index) {
 		loadFromFile->GetShapeBoneWeights(shape, index, weights);
-		loadFromFile->GetShapeBoneTransform(shape, index, xform);
+		loadFromFile->GetShapeTransformSkinToBone(shape, index, xformSkinToBone);
 		loadFromFile->GetShapeBoneBounds(shape, index, bounds);
 	}
 };
@@ -75,9 +73,11 @@ class AnimSkin {
 public:
 	std::unordered_map<int, AnimWeight> boneWeights;
 	std::unordered_map<std::string, int> boneNames;
+	MatTransform xformGlobalToSkin;
 
 	AnimSkin() { }
 	AnimSkin(NifFile* loadFromFile, NiShape* shape) {
+		loadFromFile->GetShapeTransformGlobalToSkin(shape, xformGlobalToSkin);
 		std::vector<int> idList;
 		loadFromFile->GetShapeBoneIDList(shape, idList);
 
@@ -153,10 +153,9 @@ public:
 	std::unordered_map<ushort, float>* GetWeightsPtr(const std::string& shape, const std::string& boneName);
 	bool HasWeights(const std::string& shape, const std::string& boneName);
 	void GetWeights(const std::string& shape, const std::string& boneName, std::unordered_map<ushort, float>& outVertWeights);
-	void GetBoneXForm(const std::string& boneName, MatTransform& stransform);
 	void SetWeights(const std::string& shape, const std::string& boneName, std::unordered_map<ushort, float>& inVertWeights);
-	bool GetShapeBoneXForm(const std::string& shape, const std::string& boneName, MatTransform& stransform);
-	void SetShapeBoneXForm(const std::string& shape, const std::string& boneName, MatTransform& stransform);
+	bool GetXFormSkinToBone(const std::string& shape, const std::string& boneName, MatTransform& stransform);
+	void SetXFormSkinToBone(const std::string& shape, const std::string& boneName, const MatTransform& stransform);
 	bool CalcShapeSkinBounds(const std::string& shapeName, const int& boneIndex);
 	void CleanupBones();
 	void WriteToNif(NifFile* nif, const std::string& shapeException = "");
@@ -193,8 +192,7 @@ public:
 	AnimBone* GetBonePtr(const std::string& boneName, const bool allowCustom = true);
 	AnimBone* GetRootBonePtr();
 	bool GetBone(const std::string& boneName, AnimBone& outBone);
-	bool GetBoneTransform(const std::string& boneName, MatTransform& xform);
-	bool GetSkinTransform(const std::string& boneName, const MatTransform& skinning, MatTransform& xform);
+	bool GetBoneTransformToGlobal(const std::string& boneName, MatTransform& xform);
 
 	int GetActiveBoneNames(std::vector<std::string>& outBoneNames);
 	void DisableCustomTransforms();

--- a/src/components/Automorph.cpp
+++ b/src/components/Automorph.cpp
@@ -176,21 +176,21 @@ void Automorph::MeshFromNifShape(mesh* m, NifFile& ref, NiShape* shape) {
 	m->shapeName = shape->GetName();
 
 	if (!shape->IsSkinned()) {
-		// Calculate transform from shape's CS to absolute CS.
-		MatTransform tta = shape->GetTransformToParent();
+		// Calculate transform from shape's CS to global CS.
+		MatTransform ttg = shape->GetTransformToParent();
 		NiNode* parent = ref.GetParentNode(shape);
 		while (parent) {
-			tta = parent->GetTransformToParent().ComposeTransforms(tta);
+			ttg = parent->GetTransformToParent().ComposeTransforms(ttg);
 			parent = ref.GetParentNode(parent);
 		}
 
-		// Convert tta to a glm::mat4x4.
+		// Convert ttg to a glm::mat4x4.
 		auto matShape = glm::identity<glm::mat4x4>();
-		matShape = glm::translate(matShape, glm::vec3(tta.translation.x, tta.translation.y, tta.translation.z));
+		matShape = glm::translate(matShape, glm::vec3(ttg.translation.x, ttg.translation.y, ttg.translation.z));
 		float y, p, r;
-		tta.rotation.ToEulerAngles(y, p, r);
+		ttg.rotation.ToEulerAngles(y, p, r);
 		matShape *= glm::yawPitchRoll(r, p, y);
-		matShape = glm::scale(matShape, glm::vec3(tta.scale, tta.scale, tta.scale));
+		matShape = glm::scale(matShape, glm::vec3(ttg.scale, ttg.scale, ttg.scale));
 		m->matModel = matShape;
 	}
 	else {

--- a/src/files/FBXWrangler.cpp
+++ b/src/files/FBXWrangler.cpp
@@ -166,10 +166,11 @@ void FBXWrangler::AddSkeleton(NifFile* nif, bool onlyNonSkeleton) {
 			FbxNode* rootNode = FbxNode::Create(priv->scene, root->GetName().c_str());
 			rootNode->SetNodeAttribute(rootBone);
 
-			rootNode->LclTranslation.Set(FbxDouble3(root->transform.translation.x, root->transform.translation.y, root->transform.translation.z));
+			const MatTransform &ttp = root->GetTransformToParent();
+			rootNode->LclTranslation.Set(FbxDouble3(ttp.translation.x, ttp.translation.y, ttp.translation.z));
 
 			float rx, ry, rz;
-			root->transform.ToEulerDegrees(rx, ry, rz);
+			ttp.ToEulerDegrees(rx, ry, rz);
 			rootNode->LclRotation.Set(FbxDouble3(rx, ry, rz));
 			//rootNode->SetRotationOrder(FbxNode::eSourcePivot, eEulerZYX);
 
@@ -186,10 +187,11 @@ void FBXWrangler::AddSkeleton(NifFile* nif, bool onlyNonSkeleton) {
 			FbxNode* comNode = FbxNode::Create(priv->scene, com->GetName().c_str());
 			comNode->SetNodeAttribute(comBone);
 
-			comNode->LclTranslation.Set(FbxDouble3(com->transform.translation.y, com->transform.translation.z, com->transform.translation.x));
+			const MatTransform &ttp = com->GetTransformToParent();
+			comNode->LclTranslation.Set(FbxDouble3(ttp.translation.y, ttp.translation.z, ttp.translation.x));
 
 			float rx, ry, rz;
-			com->transform.ToEulerDegrees(rx, ry, rz);
+			ttp.ToEulerDegrees(rx, ry, rz);
 			comNode->LclRotation.Set(FbxDouble3(rx, ry, rz));
 			//comNode->SetRotationOrder(FbxNode::eSourcePivot, eEulerZYX);
 
@@ -217,11 +219,11 @@ FbxNode* FBXWrangler::Priv::AddLimb(NifFile* nif, NiNode* nifBone) {
 		node = FbxNode::Create(scene, nifBone->GetName().c_str());
 		node->SetNodeAttribute(bone);
 
-		Vector3 translation = nifBone->transform.translation;
-		node->LclTranslation.Set(FbxDouble3(translation.x, translation.y, translation.z));
+		const MatTransform &ttp = nifBone->GetTransformToParent();
+		node->LclTranslation.Set(FbxDouble3(ttp.translation.x, ttp.translation.y, ttp.translation.z));
 
 		float rx, ry, rz;
-		nifBone->transform.ToEulerDegrees(rx, ry, rz);
+		ttp.ToEulerDegrees(rx, ry, rz);
 		node->LclRotation.Set(FbxDouble3(rx, ry, rz));
 		//myNode->SetRotationOrder(FbxNode::eSourcePivot, eEulerZYX);
 	}

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -1442,23 +1442,6 @@ void OutfitProject::RotateShape(NiShape* shape, const Vector3& angle, std::unord
 	workNif.RotateShape(shape, angle, mask);
 }
 
-bool OutfitProject::AddShapeBoneAndXForm(const std::string &shapeName, const std::string &boneName) {
-	if (!workAnim.AddShapeBone(shapeName, boneName))
-		return false;
-	// If the base shape has a skin-to-bone transform for this bone, copy it.
-	const std::string baseName = baseShape->GetName();
-	MatTransform xformBaseSkinToBone;
-	if (workAnim.GetXFormSkinToBone(baseName, boneName, xformBaseSkinToBone)) {
-		// The base shape's skin does not necessarily have the same
-		// global-to-skin transform as this shape, so we have to compose:
-		// this skin -> global -> base skin -> bone
-		MatTransform xformGlobalToBaseSkin = workAnim.shapeSkinning[baseName].xformGlobalToSkin;
-		MatTransform xformGlobalToThisSkin = workAnim.shapeSkinning[shapeName].xformGlobalToSkin;
-		workAnim.SetXFormSkinToBone(shapeName, boneName, xformBaseSkinToBone.ComposeTransforms(xformGlobalToBaseSkin.ComposeTransforms(xformGlobalToThisSkin.InverseTransform())));
-	}
-	return true;
-}
-
 void OutfitProject::CopyBoneWeights(NiShape* shape, const float proximityRadius, const int maxResults, std::unordered_map<ushort, float>& mask, const std::vector<std::string>& boneList, int nCopyBones, const std::vector<std::string> &lockedBones, UndoStateShape &uss, bool bSpreadWeight) {
 	if (!shape || !baseShape)
 		return;
@@ -1595,7 +1578,7 @@ void OutfitProject::TransferSelectedWeights(NiShape* shape, std::unordered_map<u
 				weights[w.first] = w.second;
 		}
 
-		AddShapeBoneAndXForm(shapeName, boneName);
+		workAnim.AddShapeBone(shapeName, boneName);
 		workAnim.SetWeights(shapeName, boneName, weights);
 		owner->UpdateProgress(prog += step, "");
 	}

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -159,7 +159,6 @@ public:
 	void ScaleShape(NiShape* shape, const Vector3& scale, std::unordered_map<ushort, float>* mask = nullptr);
 	void RotateShape(NiShape* shape, const Vector3& angle, std::unordered_map<ushort, float>* mask = nullptr);
 
-	bool AddShapeBoneAndXForm(const std::string &shapeName, const std::string &boneName);
 	// Uses the AutoMorph class to generate proximity values for bone weights.
 	// This is done by creating several virtual sliders that contain weight offsets for each vertex per bone.
 	// These data sets are then temporarily linked to the AutoMorph class and result 'diffs' are generated.

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -2133,7 +2133,7 @@ void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject *usp, bool bIsUndo)
 				if (!m) continue;
 				for (auto &bw : uss.boneWeights) {
 					if (bw.weights.empty()) continue;
-					project->AddShapeBoneAndXForm(m->shapeName, bw.boneName);
+					project->GetWorkAnim()->AddShapeBone(m->shapeName, bw.boneName);
 					auto weights = project->GetWorkAnim()->GetWeightsPtr(m->shapeName, bw.boneName);
 					if (!weights) continue;
 					for (auto &p : bw.weights) {

--- a/src/render/GLSurface.cpp
+++ b/src/render/GLSurface.cpp
@@ -993,39 +993,39 @@ mesh* GLSurface::AddMeshFromNif(NifFile* nif, const std::string& shapeName, Vect
 
 	mesh* m = new mesh();
 
-	float y, p, r;
-	auto matParents = glm::identity<glm::mat4x4>();
-	auto matShape = glm::identity<glm::mat4x4>();
-	auto matSkin = glm::identity<glm::mat4x4>();
-
 	if (!shape->IsSkinned()) {
+		// Calculate transform from shape's CS to absolute CS.
+		MatTransform tta = shape->GetTransformToParent();
 		NiNode* parent = nif->GetParentNode(shape);
 		while (parent) {
-			parent->transform.ToEulerDegrees(y, p, r);
-			matParents = glm::translate(matParents, glm::vec3(parent->transform.translation.x / -10.0f, parent->transform.translation.z / 10.0f, parent->transform.translation.y / 10.0f));
-			matParents *= glm::yawPitchRoll(r * DEG2RAD, p * DEG2RAD, y * DEG2RAD);
-			matParents = glm::scale(matParents, glm::vec3(parent->transform.scale, parent->transform.scale, parent->transform.scale));
+			tta = parent->GetTransformToParent().ComposeTransforms(tta);
 			parent = nif->GetParentNode(parent);
 		}
 
-		matShape = glm::translate(matShape, glm::vec3(shape->transform.translation.x / -10.0f, shape->transform.translation.z / 10.0f, shape->transform.translation.y / 10.0f));
-		shape->transform.ToEulerDegrees(y, p, r);
-		matShape *= glm::yawPitchRoll(r * DEG2RAD, p * DEG2RAD, y * DEG2RAD);
-		matShape = glm::scale(matShape, glm::vec3(shape->transform.scale, shape->transform.scale, shape->transform.scale));
+		// Convert tta to a glm::mat4x4
+		auto matShape = glm::identity<glm::mat4x4>();
+		matShape = glm::translate(matShape, glm::vec3(tta.translation.x / -10.0f, tta.translation.z / 10.0f, tta.translation.y / 10.0f));
+		float y, p, r;
+		tta.rotation.ToEulerAngles(y, p, r);
+		matShape *= glm::yawPitchRoll(r, p, y);
+		matShape = glm::scale(matShape, glm::vec3(tta.scale, tta.scale, tta.scale));
+		m->matModel = matShape;
 	}
 	else {
 		// Not rendered by the game for skinned meshes
 		// Keep to counter-offset bone transforms
 		MatTransform xFormSkin;
-		if (nif->GetShapeBoneTransform(shape, 0xFFFFFFFF, xFormSkin)) {
-			xFormSkin.ToEulerDegrees(y, p, r);
+		auto matSkin = glm::identity<glm::mat4x4>();
+		if (nif->GetShapeTransformGlobalToSkin(shape, xFormSkin)) {
+			float y, p, r;
+			xFormSkin.rotation.ToEulerAngles(y, p, r);
 			matSkin = glm::translate(matSkin, glm::vec3(xFormSkin.translation.x / -10.0f, xFormSkin.translation.z / 10.0f, xFormSkin.translation.y / 10.0f));
-			matSkin *= glm::yawPitchRoll(r * DEG2RAD, p * DEG2RAD, y * DEG2RAD);
+			matSkin *= glm::yawPitchRoll(r, p, y);
 			matSkin = glm::scale(matSkin, glm::vec3(xFormSkin.scale, xFormSkin.scale, xFormSkin.scale));
 		}
+		m->matModel = glm::inverse(matSkin);
 	}
 
-	m->matModel = matParents * matShape * glm::inverse(matSkin);
 
 	NiShader* shader = nif->GetShader(shape);
 	if (shader) {

--- a/src/render/GLSurface.cpp
+++ b/src/render/GLSurface.cpp
@@ -994,21 +994,21 @@ mesh* GLSurface::AddMeshFromNif(NifFile* nif, const std::string& shapeName, Vect
 	mesh* m = new mesh();
 
 	if (!shape->IsSkinned()) {
-		// Calculate transform from shape's CS to absolute CS.
-		MatTransform tta = shape->GetTransformToParent();
+		// Calculate transform from shape's CS to global CS.
+		MatTransform ttg = shape->GetTransformToParent();
 		NiNode* parent = nif->GetParentNode(shape);
 		while (parent) {
-			tta = parent->GetTransformToParent().ComposeTransforms(tta);
+			ttg = parent->GetTransformToParent().ComposeTransforms(ttg);
 			parent = nif->GetParentNode(parent);
 		}
 
-		// Convert tta to a glm::mat4x4
+		// Convert ttg to a glm::mat4x4
 		auto matShape = glm::identity<glm::mat4x4>();
-		matShape = glm::translate(matShape, glm::vec3(tta.translation.x / -10.0f, tta.translation.z / 10.0f, tta.translation.y / 10.0f));
+		matShape = glm::translate(matShape, glm::vec3(ttg.translation.x / -10.0f, ttg.translation.z / 10.0f, ttg.translation.y / 10.0f));
 		float y, p, r;
-		tta.rotation.ToEulerAngles(y, p, r);
+		ttg.rotation.ToEulerAngles(y, p, r);
 		matShape *= glm::yawPitchRoll(r, p, y);
-		matShape = glm::scale(matShape, glm::vec3(tta.scale, tta.scale, tta.scale));
+		matShape = glm::scale(matShape, glm::vec3(ttg.scale, ttg.scale, ttg.scale));
 		m->matModel = matShape;
 	}
 	else {


### PR DESCRIPTION
Fixed scaling bug in MatTransform::ToMatrix.

Moved the implementation of MatTransform::ToEulerDegrees into Matrix3.
Made a radians version, ToEulerAngles.  Used ToEulerAngles
instead of ToEulerDegrees in Automorph::MeshFromNifShape and
GLSurface::AddMeshFromNif so that those functions don't have to
convert from degrees to radians when passing the values to glm::yawPitchRoll.

Added Matrix3::operator*(const Vector3 &).

Fixed bug in Matrix3::operator*(const Matrix3 &) where the identity
matrix was used instead of this matrix.

Fixed bug in Matrix3::operator*=(const Matrix3 &) where the two matrices
were swapped in the calculation.

Added Vector3::operator[].

Added Vector3 operator*(float, const Vector3 &).

Added Matrix3 Determinant, Invert, and Inverse functions.

Added MatTransform functions: ApplyTransform, InverseTransform, and
ComposeTransforms.  Used these functions in many places to simplify code.

Added NiAVObject functions GetTransformToParent and
SetTransformToParent and made everything except IO use these functions
rather than accessing "transform" directly.  I did this purely for
clarity, not for data hiding.

Simplified NifFile::GetAbsoluteNodeTransform.  Added a new name for it:
GetNodeTransformToGlobal.

Split functionality of NifFile::GetShapeBoneTransform into
GetShapeTransformFromGlobalToSkin and GetShapeTransformFromSkinToBone.
The old function now calls one of the two.  Same for SetShapeBoneTransform.

Added new name for NifFile::GetNodeTransform: GetNodeTransformToParent.
Same for SetNodeTransform.

Renamed AnimWeight::xform to xformSkinToBone.

Renamed AnimInfo::GetShapeBoneXForm to GetXFormSkinToBone.  Same for
SetShapeBoneXForm.

Replaced AnimBone's rot, trans, scale, localRot, and localTrans with
two MatTransforms: xformToGlobal and xformToParent.

Added MatTransform xformGlobalToSkin to AnimSkin.  This is set when
the Nif is read, but it's never written back out to the Nif.  Added a
line to OutfitProject::ResetTransforms to clear this transform, though
I can't see why calling ResetTransforms would ever be a good idea, so
I'm not sure if xformGlobalToSkin needs to be reset there.

AnimInfo::AddShapeBone is called from three places.  In all three
places, xformSkinToBone was being incorrectly set afterwards.  So I
added code to AddShapeBone to set xformSkinToBone to a good default
using the skeleton, and I eliminated the incorrect code from two of
the three callers (AddBoneRef and AddCustomBoneRef).  For the third
(AddShapeBoneAndXForm), the original code was supposed to copy the
xform from the base shape; I fixed it.

Eliminated AnimInfo::GetBoneXForm, which is no longer used.

Renamed AnimSkeleton::GetBoneTransform to GetBoneTransformToGlobal.

Made AnimInfo::WriteToNif use AnimWeight::xformSkinToBone in all cases
instead of recalculating it for one case.  The code for recalculating
it was incorrect, anyway (if the global-to-skin transform was messy).

Fixed probably harmless bug in AnimInfo::WriteToNif that was making
NifFile::SetShapeBoneWeights called if not FO4, when the proper
test was not BSShape.  (That is, I changed "if (!isFO4)" to "if
(!isBSShape)".)

Fixed likely bug in AnimInfo::CalcShapeSkinBounds where radius was
not being scaled.

Eliminated AnimSkeleton::GetSkinTransform, which was no longer being called.

Commented out lines in AnimSkeleton::GetBoneTransformToGlobal and
AnimInfo::WriteToNif that were setting scale to 1 for the skeleton's
bone-to-global transforms.  Normally, scale is already 1 for every
bone in the skeleton.  If they're not 1 for the skeleton, it's probably
for a good reason, so we shouldn't override that.

Cleaned up Automorph::MeshFromNifShape and GLSurface::AddMeshFromNif,
particularly for non-skinned meshes.  The transform for non-skinned
meshes is probably still wrong, but it should be closer to being right.

testing:
Loading CBBE_Body.nif and writing it back out: transforms unchanged.

Loading TypeGNoir_1.nif and writing it back out: transforms unchanged,
unlike before.

Add a bone, give it some weight, and write: transforms look good.

Copy bone weights to new bone and write: transforms look good.

Add a bone to TypeGNoir_1.nif, give it some weight, and write: transforms
look good.

For TypeGNoir_1.nif, for shapes with scale!=1, bounding spheres don't
appear correctly in NifSkope.  I don't know if this is a bug in NifSkope
or bad data in TypeGNoir_1.nif.  When Outfit Studio writes out this file,
the bounding spheres are completely different, and NifSkope still doesn't
display them correctly.  I don't know if this is a bug in NifSkope or
Outfit Studio.

Weight painting doesn't work right for shapes with scale!=1 in Outfit
Studio.  My best guess is that this is because of brush size not scaling.
Other brushes have similar problems.