### PR TITLE
Improved add-custom-bone dialog

### DIFF
--- a/res/xrc/OutfitStudio.xrc
+++ b/res/xrc/OutfitStudio.xrc
@@ -2182,6 +2182,10 @@
 				<help>Delete bone(s) from only the selected shapes.</help>
 			</object>
 		</object>
+		<object class="wxMenuItem" name="editBone">
+			<label>Edit Bone...</label>
+			<help>Edit a custom bone or view a standard bone.</help>
+		</object>
 	</object>
 	<object class="wxMenu" name="menuBoneTreeContext">
 		<label>Bones</label>
@@ -2195,6 +2199,10 @@
 				<label>Custom Bone...</label>
 				<help>Add a custom bone to the project.</help>
 			</object>
+		</object>
+		<object class="wxMenuItem" name="editBone">
+			<label>Edit Bone...</label>
+			<help>Edit a custom bone or view a standard bone.</help>
 		</object>
 	</object>
 	<object class="wxMenu" name="menuSegmentContext">

--- a/res/xrc/Skeleton.xrc
+++ b/res/xrc/Skeleton.xrc
@@ -87,6 +87,64 @@
 					<orient>wxHORIZONTAL</orient>
 					<object class="sizeritem">
 						<option>0</option>
+						<flag>wxALL|wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxStaticText" name="lbParentBone">
+							<label>Parent</label>
+							<wrap>-1</wrap>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>1</option>
+						<flag>wxALL|wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxChoice" name="cParentBone">
+							<selection>0</selection>
+							<content />
+						</object>
+					</object>
+				</object>
+			</object>
+			<object class="sizeritem">
+				<option>0</option>
+				<flag>wxALL|wxEXPAND</flag>
+				<border>5</border>
+				<object class="wxFlexGridSizer">
+					<rows>0</rows>
+					<cols>3</cols>
+					<vgap>0</vgap>
+					<hgap>0</hgap>
+					<growablecols>1</growablecols>
+					<growablerows></growablerows>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxStaticText" name="labelblank">
+							<label></label>
+							<wrap>-1</wrap>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxStaticText" name="labelorigin">
+							<label>Origin</label>
+							<wrap>-1</wrap>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxStaticText" name="labelrot">
+							<label>Rotation</label>
+							<wrap>-1</wrap>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
 						<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
 						<border>5</border>
 						<object class="wxStaticText" name="labelX">
@@ -102,14 +160,14 @@
 							<value>0.00000</value>
 						</object>
 					</object>
-				</object>
-			</object>
-			<object class="sizeritem">
-				<option>0</option>
-				<flag>wxALL|wxEXPAND</flag>
-				<border>5</border>
-				<object class="wxBoxSizer">
-					<orient>wxHORIZONTAL</orient>
+					<object class="sizeritem">
+						<option>1</option>
+						<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxTextCtrl" name="textRX">
+							<value>0.00000</value>
+						</object>
+					</object>
 					<object class="sizeritem">
 						<option>0</option>
 						<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
@@ -127,14 +185,14 @@
 							<value>0.00000</value>
 						</object>
 					</object>
-				</object>
-			</object>
-			<object class="sizeritem">
-				<option>0</option>
-				<flag>wxALL|wxEXPAND</flag>
-				<border>5</border>
-				<object class="wxBoxSizer">
-					<orient>wxHORIZONTAL</orient>
+					<object class="sizeritem">
+						<option>1</option>
+						<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxTextCtrl" name="textRY">
+							<value>0.00000</value>
+						</object>
+					</object>
 					<object class="sizeritem">
 						<option>0</option>
 						<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
@@ -149,6 +207,14 @@
 						<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
 						<border>5</border>
 						<object class="wxTextCtrl" name="textZ">
+							<value>0.00000</value>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>1</option>
+						<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxTextCtrl" name="textRZ">
 							<value>0.00000</value>
 						</object>
 					</object>

--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -480,9 +480,8 @@ AnimBone *AnimSkeleton::LoadCustomBoneFromNif(NifFile *nif, const std::string &b
 			parentBone = LoadCustomBoneFromNif(nif, parentNode->GetName());
 	}
 	AnimBone& cstm = AnimSkeleton::getInstance().AddCustomBone(boneName);
