### PR TITLE
Added copy-bone-weight option to also copy skin transform.

### DIFF
--- a/lib/NIF/NifFile.h
+++ b/lib/NIF/NifFile.h
@@ -180,6 +180,10 @@ public:
 	void SetShapeBoneIDList(NiShape* shape, std::vector<int>& inList);
 	int GetShapeBoneWeights(NiShape* shape, const int boneIndex, std::unordered_map<ushort, float>& outWeights);
 
+	// Looks up the shape's global-to-skin transform if it has it.
+	// Otherwise, try to calculate it using skin-to-bone and node-to-global
+	// transforms.  Returns false on failure.
+	bool CalcShapeTransformGlobalToSkin(NiShape* shape, MatTransform& outTransforms);
 	// Returns false if no such transform exists in the file, in which
 	// case outTransform will not be changed.  Note that, even if this
 	// function returns false, you can not assume that the global-to-skin

--- a/lib/NIF/utils/Object3d.h
+++ b/lib/NIF/utils/Object3d.h
@@ -21,6 +21,11 @@ typedef unsigned char byte;
 typedef unsigned short ushort;
 typedef unsigned int uint;
 
+inline bool FloatsAreNearlyEqual(float a, float b) {
+	float scale = std::max(std::max(std::fabs(a), std::fabs(b)), 1.0f);
+	return std::fabs(a - b) <= EPSILON * scale;
+}
+
 struct Vector2 {
 	float u;
 	float v;
@@ -267,6 +272,12 @@ struct Vector3 {
 			y = 0.0f;
 		if (fabs(z) < EPSILON)
 			z = 0.0f;
+	}
+
+	bool IsNearlyEqualTo(const Vector3& other) const {
+		return FloatsAreNearlyEqual(x, other.x) &&
+			FloatsAreNearlyEqual(y, other.y) &&
+			FloatsAreNearlyEqual(z, other.z);
 	}
 };
 
@@ -538,6 +549,12 @@ public:
 		p *= 180.0f / PI;
 		r *= 180.0f / PI;
 		return canRot;
+	}
+
+	bool IsNearlyEqualTo(const Matrix3 &other) const {
+		return rows[0].IsNearlyEqualTo(other.rows[0]) &&
+			rows[1].IsNearlyEqualTo(other.rows[1]) &&
+			rows[2].IsNearlyEqualTo(other.rows[2]);
 	}
 };
 
@@ -963,6 +980,12 @@ struct MatTransform {
 	// of this and other.  That is, if t3 = t1.ComposeTransforms(t2), then
 	// t3.ApplyTransform(v) == t1.ApplyTransform(t2.ApplyTransform(v)).
 	MatTransform ComposeTransforms(const MatTransform &other) const;
+
+	bool IsNearlyEqualTo(const MatTransform &other) const {
+		return translation.IsNearlyEqualTo(other.translation) &&
+			rotation.IsNearlyEqualTo(other.rotation) &&
+			FloatsAreNearlyEqual(scale, other.scale);
+	}
 };
 
 

--- a/res/xrc/Actions.xrc
+++ b/res/xrc/Actions.xrc
@@ -769,7 +769,16 @@
 				<border>10</border>
 				<object class="wxCheckBox" name="cbCopySkinTrans">
 					<label>Copy global-to-skin transform from reference to selected shape(s).</label>
-					<checked>0</checked>
+					<checked>1</checked>
+				</object>
+			</object>
+			<object class="sizeritem">
+				<option>0</option>
+				<flag>wxLEFT</flag>
+				<border>10</border>
+				<object class="wxCheckBox" name="cbTransformGeo">
+					<label>Transform geometry so its position in global coordinates does not change.</label>
+					<checked>1</checked>
 				</object>
 			</object>
 			<object class="sizeritem">

--- a/res/xrc/Actions.xrc
+++ b/res/xrc/Actions.xrc
@@ -759,7 +759,7 @@
 				<flag>wxALL|wxEXPAND</flag>
 				<border>5</border>
 				<object class="wxStaticText" name="copyTransDescription">
-					<label>The selected shape(s) has a different skin coordinate system from the reference shape.  Do you want to copy the transforms so they have the same skin coordinates?</label>
+					<label>The skin coordinate system doesn't match the reference shape's. Do you want to copy the transforms?</label>
 					<wrap>550</wrap>
 				</object>
 			</object>
@@ -768,7 +768,7 @@
 				<flag>wxLEFT</flag>
 				<border>10</border>
 				<object class="wxCheckBox" name="cbCopySkinTrans">
-					<label>Copy global-to-skin transform from reference to selected shape(s).</label>
+					<label>Copy skin transform from reference</label>
 					<checked>1</checked>
 				</object>
 			</object>
@@ -777,7 +777,8 @@
 				<flag>wxLEFT</flag>
 				<border>10</border>
 				<object class="wxCheckBox" name="cbTransformGeo">
-					<label>Transform geometry so its position in global coordinates does not change.</label>
+					<label>Recalculate geometry's coordinates so it doesn't move</label>
+					<tooltip>Transform geometry so its position in global coordinates does not change.</tooltip>
 					<checked>1</checked>
 				</object>
 			</object>

--- a/res/xrc/Actions.xrc
+++ b/res/xrc/Actions.xrc
@@ -755,6 +755,24 @@
 				</object>
 			</object>
 			<object class="sizeritem">
+				<option>0</option>
+				<flag>wxALL|wxEXPAND</flag>
+				<border>5</border>
+				<object class="wxStaticText" name="copyTransDescription">
+					<label>The selected shape(s) has a different skin coordinate system from the reference shape.  Do you want to copy the transforms so they have the same skin coordinates?</label>
+					<wrap>550</wrap>
+				</object>
+			</object>
+			<object class="sizeritem">
+				<option>0</option>
+				<flag>wxLEFT</flag>
+				<border>10</border>
+				<object class="wxCheckBox" name="cbCopySkinTrans">
+					<label>Copy global-to-skin transform from reference to selected shape(s).</label>
+					<checked>0</checked>
+				</object>
+			</object>
+			<object class="sizeritem">
 				<option>1</option>
 				<flag>wxEXPAND|wxALL</flag>
 				<border>5</border>

--- a/res/xrc/Actions.xrc
+++ b/res/xrc/Actions.xrc
@@ -668,7 +668,7 @@
 			<object class="sizeritem">
 				<option>0</option>
 				<flag>wxALL|wxEXPAND</flag>
-				<border>5</border>
+				<border>10</border>
 				<object class="wxStaticText" name="copyWeightsDescription">
 					<label>Each vertex of the reference will copy its weights to the nearest collection of vertices within the given radius. Bear in mind that some geometry will always require manual tweaking to become weighted and work well. Often, the default values are sufficient.</label>
 					<wrap>550</wrap>
@@ -757,10 +757,11 @@
 			<object class="sizeritem">
 				<option>0</option>
 				<flag>wxALL|wxEXPAND</flag>
-				<border>5</border>
+				<border>10</border>
 				<object class="wxStaticText" name="copyTransDescription">
 					<label>The skin coordinate system doesn't match the reference shape's. Do you want to copy the transforms?</label>
 					<wrap>550</wrap>
+					<hidden>1</hidden>
 				</object>
 			</object>
 			<object class="sizeritem">
