### PR TITLE
Fix lighting problems for scaled shapes

### DIFF
--- a/res/shaders/default.frag
+++ b/res/shaders/default.frag
@@ -216,6 +216,7 @@ void main(void)
 				{
 					// Vertex normal for shading with disabled maps
 					normal = mat3(matModelView) * n;
+					normal = normalize(normal);
 				}
 				
 				if (bShowTexture)
@@ -228,6 +229,7 @@ void main(void)
 							normal = normalize(normalMap.rgb * 2.0 - 1.0);
 							normal.r = -normal.r;
 							normal = mat3(matModelView) * normal;
+							normal = normalize(normal);
 							
 							if (bSpecular)
 							{
@@ -257,6 +259,7 @@ void main(void)
 					vec3 reflected = reflect(-viewDir, normal);
 					vec3 reflectedVS = b * reflected.x + t * reflected.y + n * reflected.z;
 					vec3 reflectedWS = mat3(matModelView) * reflectedVS;
+					reflectedWS = normalize(reflectedWS);
 					
 					vec4 cubeMap = texture(texCubemap, reflectedWS);
 					cubeMap.rgb *= prop.envReflection;

--- a/res/shaders/fo4_default.frag
+++ b/res/shaders/fo4_default.frag
@@ -256,6 +256,7 @@ void directionalLight(in DirectionalLight light, in vec3 lightDir, inout vec3 ou
 		vec3 reflected = reflect(viewDir, normal);
 		vec3 reflectedVS = t * reflected.x + b * reflected.y + n * reflected.z;
 		vec3 reflectedWS = mat3(matModelView) * reflectedVS;
+		reflectedWS = normalize(reflectedWS);
 		
 		vec4 cube = textureLod(texCubemap, reflectedWS, 8.0 - smoothness * 8.0);
 		cube.rgb *= prop.envReflection * prop.specularStrength;


### PR DESCRIPTION
For skinned shapes with a global-to-skin transform with scale other
than 1, the lighting was wrong.  With scale < 1, the shape was too
shiny and bright.  With scale > 1, the shape was too unshiny and dim.
This was because normals were not being normalized in the non-FO4
fragment shader.