### PR TITLE
Temporary fix for split-edge diff corruption issue.

### DIFF
--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -2281,6 +2281,8 @@ void OutfitProject::CollectVertexData(NiShape* shape, UndoStateShape &uss, const
 	// For diffs, it's more efficient to reverse the loop nesting.
 	for (int si = 0; si < activeSet.size(); ++si) {
 		std::string targetDataName = activeSet[si].TargetDataName(target);
+		if (targetDataName.empty())
+			targetDataName = target + activeSet[si].name;
 		std::unordered_map<ushort, Vector3>* diffSet;
 		if (IsBaseShape(shape))
 			diffSet = baseDiffData.GetDiffSet(targetDataName);
@@ -2534,6 +2536,8 @@ void OutfitProject::ApplyShapeMeshUndo(NiShape* shape, const UndoStateShape &uss
 			// ...in diff data
 			for (const UndoStateVertexSliderDiff &diff : usv.diffs) {
 				std::string targetDataName = activeSet[diff.sliderName].TargetDataName(target);
+				if (targetDataName.empty())
+					targetDataName = target + diff.sliderName;
 				std::unordered_map<ushort, Vector3>* diffSet;
 				if (IsBaseShape(shape))
 					diffSet = baseDiffData.GetDiffSet(targetDataName);


### PR DESCRIPTION
Added code to CollectVertexData and ApplyShapeMeshUndo so that if
the function TargetDataName doesn't return anything, they'll fall
back on concatenating the target name with the slider name.  That
should make it work correctly in most cases.

The main case where it won't work is when some diff data exists for
a slider that is not in activeSet.  For such sets, functions that
add vertices won't work right: split-edge; undo of delete vertices;
undo of separate vertices; and undo of collapse-vertex.  The diff data
won't be corrupted (it'll still be renumbered), but no data will be
added for the vertices.