### PR TITLE
Segment simplification

### DIFF
--- a/lib/NIF/Geometry.cpp
+++ b/lib/NIF/Geometry.cpp
@@ -494,6 +494,22 @@ int NiShape::GetBoneID(NiHeader& hdr, const std::string& boneName) {
 	return 0xFFFFFFFF;
 }
 
+bool NiShape::ReorderTriangles(const std::vector<uint>& triInds) {
+	std::vector<Triangle> trisOrdered;
+	std::vector<Triangle> tris;
+	if (!GetTriangles(tris))
+		return false;
+	if (tris.size() != triInds.size())
+		return false;
+	for (uint id : triInds)
+		if (id < tris.size())
+			trisOrdered.push_back(tris[id]);
+	if (trisOrdered.size() != tris.size())
+		return false;
+	SetTriangles(trisOrdered);
+	return true;
+}
+
 
 BSTriShape::BSTriShape() {
 	vertexDesc.SetFlag(VF_VERTEX);
@@ -1535,6 +1551,135 @@ void BSSubIndexTriShape::Create(std::vector<Vector3>* verts, std::vector<Triangl
 	// Skinned most of the time
 	SetSkinned(true);
 	SetDefaultSegments();
+}
+
+void BSSubIndexTriShape::GetSegmentation(NifSegmentationInfo &inf, std::vector<int> &triParts) {
+	inf.segs.clear();
+	inf.ssfFile = segmentation.subSegmentData.ssfFile.GetString();
+	inf.segs.resize(segmentation.segments.size());
+	triParts.clear();
+	uint numTris = GetNumTriangles();
+	triParts.resize(numTris, -1);
+
+	int partID = 0, arrayIndex = 0;
+	for (int i = 0; i < segmentation.segments.size(); ++i) {
+		BSSITSSegment &seg = segmentation.segments[i];
+		uint startIndex = seg.startIndex / 3;
+		uint endIndex = std::min(numTris, startIndex + seg.numPrimitives);
+		for (uint id = startIndex; id < endIndex; id++)
+			triParts[id] = partID;
+		inf.segs[i].partID = partID++;
+		inf.segs[i].subs.resize(seg.subSegments.size());
+		for (int j = 0; j < seg.subSegments.size(); ++j) {
+			BSSITSSubSegment &sub = seg.subSegments[j];
+			startIndex = sub.startIndex / 3;
+			uint endIndex = std::min(numTris, startIndex + sub.numPrimitives);
+			for (uint id = startIndex; id < endIndex; id++)
+				triParts[id] = partID;
+			inf.segs[i].subs[j].partID = partID++;
+			arrayIndex++;
+			BSSITSSubSegmentDataRecord &rec = segmentation.subSegmentData.dataRecords[arrayIndex];
+			inf.segs[i].subs[j].userSlotID = rec.userSlotID < 30 ? 0 : rec.userSlotID;
+			inf.segs[i].subs[j].material = rec.material;
+			inf.segs[i].subs[j].extraData = rec.extraData;
+		}
+		arrayIndex++;
+	}
+}
+
+void BSSubIndexTriShape::SetSegmentation(const NifSegmentationInfo &inf, const std::vector<int> &inTriParts) {
+	uint numTris = GetNumTriangles();
+	if (inTriParts.size() != numTris)
+		return;
+
+	// Renumber partitions so that the partition IDs are increasing.
+	int newPartID = 0;
+	std::vector<int> oldToNewPartIDs;
+	for (const NifSegmentInfo &seg : inf.segs) {
+		if (seg.partID >= oldToNewPartIDs.size())
+			oldToNewPartIDs.resize(seg.partID + 1);
+		oldToNewPartIDs[seg.partID] = newPartID++;
+		for (const NifSubSegmentInfo &sub : seg.subs) {
+			if (sub.partID >= oldToNewPartIDs.size())
+				oldToNewPartIDs.resize(sub.partID + 1);
+			oldToNewPartIDs[sub.partID] = newPartID++;
+		}
+	}
+	std::vector<int> triParts(numTris);
+	for (int i = 0; i < numTris; ++i)
+		if (triParts[i] >= 0)
+			triParts[i] = oldToNewPartIDs[inTriParts[i]];
+
+	// Sort triangles by partition ID
+	std::vector<uint> triInds(numTris);
+	for (int i = 0; i < numTris; ++i)
+		triInds[i] = i;
+	std::stable_sort(triInds.begin(), triInds.end(), [&triParts](int i, int j) {
+		return triParts[i] < triParts[j];
+	});
+
+	ReorderTriangles(triInds);
+	// Note that triPart's indexing no longer matches triangle indexing.
+
+	// Find first triangle of each partition
+	std::vector<int> partTriInds(newPartID + 1);
+	for (int i = 0, j = 0; i < triInds.size(); ++i)
+		while (triParts[triInds[i]] >= j)
+			partTriInds[j++] = i;
+	partTriInds.back() = triInds.size();
+
+	segmentation = std::move(BSSITSSegmentation());
+	uint parentArrayIndex = 0;
+	uint segmentIndex = 0;
+	int partID = 0;
+
+	for (const NifSegmentInfo &seg : inf.segs) {
+		// Create new segment
+		segmentation.segments.emplace_back();
+		BSSITSSegment &segment = segmentation.segments.back();
+		int childCount = seg.subs.size();
+		segment.numPrimitives = partTriInds[partID + childCount + 1] - partTriInds[partID];
+		segment.startIndex = partTriInds[partID] * 3;
+		segment.numSubSegments = childCount;
+		++partID;
+
+		// Create new segment data record
+		BSSITSSubSegmentDataRecord segmentDataRecord;
+		segmentDataRecord.userSlotID = segmentIndex;
+		segmentation.subSegmentData.arrayIndices.push_back(parentArrayIndex);
+		segmentation.subSegmentData.dataRecords.push_back(segmentDataRecord);
+
+		uint subSegmentNumber = 1;
+		for (const NifSubSegmentInfo &sub : seg.subs) {
+			// Create new subsegment
+			segment.subSegments.emplace_back();
+			BSSITSSubSegment &subSegment = segment.subSegments.back();
+			subSegment.arrayIndex = parentArrayIndex;
+			subSegment.numPrimitives = partTriInds[partID + 1] - partTriInds[partID];
+			subSegment.startIndex = partTriInds[partID] * 3;
+			++partID;
+
+			// Create new subsegment data record
+			BSSITSSubSegmentDataRecord subSegmentDataRecord;
+			if (sub.userSlotID < 30)
+				subSegmentDataRecord.userSlotID = subSegmentNumber++;
+			else
+				subSegmentDataRecord.userSlotID = sub.userSlotID;
+			subSegmentDataRecord.material = sub.material;
+			subSegmentDataRecord.numData = sub.extraData.size();
+			subSegmentDataRecord.extraData = sub.extraData;
+			segmentation.subSegmentData.dataRecords.push_back(subSegmentDataRecord);
+		}
+		parentArrayIndex += childCount + 1;
+		++segmentIndex;
+	}
+
+	segmentation.numPrimitives = numTris;
+	segmentation.numSegments = segmentIndex;
+	segmentation.numTotalSegments = parentArrayIndex;
+	segmentation.subSegmentData.numSegments = segmentIndex;
+	segmentation.subSegmentData.numTotalSegments = parentArrayIndex;
+	segmentation.subSegmentData.ssfFile.SetString(inf.ssfFile);
 }
 
 

--- a/lib/NIF/Geometry.cpp
+++ b/lib/NIF/Geometry.cpp
@@ -499,13 +499,17 @@ bool NiShape::ReorderTriangles(const std::vector<uint>& triInds) {
 	std::vector<Triangle> tris;
 	if (!GetTriangles(tris))
 		return false;
+
 	if (tris.size() != triInds.size())
 		return false;
+
 	for (uint id : triInds)
 		if (id < tris.size())
 			trisOrdered.push_back(tris[id]);
+
 	if (trisOrdered.size() != tris.size())
 		return false;
+
 	SetTriangles(trisOrdered);
 	return true;
 }
@@ -1558,26 +1562,35 @@ void BSSubIndexTriShape::GetSegmentation(NifSegmentationInfo &inf, std::vector<i
 	inf.ssfFile = segmentation.subSegmentData.ssfFile.GetString();
 	inf.segs.resize(segmentation.segments.size());
 	triParts.clear();
+
 	uint numTris = GetNumTriangles();
 	triParts.resize(numTris, -1);
 
-	int partID = 0, arrayIndex = 0;
+	int partID = 0;
+	int arrayIndex = 0;
+
 	for (int i = 0; i < segmentation.segments.size(); ++i) {
 		BSSITSSegment &seg = segmentation.segments[i];
 		uint startIndex = seg.startIndex / 3;
 		uint endIndex = std::min(numTris, startIndex + seg.numPrimitives);
+
 		for (uint id = startIndex; id < endIndex; id++)
 			triParts[id] = partID;
+
 		inf.segs[i].partID = partID++;
 		inf.segs[i].subs.resize(seg.subSegments.size());
+
 		for (int j = 0; j < seg.subSegments.size(); ++j) {
 			BSSITSSubSegment &sub = seg.subSegments[j];
 			startIndex = sub.startIndex / 3;
-			uint endIndex = std::min(numTris, startIndex + sub.numPrimitives);
+
+			endIndex = std::min(numTris, startIndex + sub.numPrimitives);
 			for (uint id = startIndex; id < endIndex; id++)
 				triParts[id] = partID;
+
 			inf.segs[i].subs[j].partID = partID++;
 			arrayIndex++;
+
 			BSSITSSubSegmentDataRecord &rec = segmentation.subSegmentData.dataRecords[arrayIndex];
 			inf.segs[i].subs[j].userSlotID = rec.userSlotID < 30 ? 0 : rec.userSlotID;
 			inf.segs[i].subs[j].material = rec.material;
@@ -1598,6 +1611,7 @@ void BSSubIndexTriShape::SetSegmentation(const NifSegmentationInfo &inf, const s
 	for (const NifSegmentInfo &seg : inf.segs) {
 		if (seg.partID >= oldToNewPartIDs.size())
 			oldToNewPartIDs.resize(seg.partID + 1);
+
 		oldToNewPartIDs[seg.partID] = newPartID++;
 		for (const NifSubSegmentInfo &sub : seg.subs) {
 			if (sub.partID >= oldToNewPartIDs.size())
@@ -1605,6 +1619,7 @@ void BSSubIndexTriShape::SetSegmentation(const NifSegmentationInfo &inf, const s
 			oldToNewPartIDs[sub.partID] = newPartID++;
 		}
 	}
+
 	std::vector<int> triParts(numTris);
 	for (int i = 0; i < numTris; ++i)
 		if (triParts[i] >= 0)
@@ -1614,6 +1629,7 @@ void BSSubIndexTriShape::SetSegmentation(const NifSegmentationInfo &inf, const s
 	std::vector<uint> triInds(numTris);
 	for (int i = 0; i < numTris; ++i)
 		triInds[i] = i;
+
 	std::stable_sort(triInds.begin(), triInds.end(), [&triParts](int i, int j) {
 		return triParts[i] < triParts[j];
 	});
@@ -1626,6 +1642,7 @@ void BSSubIndexTriShape::SetSegmentation(const NifSegmentationInfo &inf, const s
 	for (int i = 0, j = 0; i < triInds.size(); ++i)
 		while (triParts[triInds[i]] >= j)
 			partTriInds[j++] = i;
+
 	partTriInds.back() = triInds.size();
 
 	segmentation = std::move(BSSITSSegmentation());
@@ -1665,11 +1682,13 @@ void BSSubIndexTriShape::SetSegmentation(const NifSegmentationInfo &inf, const s
 				subSegmentDataRecord.userSlotID = subSegmentNumber++;
 			else
 				subSegmentDataRecord.userSlotID = sub.userSlotID;
+
 			subSegmentDataRecord.material = sub.material;
 			subSegmentDataRecord.numData = sub.extraData.size();
 			subSegmentDataRecord.extraData = sub.extraData;
 			segmentation.subSegmentData.dataRecords.push_back(subSegmentDataRecord);
 		}
+
 		parentArrayIndex += childCount + 1;
 		++segmentIndex;
 	}

--- a/lib/NIF/Geometry.h
+++ b/lib/NIF/Geometry.h
@@ -708,7 +708,7 @@ public:
 	NiGeometryData* GetGeomData();
 	void SetGeomData(NiGeometryData* geomDataPtr);
 
-	virtual bool ReorderTriangles(const std::vector<uint>& triInds) {return false;}
+	virtual bool ReorderTriangles(const std::vector<uint>&) { return false; }
 
 	NiTriStrips* Clone() { return new NiTriStrips(*this); }
 };

--- a/lib/NIF/Geometry.h
+++ b/lib/NIF/Geometry.h
@@ -307,6 +307,7 @@ public:
 	virtual uint GetNumTriangles();
 	virtual bool GetTriangles(std::vector<Triangle>& tris);
 	virtual void SetTriangles(const std::vector<Triangle>& tris);
+	virtual bool ReorderTriangles(const std::vector<uint>& triInds);
 
 	virtual void SetBounds(const BoundingSphere& bounds);
 	virtual BoundingSphere GetBounds();
@@ -426,6 +427,38 @@ public:
 };
 
 
+// NifSubSegmentInfo: not in file.  The portion of a subsegment's data
+// that has nothing to do with triangle set partitioning.
+struct NifSubSegmentInfo {
+	// partID: a small nonnegative integer uniquely identifying this
+	// subsegment among all the segments and subsegments.  Used as a value
+	// in triParts.  Not in the file.
+	int partID;
+	uint userSlotID;
+	uint material;
+	std::vector<float> extraData;
+};
+
+// NifSegmentInfo: not in file.  The portion of a segment's data that
+// has nothing to do with triangle set partitioning.
+struct NifSegmentInfo {
+	// partID: a small nonnegative integer uniquely identifying this
+	// segment among all the segments and subsegments.  Used as a value
+	// in triParts.  Not in the file.
+	int partID;
+	std::vector<NifSubSegmentInfo> subs;
+};
+
+// NifSegmentationInfo: not in file.  The portion of a shape's
+// segmentation data that has nothing to do with triangle set partitioning.
+// The intention is that this data structure can be used for any type of
+// segmentation data, both BSSITSSegmentation and BSGeometrySegmentData.
+struct NifSegmentationInfo {
+	std::vector<NifSegmentInfo> segs;
+	std::string ssfFile;
+};
+
+
 class BSGeometrySegmentData {
 public:
 	byte flags = 0;
@@ -498,8 +531,8 @@ public:
 	void notifyVerticesDelete(const std::vector<ushort>& vertIndices);
 	BSSubIndexTriShape* Clone() { return new BSSubIndexTriShape(*this); }
 
-	BSSITSSegmentation GetSegmentation() { return segmentation; }
-	void SetSegmentation(const BSSITSSegmentation& seg) { segmentation = seg; }
+	void GetSegmentation(NifSegmentationInfo &inf, std::vector<int> &triParts);
+	void SetSegmentation(const NifSegmentationInfo &inf, const std::vector<int> &triParts);
 
 	void SetDefaultSegments();
 	void Create(std::vector<Vector3>* verts, std::vector<Triangle>* tris, std::vector<Vector2>* uvs, std::vector<Vector3>* normals = nullptr);
@@ -674,6 +707,8 @@ public:
 
 	NiGeometryData* GetGeomData();
 	void SetGeomData(NiGeometryData* geomDataPtr);
+
+	virtual bool ReorderTriangles(const std::vector<uint>& triInds) {return false;}
 
 	NiTriStrips* Clone() { return new NiTriStrips(*this); }
 };

--- a/lib/NIF/NifFile.cpp
+++ b/lib/NIF/NifFile.cpp
@@ -2096,21 +2096,21 @@ void NifFile::ClearShapeVertWeights(const std::string& shapeName) {
 	}
 }
 
-bool NifFile::GetShapeSegments(NiShape* shape, BSSubIndexTriShape::BSSITSSegmentation& segmentation) {
+bool NifFile::GetShapeSegments(NiShape* shape, NifSegmentationInfo& inf, std::vector<int>& triParts) {
 	auto bssits = dynamic_cast<BSSubIndexTriShape*>(shape);
 	if (!bssits)
 		return false;
 
-	segmentation = bssits->GetSegmentation();
+	bssits->GetSegmentation(inf, triParts);
 	return true;
 }
 
-void NifFile::SetShapeSegments(NiShape* shape, const BSSubIndexTriShape::BSSITSSegmentation& segmentation) {
+void NifFile::SetShapeSegments(NiShape* shape, const NifSegmentationInfo& inf, const std::vector<int>& triParts) {
 	auto bssits = dynamic_cast<BSSubIndexTriShape*>(shape);
 	if (!bssits)
 		return;
 
-	bssits->SetSegmentation(segmentation);
+	bssits->SetSegmentation(inf, triParts);
 }
 
 bool NifFile::GetShapePartitions(NiShape* shape, std::vector<BSDismemberSkinInstance::PartitionInfo>& partitionInfo, std::vector<int> &triParts) {
@@ -2326,24 +2326,7 @@ bool NifFile::ReorderTriangles(NiShape* shape, const std::vector<uint>& triangle
 	if (shape->HasType<NiTriStrips>())
 		return false;
 
-	std::vector<Triangle> trisOrdered;
-	std::vector<Triangle> tris;
-	if (shape->GetTriangles(tris)) {
-		if (triangleIndices.size() != tris.size())
-			return false;
-
-		for (auto &id : triangleIndices)
-			if (tris.size() >= id)
-				trisOrdered.push_back(tris[id]);
-
-		if (trisOrdered.size() != tris.size())
-			return false;
-
-		shape->SetTriangles(trisOrdered);
-		return true;
-	}
-
-	return false;
+	return shape->ReorderTriangles(triangleIndices);
 }
 
 const std::vector<Vector3>* NifFile::GetNormalsForShape(NiShape* shape, bool transform) {

--- a/lib/NIF/NifFile.h
+++ b/lib/NIF/NifFile.h
@@ -209,8 +209,8 @@ public:
 	void SetShapeVertWeights(const std::string& shapeName, const int vertIndex, std::vector<byte>& boneids, std::vector<float>& weights);
 	void ClearShapeVertWeights(const std::string& shapeName);
 
-	bool GetShapeSegments(NiShape* shape, BSSubIndexTriShape::BSSITSSegmentation& segmentation);
-	void SetShapeSegments(NiShape* shape, const BSSubIndexTriShape::BSSITSSegmentation& segmentation);
+	bool GetShapeSegments(NiShape* shape, NifSegmentationInfo& inf, std::vector<int>& triParts);
+	void SetShapeSegments(NiShape* shape, const NifSegmentationInfo& inf, const std::vector<int>& triParts);
 
 	bool GetShapePartitions(NiShape* shape, std::vector<BSDismemberSkinInstance::PartitionInfo>& partitionInfo, std::vector<int> &triParts);
 	void SetShapePartitions(NiShape* shape, const std::vector<BSDismemberSkinInstance::PartitionInfo>& partitionInfo, const std::vector<int> &triParts, const bool convertSkinInstance = true);

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -4565,7 +4565,9 @@ void OutfitStudioFrame::CreateSegmentTree(NiShape* shape) {
 	}
 	else {
 		triParts.clear();
-		triParts.resize(shape->GetNumTriangles(), -1);
+
+		if (shape)
+			triParts.resize(shape->GetNumTriangles(), -1);
 	}
 
 	wxTextCtrl* segmentSSF = (wxTextCtrl*)FindWindowByName("segmentSSF");

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -4547,6 +4547,7 @@ void OutfitStudioFrame::OnSegmentReset(wxCommandEvent& event) {
 }
 
 void OutfitStudioFrame::CreateSegmentTree(NiShape* shape) {
+	triParts.clear(); // DeleteChildren might call OnSegmentSelect
 	if (segmentTree->GetChildrenCount(segmentRoot) > 0)
 		segmentTree->DeleteChildren(segmentRoot);
 
@@ -4564,8 +4565,6 @@ void OutfitStudioFrame::CreateSegmentTree(NiShape* shape) {
 		}
 	}
 	else {
-		triParts.clear();
-
 		if (shape)
 			triParts.resize(shape->GetNumTriangles(), -1);
 	}
@@ -4934,6 +4933,7 @@ void OutfitStudioFrame::OnPartitionReset(wxCommandEvent& event) {
 }
 
 void OutfitStudioFrame::CreatePartitionTree(NiShape* shape) {
+	triParts.clear(); // DeleteChildren might call OnPartitionSelect
 	if (partitionTree->GetChildrenCount(partitionRoot) > 0)
 		partitionTree->DeleteChildren(partitionRoot);
 

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -4611,6 +4611,8 @@ void OutfitStudioFrame::ShowSegment(const wxTreeItemId& item, bool updateFromMas
 	std::vector<Triangle> tris;
 	if (activeItem->GetShape())
 		activeItem->GetShape()->GetTriangles(tris);
+	if (triParts.size() != tris.size())
+		return;
 
 	// selPartIDs will be true for selected item and its children.
 	std::vector<bool> selPartIDs(CalcMaxSegPartID() + 1, false);
@@ -4680,7 +4682,7 @@ void OutfitStudioFrame::ShowSegment(const wxTreeItemId& item, bool updateFromMas
 			if (updateFromMask) {
 				// Add triangles from mask
 				for (int t = 0; t < tris.size(); t++) {
-					if (mask.find(tris[t].p1) != mask.end() && mask.find(tris[t].p2) != mask.end() && mask.find(tris[t].p3) != mask.end() && !selPartIDs[triParts[t]])
+					if (mask.find(tris[t].p1) != mask.end() && mask.find(tris[t].p2) != mask.end() && mask.find(tris[t].p3) != mask.end() && (triParts[t] < 0 || !selPartIDs[triParts[t]]))
 						triParts[t] = destPartID;
 				}
 			}

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -77,22 +77,28 @@ struct ShapeItemState {
 
 class SegmentItemData : public wxTreeItemData  {
 public:
-	std::set<uint> tris;
+	// partID: a small nonnegative integer uniquely identifying this
+	// segment among all the segments and subsegments.  Used as a value
+	// in triParts.  Not in the file.
+	int partID;
 
-	SegmentItemData(const std::set<uint>& inTriangles) {
-		tris = inTriangles;
+	SegmentItemData(int inPartitionID) {
+		partID = inPartitionID;
 	}
 };
 
 class SubSegmentItemData : public wxTreeItemData  {
 public:
-	std::set<uint> tris;
+	// partID: a small nonnegative integer uniquely identifying this
+	// subsegment among all the segments and subsegments.  Used as a value
+	// in triParts.  Not in the file.
+	int partID;
 	uint userSlotID;
 	uint material;
 	std::vector<float> extraData;
 
-	SubSegmentItemData(const std::set<uint>& inTriangles, const uint& inUserSlotID, const uint& inMaterial, const std::vector<float>& inExtraData = std::vector<float>()) {
-		tris = inTriangles;
+	SubSegmentItemData(int inPartitionID, const uint& inUserSlotID, const uint& inMaterial, const std::vector<float>& inExtraData = std::vector<float>()) {
+		partID = inPartitionID;
 		userSlotID = inUserSlotID;
 		material = inMaterial;
 		extraData = inExtraData;
@@ -1122,6 +1128,7 @@ private:
 	void OnBoneContext(wxTreeEvent& event);
 	void OnBoneTreeContext(wxCommandEvent& event);
 
+	int CalcMaxSegPartID();
 	void OnSegmentSelect(wxTreeEvent& event);
 	void OnSegmentContext(wxTreeEvent& event);
 	void OnSegmentTreeContext(wxCommandEvent& event);

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -79,7 +79,7 @@ class SegmentItemData : public wxTreeItemData  {
 public:
 	// partID: a small nonnegative integer uniquely identifying this
 	// segment among all the segments and subsegments.  Used as a value
-	// in triParts.  Not in the file.
+	// in triSParts.  Not in the file.
 	int partID;
 
 	SegmentItemData(int inPartitionID) {
@@ -91,7 +91,7 @@ class SubSegmentItemData : public wxTreeItemData  {
 public:
 	// partID: a small nonnegative integer uniquely identifying this
 	// subsegment among all the segments and subsegments.  Used as a value
-	// in triParts.  Not in the file.
+	// in triSParts.  Not in the file.
 	int partID;
 	uint userSlotID;
 	uint material;
@@ -752,6 +752,7 @@ public:
 	bool bEditSlider;
 	std::string contextBone;
 	std::vector<int> triParts;  // the partition index for each triangle, or -1 for none
+	std::vector<int> triSParts;  // the segment partition index for each triangle, or -1 for none
 
 	wxTreeCtrl* outfitShapes;
 	wxTreeCtrl* outfitBones;


### PR DESCRIPTION
This PR changes the way segment triangle membership is represented in OutfitStudioFrame to the triParts representation.  The code for translating to and from the new representation is in BSSubIndexTriShape.

Incidentally, I changed the way segments are colored in the model view.  The coloring is now the same as for partitions.