-	cstm.parent = parentBone;
-	parentBone->children.push_back(&cstm);
 	cstm.SetTransformBoneToParent(node->GetTransformToParent());
+	cstm.SetParentBone(parentBone);
 	return &cstm;
 }
 
@@ -591,6 +590,21 @@ void AnimBone::UpdatePoseTransform() {
 
 void AnimBone::SetTransformBoneToParent(const MatTransform &ttp) {
 	xformToParent = ttp;
+	UpdateTransformToGlobal();
+	UpdatePoseTransform();
+}
+
+void AnimBone::SetParentBone(AnimBone* newParent) {
+	if (parent == newParent)
+		return;
+	if (parent) {
+		//std::erase(parent->children, this);
+		auto it = std::remove(parent->children.begin(), parent->children.end(), this);
+		parent->children.erase(it, parent->children.end());
+	}
+	parent = newParent;
+	if (parent)
+		parent->children.push_back(this);
 	UpdateTransformToGlobal();
 	UpdatePoseTransform();
 }

--- a/src/components/Anim.h
+++ b/src/components/Anim.h
@@ -150,6 +150,12 @@ public:
 	void SetWeights(const std::string& shape, const std::string& boneName, std::unordered_map<ushort, float>& inVertWeights);
 	bool GetXFormSkinToBone(const std::string& shape, const std::string& boneName, MatTransform& stransform);
 	void SetXFormSkinToBone(const std::string& shape, const std::string& boneName, const MatTransform& stransform);
+	// RecalcXFormSkinToBone recalculates a shape bone's xformSkinToBone
+	// from other transforms.
+	void RecalcXFormSkinToBone(const std::string& shape, const std::string& boneName);
+	// RecursiveRecalcXFormSkinToBone calls RecalcXFormSkinToBone for the
+	// given bone and all its descendants.
+	void RecursiveRecalcXFormSkinToBone(const std::string& shape, AnimBone *bPtr);
 	bool CalcShapeSkinBounds(const std::string& shapeName, const int& boneIndex);
 	void CleanupBones();
 	void WriteToNif(NifFile* nif, const std::string& shapeException = "");

--- a/src/components/Anim.h
+++ b/src/components/Anim.h
@@ -56,13 +56,17 @@ public:
 	// and xformPoseToGlobal, for this and for descendants.
 	void SetTransformBoneToParent(const MatTransform &ttp);
 	// UpdateTransformToGlobal updates xformToGlobal for this and for
-	// descendants.  This should only be called from itself and
-	// SetTransformBoneToParent.
+	// descendants.  This should only be called from itself,
+	// SetTransformBoneToParent, and SetParentBone.
 	void UpdateTransformToGlobal();
 	// UpdatePoseTransform updates xformPoseToGlobal for this and all
 	// descendants.  Call it after poseRotVec, poseTranVec, or
 	// xformToGlobal is changed.
 	void UpdatePoseTransform();
+	// SetParentBone updates "parent" of this and "children" of the old
+	// and new parents.  It also calls UpdateTransformToGlobal and
+	// UpdatePoseTranform.
+	void SetParentBone(AnimBone* newParent);
 };
 
 // Vertex to weight value association. Also keeps track of skin-to-bone transform and bounding sphere.

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -1755,13 +1755,10 @@ void OutfitProject::AddBoneRef(const std::string& boneName) {
 		workAnim.AddShapeBone(s, boneName);
 }
 
