### PR TITLE
Made ApplyTransformToShapeGeometry also apply to diffs.

### DIFF
--- a/lib/NIF/utils/Object3d.h
+++ b/lib/NIF/utils/Object3d.h
@@ -517,6 +517,14 @@ public:
 			rows[2][0] * v.x + rows[2][1] * v.y + rows[2][2] * v.z);
 	}
 
+	Matrix3 operator*(float f) const {
+		Matrix3 res;
+		res.rows[0] = f * rows[0];
+		res.rows[1] = f * rows[1];
+		res.rows[2] = f * rows[2];
+		return res;
+	}
+
 	float Determinant() const;
 
 	// Invert attempts to invert this matrix, returning the result in
@@ -557,6 +565,10 @@ public:
 			rows[2].IsNearlyEqualTo(other.rows[2]);
 	}
 };
+
+inline Matrix3 operator*(float f, const Matrix3 &m) {
+	return m * f;
+}
 
 // RotVecToMat: converts a rotation vector to a rotation matrix.
 // (A rotation vector has direction the axis of the rotation

--- a/src/components/Automorph.cpp
+++ b/src/components/Automorph.cpp
@@ -244,6 +244,10 @@ void Automorph::SetVertexDiffs(const std::string& target, int vertIndex, const s
 	resultDiffData.SetVertexDiffs(target, vertIndex, diffs);
 }
 
+void Automorph::ApplyTransformToDiffSet(const std::string &setName, const MatTransform &t) {
+	resultDiffData.ApplyTransformToDiffSet(setName, t);
+}
+
 void Automorph::ClearProximityCache() {
 	prox_cache.clear();
 }

--- a/src/components/Automorph.h
+++ b/src/components/Automorph.h
@@ -68,6 +68,8 @@ public:
 	void GetVertexDiffs(const std::string& target, int vertIndex, std::vector<UndoStateVertexSliderDiff> &diffs);
 	void SetVertexDiffs(const std::string& target, int vertIndex, const std::vector<UndoStateVertexSliderDiff> &diffs);
 
+	void ApplyTransformToDiffSet(const std::string &setName, const MatTransform &t);
+
 	void ClearProximityCache();
 	void BuildProximityCache(const std::string& shapeName, const float proximityRadius = 10.0f);
 

--- a/src/components/DiffData.cpp
+++ b/src/components/DiffData.cpp
@@ -444,6 +444,13 @@ void DiffDataSets::SetVertexDiffs(const std::string& target, int vertIndex, cons
 	}
 }
 
+void DiffDataSets::ApplyTransformToDiffSet(const std::string& setName, const MatTransform &t) {
+	if (namedSet.find(setName) == namedSet.end())
+		return;
+	for (auto &vdiff : namedSet[setName])
+		vdiff.second = t.ApplyTransform(vdiff.second);
+}
+
 void DiffDataSets::ClearSet(const std::string& name) {
 	namedSet.erase(name);
 	dataTargets.erase(name);

--- a/src/components/DiffData.h
+++ b/src/components/DiffData.h
@@ -62,6 +62,9 @@ public:
 	void InsertVertexIndices(const std::string& target, const std::vector<ushort>& indices);
 	void GetVertexDiffs(const std::string& target, int vertIndex, std::vector<UndoStateVertexSliderDiff> &diffs);
 	void SetVertexDiffs(const std::string& target, int vertIndex, const std::vector<UndoStateVertexSliderDiff> &diffs);
+
+	void ApplyTransformToDiffSet(const std::string &setName, const MatTransform &t);
+
 	void ClearSet(const std::string& name);
 	void EmptySet(const std::string& set, const std::string& target) {
 		if (!TargetMatch(set, target))


### PR DESCRIPTION
This affects the copy-bone-weights and shape-properties commands when
the user chooses to transform the geometry.

ScaleShape and RotateShape also should be updated at some point.  This
commit does not affect those functions.