@@ -770,6 +771,7 @@
 				<object class="wxCheckBox" name="cbCopySkinTrans">
 					<label>Copy skin transform from reference</label>
 					<checked>1</checked>
+					<hidden>1</hidden>
 				</object>
 			</object>
 			<object class="sizeritem">
@@ -780,6 +782,7 @@
 					<label>Recalculate geometry's coordinates so it doesn't move</label>
 					<tooltip>Transform geometry so its position in global coordinates does not change.</tooltip>
 					<checked>1</checked>
+					<hidden>1</hidden>
 				</object>
 			</object>
 			<object class="sizeritem">
@@ -815,7 +818,7 @@
 			<object class="sizeritem">
 				<option>0</option>
 				<flag>wxALL|wxEXPAND</flag>
-				<border>5</border>
+				<border>10</border>
 				<object class="wxStaticText" name="conformingDescription">
 					<label>Each vertex of the reference will copy its slider data to the nearest collection of vertices within the given radius. Bear in mind that some geometry will always require manual tweaking to become conformed and work well. Often, the default values are sufficient.</label>
 					<wrap>550</wrap>

--- a/res/xrc/ShapeProperties.xrc
+++ b/res/xrc/ShapeProperties.xrc
@@ -559,6 +559,172 @@
 							</object>
 						</object>
 					</object>
+					<object class="notebookpage">
+						<label>Coordinates</label>
+						<object class="wxPanel" name="pgCoordinates">
+							<object class="wxBoxSizer">
+								<orient>wxVERTICAL</orient>
+								<object class="sizeritem">
+									<option>0</option>
+									<flag>wxALIGN_CENTER_VERTICAL|wxTOP|wxLEFT|wxRIGHT</flag>
+									<border>5</border>
+									<object class="wxStaticText" name="lbCoordIntro">
+										<label>The shape's transform from global coordinates to skin coordinates: (All shape geometry is represented in skin coordinates)</label>
+										<wrap>500</wrap>
+									</object>
+								</object>
+								<object class="sizeritem">
+									<option>0</option>
+									<flag>wxALL|wxEXPAND</flag>
+									<border>5</border>
+									<object class="wxBoxSizer">
+										<orient>wxHORIZONTAL</orient>
+										<object class="sizeritem">
+											<option>0</option>
+											<flag>wxALL</flag>
+											<border>5</border>
+											<object class="wxStaticText" name="lbScale">
+												<label>Scale</label>
+												<wrap>-1</wrap>
+											</object>
+										</object>
+										<object class="sizeritem">
+											<option>1</option>
+											<flag>wxALL</flag>
+											<border>5</border>
+											<object class="wxTextCtrl" name="textScale">
+												<value>1.00000</value>
+											</object>
+										</object>
+									</object>
+								</object>
+								<object class="sizeritem">
+									<option>0</option>
+									<flag>wxALL|wxEXPAND</flag>
+									<border>5</border>
+									<object class="wxFlexGridSizer">
+										<rows>0</rows>
+										<cols>3</cols>
+										<vgap>0</vgap>
+										<hgap>0</hgap>
+										<growablecols>2</growablecols>
+										<growablerows></growablerows>
+										<object class="sizeritem">
+											<option>0</option>
+											<flag>wxLEFT|wxRIGHT</flag>
+											<border>5</border>
+											<object class="wxStaticText" name="labelblank">
+												<label></label>
+												<wrap>-1</wrap>
+											</object>
+										</object>
+										<object class="sizeritem">
+											<option>0</option>
+											<flag>wxLEFT|wxRIGHT</flag>
+											<border>5</border>
+											<object class="wxStaticText" name="labelorigin">
+												<label>Origin</label>
+												<wrap>-1</wrap>
+											</object>
+										</object>
+										<object class="sizeritem">
+											<option>0</option>
+											<flag>wxLEFT|wxRIGHT</flag>
+											<border>5</border>
+											<object class="wxStaticText" name="labelrot">
+												<label>Rotation</label>
+												<wrap>-1</wrap>
+											</object>
+										</object>
+										<object class="sizeritem">
+											<option>0</option>
+											<flag>wxLEFT|wxRIGHT</flag>
+											<border>5</border>
+											<object class="wxStaticText" name="labelX">
+												<label>X</label>
+												<wrap>-1</wrap>
+											</object>
+										</object>
+										<object class="sizeritem">
+											<option>1</option>
+											<flag>wxLEFT|wxRIGHT</flag>
+											<border>5</border>
+											<object class="wxTextCtrl" name="textX">
+												<value>0.00000</value>
+											</object>
+										</object>
+										<object class="sizeritem">
+											<option>1</option>
+											<flag>wxLEFT|wxRIGHT</flag>
+											<border>5</border>
+											<object class="wxTextCtrl" name="textRX">
+												<value>0.00000</value>
+											</object>
+										</object>
+										<object class="sizeritem">
+											<option>0</option>
+											<flag>wxLEFT|wxRIGHT</flag>
+											<border>5</border>
+											<object class="wxStaticText" name="labelY">
+												<label>Y</label>
+												<wrap>-1</wrap>
+											</object>
+										</object>
+										<object class="sizeritem">
+											<option>1</option>
+											<flag>wxLEFT|wxRIGHT</flag>
+											<border>5</border>
+											<object class="wxTextCtrl" name="textY">
+												<value>0.00000</value>
+											</object>
+										</object>
+										<object class="sizeritem">
+											<option>1</option>
+											<flag>wxLEFT|wxRIGHT</flag>
+											<border>5</border>
+											<object class="wxTextCtrl" name="textRY">
+												<value>0.00000</value>
+											</object>
+										</object>
+										<object class="sizeritem">
+											<option>0</option>
+											<flag>wxLEFT|wxRIGHT</flag>
+											<border>5</border>
+											<object class="wxStaticText" name="labelZ">
+												<label>Z</label>
+												<wrap>-1</wrap>
+											</object>
+										</object>
+										<object class="sizeritem">
+											<option>1</option>
+											<flag>wxLEFT|wxRIGHT</flag>
+											<border>5</border>
+											<object class="wxTextCtrl" name="textZ">
+												<value>0.00000</value>
+											</object>
+										</object>
+										<object class="sizeritem">
+											<option>1</option>
+											<flag>wxLEFT|wxRIGHT</flag>
+											<border>5</border>
+											<object class="wxTextCtrl" name="textRZ">
+												<value>0.00000</value>
+											</object>
+										</object>
+									</object>
+								</object>
+								<object class="sizeritem">
+									<option>0</option>
+									<flag>wxLEFT</flag>
+									<border>10</border>
+									<object class="wxCheckBox" name="cbTransformGeo">
+										<label>Transform geometry so its position in global coordinates does not change.</label>
+										<checked>1</checked>
+									</object>
+								</object>
+							</object>
+						</object>
+					</object>
 				</object>
 			</object>
 			<object class="spacer">

--- a/res/xrc/ShapeProperties.xrc
+++ b/res/xrc/ShapeProperties.xrc
@@ -567,9 +567,9 @@
 								<object class="sizeritem">
 									<option>0</option>
 									<flag>wxALIGN_CENTER_VERTICAL|wxTOP|wxLEFT|wxRIGHT</flag>
-									<border>5</border>
+									<border>10</border>
 									<object class="wxStaticText" name="lbCoordIntro">
