### PR TITLE
Fix split edge

### DIFF
--- a/lib/NIF/Geometry.cpp
+++ b/lib/NIF/Geometry.cpp
@@ -1134,7 +1134,7 @@ void BSTriShape::SetEyeData(const std::vector<float>& in) {
 		vertData[i].eyeData = in[i];
 }
 
-static void CalculateNormals(const std::vector<Vector3> &verts, const std::vector<Triangle> &tris, std::vector<Vector3> norms, const bool smooth, float smoothThresh) {
+static void CalculateNormals(const std::vector<Vector3> &verts, const std::vector<Triangle> &tris, std::vector<Vector3> &norms, const bool smooth, float smoothThresh) {
 	// Zero norms
 	norms.clear();
 	norms.resize(verts.size());

--- a/lib/NIF/Geometry.cpp
+++ b/lib/NIF/Geometry.cpp
@@ -10,8 +10,6 @@ See the included LICENSE file
 #include "utils/KDMatcher.h"
 #include "NifUtil.h"
 
-#include <unordered_map>
-
 void NiAdditionalGeometryData::Get(NiStream & stream) {
 	AdditionalGeomData::Get(stream);
 

--- a/lib/NIF/Geometry.cpp
+++ b/lib/NIF/Geometry.cpp
@@ -1154,9 +1154,10 @@ static void CalculateNormals(const std::vector<Vector3> &verts, const std::vecto
 	// Smooth normals
 	if (smooth) {
 		smoothThresh *= DEG2RAD;
-		std::unordered_map<int, Vector3> seamNorms;
-		kd_matcher matcher(verts.data(), verts.size());
+		std::vector<Vector3> seamNorms;
+		SortingMatcher matcher(verts.data(), verts.size());
 		for (const std::vector<int> &matchset : matcher.matches) {
+			seamNorms.resize(matchset.size());
 			for (int j = 0; j < matchset.size(); ++j) {
 				const Vector3 &n = norms[matchset[j]];
 				Vector3 sn = n;
@@ -1171,9 +1172,9 @@ static void CalculateNormals(const std::vector<Vector3> &verts, const std::vecto
 				sn.Normalize();
 				seamNorms[j] = sn;
 			}
+			for (int j = 0; j < matchset.size(); ++j)
+				norms[matchset[j]] = seamNorms[j];
 		}
-		for (auto &snp : seamNorms)
-			norms[snp.first] = snp.second;
 	}
 }
 

--- a/lib/NIF/Geometry.cpp
+++ b/lib/NIF/Geometry.cpp
@@ -1134,49 +1134,62 @@ void BSTriShape::SetEyeData(const std::vector<float>& in) {
 		vertData[i].eyeData = in[i];
 }
 
+static void CalculateNormals(const std::vector<Vector3> &verts, const std::vector<Triangle> &tris, std::vector<Vector3> norms, const bool smooth, float smoothThresh) {
+	// Zero norms
+	norms.clear();
+	norms.resize(verts.size());
+
+	// Face normals
+	for (const Triangle &t : tris) {
+		Vector3 tn;
+		t.trinormal(verts, &tn);
+		norms[t.p1] += tn;
+		norms[t.p2] += tn;
+		norms[t.p3] += tn;
+	}
+
+	for (Vector3 &n : norms)
+		n.Normalize();
+
+	// Smooth normals
+	if (smooth) {
+		smoothThresh *= DEG2RAD;
+		std::unordered_map<int, Vector3> seamNorms;
+		kd_matcher matcher(verts.data(), verts.size());
+		for (const std::vector<int> &matchset : matcher.matches) {
+			for (int j = 0; j < matchset.size(); ++j) {
+				const Vector3 &n = norms[matchset[j]];
+				Vector3 sn = n;
+				for (int k = 0; k < matchset.size(); ++k) {
+					if (j == k)
+						continue;
+					const Vector3 &mn = norms[matchset[k]];
+					if (n.angle(mn) >= smoothThresh)
+						continue;
+					sn += mn;
+				}
+				sn.Normalize();
+				seamNorms[j] = sn;
+			}
+		}
+		for (auto &snp : seamNorms)
+			norms[snp.first] = snp.second;
+	}
+}
+
 void BSTriShape::RecalcNormals(const bool smooth, const float smoothThresh) {
 	GetRawVerts();
 	SetNormals(true);
 
 	std::vector<Vector3> verts(numVertices);
-	std::vector<Vector3> norms(numVertices);
 	for (int i = 0; i < numVertices; i++) {
 		verts[i].x = rawVertices[i].x * -0.1f;
 		verts[i].z = rawVertices[i].y * 0.1f;
 		verts[i].y = rawVertices[i].z * 0.1f;
 	}
 
-	// Face normals
-	Vector3 tn;
-	for (int t = 0; t < numTriangles; t++) {
-		triangles[t].trinormal(verts, &tn);
-		norms[triangles[t].p1] += tn;
-		norms[triangles[t].p2] += tn;
-		norms[triangles[t].p3] += tn;
-	}
-
-	for (auto &n : norms)
-		n.Normalize();
-
-	// Smooth normals
-	if (smooth) {
-		kd_matcher matcher(verts.data(), numVertices);
-		for (int i = 0; i < matcher.matches.size(); i++) {
-			std::pair<Vector3*, int>& a = matcher.matches[i].first;
-			std::pair<Vector3*, int>& b = matcher.matches[i].second;
-
-			Vector3& an = norms[a.second];
-			Vector3& bn = norms[b.second];
-			if (an.angle(bn) < smoothThresh * DEG2RAD) {
-				Vector3 anT = an;
-				an += bn;
-				bn += anT;
-			}
-		}
-
-		for (auto &n : norms)
-			n.Normalize();
-	}
+	std::vector<Vector3> norms;
+	CalculateNormals(verts, triangles, norms, smooth, smoothThresh);
 
 	rawNormals.resize(numVertices);
 	for (int i = 0; i < numVertices; i++) {
@@ -2088,41 +2101,7 @@ void NiTriShapeData::RecalcNormals(const bool smooth, const float smoothThresh) 
 
 	NiTriBasedGeomData::RecalcNormals();
 
-	// Zero out existing normals
-	for (auto &n : normals)
-		n.Zero();
-
-	// Face normals
-	Vector3 tn;
-	for (int t = 0; t < numTriangles; t++) {
-		triangles[t].trinormal(vertices, &tn);
-		normals[triangles[t].p1] += tn;
-		normals[triangles[t].p2] += tn;
-		normals[triangles[t].p3] += tn;
-	}
-
-	for (auto &n : normals)
-		n.Normalize();
-
-	// Smooth normals
-	if (smooth) {
-		kd_matcher matcher(vertices.data(), numVertices);
-		for (int i = 0; i < matcher.matches.size(); i++) {
-			std::pair<Vector3*, int>& a = matcher.matches[i].first;
-			std::pair<Vector3*, int>& b = matcher.matches[i].second;
-
-			Vector3& an = normals[a.second];
-			Vector3& bn = normals[b.second];
-			if (an.angle(bn) < smoothThresh * DEG2RAD) {
-				Vector3 anT = an;
-				an += bn;
-				bn += anT;
-			}
-		}
-
-		for (auto &n : normals)
-			n.Normalize();
-	}
+	CalculateNormals(vertices, triangles, normals, smooth, smoothThresh);
 }
 
 void NiTriShapeData::CalcTangentSpace() {
@@ -2302,41 +2281,7 @@ void NiTriStripsData::RecalcNormals(const bool smooth, const float smoothThresh)
 
 	std::vector<Triangle> tris = StripsToTris();
 
-	// Zero out existing normals
-	for (auto &n : normals)
-		n.Zero();
-
-	// Face normals
-	Vector3 tn;
-	for (int t = 0; t < tris.size(); t++) {
-		tris[t].trinormal(vertices, &tn);
-		normals[tris[t].p1] += tn;
-		normals[tris[t].p2] += tn;
-		normals[tris[t].p3] += tn;
-	}
-
-	for (auto &n : normals)
-		n.Normalize();
-
-	// Smooth normals
-	if (smooth) {
-		kd_matcher matcher(vertices.data(), numVertices);
-		for (int i = 0; i < matcher.matches.size(); i++) {
-			std::pair<Vector3*, int>& a = matcher.matches[i].first;
-			std::pair<Vector3*, int>& b = matcher.matches[i].second;
-
-			Vector3& an = normals[a.second];
-			Vector3& bn = normals[b.second];
-			if (an.angle(bn) < smoothThresh * DEG2RAD) {
-				Vector3 anT = an;
-				an += bn;
-				bn += anT;
-			}
-		}
-
-		for (auto &n : normals)
-			n.Normalize();
-	}
+	CalculateNormals(vertices, tris, normals, smooth, smoothThresh);
 }
 
 void NiTriStripsData::CalcTangentSpace() {

--- a/lib/NIF/Geometry.cpp
+++ b/lib/NIF/Geometry.cpp
@@ -10,6 +10,8 @@ See the included LICENSE file
 #include "utils/KDMatcher.h"
 #include "NifUtil.h"
 
+#include <unordered_map>
+
 void NiAdditionalGeometryData::Get(NiStream & stream) {
 	AdditionalGeomData::Get(stream);
 

--- a/lib/NIF/utils/KDMatcher.h
+++ b/lib/NIF/utils/KDMatcher.h
@@ -71,6 +71,43 @@ public:
 	}
 };
 
+// SortingMatcher: finds matching points, just like kd_matcher,
+// but hopefully more efficiently.
+class SortingMatcher {
+public:
+	std::vector<std::vector<int>> matches;
+
+	SortingMatcher(const Vector3* pts, int cnt) {
+		if (cnt <= 0)
+			return;
+
+		std::vector<int> inds(cnt);
+		for (int i = 0; i < cnt; ++i)
+			inds[i] = i;
+
+		std::sort(inds.begin(), inds.end(), [&pts](int i, int j) {
+			if (std::fabs(pts[i].x - pts[j].x) >= EPSILON)
+				return pts[i].x < pts[j].x;
+			if (std::fabs(pts[i].y - pts[j].y) >= EPSILON)
+				return pts[i].y < pts[j].y;
+			if (std::fabs(pts[i].z - pts[j].z) >= EPSILON)
+				return pts[i].z < pts[j].z;
+			return false;
+		});
+
+		for (int si = 0, ei = 1; ei <= cnt; ++ei) {
+			if (ei < cnt &&
+				std::fabs(pts[inds[si]].x - pts[inds[ei]].x) < EPSILON &&
+				std::fabs(pts[inds[si]].y - pts[inds[ei]].y) < EPSILON &&
+				std::fabs(pts[inds[si]].z - pts[inds[ei]].z) < EPSILON)
+				continue;
+			if (ei - si > 1)
+				matches.emplace_back(std::vector<int>(inds.begin() + si, inds.begin() + ei));
+			si = ei;
+		}
+	}
+};
+
 class kd_query_result {
 public:
 	Vector3* v;

--- a/lib/NIF/utils/KDMatcher.h
+++ b/lib/NIF/utils/KDMatcher.h
@@ -15,64 +15,59 @@ class kd_matcher {
 public:
 	class kd_node {
 	public:
-		std::pair<Vector3*, int> p = std::pair<Vector3*, int>(nullptr, -1);
+		int p;
+		std::vector<int> matchset;
 		std::unique_ptr<kd_node> less;
 		std::unique_ptr<kd_node> more;
 
-		kd_node(const std::pair<Vector3*, int>& point) {
+		kd_node(int point) {
 			p = point;
 		}
 
-		std::pair<Vector3*, int> add(const std::pair<Vector3*, int>& point, int depth) {
-			int axis = depth % 3;
-			bool domore = false;
-			float dx = p.first->x - point.first->x;
-			float dy = p.first->y - point.first->y;
-			float dz = p.first->z - point.first->z;
+		void add(const Vector3 *pts, int point, int depth) {
+			Vector3 d = pts[p] - pts[point];
 
-			if (std::fabs(dx) < EPSILON && std::fabs(dy) < EPSILON && std::fabs(dz) < EPSILON)
-				return p;
-
-			switch (axis) {
-			case 0:
-				if (dx > 0) domore = true;
-				break;
-			case 1:
-				if (dy > 0) domore = true;
-				break;
-			case 2:
-				if (dz > 0) domore = true;
-				break;
+			if (std::fabs(d.x) < EPSILON && std::fabs(d.y) < EPSILON && std::fabs(d.z) < EPSILON) {
+				if (matchset.empty())
+					matchset.push_back(p);
+				matchset.push_back(point);
+				return;
 			}
-			if (domore) {
-				if (more) return more->add(point, depth + 1);
-				else more = std::make_unique<kd_node>(point);
+
+			if (d[depth % 3] > 0) {
+				if (more)
+					more->add(pts, point, depth + 1);
+				else
+					more = std::make_unique<kd_node>(point);
 			}
 			else {
-				if (less) return less->add(point, depth + 1);
-				else less = std::make_unique<kd_node>(point);
+				if (less)
+					less->add(pts, point, depth + 1);
+				else
+					less = std::make_unique<kd_node>(point);
 			}
-			return std::pair<Vector3*, int>(nullptr, -1);
+		}
+
+		void collect(std::vector<std::vector<int>> &matches) {
+			if (!matchset.empty())
+				matches.push_back(std::move(matchset));
+			if (more)
+				more->collect(matches);
+			if (less)
+				less->collect(matches);
 		}
 	};
 
-	std::unique_ptr<kd_node> root;
-	Vector3* points = nullptr;
-	int count;
-	std::vector<std::pair<std::pair<Vector3*, int>, std::pair<Vector3*, int>>> matches;
+	std::vector<std::vector<int>> matches;
 
-	kd_matcher(Vector3* pts, int cnt) {
+	kd_matcher(const Vector3* pts, int cnt) {
 		if (cnt <= 0)
 			return;
 
-		std::pair<Vector3*, int> pong;
-		root = std::make_unique<kd_node>(std::pair<Vector3*, int>(&pts[0], 0));
-		for (int i = 1; i < cnt; i++) {
-			std::pair<Vector3*, int> point(&pts[i], i);
-			pong = root->add(point, 0);
-			if (pong.first)
-				matches.push_back(std::pair<std::pair<Vector3*, int>, std::pair<Vector3*, int>>(point, pong));
-		}
+		kd_node root(0);
+		for (int i = 1; i < cnt; i++)
+			root.add(pts, i, 0);
+		root.collect(matches);
 	}
 };
 

--- a/src/components/Mesh.cpp
+++ b/src/components/Mesh.cpp
@@ -4,6 +4,7 @@ See the included LICENSE file
 */
 
 #include "Mesh.h"
+#include "../NIF/utils/KDMatcher.h"
 
 mesh::mesh() {
 }
@@ -391,6 +392,20 @@ int mesh::GetAdjacentUnvisitedPoints(int querypoint, int outPoints[], int maxPoi
 	/* TODO: sort by distance */
 }
 
+void mesh::CalcWeldVerts() {
+	kd_matcher matcher(verts.get(), nVerts);
+	for (const std::vector<int> &matchset : matcher.matches) {
+		for (int j = 0; j < matchset.size(); ++j) {
+			std::vector<int> &wv = weldVerts[matchset[j]];
+			for (int k = 0; k < matchset.size(); ++k) {
+				if (j != k)
+					wv.push_back(matchset[k]);
+			}
+		}
+	}
+	bGotWeldVerts = true;
+}
+
 float mesh::GetSmoothThreshold() {
 	return (smoothThresh * 180) / PI;
 }
@@ -441,32 +456,27 @@ void mesh::SmoothNormals(const std::set<int>& vertices) {
 		pn.Normalize();
 	}
 
-	// Smooth normals
+	// Smooth welded vertex normals
 	if (smoothSeamNormals) {
-		kd_matcher matcher(verts.get(), nVerts);
-		for (int i = 0; i < matcher.matches.size(); i++) {
-			std::pair<Vector3*, int>& a = matcher.matches[i].first;
-			std::pair<Vector3*, int>& b = matcher.matches[i].second;
+		if (!bGotWeldVerts)
+			CalcWeldVerts();
 
-			if (!vertices.empty()) {
-				if (vertices.find(a.second) == vertices.end() ||
-					vertices.find(b.second) == vertices.end())
-					continue;
-			}
+		std::unordered_map<int, Vector3> seamNorms;
 
-			Vector3& an = norms[a.second];
-			Vector3& bn = norms[b.second];
-			if (an.angle(bn) < smoothThresh) {
-				Vector3 anT = an;
-				an += bn;
-				bn += anT;
-			}
+		for (auto &wvp : weldVerts) {
+			if (!vertices.empty() && vertices.find(wvp.first) != vertices.end())
+				continue;
+			const Vector3 &n = norms[wvp.first];
+			Vector3 sn = n;
+			for (int wvi : wvp.second)
+				if (n.angle(norms[wvi]) < smoothThresh)
+					sn += norms[wvi];
+			sn.Normalize();
+			seamNorms[wvp.first] = sn;
 		}
 
-		for (int i = 0; i < nVerts; i++) {
-			Vector3& pn = norms[i];
-			pn.Normalize();
-		}
+		for (auto &snp : seamNorms)
+			norms[snp.first] = snp.second;
 	}
 
 	queueUpdate[UpdateType::Normals] = true;

--- a/src/components/Mesh.cpp
+++ b/src/components/Mesh.cpp
@@ -393,7 +393,7 @@ int mesh::GetAdjacentUnvisitedPoints(int querypoint, int outPoints[], int maxPoi
 }
 
 void mesh::CalcWeldVerts() {
-	kd_matcher matcher(verts.get(), nVerts);
+	SortingMatcher matcher(verts.get(), nVerts);
 	for (const std::vector<int> &matchset : matcher.matches) {
 		for (int j = 0; j < matchset.size(); ++j) {
 			std::vector<int> &wv = weldVerts[matchset[j]];
@@ -461,7 +461,7 @@ void mesh::SmoothNormals(const std::set<int>& vertices) {
 		if (!bGotWeldVerts)
 			CalcWeldVerts();
 
-		std::unordered_map<int, Vector3> seamNorms;
+		std::vector<std::pair<int, Vector3>> seamNorms;
 
 		for (auto &wvp : weldVerts) {
 			if (!vertices.empty() && vertices.find(wvp.first) != vertices.end())
@@ -472,7 +472,7 @@ void mesh::SmoothNormals(const std::set<int>& vertices) {
 				if (n.angle(norms[wvi]) < smoothThresh)
 					sn += norms[wvi];
 			sn.Normalize();
-			seamNorms[wvp.first] = sn;
+			seamNorms.emplace_back(wvp.first, sn);
 		}
 
 		for (auto &snp : seamNorms)

--- a/src/components/Mesh.h
+++ b/src/components/Mesh.h
@@ -5,7 +5,6 @@ See the included LICENSE file
 
 #pragma once
 
-#include "../NIF/utils/KDMatcher.h"
 #include "../utils/AABBTree.h"
 #include "../render/GLExtensions.h"
 #include "../files/MaterialFile.h"
@@ -95,6 +94,7 @@ public:
 	std::unique_ptr<std::vector<int>[]> vertTris;				// Map of triangles for which each vert is a member.
 	std::unique_ptr<std::vector<int>[]> vertEdges;				// Map of edges for which each vert is a member.
 	std::unordered_map<int, std::vector<int>> weldVerts;		// Verts that are duplicated for UVs but are in the same position.
+	bool bGotWeldVerts = false;	// Whether weldVerts has been calculated yet.
 
 	RenderMode rendermode = RenderMode::Normal;
 	bool doublesided = false;
@@ -136,6 +136,8 @@ public:
 
 	void BuildTriAdjacency();	// Triangle adjacency optional to reduce overhead when it's not needed.
 	void BuildEdgeList();		// Edge list optional to reduce overhead when it's not needed.
+
+	void CalcWeldVerts();
 
 	void CreateBuffers();
 	void UpdateBuffers();

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -2281,6 +2281,8 @@ void OutfitProject::CollectVertexData(NiShape* shape, UndoStateShape &uss, const
 	// For diffs, it's more efficient to reverse the loop nesting.
 	for (int si = 0; si < activeSet.size(); ++si) {
 		std::string targetDataName = activeSet[si].TargetDataName(target);
+		if (targetDataName.empty())
+			targetDataName = target + activeSet[si].name;
 		std::unordered_map<ushort, Vector3>* diffSet;
 		if (IsBaseShape(shape))
 			diffSet = baseDiffData.GetDiffSet(targetDataName);
@@ -2534,6 +2536,8 @@ void OutfitProject::ApplyShapeMeshUndo(NiShape* shape, const UndoStateShape &uss
 			// ...in diff data
 			for (const UndoStateVertexSliderDiff &diff : usv.diffs) {
 				std::string targetDataName = activeSet[diff.sliderName].TargetDataName(target);
+				if (targetDataName.empty())
+					targetDataName = target + diff.sliderName;
 				std::unordered_map<ushort, Vector3>* diffSet;
 				if (IsBaseShape(shape))
 					diffSet = baseDiffData.GetDiffSet(targetDataName);

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -200,7 +200,7 @@ public:
 
 	bool PrepareCollapseVertex(NiShape* shape, UndoStateShape &uss, const std::vector<int> &indices);
 	bool PrepareFlipEdge(NiShape* shape, UndoStateShape &uss, const Edge &edge);
-	bool PrepareSplitEdge(NiShape* shape, UndoStateShape &uss, const Edge &edge, const Edge &redge);
+	bool PrepareSplitEdge(NiShape* shape, UndoStateShape &uss, const std::vector<int> &p1s, const std::vector<int> &p2s);
 
 	NiShape* DuplicateShape(NiShape* sourceShape, const std::string& destShapeName);
 	void DeleteShape(NiShape* shape);

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -9708,40 +9708,22 @@ void wxGLPanel::ClickSplitEdge() {
 		return;
 	}
 
-	// Determine reverse edge
-	int p1 = mouseDownEdge.p1, p2 = mouseDownEdge.p2;
-	Edge redge(p2, p1);
-	std::vector<int> p1w, p2w;
-	if (m->weldVerts.find(p1) != m->weldVerts.end())
-		p1w = m->weldVerts[p1];
-
-	if (m->weldVerts.find(p2) != m->weldVerts.end())
-		p2w = m->weldVerts[p2];
-
-	if (!p1w.empty() || !p2w.empty()) {
-		if (p1w.empty())
-			p1w.push_back(p1);
-
-		if (p2w.empty())
-			p2w.push_back(p2);
-
-		for (int ap1 : p1w) {
-			for (int ei : m->vertEdges[ap1]) {
-				int ep2 = m->edges[ei].p1 == ap1 ? m->edges[ei].p2 : m->edges[ei].p1;
-				for (int ap2 : p2w) {
-					if (ap2 == ep2) {
-						redge.p1 = ap2;
-						redge.p2 = ap1;
-					}
-				}
-			}
-		}
-	}
+	// Collect welded vertices
+	int p1 = mouseDownEdge.p1;
+	int p2 = mouseDownEdge.p2;
+	std::vector<int> p1s(1, p1);
+	std::vector<int> p2s(1, p2);
+	auto wvit = m->weldVerts.find(p1);
+	if (wvit != m->weldVerts.end())
+		std::copy(wvit->second.begin(), wvit->second.end(), std::back_inserter(p1s));
+	wvit = m->weldVerts.find(p2);
+	if (wvit != m->weldVerts.end())
+		std::copy(wvit->second.begin(), wvit->second.end(), std::back_inserter(p2s));
 
 	// Prepare list of changes
 	UndoStateShape uss;
 	uss.shapeName = mouseDownMeshName;
-	if (!os->project->PrepareSplitEdge(shape, uss, mouseDownEdge, redge)) {
+	if (!os->project->PrepareSplitEdge(shape, uss, p1s, p2s)) {
 		wxMessageBox(_("The edge picked has multiple triangles of the same orientation.  Correct the orientations before splitting."), _("Error"), wxICON_ERROR, os);
 		return;
 	}

--- a/src/render/GLSurface.cpp
+++ b/src/render/GLSurface.cpp
@@ -1171,32 +1171,8 @@ mesh* GLSurface::AddMeshFromNif(NifFile* nif, const std::string& shapeName, Vect
 		for (int t = 0; t < m->nTris; t++)
 			m->tris[t] = nifTris[t];
 
-		// Face normals
-		m->FacetNormals();
-
-		// Smooth normals
-		if (m->smoothSeamNormals) {
-			kd_matcher matcher(m->verts.get(), m->nVerts);
-			for (int i = 0; i < matcher.matches.size(); i++) {
-				std::pair<Vector3*, int>& a = matcher.matches[i].first;
-				std::pair<Vector3*, int>& b = matcher.matches[i].second;
-				m->weldVerts[a.second].push_back(b.second);
-				m->weldVerts[b.second].push_back(a.second);
-
-				Vector3& an = m->norms[a.second];
-				Vector3& bn = m->norms[b.second];
-				if (an.angle(bn) < 60.0f * DEG2RAD) {
-					Vector3 anT = an;
-					an += bn;
-					bn += anT;
-				}
-			}
-
-			for (int i = 0; i < m->nVerts; i++) {
-				Vector3& pn = m->norms[i];
-				pn.Normalize();
-			}
-		}
+		// Calc weldVerts and normals
+		m->SmoothNormals();
 	}
 	else {
 		// Already have normals, just copy the data over.
@@ -1213,13 +1189,7 @@ mesh* GLSurface::AddMeshFromNif(NifFile* nif, const std::string& shapeName, Vect
 		}
 
 		// Virtually weld verts across UV seams
-		kd_matcher matcher(m->verts.get(), m->nVerts);
-		for (int i = 0; i < matcher.matches.size(); i++) {
-			std::pair<Vector3*, int>& a = matcher.matches[i].first;
-			std::pair<Vector3*, int>& b = matcher.matches[i].second;
-			m->weldVerts[a.second].push_back(b.second);
-			m->weldVerts[b.second].push_back(a.second);
-		}
+		m->CalcWeldVerts();
 	}
 
 	m->CalcTangentSpace();


### PR DESCRIPTION
- FindNeighboring triangles wasn't checking for not-found triangles before trying to determine the opposite vertex.

- ClickSplitEdge was not checking for edge orientation mismatches when finding welded edges.  The code was moved into PrepareSplitEdge.

- PrepareSplitEdge was not handling uv diffs for welded edges properly.

Note that Split Edge still does not work correctly.  There's a flaw in kd_matcher that causes the welded vertex lists to be incomplete, which prevents Split Edge from working correctly if a vertex is welded to more than one other vertex.