-void OutfitProject::AddCustomBoneRef(const std::string& boneName, const Vector3& translation) {
+void OutfitProject::AddCustomBoneRef(const std::string& boneName, const std::string& parentBone, const MatTransform &xformToParent) {
 	AnimBone& customBone = AnimSkeleton::getInstance().AddCustomBone(boneName);
-
-	MatTransform xformBoneToGlobal;
-	xformBoneToGlobal.translation = translation;
-
-	customBone.SetTransformBoneToParent(xformBoneToGlobal);
+	customBone.SetTransformBoneToParent(xformToParent);
+	customBone.SetParentBone(AnimSkeleton::getInstance().GetBonePtr(parentBone));
 
 	for (auto &s : workNif.GetShapeNames())
 		workAnim.AddShapeBone(s, boneName);

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -1764,6 +1764,14 @@ void OutfitProject::AddCustomBoneRef(const std::string& boneName, const std::str
 		workAnim.AddShapeBone(s, boneName);
 }
 
+void OutfitProject::ModifyCustomBone(AnimBone *bPtr, const std::string& parentBone, const MatTransform &xformToParent) {
+	bPtr->SetTransformBoneToParent(xformToParent);
+	bPtr->SetParentBone(AnimSkeleton::getInstance().GetBonePtr(parentBone));
+
+	for (auto &s : workNif.GetShapeNames())
+		workAnim.RecursiveRecalcXFormSkinToBone(s, bPtr);
+}
+
 void OutfitProject::ClearWorkSliders() {
 	morpher.ClearResultDiff();
 }

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -175,6 +175,7 @@ public:
 
 	void AddBoneRef(const std::string& boneName);
 	void AddCustomBoneRef(const std::string& boneName, const std::string& parentBone, const MatTransform &xformToParent);
+	void ModifyCustomBone(AnimBone *bPtr, const std::string& parentBone, const MatTransform &xformToParent);
 
 	void ClearWorkSliders();
 	void ClearReference();

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -174,7 +174,7 @@ public:
 	void ClearBoneScale(bool clear = true);
 
 	void AddBoneRef(const std::string& boneName);
-	void AddCustomBoneRef(const std::string& boneName, const Vector3& translation);
+	void AddCustomBoneRef(const std::string& boneName, const std::string& parentBone, const MatTransform &xformToParent);
 
 	void ClearWorkSliders();
 	void ClearReference();

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -7872,23 +7872,27 @@ void OutfitStudioFrame::OnAddBone(wxCommandEvent& WXUNUSED(event)) {
 void OutfitStudioFrame::FillParentBoneChoice(wxDialog &dlg, const std::string &selBone) {
 	wxChoice *cParentBone = XRCCTRL(dlg, "cParentBone", wxChoice);
 	cParentBone->AppendString("(none)");
+
 	std::set<std::string> boneSet;
 	for (auto selItem : selectedItems) {
 		const std::vector<std::string> &bones = project->GetWorkAnim()->shapeBones[selItem->GetShape()->GetName()];
 		for (const std::string &b : bones)
 			boneSet.insert(b);
 	}
+
 	for (auto &bone : boneSet) {
 		cParentBone->AppendString(bone);
 		if (bone == selBone)
-			cParentBone->SetSelection(cParentBone->GetCount()-1);
+			cParentBone->SetSelection(cParentBone->GetCount() - 1);
 	}
+
 	if (cParentBone->GetSelection() == wxNOT_FOUND) {
-		if (selBone.empty())
+		if (selBone.empty()) {
 			cParentBone->SetSelection(0);
+		}
 		else {
 			cParentBone->AppendString(selBone);
-			cParentBone->SetSelection(cParentBone->GetCount()-1);
+			cParentBone->SetSelection(cParentBone->GetCount() - 1);
 		}
 	}
 }
@@ -7897,15 +7901,18 @@ void OutfitStudioFrame::GetBoneDlgData(wxDialog &dlg, MatTransform &xform, std::
 	xform.translation.x = atof(XRCCTRL(dlg, "textX", wxTextCtrl)->GetValue().c_str());
 	xform.translation.y = atof(XRCCTRL(dlg, "textY", wxTextCtrl)->GetValue().c_str());
 	xform.translation.z = atof(XRCCTRL(dlg, "textZ", wxTextCtrl)->GetValue().c_str());
+
 	Vector3 rotvec;
 	rotvec.x = atof(XRCCTRL(dlg, "textRX", wxTextCtrl)->GetValue().c_str());
 	rotvec.y = atof(XRCCTRL(dlg, "textRY", wxTextCtrl)->GetValue().c_str());
 	rotvec.z = atof(XRCCTRL(dlg, "textRZ", wxTextCtrl)->GetValue().c_str());
 	xform.rotation = RotVecToMat(rotvec);
+
 	wxChoice *cParentBone = XRCCTRL(dlg, "cParentBone", wxChoice);
 	int pBChoice = cParentBone->GetSelection();
 	if (pBChoice != wxNOT_FOUND)
 		parentBone = cParentBone->GetString(pBChoice).ToStdString();
+
 	if (parentBone == "(none)")
 		parentBone = std::string();
 }
@@ -7914,11 +7921,13 @@ void OutfitStudioFrame::OnAddCustomBone(wxCommandEvent& WXUNUSED(event)) {
 	wxDialog dlg;
 	if (!wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgCustomBone"))
 		return;
+
 	dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
 	FillParentBoneChoice(dlg, contextBone);
 
 	if (dlg.ShowModal() != wxID_OK)
 		return;
+
 	wxString bone = XRCCTRL(dlg, "boneName", wxTextCtrl)->GetValue();
 	if (bone.empty()) {
 		wxMessageBox(_("No bone name was entered!"), _("Error"), wxICON_INFORMATION, this);
@@ -7955,13 +7964,18 @@ void OutfitStudioFrame::OnEditBone(wxCommandEvent& WXUNUSED(event)) {
 	wxDialog dlg;
 	if (!wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgCustomBone"))
 		return;
+
 	dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
 
-	FillParentBoneChoice(dlg, bPtr->parent ? bPtr->parent->boneName : std::string());
-	wxChoice *cParentBone = XRCCTRL(dlg, "cParentBone", wxChoice);
+	if (bPtr->parent)
+		FillParentBoneChoice(dlg, bPtr->parent->boneName);
+	else
+		FillParentBoneChoice(dlg);
+
 	wxTextCtrl *boneNameTC = XRCCTRL(dlg, "boneName", wxTextCtrl);
 	boneNameTC->SetValue(bPtr->boneName);
 	boneNameTC->Disable();
+
 	Vector3 rotvec = RotMatToVec(bPtr->xformToParent.rotation);
 	XRCCTRL(dlg, "textX", wxTextCtrl)->SetValue(wxString() << bPtr->xformToParent.translation.x);
 	XRCCTRL(dlg, "textY", wxTextCtrl)->SetValue(wxString() << bPtr->xformToParent.translation.y);

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -1196,6 +1196,9 @@ private:
 	void OnAddCustomBone(wxCommandEvent& event);
 	void OnDeleteBone(wxCommandEvent& event);
 	void OnDeleteBoneFromSelected(wxCommandEvent& event);
+	void FillParentBoneChoice(wxDialog &dlg, const std::string &selBone);
+	void GetBoneDlgData(wxDialog &dlg, MatTransform &xform, std::string &parentBone);
+	void OnEditBone(wxCommandEvent& event);
 	void OnCopyBoneWeight(wxCommandEvent& event);
 	void OnCopySelectedWeight(wxCommandEvent& event);
 	void OnTransferSelectedWeight(wxCommandEvent& event);

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -731,6 +731,7 @@ public:
 	ShapeItemData* activeItem = nullptr;
 	std::string activeSlider;
 	bool bEditSlider;
+	std::string contextBone;
 
 	wxTreeCtrl* outfitShapes;
 	wxTreeCtrl* outfitBones;

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -1196,7 +1196,7 @@ private:
 	void OnAddCustomBone(wxCommandEvent& event);
 	void OnDeleteBone(wxCommandEvent& event);
 	void OnDeleteBoneFromSelected(wxCommandEvent& event);
-	void FillParentBoneChoice(wxDialog &dlg, const std::string &selBone);
+	void FillParentBoneChoice(wxDialog &dlg, const std::string &selBone = "");
 	void GetBoneDlgData(wxDialog &dlg, MatTransform &xform, std::string &parentBone);
 	void OnEditBone(wxCommandEvent& event);
 	void OnCopyBoneWeight(wxCommandEvent& event);


### PR DESCRIPTION
- Added "parent bone" and "rotation" UI elements to the add-custom-bone dialog (dlgCustomBone) and implemented them.

- Added functions to Anim.cpp for changing a bone's parent bone and updating skin-to-bone transforms.

- Added menu item "Edit Bone..." to the bone tree context menu.  It re-opens the add-custom-bone dialog so that the parent bone and transform can be modified.

- Standard (non-custom) bones can not be modified.  For standard bones, the edit-bone dialog is read only.

For more details, see the commit messages.