-										<label>The shape's transform from global coordinates to skin coordinates: (All shape geometry is represented in skin coordinates)</label>
+										<label>Transform from global to skin coordinates:</label>
 										<wrap>500</wrap>
 									</object>
 								</object>
@@ -581,7 +581,7 @@
 										<orient>wxHORIZONTAL</orient>
 										<object class="sizeritem">
 											<option>0</option>
-											<flag>wxALL</flag>
+											<flag>wxALL|wxALIGN_CENTER</flag>
 											<border>5</border>
 											<object class="wxStaticText" name="lbScale">
 												<label>Scale</label>
@@ -607,7 +607,7 @@
 										<cols>3</cols>
 										<vgap>0</vgap>
 										<hgap>0</hgap>
-										<growablecols>2</growablecols>
+										<growablecols>1,2</growablecols>
 										<growablerows></growablerows>
 										<object class="sizeritem">
 											<option>0</option>
@@ -620,7 +620,7 @@
 										</object>
 										<object class="sizeritem">
 											<option>0</option>
-											<flag>wxLEFT|wxRIGHT</flag>
+											<flag>wxLEFT|wxRIGHT|wxALIGN_CENTER</flag>
 											<border>5</border>
 											<object class="wxStaticText" name="labelorigin">
 												<label>Origin</label>
@@ -629,7 +629,7 @@
 										</object>
 										<object class="sizeritem">
 											<option>0</option>
-											<flag>wxLEFT|wxRIGHT</flag>
+											<flag>wxLEFT|wxRIGHT|wxALIGN_CENTER</flag>
 											<border>5</border>
 											<object class="wxStaticText" name="labelrot">
 												<label>Rotation</label>
@@ -638,7 +638,7 @@
 										</object>
 										<object class="sizeritem">
 											<option>0</option>
-											<flag>wxLEFT|wxRIGHT</flag>
+											<flag>wxLEFT|wxRIGHT|wxALIGN_CENTER</flag>
 											<border>5</border>
 											<object class="wxStaticText" name="labelX">
 												<label>X</label>
@@ -646,16 +646,16 @@
 											</object>
 										</object>
 										<object class="sizeritem">
-											<option>1</option>
-											<flag>wxLEFT|wxRIGHT</flag>
+											<option>0</option>
+											<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
 											<border>5</border>
 											<object class="wxTextCtrl" name="textX">
 												<value>0.00000</value>
 											</object>
 										</object>
 										<object class="sizeritem">
-											<option>1</option>
-											<flag>wxLEFT|wxRIGHT</flag>
+											<option>0</option>
+											<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
 											<border>5</border>
 											<object class="wxTextCtrl" name="textRX">
 												<value>0.00000</value>
@@ -663,7 +663,7 @@
 										</object>
 										<object class="sizeritem">
 											<option>0</option>
-											<flag>wxLEFT|wxRIGHT</flag>
+											<flag>wxLEFT|wxRIGHT|wxALIGN_CENTER</flag>
 											<border>5</border>
 											<object class="wxStaticText" name="labelY">
 												<label>Y</label>
@@ -671,16 +671,16 @@
 											</object>
 										</object>
 										<object class="sizeritem">
-											<option>1</option>
-											<flag>wxLEFT|wxRIGHT</flag>
+											<option>0</option>
+											<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
 											<border>5</border>
 											<object class="wxTextCtrl" name="textY">
 												<value>0.00000</value>
 											</object>
 										</object>
 										<object class="sizeritem">
-											<option>1</option>
-											<flag>wxLEFT|wxRIGHT</flag>
+											<option>0</option>
+											<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
 											<border>5</border>
 											<object class="wxTextCtrl" name="textRY">
 												<value>0.00000</value>
@@ -688,7 +688,7 @@
 										</object>
 										<object class="sizeritem">
 											<option>0</option>
-											<flag>wxLEFT|wxRIGHT</flag>
+											<flag>wxLEFT|wxRIGHT|wxALIGN_CENTER</flag>
 											<border>5</border>
 											<object class="wxStaticText" name="labelZ">
 												<label>Z</label>
@@ -696,16 +696,16 @@
 											</object>
 										</object>
 										<object class="sizeritem">
-											<option>1</option>
-											<flag>wxLEFT|wxRIGHT</flag>
+											<option>0</option>
+											<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
 											<border>5</border>
 											<object class="wxTextCtrl" name="textZ">
 												<value>0.00000</value>
 											</object>
 										</object>
 										<object class="sizeritem">
-											<option>1</option>
-											<flag>wxLEFT|wxRIGHT</flag>
+											<option>0</option>
+											<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
 											<border>5</border>
 											<object class="wxTextCtrl" name="textRZ">
 												<value>0.00000</value>
@@ -715,10 +715,11 @@
 								</object>
 								<object class="sizeritem">
 									<option>0</option>
-									<flag>wxLEFT</flag>
+									<flag>wxALL</flag>
 									<border>10</border>
 									<object class="wxCheckBox" name="cbTransformGeo">
-										<label>Transform geometry so its position in global coordinates does not change.</label>
+										<label>Recalculate geometry's coordinates so it doesn't move</label>
+										<tooltip>Transform geometry so its position in global coordinates does not change.</tooltip>
 										<checked>1</checked>
 									</object>
 								</object>

--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -91,6 +91,16 @@ void AnimInfo::ClearShape(const std::string& shape) {
 	shapeSkinning.erase(shape);
 }
 
