### PR TITLE
Reduced roundoff in global-to-skin transform calculation by using median

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ set(BSsources
 	src/program/NormalsGenDialog.cpp
 	src/program/PreviewWindow.cpp
 	src/ui/wxNormalsGenDlg.cpp
+	src/components/BuildSelection.cpp
 	)
 
 add_executable(OutfitStudio ${OSsources})

--- a/lib/NIF/utils/Object3d.cpp
+++ b/lib/NIF/utils/Object3d.cpp
@@ -153,8 +153,13 @@ Matrix3 RotVecToMat(const Vector3 &v) {
 
 Vector3 RotMatToVec(const Matrix3 &m) {
 	double cosang = (m[0][0] + m[1][1] + m[2][2] - 1) * 0.5;
-	if (cosang >= 1)
-		return Vector3(0,0,0);
+	if (cosang > 0.5) {
+		Vector3 v(m[1][2] - m[2][1], m[2][0] - m[0][2], m[0][1] - m[1][0]);
+		double sin2ang = v.length();
+		if (sin2ang == 0)
+			return Vector3(0,0,0);
+		return v * (std::asin(sin2ang * 0.5) / sin2ang);
+	}
 	else if (cosang > -1) {
 		Vector3 v(m[1][2] - m[2][1], m[2][0] - m[0][2], m[0][1] - m[1][0]);
 		v.Normalize();

--- a/lib/NIF/utils/Object3d.cpp
+++ b/lib/NIF/utils/Object3d.cpp
@@ -172,3 +172,134 @@ Vector3 RotMatToVec(const Matrix3 &m) {
 		return v * PI;
 	}
 }
+
+Matrix3 CalcAverageRotation(const std::vector<Matrix3> &rots) {
+	int n = rots.size();
+	if (n <= 0)
+		return Matrix3();
+
+	// First, calculate an approximate average as a base point in
+	// the manifold of rotations.
+	Vector3 sum1;
+	for (const Matrix3 &r : rots)
+		sum1 += RotMatToVec(r);
+	sum1 /= n;
+
+	// Now, rebase each rotation to the base point and average them
+	// there.
+	Matrix3 base = RotVecToMat(sum1);
+	Matrix3 baseinv = base.Transpose();
+	Vector3 sum2;
+	for (const Matrix3 &r : rots)
+		sum2 += RotMatToVec(baseinv * r);
+
+	// The result is the new average offset from the base.
+	return base * RotVecToMat(sum2);
+}
+
+MatTransform CalcAverageMatTransform(const std::vector<MatTransform> &ts) {
+	int n = ts.size();
+	if (n <= 0)
+		return MatTransform();
+
+	std::vector<Matrix3> rots(n);
+	Vector3 sumtrans;
+	float sumscale = 0.0f;
+	for (int i = 0; i < n; ++i) {
+		rots[i] = ts[i].rotation;
+		sumtrans += ts[i].translation;
+		sumscale += ts[i].scale;
+	}
+
+	MatTransform res;
+	res.rotation = CalcAverageRotation(rots);
+	res.translation = sumtrans / n;
+	res.scale = sumscale / n;
+	return res;
+}
+
+float CalcMedianOfFloats(std::vector<float> &data) {
+	int n = data.size();
+	if (n <= 0)
+		return 0;
+
+	if (n & 1) {// n is odd
+		std::nth_element(data.begin(), data.begin() + n/2, data.end());
+		return data[n/2];
+	}
+	else {// n is even
+		std::nth_element(data.begin(), data.begin() + n/2, data.end());
+		std::nth_element(data.begin(), data.begin() + n/2-1, data.begin() + n/2);
+		return (data[n/2] + data[n/2-1]) / 2;
+	}
+}
+
+Vector3 CalcMedianOfVector3(const std::vector<Vector3> &data) {
+	int n = data.size();
+	if (n <= 0)
+		return Vector3();
+
+	Vector3 res;
+	std::vector<float> nums(n);
+
+	for (int i = 0; i < n; ++i)
+		nums[i] = data[i].x;
+	res.x = CalcMedianOfFloats(nums);
+
+	for (int i = 0; i < n; ++i)
+		nums[i] = data[i].y;
+	res.y = CalcMedianOfFloats(nums);
+
+	for (int i = 0; i < n; ++i)
+		nums[i] = data[i].z;
+	res.z = CalcMedianOfFloats(nums);
+
+	return res;
+}
+
+Matrix3 CalcMedianRotation(const std::vector<Matrix3> &rots) {
+	int n = rots.size();
+	if (n <= 0)
+		return Matrix3();
+
+	// First, calculate an approximate average as a base point in
+	// the manifold of rotations.
+	Vector3 sum1;
+	for (const Matrix3 &r : rots)
+		sum1 += RotMatToVec(r);
+	sum1 /= n;
+
+	// Now, rebase each rotation to the base point.
+	std::vector<Vector3> vecs(n);
+	Matrix3 base = RotVecToMat(sum1);
+	Matrix3 baseinv = base.Transpose();
+	for (int i = 0; i < n; ++i)
+		vecs[i] = RotMatToVec(baseinv * rots[i]);
+
+	// Calculate median of the rebased rotation vectors.
+	Vector3 mvec = CalcMedianOfVector3(vecs);
+
+	// The result is the median rebased rotation offset from the base.
+	return base * RotVecToMat(mvec);
+}
+
+MatTransform CalcMedianMatTransform(const std::vector<MatTransform> &ts) {
+	int n = ts.size();
+	if (n <= 0)
+		return MatTransform();
+
+	std::vector<Matrix3> rots(n);
+	std::vector<Vector3> trans(n);
+	std::vector<float> scales(n);
+	for (int i = 0; i < n; ++i) {
+		rots[i] = ts[i].rotation;
+		trans[i] = ts[i].translation;
+		scales[i] = ts[i].scale;
+	}
+
+	MatTransform res;
+	res.rotation = CalcMedianRotation(rots);
+	res.translation = CalcMedianOfVector3(trans);
+	res.scale = CalcMedianOfFloats(scales);
+	return res;
+}

--- a/lib/NIF/utils/Object3d.h
+++ b/lib/NIF/utils/Object3d.h
@@ -26,6 +26,8 @@ inline bool FloatsAreNearlyEqual(float a, float b) {
 	return std::fabs(a - b) <= EPSILON * scale;
 }
 
+float CalcMedianOfFloats(const std::vector<float> &data);
+
 struct Vector2 {
 	float u;
 	float v;
@@ -304,6 +306,8 @@ inline Vector3 operator*(float f, const Vector3 &v) {
 	return Vector3(f*v.x, f*v.y, f*v.z);
 }
 
+Vector3 CalcMedianOfVector3(const std::vector<Vector3> &data);
+
 struct Vector4 {
 	float x;
 	float y;
@@ -536,6 +540,20 @@ public:
 			rows[2][0] * v.x + rows[2][1] * v.y + rows[2][2] * v.z);
 	}
 
+	Matrix3 Transpose() const {
+		Matrix3 res;
+		res[0][0] = rows[0][0];
+		res[0][1] = rows[1][0];
+		res[0][2] = rows[2][0];
+		res[1][0] = rows[0][1];
+		res[1][1] = rows[1][1];
+		res[1][2] = rows[2][1];
+		res[2][0] = rows[0][2];
+		res[2][1] = rows[1][2];
+		res[2][2] = rows[2][2];
+		return res;
+	}
+
 	float Determinant() const;
 
 	// Invert attempts to invert this matrix, returning the result in
@@ -588,6 +606,9 @@ Matrix3 RotVecToMat(const Vector3 &v);
 // Note that this function is unstable for angles near pi, but it
 // should still work.
 Vector3 RotMatToVec(const Matrix3 &m);
+
+Matrix3 CalcAverageRotation(const std::vector<Matrix3> &rots);
+Matrix3 CalcMedianRotation(const std::vector<Matrix3> &rots);
 
 // 4D Matrix class for calculating and applying transformations.
 class Matrix4 {
@@ -1006,6 +1027,9 @@ struct MatTransform {
 			FloatsAreNearlyEqual(scale, other.scale);
 	}
 };
+
+MatTransform CalcAverageMatTransform(const std::vector<MatTransform> &ts);
+MatTransform CalcMedianMatTransform(const std::vector<MatTransform> &ts);
 
 
 struct Edge {

--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -138,6 +138,7 @@ void AnimSkin::LoadFromNif(NifFile* loadFromFile, NiShape* shape) {
 	loadFromFile->GetShapeBoneIDList(shape, idList);
 
 	int newID = 0;
+	std::vector<MatTransform> eachXformGlobalToSkin;
 	for (auto &id : idList) {
 		auto node = loadFromFile->GetHeader().GetBlock<NiNode>(id);
 		if (!node) continue;
@@ -151,12 +152,13 @@ void AnimSkin::LoadFromNif(NifFile* loadFromFile, NiShape* shape) {
 			// and inverting.
 			MatTransform xformBoneToGlobal;
 			if (AnimSkeleton::getInstance().GetBoneTransformToGlobal(node->GetName(), xformBoneToGlobal)) {
-				xformGlobalToSkin = xformBoneToGlobal.ComposeTransforms(boneWeights[newID].xformSkinToBone).InverseTransform();
-				gotGTS = true;
+				eachXformGlobalToSkin.push_back(xformBoneToGlobal.ComposeTransforms(boneWeights[newID].xformSkinToBone).InverseTransform());
 			}
 		}
 		newID++;
 	}
+	if (!eachXformGlobalToSkin.empty())
+		xformGlobalToSkin = CalcMedianMatTransform(eachXformGlobalToSkin);
 }
 
 bool AnimInfo::LoadFromNif(NifFile* nif) {

--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -273,7 +273,8 @@ void AnimInfo::RecursiveRecalcXFormSkinToBone(const std::string& shape, AnimBone
 
 void AnimInfo::ChangeGlobalToSkinTransform(const std::string& shape, const MatTransform &newTrans) {
 	shapeSkinning[shape].xformGlobalToSkin = newTrans;
-	RecursiveRecalcXFormSkinToBone(shape, AnimSkeleton::getInstance().GetRootBonePtr());
+	for (const std::string &bone : shapeBones[shape])
+		RecalcXFormSkinToBone(shape, bone);
 }
 
 bool AnimInfo::CalcShapeSkinBounds(const std::string& shapeName, const int& boneIndex) {

--- a/src/program/ShapeProperties.cpp
+++ b/src/program/ShapeProperties.cpp
@@ -658,13 +658,13 @@ void ShapeProperties::GetCoordTrans() {
 	newXformGlobalToSkin = oldXformGlobalToSkin;
 	Vector3 rotvec = RotMatToVec(newXformGlobalToSkin.rotation);
 
-	textScale->ChangeValue(wxString() << newXformGlobalToSkin.scale);
-	textX->ChangeValue(wxString() << newXformGlobalToSkin.translation.x);
-	textY->ChangeValue(wxString() << newXformGlobalToSkin.translation.y);
-	textZ->ChangeValue(wxString() << newXformGlobalToSkin.translation.z);
-	textRX->ChangeValue(wxString() << rotvec.x);
-	textRY->ChangeValue(wxString() << rotvec.y);
-	textRZ->ChangeValue(wxString() << rotvec.z);
+	textScale->ChangeValue(wxString::Format("%.10f", newXformGlobalToSkin.scale));
+	textX->ChangeValue(wxString::Format("%.10f", newXformGlobalToSkin.translation.x));
+	textY->ChangeValue(wxString::Format("%.10f", newXformGlobalToSkin.translation.y));
+	textZ->ChangeValue(wxString::Format("%.10f", newXformGlobalToSkin.translation.z));
+	textRX->ChangeValue(wxString::Format("%.10f", rotvec.x));
+	textRY->ChangeValue(wxString::Format("%.10f", rotvec.y));
+	textRZ->ChangeValue(wxString::Format("%.10f", rotvec.z));
 
 	cbTransformGeo->Disable();
 }


### PR DESCRIPTION
This change is primarily to the function AnimSkin::LoadFromNif, which, among other things, calculates the global-to-skin transform for FO4 nif files, since this transform is not present in those files.  Unfortunately, it has been discovered that this calculation can have quite a bit of roundoff error.  So the calculation has been changed.  Instead of using the first skin-to-bone transform in the shape to calculate the global-to-skin transform, it uses every shape bone and takes the median of all the calculated global-to-skin transforms.

The primary helper functions added are:
Matrix3::Transpose
CalcMedianOfFloats
CalcMedianOfVector3
CalcMedianRotation
CalcMedianMatTransform

In addition, I wrote these functions that are currently unused:
CalcAverageRotation
CalcAverageMatTransform

The resulting global-to-skin transforms definitely have less roundoff error if the shape uses lots of bones, but there's still a noticeable amount of roundoff error.  This is visible at the seam between eye and face for some FO4 head models.