+bool AnimInfo::HasSkinnedShape(NiShape* shape) {
+	if (!shape)
+		return false;
+
+	if (shapeSkinning.find(shape->GetName()) != shapeSkinning.end())
+		return true;
+	else
+		return false;
+}
+
 void AnimInfo::DeleteVertsForShape(const std::string& shape, const std::vector<ushort>& indices) {
 	if (indices.empty())
 		return;

--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -269,6 +269,11 @@ void AnimInfo::RecursiveRecalcXFormSkinToBone(const std::string& shape, AnimBone
 		RecursiveRecalcXFormSkinToBone(shape, cptr);
 }
 
+void AnimInfo::ChangeGlobalToSkinTransform(const std::string& shape, const MatTransform &newTrans) {
+	shapeSkinning[shape].xformGlobalToSkin = newTrans;
+	RecursiveRecalcXFormSkinToBone(shape, AnimSkeleton::getInstance().GetRootBonePtr());
+}
+
 bool AnimInfo::CalcShapeSkinBounds(const std::string& shapeName, const int& boneIndex) {
 	if (!refNif || !refNif->IsValid())	// Check for existence of reference nif
 		return false;

--- a/src/components/Anim.h
+++ b/src/components/Anim.h
@@ -142,6 +142,7 @@ public:
 
 	void Clear();
 	void ClearShape(const std::string& shape);
+	bool HasSkinnedShape(NiShape* shape);
 	void DeleteVertsForShape(const std::string& shape, const std::vector<ushort>& indices);
 
 	// Loads the skinning information contained in the nif for all shapes.

--- a/src/components/Anim.h
+++ b/src/components/Anim.h
@@ -161,6 +161,9 @@ public:
 	// RecursiveRecalcXFormSkinToBone calls RecalcXFormSkinToBone for the
 	// given bone and all its descendants.
 	void RecursiveRecalcXFormSkinToBone(const std::string& shape, AnimBone *bPtr);
+	// ChangeGlobalToSkinTransform sets the global-to-skin transform for a
+	// shape and updates all skin-to-bone transforms.
+	void ChangeGlobalToSkinTransform(const std::string& shape, const MatTransform &newTrans);
 	bool CalcShapeSkinBounds(const std::string& shapeName, const int& boneIndex);
 	void CleanupBones();
 	void WriteToNif(NifFile* nif, const std::string& shapeException = "");

--- a/src/components/Automorph.h
+++ b/src/components/Automorph.h
@@ -10,6 +10,8 @@ See the included LICENSE file
 #include "Mesh.h"
 #include "SliderSet.h"
 
+class AnimInfo;
+
 class Automorph {
 	std::unique_ptr<kd_tree> refTree;
 	std::map<std::string, mesh*> sourceShapes;
@@ -45,7 +47,7 @@ public:
 		bEnableMask = enable;
 	}
 
-	void SetRef(NifFile& Ref, NiShape* refShape);
+	void SetRef(NifFile& Ref, NiShape* refShape, const AnimInfo *workAnim);
 
 	void LinkRefDiffData(DiffDataSets* diffData);
 	void UnlinkRefDiffData();
@@ -54,11 +56,11 @@ public:
 	bool ApplyResultToVerts(const std::string& sliderName, const std::string& shapeTargetName, std::vector<Vector3>* inOutResult, float strength = 1.0f);
 	bool ApplyResultToUVs(const std::string& sliderName, const std::string& shapeTargetName, std::vector<Vector2>* inOutResult, float strength = 1.0f);
 
-	void SourceShapesFromNif(NifFile& baseNif);
+	void SourceShapesFromNif(NifFile& baseNif, const AnimInfo *workAnim);
 	void UpdateMeshFromNif(NifFile &baseNif, const std::string& shapeName);
 	void CopyMeshMask(mesh*m, const std::string& shapeName);
 
-	void MeshFromNifShape(mesh* m, NifFile& ref, NiShape* shape);
+	void MeshFromNifShape(mesh* m, NifFile& ref, NiShape* shape, const AnimInfo *workAnim);
 	void DeleteVerts(const std::string& shapeName, const std::vector<ushort>& indices);
 
 	void ClearProximityCache();

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -2213,9 +2213,9 @@ int OutfitProject::AddFromSliderSet(const std::string& fileName, const std::stri
 
 void OutfitProject::InitConform() {
 	if (baseShape) {
-		morpher.SetRef(workNif, baseShape);
+		morpher.SetRef(workNif, baseShape, &workAnim);
 		morpher.LinkRefDiffData(&baseDiffData);
-		morpher.SourceShapesFromNif(workNif);
+		morpher.SourceShapesFromNif(workNif, &workAnim);
 	}
 }
 

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -1486,21 +1486,26 @@ void OutfitProject::ApplyTransformToShapeGeometry(NiShape* shape, const MatTrans
 	const std::vector<Vector3>* oldVerts = workNif.GetRawVertsForShape(shape);
 	if (!oldVerts || oldVerts->empty())
 		return;
+
 	int nVerts = oldVerts->size();
 	std::vector<Vector3> verts(nVerts);
 	for (int i = 0; i < nVerts; ++i)
 		verts[i] = t.ApplyTransform((*oldVerts)[i]);
+
 	workNif.SetVertsForShape(shape, verts);
 
 	// Normals
 	if (t.rotation.IsNearlyEqualTo(Matrix3()))
 		return;
+
 	const std::vector<Vector3>* oldNorms = workNif.GetNormalsForShape(shape, false);
 	if (!oldNorms || oldNorms->size() != nVerts)
 		return;
+
 	std::vector<Vector3> norms(nVerts);
 	for (int i = 0; i < nVerts; ++i)
 		norms[i] = t.rotation * (*oldNorms)[i];
+
 	workNif.SetNormalsForShape(shape, norms);
 }
 

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -1478,6 +1478,32 @@ void OutfitProject::RotateShape(NiShape* shape, const Vector3& angle, std::unord
 	workNif.RotateShape(shape, angle, mask);
 }
 
+void OutfitProject::ApplyTransformToShapeGeometry(NiShape* shape, const MatTransform &t) {
+	if (!shape)
+		return;
+
+	// Vertices
+	const std::vector<Vector3>* oldVerts = workNif.GetRawVertsForShape(shape);
+	if (!oldVerts || oldVerts->empty())
+		return;
+	int nVerts = oldVerts->size();
+	std::vector<Vector3> verts(nVerts);
+	for (int i = 0; i < nVerts; ++i)
+		verts[i] = t.ApplyTransform((*oldVerts)[i]);
+	workNif.SetVertsForShape(shape, verts);
+
+	// Normals
+	if (t.rotation.IsNearlyEqualTo(Matrix3()))
+		return;
+	const std::vector<Vector3>* oldNorms = workNif.GetNormalsForShape(shape, false);
+	if (!oldNorms || oldNorms->size() != nVerts)
+		return;
+	std::vector<Vector3> norms(nVerts);
+	for (int i = 0; i < nVerts; ++i)
+		norms[i] = t.rotation * (*oldNorms)[i];
+	workNif.SetNormalsForShape(shape, norms);
+}
+
 void OutfitProject::CopyBoneWeights(NiShape* shape, const float proximityRadius, const int maxResults, std::unordered_map<ushort, float>& mask, const std::vector<std::string>& boneList, int nCopyBones, const std::vector<std::string> &lockedBones, UndoStateShape &uss, bool bSpreadWeight) {
 	if (!shape || !baseShape)
 		return;

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -159,6 +159,7 @@ public:
 	void OffsetShape(NiShape* shape, const Vector3& xlate, std::unordered_map<ushort, float>* mask = nullptr);
 	void ScaleShape(NiShape* shape, const Vector3& scale, std::unordered_map<ushort, float>* mask = nullptr);
 	void RotateShape(NiShape* shape, const Vector3& angle, std::unordered_map<ushort, float>* mask = nullptr);
+	void ApplyTransformToShapeGeometry(NiShape* shape, const MatTransform& t);
 
 	// Uses the AutoMorph class to generate proximity values for bone weights.
 	// This is done by creating several virtual sliders that contain weight offsets for each vertex per bone.

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -219,7 +219,7 @@ public:
 	int ExportShapeNIF(const std::string& fileName, const std::vector<std::string>& exportShapes);
 
 	int ImportOBJ(const std::string& fileName, const std::string& shapeName, NiShape* mergeShape = nullptr);
-	int ExportOBJ(const std::string& fileName, const std::vector<NiShape*>& shapes, const Vector3& scale = Vector3(1.0f, 1.0f, 1.0f), const Vector3& offset = Vector3());
+	int ExportOBJ(const std::string& fileName, const std::vector<NiShape*>& shapes, bool transToGlobal, const Vector3& scale = Vector3(1.0f, 1.0f, 1.0f), const Vector3& offset = Vector3());
 
 	int ImportFBX(const std::string& fileName, const std::string& shapeName = "", NiShape* mergeShape = nullptr);
 	int ExportFBX(const std::string& fileName, const std::vector<NiShape*>& shapes);

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -8878,22 +8878,23 @@ void wxGLPanel::AddMeshFromNif(NifFile* nif, const std::string& shapeName) {
 	std::vector<std::string> shapeList = nif->GetShapeNames();
 
 	for (int i = 0; i < shapeList.size(); i++) {
-		mesh* m = nullptr;
-		if (!shapeName.empty() && (shapeList[i] == shapeName))
-			m = gls.AddMeshFromNif(nif, shapeList[i]);
-		else if (!shapeName.empty())
+		if (!shapeName.empty() && shapeList[i] != shapeName)
 			continue;
-		else
-			m = gls.AddMeshFromNif(nif, shapeList[i]);
 
-		if (m) {
-			m->BuildTriAdjacency();
-			m->BuildEdgeList();
-			m->ColorFill(Vector3());
+		mesh* m = gls.AddMeshFromNif(nif, shapeList[i]);
+		if (!m)
+			continue;
 
-			if (extInitialized)
-				m->CreateBuffers();
-		}
+		NiShape* shape = nif->FindBlockByName<NiShape>(shapeList[i]);
+		if (shape && shape->IsSkinned())
+			gls.SetSkinModelMat(m, os->project->GetWorkAnim()->shapeSkinning[shapeList[i]].xformGlobalToSkin);
+
+		m->BuildTriAdjacency();
+		m->BuildEdgeList();
+		m->ColorFill(Vector3());
+
+		if (extInitialized)
+			m->CreateBuffers();
 	}
 }
 

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -8047,18 +8047,29 @@ void OutfitStudioFrame::ReselectBone() {
 void OutfitStudioFrame::CalcCopySkinTransOption(WeightCopyOptions &options) {
 	// This function calculates whether the "copy global-to-skin transform
 	// from base shape" checkbox should be shown and what the default value
-	// for the "transform-geometry" checkbox should be.
+	// for the "transform-geometry" checkbox should be
 
 	NifFile *nif = project->GetWorkNif();
 	NiShape *baseShape = project->GetBaseShape();
+	if (!baseShape)
+		return;
+
 	AnimInfo &workAnim = *project->GetWorkAnim();
+
+	if (!workAnim.HasSkinnedShape(baseShape))
+		return;
+
 	const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[baseShape->GetName()].xformGlobalToSkin;
 
-	// Check if any shape's skin CS is different from the base shape's.
+	// Check if any shape's skin CS is different from the base shape's
 	for (int i = 0; i < selectedItems.size(); i++) {
 		NiShape *shape = selectedItems[i]->GetShape();
 		if (shape == baseShape)
 			continue;
+
+		if (!workAnim.HasSkinnedShape(shape))
+			continue;
+
 		if (!workAnim.shapeSkinning[shape->GetName()].xformGlobalToSkin.IsNearlyEqualTo(baseXformGlobalToSkin)) {
 			options.showSkinTransOption = true;
 			break;
@@ -8066,31 +8077,32 @@ void OutfitStudioFrame::CalcCopySkinTransOption(WeightCopyOptions &options) {
 	}
 
 	if (!options.showSkinTransOption)
-		// They're all the same, so hide the option.
+		// They're all the same, so hide the option
 		return;
+
 	options.doSkinTransCopy = true;
 
-	// As a first step in calculating a good default for the
-	// transform-geometry option, find the average vertex position of the
-	// base shape in its own skin coordinates.
+	// As a first step in calculating a good default for the transform-geometry option,
+	// find the average vertex position of the base shape in its own skin coordinates
 	Vector3 baseAvg;
-	{
-		const std::vector<Vector3> &verts = *nif->GetRawVertsForShape(baseShape);
-		for (int i = 0; i < verts.size(); ++i)
-			baseAvg += verts[i];
-		if (verts.size())
-			baseAvg /= verts.size();
-	}
 
-	// Now check if any shape would be better aligned by changing its
-	// global-to-skin transform.
+	const std::vector<Vector3> &baseVerts = *nif->GetRawVertsForShape(baseShape);
+	for (int i = 0; i < baseVerts.size(); ++i)
+		baseAvg += baseVerts[i];
+
+	if (baseVerts.size())
+		baseAvg /= baseVerts.size();
+
+	// Now check if any shape would be better aligned by changing its global-to-skin transform
 	for (int i = 0; i < selectedItems.size(); i++) {
 		NiShape *shape = selectedItems[i]->GetShape();
 		if (shape == baseShape)
 			continue;
+
 		const MatTransform &globalToSkin = workAnim.shapeSkinning[shape->GetName()].xformGlobalToSkin;
 		if (globalToSkin.IsNearlyEqualTo(baseXformGlobalToSkin))
 			continue;
+
 		const std::vector<Vector3> &verts = *nif->GetRawVertsForShape(shape);
 		if (verts.empty())
 			continue;
@@ -8098,17 +8110,18 @@ void OutfitStudioFrame::CalcCopySkinTransOption(WeightCopyOptions &options) {
 		// Calculate old average and new average.
 		MatTransform skinToGlobal = globalToSkin.InverseTransform();
 		MatTransform skinToBaseSkin = baseXformGlobalToSkin.ComposeTransforms(skinToGlobal);
+
 		Vector3 oldAvg, newAvg;
 		for (int j = 0; j < verts.size(); ++j) {
 			oldAvg += skinToBaseSkin.ApplyTransform(verts[j]);
 			newAvg += verts[j];
 		}
+
 		oldAvg /= verts.size();
 		newAvg /= verts.size();
 
 		// Check whether old or new is closer to the base shape.
-		// If new is farther away, then transforming the geometry would
-		// be a good idea.
+		// If new is farther away, then transforming the geometry would be a good idea
 		if (newAvg.DistanceTo(baseAvg) > oldAvg.DistanceTo(baseAvg)) {
 			options.doTransformGeo = true;
 			break;
@@ -8136,6 +8149,7 @@ void OutfitStudioFrame::OnCopyBoneWeight(wxCommandEvent& WXUNUSED(event)) {
 
 		UndoStateProject *usp = glView->GetUndoHistory()->PushState();
 		usp->undoType = UT_WEIGHT;
+
 		std::vector<std::string> baseBones = workAnim.shapeBones[project->GetBaseShape()->GetName()];
 		std::sort(baseBones.begin(), baseBones.end());
 		std::unordered_map<ushort, float> mask;
@@ -8143,23 +8157,31 @@ void OutfitStudioFrame::OnCopyBoneWeight(wxCommandEvent& WXUNUSED(event)) {
 			NiShape *shape = selectedItems[i]->GetShape();
 			if (!project->IsBaseShape(shape)) {
 				wxLogMessage("Copying bone weights to '%s'...", shape->GetName());
+
 				if (options.doSkinTransCopy) {
 					const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->GetName()].xformGlobalToSkin;
 					const MatTransform &oldXformGlobalToSkin = workAnim.shapeSkinning[shape->GetName()].xformGlobalToSkin;
+
 					if (options.doTransformGeo && !baseXformGlobalToSkin.IsNearlyEqualTo(oldXformGlobalToSkin))
 						project->ApplyTransformToShapeGeometry(shape, baseXformGlobalToSkin.ComposeTransforms(oldXformGlobalToSkin.InverseTransform()));
+
 					workAnim.ChangeGlobalToSkinTransform(shape->GetName(), baseXformGlobalToSkin);
 					project->GetWorkNif()->SetShapeTransformGlobalToSkin(shape, baseXformGlobalToSkin);
 				}
-				usp->usss.resize(usp->usss.size()+1);
+
+				usp->usss.resize(usp->usss.size() + 1);
 				usp->usss.back().shapeName = shape->GetName();
+
 				mask.clear();
 				glView->GetShapeMask(mask, shape->GetName());
+
 				std::vector<std::string> bones = workAnim.shapeBones[shape->GetName()];
 				std::vector<std::string> mergedBones = baseBones;
+
 				for (auto b : bones)
 					if (!std::binary_search(baseBones.begin(), baseBones.end(), b))
 						mergedBones.push_back(b);
+
 				std::vector<std::string> lockedBones;
 				project->CopyBoneWeights(shape, options.proximityRadius, options.maxResults, mask, mergedBones, baseBones.size(), lockedBones, usp->usss.back(), false);
 			}
@@ -8169,6 +8191,7 @@ void OutfitStudioFrame::OnCopyBoneWeight(wxCommandEvent& WXUNUSED(event)) {
 
 		if (options.doSkinTransCopy || options.doTransformGeo)
 			MeshesFromProj();
+
 		ActiveShapesUpdated(usp, false);
 		project->morpher.ClearProximityCache();
 
@@ -8195,7 +8218,8 @@ void OutfitStudioFrame::OnCopySelectedWeight(wxCommandEvent& WXUNUSED(event)) {
 	int nSelBones = boneList.size();
 	if (nSelBones < 1)
 		return;
-	std::unordered_set<std::string> selBones{boneList.begin(), boneList.end()};
+
+	std::unordered_set<std::string> selBones{ boneList.begin(), boneList.end() };
 
 	std::string bonesString;
 	for (std::string &boneName : boneList)
@@ -8206,6 +8230,7 @@ void OutfitStudioFrame::OnCopySelectedWeight(wxCommandEvent& WXUNUSED(event)) {
 	for (auto &bone : normBones)
 		if (!selBones.count(bone))
 			boneList.push_back(bone);
+
 	bool bHasNormBones = static_cast<int>(boneList.size()) > nSelBones;
 	if (bHasNormBones) {
 		for (auto &bone : notNormBones)
@@ -8235,15 +8260,20 @@ void OutfitStudioFrame::OnCopySelectedWeight(wxCommandEvent& WXUNUSED(event)) {
 				if (options.doSkinTransCopy) {
 					const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->GetName()].xformGlobalToSkin;
 					const MatTransform &oldXformGlobalToSkin = workAnim.shapeSkinning[shape->GetName()].xformGlobalToSkin;
+
 					if (options.doTransformGeo && !baseXformGlobalToSkin.IsNearlyEqualTo(oldXformGlobalToSkin))
 						project->ApplyTransformToShapeGeometry(shape, baseXformGlobalToSkin.ComposeTransforms(oldXformGlobalToSkin.InverseTransform()));
+
 					workAnim.ChangeGlobalToSkinTransform(shape->GetName(), baseXformGlobalToSkin);
 					project->GetWorkNif()->SetShapeTransformGlobalToSkin(shape, baseXformGlobalToSkin);
 				}
-				usp->usss.resize(usp->usss.size()+1);
+
+				usp->usss.resize(usp->usss.size() + 1);
 				usp->usss.back().shapeName = shape->GetName();
+
 				mask.clear();
 				glView->GetShapeMask(mask, shape->GetName());
+
 				project->CopyBoneWeights(shape, options.proximityRadius, options.maxResults, mask, boneList, nSelBones, lockedBones, usp->usss.back(), bHasNormBones);
 			}
 			else
@@ -8252,6 +8282,7 @@ void OutfitStudioFrame::OnCopySelectedWeight(wxCommandEvent& WXUNUSED(event)) {
 
 		if (options.doSkinTransCopy || options.doTransformGeo)
 			MeshesFromProj();
+
 		ActiveShapesUpdated(usp, false);
 		project->morpher.ClearProximityCache();
 

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -8005,15 +8005,15 @@ bool OutfitStudioFrame::ShowWeightCopy(WeightCopyOptions& options) {
 		if (options.showSkinTransOption) {
 			cbCopySkinTrans->SetValue(options.doSkinTransCopy);
 			cbTransformGeo->SetValue(options.doTransformGeo);
-		}
-		else {
-			cbCopySkinTrans->Hide();
-			cbTransformGeo->Hide();
-			XRCCTRL(dlg, "copyTransDescription", wxStaticText)->Hide();
+			cbCopySkinTrans->Show();
+			cbTransformGeo->Show();
+			XRCCTRL(dlg, "copyTransDescription", wxStaticText)->Show();
 		}
 
 		dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
 
+		dlg.SetSize(dlg.GetBestSize());
+		
 		if (dlg.ShowModal() == wxID_OK) {
 			options.proximityRadius = atof(XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->GetValue().c_str());
 

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -8099,9 +8099,9 @@ void OutfitStudioFrame::CalcCopySkinTransOption(WeightCopyOptions &options) {
 		MatTransform skinToGlobal = globalToSkin.InverseTransform();
 		MatTransform skinToBaseSkin = baseXformGlobalToSkin.ComposeTransforms(skinToGlobal);
 		Vector3 oldAvg, newAvg;
-		for (int i = 0; i < verts.size(); ++i) {
-			oldAvg += skinToBaseSkin.ApplyTransform(verts[i]);
-			newAvg += verts[i];
+		for (int j = 0; j < verts.size(); ++j) {
+			oldAvg += skinToBaseSkin.ApplyTransform(verts[j]);
+			newAvg += verts[j];
 		}
 		oldAvg /= verts.size();
 		newAvg /= verts.size();

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -115,6 +115,7 @@ struct WeightCopyOptions {
 	int maxResults = 0;
 	bool showSkinTransOption = false;
 	bool doSkinTransCopy = false;
+	bool doTransformGeo = false;
 };
 
 struct ConformOptions {

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -113,6 +113,8 @@ public:
 struct WeightCopyOptions {
 	float proximityRadius = 0.0f;
 	int maxResults = 0;
+	bool showSkinTransOption = false;
+	bool doSkinTransCopy = false;
 };
 
 struct ConformOptions {
@@ -1038,6 +1040,7 @@ private:
 	void FillVertexColors();
 
 	bool HasUnweightedCheck();
+	void CalcCopySkinTransOption(WeightCopyOptions &options);
 	bool ShowWeightCopy(WeightCopyOptions& options);
 	void ReselectBone();
 

--- a/src/program/ShapeProperties.cpp
+++ b/src/program/ShapeProperties.cpp
@@ -74,7 +74,6 @@ ShapeProperties::ShapeProperties(wxWindow* parent, NifFile* refNif, NiShape* ref
 	pgExtraData = XRCCTRL(*this, "pgExtraData", wxPanel);
 	extraDataGrid = (wxFlexGridSizer*)XRCCTRL(*this, "btnAddExtraData", wxButton)->GetContainingSizer();
 
-	pgCoordinates = XRCCTRL(*this, "pgCoordinates", wxPanel);
 	textScale = XRCCTRL(*this, "textScale", wxTextCtrl);
 	textX = XRCCTRL(*this, "textX", wxTextCtrl);
 	textY = XRCCTRL(*this, "textY", wxTextCtrl);

--- a/src/program/ShapeProperties.cpp
+++ b/src/program/ShapeProperties.cpp
@@ -15,7 +15,6 @@ wxBEGIN_EVENT_TABLE(ShapeProperties, wxDialog)
 	EVT_BUTTON(XRCID("btnAddTransparency"), ShapeProperties::OnAddTransparency)
 	EVT_BUTTON(XRCID("btnRemoveTransparency"), ShapeProperties::OnRemoveTransparency)
 	EVT_BUTTON(XRCID("btnAddExtraData"), ShapeProperties::OnAddExtraData)
-	EVT_BUTTON(wxID_OK, ShapeProperties::OnApply)
 	EVT_TEXT(XRCID("textScale"), ShapeProperties::OnTransChanged)
 	EVT_TEXT(XRCID("textX"), ShapeProperties::OnTransChanged)
 	EVT_TEXT(XRCID("textY"), ShapeProperties::OnTransChanged)
@@ -23,6 +22,7 @@ wxBEGIN_EVENT_TABLE(ShapeProperties, wxDialog)
 	EVT_TEXT(XRCID("textRX"), ShapeProperties::OnTransChanged)
 	EVT_TEXT(XRCID("textRY"), ShapeProperties::OnTransChanged)
 	EVT_TEXT(XRCID("textRZ"), ShapeProperties::OnTransChanged)
+	EVT_BUTTON(wxID_OK, ShapeProperties::OnApply)
 wxEND_EVENT_TABLE()
 
 ShapeProperties::ShapeProperties(wxWindow* parent, NifFile* refNif, NiShape* refShape) {
@@ -649,6 +649,7 @@ void ShapeProperties::GetCoordTrans() {
 	oldXformGlobalToSkin = os->project->GetWorkAnim()->shapeSkinning[shape->GetName()].xformGlobalToSkin;
 	newXformGlobalToSkin = oldXformGlobalToSkin;
 	Vector3 rotvec = RotMatToVec(newXformGlobalToSkin.rotation);
+
 	textScale->ChangeValue(wxString() << newXformGlobalToSkin.scale);
 	textX->ChangeValue(wxString() << newXformGlobalToSkin.translation.x);
 	textY->ChangeValue(wxString() << newXformGlobalToSkin.translation.y);
@@ -656,12 +657,14 @@ void ShapeProperties::GetCoordTrans() {
 	textRX->ChangeValue(wxString() << rotvec.x);
 	textRY->ChangeValue(wxString() << rotvec.y);
 	textRZ->ChangeValue(wxString() << rotvec.z);
+
 	cbTransformGeo->Disable();
 }
 
 void ShapeProperties::OnTransChanged(wxCommandEvent&) {
 	if (!textScale || !textX || !textY || !textZ || !textRX || !textRY || !textRZ)
 		return;
+
 	double scale, x, y, z, rx, ry, rz;
 	if (!textScale->GetValue().ToDouble(&scale))
 		return;
@@ -679,6 +682,7 @@ void ShapeProperties::OnTransChanged(wxCommandEvent&) {
 		return;
 	if (!textRZ->GetValue().ToDouble(&rz))
 		return;
+
 	newXformGlobalToSkin.scale = scale;
 	newXformGlobalToSkin.translation.x = x;
 	newXformGlobalToSkin.translation.y = y;
@@ -719,7 +723,7 @@ void ShapeProperties::ApplyChanges() {
 
 		shader->SetName(name);
 		shader->SetVertexColors(vertexColors->IsChecked());
-		
+
 		if (vertexColors->IsChecked() && currentVertexColors != vertexColors->IsChecked())
 			shape->SetVertexColors(true);
 
@@ -875,6 +879,7 @@ void ShapeProperties::ApplyChanges() {
 	if (!newXformGlobalToSkin.IsNearlyEqualTo(oldXformGlobalToSkin)) {
 		if (cbTransformGeo->IsChecked())
 			os->project->ApplyTransformToShapeGeometry(shape, newXformGlobalToSkin.ComposeTransforms(oldXformGlobalToSkin.InverseTransform()));
+
 		os->project->GetWorkAnim()->ChangeGlobalToSkinTransform(shape->GetName(), newXformGlobalToSkin);
 		nif->SetShapeTransformGlobalToSkin(shape, newXformGlobalToSkin);
 	}

--- a/src/program/ShapeProperties.cpp
+++ b/src/program/ShapeProperties.cpp
@@ -16,6 +16,13 @@ wxBEGIN_EVENT_TABLE(ShapeProperties, wxDialog)
 	EVT_BUTTON(XRCID("btnRemoveTransparency"), ShapeProperties::OnRemoveTransparency)
 	EVT_BUTTON(XRCID("btnAddExtraData"), ShapeProperties::OnAddExtraData)
 	EVT_BUTTON(wxID_OK, ShapeProperties::OnApply)
+	EVT_TEXT(XRCID("textScale"), ShapeProperties::OnTransChanged)
+	EVT_TEXT(XRCID("textX"), ShapeProperties::OnTransChanged)
+	EVT_TEXT(XRCID("textY"), ShapeProperties::OnTransChanged)
+	EVT_TEXT(XRCID("textZ"), ShapeProperties::OnTransChanged)
+	EVT_TEXT(XRCID("textRX"), ShapeProperties::OnTransChanged)
+	EVT_TEXT(XRCID("textRY"), ShapeProperties::OnTransChanged)
+	EVT_TEXT(XRCID("textRZ"), ShapeProperties::OnTransChanged)
 wxEND_EVENT_TABLE()
 
 ShapeProperties::ShapeProperties(wxWindow* parent, NifFile* refNif, NiShape* refShape) {
@@ -67,6 +74,16 @@ ShapeProperties::ShapeProperties(wxWindow* parent, NifFile* refNif, NiShape* ref
 	pgExtraData = XRCCTRL(*this, "pgExtraData", wxPanel);
 	extraDataGrid = (wxFlexGridSizer*)XRCCTRL(*this, "btnAddExtraData", wxButton)->GetContainingSizer();
 
+	pgCoordinates = XRCCTRL(*this, "pgCoordinates", wxPanel);
+	textScale = XRCCTRL(*this, "textScale", wxTextCtrl);
+	textX = XRCCTRL(*this, "textX", wxTextCtrl);
+	textY = XRCCTRL(*this, "textY", wxTextCtrl);
+	textZ = XRCCTRL(*this, "textZ", wxTextCtrl);
+	textRX = XRCCTRL(*this, "textRX", wxTextCtrl);
+	textRY = XRCCTRL(*this, "textRY", wxTextCtrl);
+	textRZ = XRCCTRL(*this, "textRZ", wxTextCtrl);
+	cbTransformGeo = XRCCTRL(*this, "cbTransformGeo", wxCheckBox);
+
 	auto targetGame = (TargetGame)Config.GetIntValue("TargetGame");
 	if (targetGame == FO4 || targetGame == FO4VR) {
 		lbShaderName->SetLabel(_("Material"));
@@ -78,6 +95,7 @@ ShapeProperties::ShapeProperties(wxWindow* parent, NifFile* refNif, NiShape* ref
 	GetTransparency();
 	GetGeometry();
 	GetExtraData();
+	GetCoordTrans();
 }
 
 ShapeProperties::~ShapeProperties() {
@@ -628,6 +646,48 @@ void ShapeProperties::RemoveExtraData(int id) {
 	pgExtraData->Layout();
 }
 
+void ShapeProperties::GetCoordTrans() {
+	oldXformGlobalToSkin = os->project->GetWorkAnim()->shapeSkinning[shape->GetName()].xformGlobalToSkin;
+	newXformGlobalToSkin = oldXformGlobalToSkin;
+	Vector3 rotvec = RotMatToVec(newXformGlobalToSkin.rotation);
+	textScale->ChangeValue(wxString() << newXformGlobalToSkin.scale);
+	textX->ChangeValue(wxString() << newXformGlobalToSkin.translation.x);
+	textY->ChangeValue(wxString() << newXformGlobalToSkin.translation.y);
+	textZ->ChangeValue(wxString() << newXformGlobalToSkin.translation.z);
+	textRX->ChangeValue(wxString() << rotvec.x);
+	textRY->ChangeValue(wxString() << rotvec.y);
+	textRZ->ChangeValue(wxString() << rotvec.z);
+	cbTransformGeo->Disable();
+}
+
+void ShapeProperties::OnTransChanged(wxCommandEvent&) {
+	if (!textScale || !textX || !textY || !textZ || !textRX || !textRY || !textRZ)
+		return;
+	double scale, x, y, z, rx, ry, rz;
+	if (!textScale->GetValue().ToDouble(&scale))
+		return;
+	if (scale <= 0)
+		return;
+	if (!textX->GetValue().ToDouble(&x))
+		return;
+	if (!textY->GetValue().ToDouble(&y))
+		return;
+	if (!textZ->GetValue().ToDouble(&z))
+		return;
+	if (!textRX->GetValue().ToDouble(&rx))
+		return;
+	if (!textRY->GetValue().ToDouble(&ry))
+		return;
+	if (!textRZ->GetValue().ToDouble(&rz))
+		return;
+	newXformGlobalToSkin.scale = scale;
+	newXformGlobalToSkin.translation.x = x;
+	newXformGlobalToSkin.translation.y = y;
+	newXformGlobalToSkin.translation.z = z;
+	newXformGlobalToSkin.rotation = RotVecToMat(Vector3(rx, ry, rz));
+	cbTransformGeo->Enable(!newXformGlobalToSkin.IsNearlyEqualTo(oldXformGlobalToSkin));
+}
+
 void ShapeProperties::RefreshMesh() {
 	os->project->SetTextures(shape);
 	os->MeshFromProj(shape, true);
@@ -811,5 +871,12 @@ void ShapeProperties::ApplyChanges() {
 					floatExtraData->SetFloatData((float)val);
 			}
 		}
+	}
+
+	if (!newXformGlobalToSkin.IsNearlyEqualTo(oldXformGlobalToSkin)) {
+		if (cbTransformGeo->IsChecked())
+			os->project->ApplyTransformToShapeGeometry(shape, newXformGlobalToSkin.ComposeTransforms(oldXformGlobalToSkin.InverseTransform()));
+		os->project->GetWorkAnim()->ChangeGlobalToSkinTransform(shape->GetName(), newXformGlobalToSkin);
+		nif->SetShapeTransformGlobalToSkin(shape, newXformGlobalToSkin);
 	}
 }

--- a/src/program/ShapeProperties.h
+++ b/src/program/ShapeProperties.h
@@ -43,7 +43,6 @@ private:
 	wxPanel* pgExtraData = nullptr;
 	wxFlexGridSizer* extraDataGrid = nullptr;
 
-	wxPanel* pgCoordinates = nullptr;
 	wxTextCtrl* textScale = nullptr;
 	wxTextCtrl* textX = nullptr;
 	wxTextCtrl* textY = nullptr;

--- a/src/program/ShapeProperties.h
+++ b/src/program/ShapeProperties.h
@@ -43,6 +43,17 @@ private:
 	wxPanel* pgExtraData = nullptr;
 	wxFlexGridSizer* extraDataGrid = nullptr;
 
+	wxPanel* pgCoordinates = nullptr;
+	wxTextCtrl* textScale = nullptr;
+	wxTextCtrl* textX = nullptr;
+	wxTextCtrl* textY = nullptr;
+	wxTextCtrl* textZ = nullptr;
+	wxTextCtrl* textRX = nullptr;
+	wxTextCtrl* textRY = nullptr;
+	wxTextCtrl* textRZ = nullptr;
+	wxCheckBox* cbTransformGeo = nullptr;
+	MatTransform oldXformGlobalToSkin, newXformGlobalToSkin;
+
 	OutfitStudioFrame* os = nullptr;
 	NifFile* nif = nullptr;
 	NiShape* shape = nullptr;
@@ -67,6 +78,9 @@ private:
 	void AddExtraData(NiExtraData* extraData, bool uiOnly = false);
 	void ChangeExtraDataType(int index);
 	void RemoveExtraData(int index);
+
+	void GetCoordTrans();
+	void OnTransChanged(wxCommandEvent&);
 
 	void AssignDefaultTexture();
 	void RefreshMesh();

--- a/src/render/GLSurface.h
+++ b/src/render/GLSurface.h
@@ -291,6 +291,7 @@ public:
 	mesh* AddVisPlane(const Vector3& center, const Vector2& size, float uvScale = 1.0f, float uvOffset = 0.0f, const std::string& name = "PlaneMesh", const Vector3* color = nullptr);
 
 	mesh* AddMeshFromNif(NifFile* nif, const std::string& shapeName, Vector3* color = nullptr);
+	void SetSkinModelMat(mesh *m, const MatTransform &xformGlobalToSkin);
 	void Update(const std::string& shapeName, std::vector<Vector3>* vertices, std::vector<Vector2>* uvs = nullptr, std::set<int>* changed = nullptr);
 	void Update(int shapeIndex, std::vector<Vector3>* vertices, std::vector<Vector2>* uvs = nullptr, std::set<int>* changed = nullptr);
 	mesh* ReloadMeshFromNif(NifFile* nif, std::string shapeName);


### PR DESCRIPTION
-Added a checkbox with explanatory text to the copy-bone-weights dialog
(dlgCopyWeights) for copying the reference's global-to-skin transform,
and implemented it.

-Added a function OutfitStudioFrame::CalcCopySkinTransOption that
calculates whether it makes sense to show the option and what the default
value for the option should be.

-Added function AnimInfo::ChangeGlobalToSkinTransform that sets the
transform and updates all the skin-to-bone transforms.

-Added IsNearlyEqualTo functions to MatTransform, Matrix3, and
Vector3, and added a FloatsAreNearlyEqual function.  These are in
lib/NIF/utils/Object3d.h.

Testing: I loaded FO4 CBBEBody, exported it to obj, imported it from
obj, merged in the CBBEBody as a reference, and copied bone weights.
The option appeared and was checked.  I then saved and checked that the
two shapes had identical skin-to-bone transforms for Spine2 in NifSkope.

When the copy-transforms option is hidden in the dialog, it leaves
an empty space.  Perhaps there's some good way to make the dialog lay
itself out again, but I'm no expert in wxWidgets, so I left that bug
to someone else to fix.