### PR TITLE
1 click 'Convert Body Reference' wizard (ie, CBBE to BHUNP) & 'Keep Zap Sliders' on loading a reference

### DIFF
--- a/res/xrc/OutfitStudio.xrc
+++ b/res/xrc/OutfitStudio.xrc
@@ -1661,6 +1661,11 @@
 				<label>Load Outfit...</label>
 				<help>Load a NIF file as the working outfit, replacing any current outfit objects.</help>
 			</object>
+      <object class="separator" />
+      <object class="wxMenuItem" name="fileConvBodyRef">
+        <label>Convert Body Reference...</label>
+        <help>Convert an outfits body reference to use a different reference</help>
+      </object>
 			<object class="separator" />
 			<object class="wxMenuItem" name="fileSave">
 				<label>Save Project\tCtrl+S</label>

--- a/res/xrc/OutfitStudio.xrc
+++ b/res/xrc/OutfitStudio.xrc
@@ -1662,10 +1662,10 @@
 				<help>Load a NIF file as the working outfit, replacing any current outfit objects.</help>
 			</object>
       <object class="separator" />
-      <object class="wxMenuItem" name="fileConvBodyRef">
-        <label>Convert Body Reference...</label>
-        <help>Convert an outfits body reference to use a different reference</help>
-      </object>
+			<object class="wxMenuItem" name="fileConvBodyRef">
+				<label>Convert Body Reference...</label>
+				<help>Convert an outfits body reference to use a different reference</help>
+			</object>
 			<object class="separator" />
 			<object class="wxMenuItem" name="fileSave">
 				<label>Save Project\tCtrl+S</label>
@@ -1964,10 +1964,10 @@
 				<help>Create a new Zap slider based on unmasked vertices</help>
 			</object>
 			<object class="separator" />
-      <object class="wxMenuItem" name="bakeNifInPlace">
-        <label>Bake Conversion Ref</label>
-        <help>Bake the conversion slider</help>
-      </object>
+			<object class="wxMenuItem" name="bakeNifInPlace">
+				<label>Bake Conversion Ref</label>
+				<help>Bake the conversion slider</help>
+			</object>
 			<object class="separator" />
 			<object class="wxMenuItem" name="sliderImportOSD">
 				<label>Import OSD...</label>

--- a/res/xrc/OutfitStudio.xrc
+++ b/res/xrc/OutfitStudio.xrc
@@ -1964,11 +1964,6 @@
 				<help>Create a new Zap slider based on unmasked vertices</help>
 			</object>
 			<object class="separator" />
-			<object class="wxMenuItem" name="bakeNifInPlace">
-				<label>Bake Conversion Ref</label>
-				<help>Bake the conversion slider</help>
-			</object>
-			<object class="separator" />
 			<object class="wxMenuItem" name="sliderImportOSD">
 				<label>Import OSD...</label>
 				<help>Imports OSD file and creates sliders for shapes with a matching name.</help>

--- a/res/xrc/OutfitStudio.xrc
+++ b/res/xrc/OutfitStudio.xrc
@@ -1661,7 +1661,7 @@
 				<label>Load Outfit...</label>
 				<help>Load a NIF file as the working outfit, replacing any current outfit objects.</help>
 			</object>
-      <object class="separator" />
+			<object class="separator" />
 			<object class="wxMenuItem" name="fileConvBodyRef">
 				<label>Convert Body Reference...</label>
 				<help>Convert an outfits body reference to use a different reference</help>

--- a/res/xrc/OutfitStudio.xrc
+++ b/res/xrc/OutfitStudio.xrc
@@ -1959,6 +1959,11 @@
 				<help>Create a new Zap slider based on unmasked vertices</help>
 			</object>
 			<object class="separator" />
+      <object class="wxMenuItem" name="bakeNifInPlace">
+        <label>Bake Conversion Ref</label>
+        <help>Bake the conversion slider</help>
+      </object>
+			<object class="separator" />
 			<object class="wxMenuItem" name="sliderImportOSD">
 				<label>Import OSD...</label>
 				<help>Imports OSD file and creates sliders for shapes with a matching name.</help>

--- a/res/xrc/Project.xrc
+++ b/res/xrc/Project.xrc
@@ -293,7 +293,7 @@
 	</object>
 	<object class="wxDialog" name="dlgSaveProject">
 		<style>wxDEFAULT_DIALOG_STYLE</style>
-		<size>486,365</size>
+		<size>486,345</size>
 		<title>Save Project As...</title>
 		<centered>1</centered>
 		<object class="wxBoxSizer">
@@ -693,21 +693,21 @@
 						<option>0</option>
 						<flag>wxALL</flag>
 						<border>5</border>
-            <object class="wxCheckBox" name="chkKeepZapSliders">
-              <label>Keep Zap Sliders</label>
-              <checked>1</checked>
-            </object>
-				  </object>
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxALL</flag>
-            <border>5</border>
+						<object class="wxCheckBox" name="chkKeepZapSliders">
+							<label>Keep Zap Sliders</label>
+							<checked>1</checked>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxALL</flag>
+						<border>5</border>
 						<object class="wxCheckBox" name="chkClearSliders">
 							<label>Merge new sliders with existing sliders</label>
 							<checked>0</checked>
 						</object>
 					</object>
-        </object>
+				</object>
 			</object>
 			<object class="sizeritem">
 				<option>0</option>
@@ -1058,7 +1058,7 @@
 		<centered>1</centered>
 		<object class="wxBoxSizer">
 			<orient>wxVERTICAL</orient>
-      <object class="sizeritem">
+			<object class="sizeritem">
 				<option>0</option>
 				<flag>wxALL|wxEXPAND</flag>
 				<border>10</border>
@@ -1090,98 +1090,98 @@
 								<option>1</option>
 								<flag>wxALL|wxEXPAND</flag>
 								<border>5</border>
-                <minsize>200,30</minsize>
-                <object class="wxChoice" name="npConvRefChoice">
+								<minsize>200,30</minsize>
+								<object class="wxChoice" name="npConvRefChoice">
 									<style>wxCB_SORT</style>
 									<selection>0</selection>
 									<content />
 								</object>
 							</object>
-              <object class="sizeritem">
-                <option>1</option>
-                <flag>wxALL|wxEXPAND</flag>
-                <border>5</border>
-                <object class="wxStaticText" name="npNewRef">
-                  <style>wxRB_GROUP</style>
-                  <label>New Body Reference</label>
-                  <value translate="0">1</value>
-                </object>
-              </object>
-              <object class="sizeritem">
-                <option>1</option>
-                <flag>wxALL|wxEXPAND</flag>
-                <border>5</border>
-                <minsize>200,30</minsize>
-                <object class="wxChoice" name="npNewRefChoice">
-                  <style>wxCB_SORT</style>
-                  <selection>0</selection>
-                  <content />
-                </object>
-              </object>
-              <object class="spacer">
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>5</border>
+								<object class="wxStaticText" name="npNewRef">
+									<style>wxRB_GROUP</style>
+									<label>New Body Reference</label>
+									<value translate="0">1</value>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>5</border>
+								<minsize>200,30</minsize>
+								<object class="wxChoice" name="npNewRefChoice">
+									<style>wxCB_SORT</style>
+									<selection>0</selection>
+									<content />
+								</object>
+							</object>
+							<object class="spacer">
 								<option>1</option>
 								<flag>wxEXPAND</flag>
 								<border>5</border>
 								<size>0,0</size>
 							</object>
-            </object>
+						</object>
 					</object>
 					<object class="sizeritem">
 						<option>0</option>
 						<flag>wxALL</flag>
 						<border>5</border>
-            <object class="wxCheckBox" name="chkKeepZapSliders">
-              <label>Keep Zap Sliders</label>
-              <checked>1</checked>
-            </object>
-				  </object>
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxEXPAND</flag>
-            <border>5</border>
-            <object class="wxFlexGridSizer">
-              <rows>0</rows>
-              <cols>2</cols>
-              <vgap>0</vgap>
-              <hgap>0</hgap>
-              <growablecols>1</growablecols>
-              <growablerows></growablerows>
-              <object class="sizeritem">
-                <option>1</option>
-                <flag>wxALL|wxEXPAND</flag>
-                <border>5</border>
-                <object class="wxStaticText">
-                  <style>wxRB_GROUP</style>
-                  <label>Remove from project names</label>
-                  <value translate="0">1</value>
-                </object>
-              </object>
-              <object class="sizeritem">
-                <border>5</border>
-                <minsize>200,22</minsize>
-                <object class="wxTextCtrl" name="npRemoveText">
-                </object>
-              </object>
-              <object class="sizeritem">
-                <option>1</option>
-                <flag>wxALL|wxEXPAND</flag>
-                <border>5</border>
-                <object class="wxStaticText">
-                  <style>wxRB_GROUP</style>
-                  <label>Append to project names</label>
-                  <value translate="0">1</value>
-                </object>
-              </object>
-              <object class="sizeritem">
-                <border>5</border>
-                <minsize>200,22</minsize>
-                <object class="wxTextCtrl" name="npAppendText">
-                </object>
-              </object>
-            </object>
-          </object>
-        </object>
-      </object>
+						<object class="wxCheckBox" name="chkKeepZapSliders">
+							<label>Keep Zap Sliders</label>
+							<checked>1</checked>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxFlexGridSizer">
+							<rows>0</rows>
+							<cols>2</cols>
+							<vgap>0</vgap>
+							<hgap>0</hgap>
+							<growablecols>1</growablecols>
+							<growablerows></growablerows>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>5</border>
+								<object class="wxStaticText">
+									<style>wxRB_GROUP</style>
+									<label>Remove from project names</label>
+									<value translate="0">1</value>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<border>5</border>
+								<minsize>200,22</minsize>
+								<object class="wxTextCtrl" name="npRemoveText">
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>5</border>
+								<object class="wxStaticText">
+									<style>wxRB_GROUP</style>
+									<label>Append to project names</label>
+									<value translate="0">1</value>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<border>5</border>
+								<minsize>200,22</minsize>
+								<object class="wxTextCtrl" name="npAppendText">
+								</object>
+							</object>
+						</object>
+					</object>
+				</object>
+			</object>
 			<object class="sizeritem">
 				<option>0</option>
 				<flag>wxEXPAND|wxALL</flag>

--- a/res/xrc/Project.xrc
+++ b/res/xrc/Project.xrc
@@ -293,7 +293,7 @@
 	</object>
 	<object class="wxDialog" name="dlgSaveProject">
 		<style>wxDEFAULT_DIALOG_STYLE</style>
-		<size>486,345</size>
+		<size>486,365</size>
 		<title>Save Project As...</title>
 		<centered>1</centered>
 		<object class="wxBoxSizer">
@@ -707,7 +707,7 @@
 							<checked>0</checked>
 						</object>
 					</object>
-				</object>
+        </object>
 			</object>
 			<object class="sizeritem">
 				<option>0</option>
@@ -1050,6 +1050,159 @@
 		</object>
 		<object class="wxMenuItem" name="projectListInvert">
 			<label>Invert Selection</label>
+		</object>
+	</object>
+	<object class="wxDialog" name="dlgConvertBodyRef">
+		<style>wxDEFAULT_DIALOG_STYLE</style>
+		<title>Convert Body Reference</title>
+		<centered>1</centered>
+		<object class="wxBoxSizer">
+			<orient>wxVERTICAL</orient>
+      <object class="sizeritem">
+				<option>0</option>
+				<flag>wxALL|wxEXPAND</flag>
+				<border>10</border>
+				<object class="wxStaticBoxSizer">
+					<orient>wxVERTICAL</orient>
+					<label>Reference</label>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxFlexGridSizer">
+							<rows>0</rows>
+							<cols>2</cols>
+							<vgap>0</vgap>
+							<hgap>0</hgap>
+							<growablecols>1</growablecols>
+							<growablerows></growablerows>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>5</border>
+								<object class="wxStaticText" name="npConvRef">
+									<style>wxRB_GROUP</style>
+									<label>Conversion Body Reference</label>
+									<value translate="0">1</value>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>5</border>
+                <minsize>200,30</minsize>
+                <object class="wxChoice" name="npConvRefChoice">
+									<style>wxCB_SORT</style>
+									<selection>0</selection>
+									<content />
+								</object>
+							</object>
+              <object class="sizeritem">
+                <option>1</option>
+                <flag>wxALL|wxEXPAND</flag>
+                <border>5</border>
+                <object class="wxStaticText" name="npNewRef">
+                  <style>wxRB_GROUP</style>
+                  <label>New Body Reference</label>
+                  <value translate="0">1</value>
+                </object>
+              </object>
+              <object class="sizeritem">
+                <option>1</option>
+                <flag>wxALL|wxEXPAND</flag>
+                <border>5</border>
+                <minsize>200,30</minsize>
+                <object class="wxChoice" name="npNewRefChoice">
+                  <style>wxCB_SORT</style>
+                  <selection>0</selection>
+                  <content />
+                </object>
+              </object>
+              <object class="spacer">
+								<option>1</option>
+								<flag>wxEXPAND</flag>
+								<border>5</border>
+								<size>0,0</size>
+							</object>
+            </object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxALL</flag>
+						<border>5</border>
+            <object class="wxCheckBox" name="chkKeepZapSliders">
+              <label>Keep Zap Sliders</label>
+              <checked>1</checked>
+            </object>
+				  </object>
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxEXPAND</flag>
+            <border>5</border>
+            <object class="wxFlexGridSizer">
+              <rows>0</rows>
+              <cols>2</cols>
+              <vgap>0</vgap>
+              <hgap>0</hgap>
+              <growablecols>1</growablecols>
+              <growablerows></growablerows>
+              <object class="sizeritem">
+                <option>1</option>
+                <flag>wxALL|wxEXPAND</flag>
+                <border>5</border>
+                <object class="wxStaticText">
+                  <style>wxRB_GROUP</style>
+                  <label>Remove from project names</label>
+                  <value translate="0">1</value>
+                </object>
+              </object>
+              <object class="sizeritem">
+                <border>5</border>
+                <minsize>200,22</minsize>
+                <object class="wxTextCtrl" name="npRemoveText">
+                </object>
+              </object>
+              <object class="sizeritem">
+                <option>1</option>
+                <flag>wxALL|wxEXPAND</flag>
+                <border>5</border>
+                <object class="wxStaticText">
+                  <style>wxRB_GROUP</style>
+                  <label>Append to project names</label>
+                  <value translate="0">1</value>
+                </object>
+              </object>
+              <object class="sizeritem">
+                <border>5</border>
+                <minsize>200,22</minsize>
+                <object class="wxTextCtrl" name="npAppendText">
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+			<object class="sizeritem">
+				<option>0</option>
+				<flag>wxEXPAND|wxALL</flag>
+				<border>10</border>
+				<object class="wxStdDialogButtonSizer">
+					<object class="button">
+						<flag>wxALIGN_CENTER_HORIZONTAL|wxALL</flag>
+						<border>5</border>
+						<object class="wxButton" name="wxID_OK">
+							<label>&amp;OK</label>
+						</object>
+					</object>
+					<object class="button">
+						<flag>wxALIGN_CENTER_HORIZONTAL|wxALL</flag>
+						<border>5</border>
+						<object class="wxButton" name="wxID_CANCEL">
+							<label>&amp;Cancel</label>
+						</object>
+					</object>
+				</object>
+			</object>
 		</object>
 	</object>
 </resource>

--- a/res/xrc/Project.xrc
+++ b/res/xrc/Project.xrc
@@ -1301,6 +1301,15 @@
 							<checked>0</checked>
 						</object>
 					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxALL</flag>
+						<border>5</border>
+						<object class="wxCheckBox" name="chkDeleteReferenceOnComplete">
+							<label>Delete Reference On Completed</label>
+							<checked>0</checked>
+						</object>
+					</object>
 				</object>
 			</object>
 			<object class="sizeritem">

--- a/res/xrc/Project.xrc
+++ b/res/xrc/Project.xrc
@@ -1060,11 +1060,33 @@
 			<orient>wxVERTICAL</orient>
 			<object class="sizeritem">
 				<option>0</option>
+				<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+				<border>10</border>
+				<object class="wxStaticText" name="lbLoadRef">
+					<label>This tool aids in the conversion process between different body references (ie. CBBE to BHUNP).</label>
+				</object>
+			</object>
+			<object class="sizeritem">
+				<option>0</option>
 				<flag>wxALL|wxEXPAND</flag>
 				<border>10</border>
 				<object class="wxStaticBoxSizer">
 					<orient>wxVERTICAL</orient>
-					<label>Reference</label>
+					<label>Reference Bodies</label>
+					<object class="spacer">
+						<option>1</option>
+						<flag>wxEXPAND</flag>
+						<border>5</border>
+						<size>0,5</size>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+						<object class="wxStaticText" name="lbLoadRef">
+							<label>1) Select a conversion reference (ie.'Convert: CBBE SE to BHUNP'):</label>
+							<wrap>380</wrap>
+						</object>
+					</object>
 					<object class="sizeritem">
 						<option>0</option>
 						<flag>wxEXPAND</flag>
@@ -1080,6 +1102,7 @@
 								<option>1</option>
 								<flag>wxALL|wxEXPAND</flag>
 								<border>5</border>
+								<minsize>170,25</minsize>
 								<object class="wxStaticText" name="npConvRef">
 									<style>wxRB_GROUP</style>
 									<label>Conversion Body Reference</label>
@@ -1097,42 +1120,14 @@
 									<content />
 								</object>
 							</object>
-							<object class="sizeritem">
-								<option>1</option>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-								<object class="wxStaticText" name="npNewRef">
-									<style>wxRB_GROUP</style>
-									<label>New Body Reference</label>
-									<value translate="0">1</value>
-								</object>
-							</object>
-							<object class="sizeritem">
-								<option>1</option>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-								<minsize>200,30</minsize>
-								<object class="wxChoice" name="npNewRefChoice">
-									<style>wxCB_SORT</style>
-									<selection>0</selection>
-									<content />
-								</object>
-							</object>
-							<object class="spacer">
-								<option>1</option>
-								<flag>wxEXPAND</flag>
-								<border>5</border>
-								<size>0,0</size>
-							</object>
 						</object>
 					</object>
 					<object class="sizeritem">
 						<option>0</option>
-						<flag>wxALL</flag>
-						<border>5</border>
-						<object class="wxCheckBox" name="chkKeepZapSliders">
-							<label>Keep Zap Sliders</label>
-							<checked>1</checked>
+						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+						<object class="wxStaticText" name="lbLoadRef">
+							<label>2) Select a body reference to convert to (ie.'BHUNP 3BBB Advanced'):</label>
+							<wrap>380</wrap>
 						</object>
 					</object>
 					<object class="sizeritem">
@@ -1150,6 +1145,70 @@
 								<option>1</option>
 								<flag>wxALL|wxEXPAND</flag>
 								<border>5</border>
+								<minsize>170,25</minsize>
+								<object class="wxStaticText" name="npNewRef">
+									<style>wxRB_GROUP</style>
+									<label>New Body Reference</label>
+									<value translate="0">1</value>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>5</border>
+								<object class="wxChoice" name="npNewRefChoice">
+									<style>wxCB_SORT</style>
+									<selection>0</selection>
+									<content />
+								</object>
+							</object>
+							<object class="spacer">
+								<option>1</option>
+								<flag>wxEXPAND</flag>
+								<border>5</border>
+								<size>0,0</size>
+							</object>
+						</object>
+					</object>
+				</object>
+			</object>
+			<object class="sizeritem">
+				<option>0</option>
+				<flag>wxALL|wxEXPAND</flag>
+				<border>10</border>
+				<object class="wxStaticBoxSizer">
+					<orient>wxVERTICAL</orient>
+					<label>Project Rename</label>
+					<object class="spacer">
+						<option>1</option>
+						<flag>wxEXPAND</flag>
+						<border>5</border>
+						<size>0,5</size>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+						<object class="wxStaticText" name="lbLoadRef">
+							<label>3) Specify text to be removed from the project output names (comma delimited):</label>
+						</object>
+					</object>
+					
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxFlexGridSizer">
+							<rows>0</rows>
+							<cols>2</cols>
+							<vgap>0</vgap>
+							<hgap>0</hgap>
+							<growablecols>1</growablecols>
+							<growablerows></growablerows>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>5</border>
+								<minsize>170,20</minsize>
 								<object class="wxStaticText">
 									<style>wxRB_GROUP</style>
 									<label>Remove from project names</label>
@@ -1158,26 +1217,88 @@
 							</object>
 							<object class="sizeritem">
 								<border>5</border>
-								<minsize>200,22</minsize>
-								<object class="wxTextCtrl" name="npRemoveText">
-								</object>
+								<flag>wxALL|wxEXPAND</flag>
+								<object class="wxTextCtrl" name="npRemoveText"></object>
 							</object>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+						<object class="wxStaticText" name="lbLoadRef">
+							<label>4) Specify any text to be prepended to project names:</label>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxFlexGridSizer">
+							<rows>0</rows>
+							<cols>2</cols>
+							<vgap>0</vgap>
+							<hgap>0</hgap>
+							<growablecols>1</growablecols>
+							<growablerows></growablerows>
 							<object class="sizeritem">
 								<option>1</option>
 								<flag>wxALL|wxEXPAND</flag>
 								<border>5</border>
+								<minsize>170,20</minsize>
 								<object class="wxStaticText">
 									<style>wxRB_GROUP</style>
-									<label>Append to project names</label>
+									<label>Prepend to project names</label>
 									<value translate="0">1</value>
 								</object>
 							</object>
 							<object class="sizeritem">
 								<border>5</border>
-								<minsize>200,22</minsize>
-								<object class="wxTextCtrl" name="npAppendText">
-								</object>
+								<flag>wxALL|wxEXPAND</flag>
+								<object class="wxTextCtrl" name="npAppendText"></object>
 							</object>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+						<object class="wxStaticText" name="lbLoadRef">
+							<label>Note. Game file output path is unaffected by this</label>
+						</object>
+					</object>
+				</object>
+			</object>
+			<object class="sizeritem">
+				<option>0</option>
+				<flag>wxALL|wxEXPAND</flag>
+				<border>10</border>
+				<object class="wxStaticBoxSizer">
+					<orient>wxVERTICAL</orient>
+					<label>Options</label>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxALL</flag>
+						<border>5</border>
+						<object class="wxCheckBox" name="chkKeepZapSliders">
+							<label>Keep Zap Sliders</label>
+							<checked>0</checked>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxALL</flag>
+						<border>5</border>
+						<object class="wxCheckBox" name="chkSkipConformPopup">
+							<label>Skip Conform Popup (Use Default Settings)</label>
+							<checked>0</checked>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxALL</flag>
+						<border>5</border>
+						<object class="wxCheckBox" name="chkSkipCopyBonesPopup">
+							<label>Skip Copy Bones Popup (Use Default Settings)</label>
+							<checked>0</checked>
 						</object>
 					</object>
 				</object>

--- a/res/xrc/Project.xrc
+++ b/res/xrc/Project.xrc
@@ -693,6 +693,15 @@
 						<option>0</option>
 						<flag>wxALL</flag>
 						<border>5</border>
+            <object class="wxCheckBox" name="chkKeepZapSliders">
+              <label>Keep Zap Sliders</label>
+              <checked>1</checked>
+            </object>
+				  </object>
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxALL</flag>
+            <border>5</border>
 						<object class="wxCheckBox" name="chkClearSliders">
 							<label>Merge new sliders with existing sliders</label>
 							<checked>0</checked>

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -3506,55 +3506,6 @@ int OutfitProject::ImportNIF(const std::string& fileName, bool clear, const std:
 	return 0;
 }
 
-int OutfitProject::BakeConversionReference(const std::vector<mesh*>& modMeshes, bool withRef) {
-	workAnim.CleanupBones();
-	owner->UpdateAnimationGUI();
-
-	std::vector<Vector3> liveVerts;
-	std::vector<Vector3> liveNorms;
-	for (auto &m : modMeshes) {
-		auto shape = workNif.FindBlockByName<NiShape>(m->shapeName);
-		if (shape) {
-			liveVerts.clear();
-			liveNorms.clear();
-
-			for (int i = 0; i < m->nVerts; i++) {
-				liveVerts.emplace_back(std::move(Vector3(m->verts[i].x * -10, m->verts[i].z * 10, m->verts[i].y * 10)));
-				liveNorms.emplace_back(std::move(Vector3(m->norms[i].x * -1, m->norms[i].z, m->norms[i].y)));
-			}
-
-			workNif.SetVertsForShape(shape, liveVerts);
-
-			if (workNif.GetHeader().GetVersion().IsSK() || workNif.GetHeader().GetVersion().IsSSE()) {
-				NiShader* shader = workNif.GetShader(shape);
-				if (shader && shader->IsModelSpace())
-					continue;
-			}
-
-			workNif.SetNormalsForShape(shape, liveNorms);
-			workNif.CalcTangentsForShape(shape);
-		}
-	}
-
-	if (!withRef && baseShape) {
-		std::string baseShapeName = baseShape->name.get();
-		auto bshape = workNif.FindBlockByName<NiShape>(baseShapeName);
-		workNif.DeleteShape(bshape);
-		workAnim.WriteToNif(&workNif, baseShapeName);
-	}
-	else
-		workAnim.WriteToNif(&workNif);
-
-	DeleteShape(baseShape);
-	owner->DeleteSliders(true);
-	
-	workAnim.Clear();
-
-	owner->RefreshGUIFromProj(false);
-	
-	return 0;
-}
-
 int OutfitProject::ExportNIF(const std::string& fileName, const std::vector<mesh*>& modMeshes, bool withRef) {
 	workAnim.CleanupBones();
 	owner->UpdateAnimationGUI();

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -1511,11 +1511,11 @@ void OutfitProject::CopyBoneWeights(NiShape* shape, const float proximityRadius,
 	std::string shapeName = shape->name.get();
 	std::string baseShapeName = baseShape->name.get();
 
-    owner->UpdateProgress(1, _("Gathering bones..."));
+	owner->UpdateProgress(1, _("Gathering bones..."));
 
 	int nBones = boneList.size();
 	if (nBones <= 0 || nCopyBones <= 0) {
-        owner->UpdateProgress(90);
+		owner->UpdateProgress(90);
 		return;
 	}
 
@@ -1539,16 +1539,16 @@ void OutfitProject::CopyBoneWeights(NiShape* shape, const float proximityRadius,
 	nzer.SetUp(&uss, &workAnim, shapeName, boneList, lockedBones, nCopyBones, bSpreadWeight);
 	std::unordered_set<int> vertList;
 
-    owner->UpdateProgress(10, _("Initializing proximity data..."));
+	owner->UpdateProgress(10, _("Initializing proximity data..."));
 	
 	InitConform();
 	morpher.LinkRefDiffData(&dds);
 	morpher.BuildProximityCache(shapeName, proximityRadius);
 	workNif.CreateSkinning(shape);
 
-    int step = 40 / nCopyBones;
-    int prog = 40;
-    owner->UpdateProgress(prog);
+	int step = 40 / nCopyBones;
+	int prog = 40;
+	owner->UpdateProgress(prog);
 
 	for (int bi = 0; bi < nCopyBones; ++bi) {
 		const std::string &boneName = boneList[bi];
@@ -1879,7 +1879,7 @@ int OutfitProject::LoadReferenceTemplate(const std::string& sourceFile, const st
 
 	if (loadAll) {
 		owner->StartSubProgress(10, 20);
-		return AddFromSliderSet(sourceFile, set);
+		return AddFromSliderSet(sourceFile, set, false);
 	}
 	else
 		return LoadReference(sourceFile, set, mergeSliders, shape, keepZaps);
@@ -1935,7 +1935,6 @@ int OutfitProject::LoadReferenceNif(const std::string& fileName, const std::stri
 			if (s->name != shapeName)
 				DeleteShape(s);
 	}
-
 	baseShape = workNif.FindBlockByName<NiShape>(shapeName);
 
 	if(keepZaps)
@@ -2048,7 +2047,6 @@ int OutfitProject::LoadReference(const std::string& fileName, const std::string&
 		activeSet.LoadSetDiffData(baseDiffData, shape);
 	else
 		activeSet.LoadSetDiffData(baseDiffData);
-
 	
 	activeSet.SetReferencedData(shape);
 	for (auto &dn : dataNames)
@@ -2154,7 +2152,6 @@ int OutfitProject::AddFromSliderSet(const std::string& fileName, const std::stri
 	}
 
 	SliderSet addSet;
-	
 	owner->UpdateProgress(20, _("Retrieving sliders..."));
 	if (InSS.GetSet(sliderSetName, addSet)) {
 		owner->EndProgress();
@@ -2221,7 +2218,6 @@ int OutfitProject::AddFromSliderSet(const std::string& fileName, const std::stri
 
 	owner->UpdateProgress(100, _("Finished"));
 	owner->EndProgress();
-	
 	return 0;
 }
 

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -1870,7 +1870,7 @@ int OutfitProject::LoadSkeletonReference(const std::string& skeletonFileName) {
 	return AnimSkeleton::getInstance().LoadFromNif(skeletonFileName);
 }
 
-int OutfitProject::LoadReferenceTemplate(const std::string& sourceFile, const std::string& set, const std::string& shape, bool loadAll, bool mergeSliders) {
+int OutfitProject::LoadReferenceTemplate(const std::string& sourceFile, const std::string& set, const std::string& shape, bool loadAll, bool mergeSliders, bool keepZaps) {
 	if (sourceFile.empty() || set.empty()) {
 		wxLogError("Template source entries are invalid.");
 		wxMessageBox(_("Template source entries are invalid."), _("Reference Error"), wxICON_ERROR, owner);
@@ -1882,10 +1882,10 @@ int OutfitProject::LoadReferenceTemplate(const std::string& sourceFile, const st
 		return AddFromSliderSet(sourceFile, set, false);
 	}
 	else
-		return LoadReference(sourceFile, set, mergeSliders, shape);
+		return LoadReference(sourceFile, set, mergeSliders, shape, keepZaps);
 }
 
-int OutfitProject::LoadReferenceNif(const std::string& fileName, const std::string& shapeName, bool mergeSliders) {
+int OutfitProject::LoadReferenceNif(const std::string& fileName, const std::string& shapeName, bool mergeSliders, bool keepZaps) {
 	if (mergeSliders)
 		DeleteShape(baseShape);
 	else
@@ -1937,12 +1937,16 @@ int OutfitProject::LoadReferenceNif(const std::string& fileName, const std::stri
 	}
 
 	baseShape = workNif.FindBlockByName<NiShape>(shapeName);
+
+	if(keepZaps)
+		owner->DeleteSliders(true);
+	
 	activeSet.LoadSetDiffData(baseDiffData);
 	return 0;
 }
 
-int OutfitProject::LoadReference(const std::string& fileName, const std::string& setName, bool mergeSliders, const std::string& shapeName) {
-	if (mergeSliders)
+int OutfitProject::LoadReference(const std::string& fileName, const std::string& setName, bool mergeSliders, const std::string& shapeName, bool keepZaps) {
+	if (keepZaps || mergeSliders)
 		DeleteShape(baseShape);
 	else
 		ClearReference();
@@ -2037,11 +2041,15 @@ int OutfitProject::LoadReference(const std::string& fileName, const std::string&
 
 	baseShape = workNif.FindBlockByName<NiShape>(shape);
 
+	if(keepZaps)
+		owner->DeleteSliders(true);
+	
 	if (mergeSliders)
 		activeSet.LoadSetDiffData(baseDiffData, shape);
 	else
 		activeSet.LoadSetDiffData(baseDiffData);
 
+	
 	activeSet.SetReferencedData(shape);
 	for (auto &dn : dataNames)
 		activeSet.SetReferencedDataByName(shape, dn, true);

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -3490,6 +3490,55 @@ int OutfitProject::ImportNIF(const std::string& fileName, bool clear, const std:
 	return 0;
 }
 
+int OutfitProject::BakeNifInPlace(const std::vector<mesh*>& modMeshes, bool withRef) {
+	workAnim.CleanupBones();
+	owner->UpdateAnimationGUI();
+
+	std::vector<Vector3> liveVerts;
+	std::vector<Vector3> liveNorms;
+	for (auto &m : modMeshes) {
+		auto shape = workNif.FindBlockByName<NiShape>(m->shapeName);
+		if (shape) {
+			liveVerts.clear();
+			liveNorms.clear();
+
+			for (int i = 0; i < m->nVerts; i++) {
+				liveVerts.emplace_back(std::move(Vector3(m->verts[i].x * -10, m->verts[i].z * 10, m->verts[i].y * 10)));
+				liveNorms.emplace_back(std::move(Vector3(m->norms[i].x * -1, m->norms[i].z, m->norms[i].y)));
+			}
+
+			workNif.SetVertsForShape(shape, liveVerts);
+
+			if (workNif.GetHeader().GetVersion().IsSK() || workNif.GetHeader().GetVersion().IsSSE()) {
+				NiShader* shader = workNif.GetShader(shape);
+				if (shader && shader->IsModelSpace())
+					continue;
+			}
+
+			workNif.SetNormalsForShape(shape, liveNorms);
+			workNif.CalcTangentsForShape(shape);
+		}
+	}
+
+	if (!withRef && baseShape) {
+		std::string baseShapeName = baseShape->name.get();
+		auto bshape = workNif.FindBlockByName<NiShape>(baseShapeName);
+		workNif.DeleteShape(bshape);
+		workAnim.WriteToNif(&workNif, baseShapeName);
+	}
+	else
+		workAnim.WriteToNif(&workNif);
+
+	DeleteShape(baseShape);
+	owner->DeleteSliders(true);
+	
+	workAnim.Clear();
+
+	owner->RefreshGUIFromProj(false);
+	
+	return 0;
+}
+
 int OutfitProject::ExportNIF(const std::string& fileName, const std::vector<mesh*>& modMeshes, bool withRef) {
 	workAnim.CleanupBones();
 	owner->UpdateAnimationGUI();

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -216,9 +216,9 @@ public:
 	void DeleteSlider(const std::string& sliderName);
 
 	int LoadSkeletonReference(const std::string& skeletonFileName);
-	int LoadReferenceTemplate(const std::string& sourceFile, const std::string& set, const std::string& shape, bool loadAll = false, bool mergeSliders = false);
-	int LoadReferenceNif(const std::string& fileName, const std::string& shapeName, bool mergeSliders = false);
-	int LoadReference(const std::string& fileName, const std::string& setName, bool mergeSliders = false, const std::string& shapeName = "");
+	int LoadReferenceTemplate(const std::string& sourceFile, const std::string& set, const std::string& shape, bool loadAll = false, bool mergeSliders = false, bool keepZaps = false);
+	int LoadReferenceNif(const std::string& fileName, const std::string& shapeName, bool mergeSliders = false, bool keepZaps = false);
+	int LoadReference(const std::string& fileName, const std::string& setName, bool mergeSliders = false, const std::string& shapeName = "", bool keepZaps = false);
 
 	int LoadFromSliderSet(const std::string& fileName, const std::string& setName, std::vector<std::string>* origShapeOrder = nullptr);
 	int AddFromSliderSet(const std::string& fileName, const std::string& setName, const bool newDataLocal = true);

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -195,7 +195,7 @@ public:
 	// This is done by creating several virtual sliders that contain weight offsets for each vertex per bone.
 	// These data sets are then temporarily linked to the AutoMorph class and result 'diffs' are generated.
 	// The resulting data is then written back to the outfit shape as the green color channel.
-	void CopyBoneWeights(nifly::NiShape* shape, const float proximityRadius, const int maxResults, std::unordered_map<uint16_t, float>& mask, const std::vector<std::string>& boneList, int nCopyBones, const std::vector<std::string> &lockedBones, UndoStateShape &uss, bool bSpreadWeight, bool silent = false);
+	void CopyBoneWeights(nifly::NiShape* shape, const float proximityRadius, const int maxResults, std::unordered_map<uint16_t, float>& mask, const std::vector<std::string>& boneList, int nCopyBones, const std::vector<std::string> &lockedBones, UndoStateShape &uss, bool bSpreadWeight, int minProgress = 1, int maxProgress = 90);
 	// Transfers the weights of the selected bones from reference to chosen shape 1:1. Requires same vertex count and order.
 	void TransferSelectedWeights(nifly::NiShape* shape, std::unordered_map<uint16_t, float>* mask = nullptr, std::vector<std::string>* inBoneList = nullptr);
 	bool HasUnweighted(std::vector<std::string>* shapeNames = nullptr);

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -258,6 +258,7 @@ public:
 
 	int ImportNIF(const std::string& fileName, bool clear = true, const std::string& inOutfitName = "", std::map<std::string, std::string>* renamedShapes = nullptr);
 	int ExportNIF(const std::string& fileName, const std::vector<mesh*>& modMeshes, bool withRef = false);
+	int BakeNifInPlace(const std::vector<mesh*>& modMeshes, bool withRef = false);
 	int ExportShapeNIF(const std::string& fileName, const std::vector<std::string>& exportShapes);
 
 	int ImportOBJ(const std::string& fileName, const std::string& shapeName = "", nifly::NiShape* mergeShape = nullptr);

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -195,7 +195,7 @@ public:
 	// This is done by creating several virtual sliders that contain weight offsets for each vertex per bone.
 	// These data sets are then temporarily linked to the AutoMorph class and result 'diffs' are generated.
 	// The resulting data is then written back to the outfit shape as the green color channel.
-	void CopyBoneWeights(nifly::NiShape* shape, const float proximityRadius, const int maxResults, std::unordered_map<uint16_t, float>& mask, const std::vector<std::string>& boneList, int nCopyBones, const std::vector<std::string> &lockedBones, UndoStateShape &uss, bool bSpreadWeight, int minProgress = 1, int maxProgress = 90);
+	void CopyBoneWeights(nifly::NiShape* shape, const float proximityRadius, const int maxResults, std::unordered_map<uint16_t, float>& mask, const std::vector<std::string>& boneList, int nCopyBones, const std::vector<std::string> &lockedBones, UndoStateShape &uss, bool bSpreadWeight);
 	// Transfers the weights of the selected bones from reference to chosen shape 1:1. Requires same vertex count and order.
 	void TransferSelectedWeights(nifly::NiShape* shape, std::unordered_map<uint16_t, float>* mask = nullptr, std::vector<std::string>* inBoneList = nullptr);
 	bool HasUnweighted(std::vector<std::string>* shapeNames = nullptr);
@@ -216,12 +216,12 @@ public:
 	void DeleteSlider(const std::string& sliderName);
 
 	int LoadSkeletonReference(const std::string& skeletonFileName);
-	int LoadReferenceTemplate(const std::string& sourceFile, const std::string& set, const std::string& shape, bool loadAll = false, bool mergeSliders = false, bool keepZaps = false, bool silent = false);
+	int LoadReferenceTemplate(const std::string& sourceFile, const std::string& set, const std::string& shape, bool loadAll = false, bool mergeSliders = false, bool keepZaps = false);
 	int LoadReferenceNif(const std::string& fileName, const std::string& shapeName, bool mergeSliders = false, bool keepZaps = false);
 	int LoadReference(const std::string& fileName, const std::string& setName, bool mergeSliders = false, const std::string& shapeName = "", bool keepZaps = false);
 
 	int LoadFromSliderSet(const std::string& fileName, const std::string& setName, std::vector<std::string>* origShapeOrder = nullptr);
-	int AddFromSliderSet(const std::string& fileName, const std::string& setName, const bool newDataLocal = true, bool silent = false);
+	int AddFromSliderSet(const std::string& fileName, const std::string& setName, const bool newDataLocal = true);
 
 	void CollectVertexData(nifly::NiShape *shape, UndoStateShape &uss, const std::vector<uint16_t> &indices);
 	void CollectTriangleData(nifly::NiShape *shape, UndoStateShape &uss, const std::vector<uint32_t> &indices);

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -258,7 +258,6 @@ public:
 
 	int ImportNIF(const std::string& fileName, bool clear = true, const std::string& inOutfitName = "", std::map<std::string, std::string>* renamedShapes = nullptr);
 	int ExportNIF(const std::string& fileName, const std::vector<mesh*>& modMeshes, bool withRef = false);
-	int BakeConversionReference(const std::vector<mesh*>& modMeshes, bool withRef = false);
 	int ExportShapeNIF(const std::string& fileName, const std::vector<std::string>& exportShapes);
 
 	int ImportOBJ(const std::string& fileName, const std::string& shapeName = "", nifly::NiShape* mergeShape = nullptr);

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -195,7 +195,7 @@ public:
 	// This is done by creating several virtual sliders that contain weight offsets for each vertex per bone.
 	// These data sets are then temporarily linked to the AutoMorph class and result 'diffs' are generated.
 	// The resulting data is then written back to the outfit shape as the green color channel.
-	void CopyBoneWeights(nifly::NiShape* shape, const float proximityRadius, const int maxResults, std::unordered_map<uint16_t, float>& mask, const std::vector<std::string>& boneList, int nCopyBones, const std::vector<std::string> &lockedBones, UndoStateShape &uss, bool bSpreadWeight);
+	void CopyBoneWeights(nifly::NiShape* shape, const float proximityRadius, const int maxResults, std::unordered_map<uint16_t, float>& mask, const std::vector<std::string>& boneList, int nCopyBones, const std::vector<std::string> &lockedBones, UndoStateShape &uss, bool bSpreadWeight, bool silent = false);
 	// Transfers the weights of the selected bones from reference to chosen shape 1:1. Requires same vertex count and order.
 	void TransferSelectedWeights(nifly::NiShape* shape, std::unordered_map<uint16_t, float>* mask = nullptr, std::vector<std::string>* inBoneList = nullptr);
 	bool HasUnweighted(std::vector<std::string>* shapeNames = nullptr);
@@ -216,12 +216,12 @@ public:
 	void DeleteSlider(const std::string& sliderName);
 
 	int LoadSkeletonReference(const std::string& skeletonFileName);
-	int LoadReferenceTemplate(const std::string& sourceFile, const std::string& set, const std::string& shape, bool loadAll = false, bool mergeSliders = false, bool keepZaps = false);
+	int LoadReferenceTemplate(const std::string& sourceFile, const std::string& set, const std::string& shape, bool loadAll = false, bool mergeSliders = false, bool keepZaps = false, bool silent = false);
 	int LoadReferenceNif(const std::string& fileName, const std::string& shapeName, bool mergeSliders = false, bool keepZaps = false);
 	int LoadReference(const std::string& fileName, const std::string& setName, bool mergeSliders = false, const std::string& shapeName = "", bool keepZaps = false);
 
 	int LoadFromSliderSet(const std::string& fileName, const std::string& setName, std::vector<std::string>* origShapeOrder = nullptr);
-	int AddFromSliderSet(const std::string& fileName, const std::string& setName, const bool newDataLocal = true);
+	int AddFromSliderSet(const std::string& fileName, const std::string& setName, const bool newDataLocal = true, bool silent = false);
 
 	void CollectVertexData(nifly::NiShape *shape, UndoStateShape &uss, const std::vector<uint16_t> &indices);
 	void CollectTriangleData(nifly::NiShape *shape, UndoStateShape &uss, const std::vector<uint32_t> &indices);
@@ -258,7 +258,7 @@ public:
 
 	int ImportNIF(const std::string& fileName, bool clear = true, const std::string& inOutfitName = "", std::map<std::string, std::string>* renamedShapes = nullptr);
 	int ExportNIF(const std::string& fileName, const std::vector<mesh*>& modMeshes, bool withRef = false);
-	int BakeNifInPlace(const std::vector<mesh*>& modMeshes, bool withRef = false);
+	int BakeConversionReference(const std::vector<mesh*>& modMeshes, bool withRef = false);
 	int ExportShapeNIF(const std::string& fileName, const std::vector<std::string>& exportShapes);
 
 	int ImportOBJ(const std::string& fileName, const std::string& shapeName = "", nifly::NiShape* mergeShape = nullptr);

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -83,7 +83,7 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_BUTTON(XRCID("savePose"), OutfitStudioFrame::OnSavePose)
 	EVT_BUTTON(XRCID("saveAsPose"), OutfitStudioFrame::OnSaveAsPose)
 	EVT_BUTTON(XRCID("deletePose"), OutfitStudioFrame::OnDeletePose)
-
+	
 	// The following line with "EVT_COMMAND_SCROLL(wxID_ANY" apparently
 	// suppresses all following lines with EVT_COMMAND_SCROLL.
 	EVT_COMMAND_SCROLL(wxID_ANY, OutfitStudioFrame::OnSlider)
@@ -101,7 +101,6 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_MENU(XRCID("importNIF"), OutfitStudioFrame::OnImportNIF)
 	EVT_MENU(XRCID("exportNIF"), OutfitStudioFrame::OnExportNIF)
 	EVT_MENU(XRCID("exportNIFWithRef"), OutfitStudioFrame::OnExportNIFWithRef)
-	EVT_MENU(XRCID("bakeNifInPlace"), OutfitStudioFrame::OnBakeConversionReference)
 	EVT_MENU(XRCID("exportShapeNIF"), OutfitStudioFrame::OnExportShapeNIF)
 
 	EVT_MENU(XRCID("importOBJ"), OutfitStudioFrame::OnImportOBJ)
@@ -118,7 +117,7 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 
 	EVT_MENU(XRCID("importPhysicsData"), OutfitStudioFrame::OnImportPhysicsData)
 	EVT_MENU(XRCID("exportPhysicsData"), OutfitStudioFrame::OnExportPhysicsData)
-
+	
 	EVT_MENU(XRCID("sliderLoadPreset"), OutfitStudioFrame::OnLoadPreset)
 	EVT_MENU(XRCID("sliderSavePreset"), OutfitStudioFrame::OnSavePreset)
 	EVT_MENU(XRCID("sliderConform"), OutfitStudioFrame::OnSliderConform)
@@ -143,11 +142,11 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_MENU(XRCID("sliderClear"), OutfitStudioFrame::OnClearSlider)
 	EVT_MENU(XRCID("sliderDelete"), OutfitStudioFrame::OnDeleteSlider)
 	EVT_MENU(XRCID("sliderProperties"), OutfitStudioFrame::OnSliderProperties)
-
+	
 	EVT_MENU(XRCID("btnXMirror"), OutfitStudioFrame::OnXMirror)
 	EVT_MENU(XRCID("btnConnected"), OutfitStudioFrame::OnConnectedOnly)
 	EVT_MENU(XRCID("btnBrushCollision"), OutfitStudioFrame::OnGlobalBrushCollision)
-
+	
 	EVT_MENU(XRCID("btnSelect"), OutfitStudioFrame::OnSelectTool)
 	EVT_MENU(XRCID("btnTransform"), OutfitStudioFrame::OnSelectTool)
 	EVT_MENU(XRCID("btnPivot"), OutfitStudioFrame::OnSelectTool)
@@ -176,7 +175,7 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_MENU(XRCID("btnShowNodes"), OutfitStudioFrame::OnShowNodes)
 	EVT_MENU(XRCID("btnShowBones"), OutfitStudioFrame::OnShowBones)
 	EVT_MENU(XRCID("btnShowFloor"), OutfitStudioFrame::OnShowFloor)
-
+	
 	EVT_MENU(XRCID("btnIncreaseSize"), OutfitStudioFrame::OnIncBrush)
 	EVT_MENU(XRCID("btnDecreaseSize"), OutfitStudioFrame::OnDecBrush)
 	EVT_MENU(XRCID("btnIncreaseStr"), OutfitStudioFrame::OnIncStr)
@@ -217,7 +216,7 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_MENU(XRCID("deleteBone"), OutfitStudioFrame::OnDeleteBone)
 	EVT_MENU(XRCID("deleteBoneSelected"), OutfitStudioFrame::OnDeleteBoneFromSelected)
 	EVT_MENU(XRCID("editBone"), OutfitStudioFrame::OnEditBone)
-	EVT_MENU(XRCID("copyBoneWeight"), OutfitStudioFrame::OnCopyBoneWeight)
+	EVT_MENU(XRCID("copyBoneWeight"), OutfitStudioFrame::OnCopyBoneWeight)	
 	EVT_MENU(XRCID("copySelectedWeight"), OutfitStudioFrame::OnCopySelectedWeight)
 	EVT_MENU(XRCID("transferSelectedWeight"), OutfitStudioFrame::OnTransferSelectedWeight)
 	EVT_MENU(XRCID("maskWeightedVerts"), OutfitStudioFrame::OnMaskWeighted)
@@ -266,7 +265,7 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_CHOICE(XRCID("partitionType"), OutfitStudioFrame::OnPartitionTypeChanged)
 	EVT_BUTTON(XRCID("partitionApply"), OutfitStudioFrame::OnPartitionApply)
 	EVT_BUTTON(XRCID("partitionReset"), OutfitStudioFrame::OnPartitionReset)
-
+	
 	EVT_BUTTON(XRCID("meshTabButton"), OutfitStudioFrame::OnTabButtonClick)
 	EVT_BUTTON(XRCID("boneTabButton"), OutfitStudioFrame::OnTabButtonClick)
 	EVT_BUTTON(XRCID("segmentTabButton"), OutfitStudioFrame::OnTabButtonClick)
@@ -300,7 +299,7 @@ wxIMPLEMENT_APP(OutfitStudio);
 ConfigurationManager Config;
 ConfigurationManager OutfitStudioConfig;
 
-const wxString TargetGames[] = {"Fallout3", "FalloutNewVegas", "Skyrim", "Fallout4", "SkyrimSpecialEdition", "Fallout4VR", "SkyrimVR", "Fallout 76", "Oblivion"};
+const wxString TargetGames[] = { "Fallout3", "FalloutNewVegas", "Skyrim", "Fallout4", "SkyrimSpecialEdition", "Fallout4VR", "SkyrimVR", "Fallout 76", "Oblivion" };
 const wxLanguage SupportedLangs[] = {
 	wxLANGUAGE_ENGLISH, wxLANGUAGE_AFRIKAANS, wxLANGUAGE_ARABIC, wxLANGUAGE_CATALAN, wxLANGUAGE_CZECH, wxLANGUAGE_DANISH, wxLANGUAGE_GERMAN,
 	wxLANGUAGE_GREEK, wxLANGUAGE_SPANISH, wxLANGUAGE_BASQUE, wxLANGUAGE_FINNISH, wxLANGUAGE_FRENCH, wxLANGUAGE_HINDI,
@@ -363,24 +362,15 @@ bool OutfitStudio::OnInit() {
 
 	wxString gameName = "Target game: ";
 	switch (targetGame) {
-	case FO3: gameName.Append("Fallout 3");
-		break;
-	case FONV: gameName.Append("Fallout New Vegas");
-		break;
-	case SKYRIM: gameName.Append("Skyrim");
-		break;
-	case FO4: gameName.Append("Fallout 4");
-		break;
-	case SKYRIMSE: gameName.Append("Skyrim Special Edition");
-		break;
-	case FO4VR: gameName.Append("Fallout 4 VR");
-		break;
-	case SKYRIMVR: gameName.Append("Skyrim VR");
-		break;
-	case FO76: gameName.Append("Fallout 76");
-		break;
-	case OB: gameName.Append("Oblivion");
-		break;
+	case FO3: gameName.Append("Fallout 3"); break;
+	case FONV: gameName.Append("Fallout New Vegas"); break;
+	case SKYRIM: gameName.Append("Skyrim"); break;
+	case FO4: gameName.Append("Fallout 4"); break;
+	case SKYRIMSE: gameName.Append("Skyrim Special Edition"); break;
+	case FO4VR: gameName.Append("Fallout 4 VR"); break;
+	case SKYRIMVR: gameName.Append("Skyrim VR"); break;
+	case FO76: gameName.Append("Fallout 76"); break;
+	case OB: gameName.Append("Oblivion"); break;
 	default: gameName.Append("Invalid");
 	}
 	wxLogMessage(gameName);
@@ -414,13 +404,13 @@ bool OutfitStudio::OnInit() {
 			wxMessageBox(_("No read/write permission for project path!\n\nPlease launch the program with admin elevation and make sure the project path in the settings is correct."), _("Warning"), wxICON_WARNING);
 	}
 
-	for (auto& file : cmdFiles) {
+	for (auto &file : cmdFiles) {
 		wxFileName loadFile(file);
 		if (loadFile.FileExists()) {
-			std::string fileName{loadFile.GetFullPath().ToUTF8()};
+			std::string fileName{ loadFile.GetFullPath().ToUTF8() };
 			wxString fileExt = loadFile.GetExt().MakeLower();
 			if (fileExt == "osp") {
-				std::string projectName{cmdProject.ToUTF8()};
+				std::string projectName{ cmdProject.ToUTF8() };
 				frame->LoadProject(fileName, projectName);
 				break;
 			}
@@ -643,10 +633,10 @@ bool OutfitStudio::SetDefaultConfig() {
 		}
 		else
 #endif
-			if (Config["WarnMissingGamePath"] == "true") {
-				wxLogWarning("Failed to find game install path registry key or GameDataPath in the config.");
-				wxMessageBox(_("Failed to find game install path registry key or GameDataPath in the config."), _("Warning"), wxICON_WARNING);
-			}
+		if (Config["WarnMissingGamePath"] == "true") {
+			wxLogWarning("Failed to find game install path registry key or GameDataPath in the config.");
+			wxMessageBox(_("Failed to find game install path registry key or GameDataPath in the config."), _("Warning"), wxICON_WARNING);
+		}
 	}
 	else
 		wxLogMessage("Game data path in config: %s", Config["GameDataPath"]);
@@ -927,7 +917,7 @@ void OutfitStudio::GetArchiveFiles(std::vector<std::string>& outList) {
 OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 	wxLogMessage("Loading Outfit Studio frame at X:%d Y:%d with W:%d H:%d...", pos.x, pos.y, size.GetWidth(), size.GetHeight());
 
-	wxXmlResource* xrc = wxXmlResource::Get();
+	wxXmlResource *xrc = wxXmlResource::Get();
 	if (!xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/OutfitStudio.xrc")) {
 		wxMessageBox(_("Failed to load OutfitStudio.xrc file!"), _("Error"), wxICON_ERROR);
 		Close(true);
@@ -948,7 +938,7 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/Skeleton.xrc");
 	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/Settings.xrc");
 
-	int statusWidths[] = {-1, 400, 100};
+	int statusWidths[] = { -1, 400, 100 };
 	statusBar = (wxStatusBar*)FindWindowByName("statusBar");
 	if (statusBar) {
 		statusBar->SetFieldsCount(3);
@@ -1007,7 +997,7 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 
 	outfitShapes = (wxTreeCtrl*)FindWindowByName("outfitShapes");
 	if (outfitShapes) {
-		wxImageList* visStateImages = new wxImageList(16, 16, false, 2);
+		wxImageList *visStateImages = new wxImageList(16, 16, false, 2);
 		wxBitmap visImg(wxString::FromUTF8(Config["AppDir"]) + "/res/images/icoVisible.png", wxBITMAP_TYPE_PNG);
 		wxBitmap invImg(wxString::FromUTF8(Config["AppDir"]) + "/res/images/icoInvisible.png", wxBITMAP_TYPE_PNG);
 		wxBitmap wfImg(wxString::FromUTF8(Config["AppDir"]) + "/res/images/icoWireframe.png", wxBITMAP_TYPE_PNG);
@@ -1027,7 +1017,7 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 	if (outfitBones) {
 		wxBitmap noneImg(wxString::FromUTF8(Config["AppDir"]) + "/res/images/icoNone.png", wxBITMAP_TYPE_PNG);
 		wxBitmap changeImg(wxString::FromUTF8(Config["AppDir"]) + "/res/images/icoChange.png", wxBITMAP_TYPE_PNG);
-		wxImageList* boneStateImages = new wxImageList(16, 16, false, 2);
+		wxImageList *boneStateImages = new wxImageList(16, 16, false, 2);
 		if (noneImg.IsOk())
 			boneStateImages->Add(noneImg);
 		if (changeImg.IsOk())
@@ -1119,7 +1109,7 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 	xrc->AttachUnknownControl("bonesFilter", bonesFilter, this);
 	bonesFilter->GetParent()->Hide();
 
-	project = new OutfitProject(this); // Create empty project
+	project = new OutfitProject(this);	// Create empty project
 	CreateSetSliders();
 
 	bEditSlider = false;
@@ -1165,7 +1155,7 @@ void OutfitStudioFrame::OnClose(wxCloseEvent& WXUNUSED(event)) {
 		project = nullptr;
 	}
 
-	for (auto& sd : sliderDisplays)
+	for (auto &sd : sliderDisplays)
 		delete sd.second;
 
 	if (glView)
@@ -1174,7 +1164,7 @@ void OutfitStudioFrame::OnClose(wxCloseEvent& WXUNUSED(event)) {
 	OutfitStudioConfig.ClearValueArray("ProjectHistory", "Project");
 
 	std::vector<std::map<std::string, std::string>> phArrayEntries;
-	for (auto& ph : projectHistory) {
+	for (auto &ph : projectHistory) {
 		std::map<std::string, std::string> attributeValues;
 		attributeValues["name"] = ph.projectName;
 		attributeValues["file"] = ph.fileName;
@@ -1310,7 +1300,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 			projectList->Clear();
 
 			// Add outfits that are no members to list
-			for (auto& project : projectSources) {
+			for (auto &project : projectSources) {
 				// Filter outfit by name
 				wxString projectStr = wxString::FromUTF8(project.first);
 				if (projectStr.Lower().Contains(filterStr)) {
@@ -1325,7 +1315,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 		wxDir::GetAllFiles(wxString::FromUTF8(GetProjectPath()) + "/SliderSets", &files, "*.osp");
 		wxDir::GetAllFiles(wxString::FromUTF8(GetProjectPath()) + "/SliderSets", &files, "*.xml");
 
-		for (auto& file : files) {
+		for (auto &file : files) {
 			std::string fileName{file.ToUTF8()};
 
 			SliderSetFile sliderDoc;
@@ -1336,7 +1326,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 			std::vector<std::string> setNames;
 			sliderDoc.GetSetNamesUnsorted(setNames, false);
 
-			for (auto& setName : setNames) {
+			for (auto &setName : setNames) {
 				if (projectSources.find(setName) != projectSources.end())
 					continue;
 
@@ -1395,7 +1385,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 			SliderSetFile projectFile;
 			projectFile.New(mergedFilePath);
 
-			for (auto& setName : selectedProjects) {
+			for (auto &setName : selectedProjects) {
 				if (projectSources.find(setName) == projectSources.end())
 					continue;
 
@@ -1441,7 +1431,8 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 
 								dataFiles.insert(set.GetDefaultDataFolder() + sep + dataFileName.substr(0, split));
 							}
-							else {
+							else
+							{
 								dataFiles.insert(set.GetDefaultDataFolder() + sep + dataFileName);
 							}
 						}
@@ -1449,7 +1440,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 				}
 
 				// Add data files to folder
-				for (auto& df : dataFiles) {
+				for (auto &df : dataFiles) {
 					wxString dataFilePath = wxString::FromUTF8(GetProjectPath() + sep + "ShapeData" + sep + df);
 					wxFileInputStream dataFileStream(dataFilePath);
 					if (!dataFileStream.IsOk()) {
@@ -1545,7 +1536,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 			wxFFileOutputStream out(fileName);
 			wxZipOutputStream zip(out);
 
-			for (auto& setName : selectedProjects) {
+			for (auto &setName : selectedProjects) {
 				if (projectSources.find(setName) == projectSources.end())
 					continue;
 
@@ -1595,7 +1586,8 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 
 								dataFiles.insert(set.GetDefaultDataFolder() + sep + dataFileName.substr(0, split));
 							}
-							else {
+							else
+							{
 								dataFiles.insert(set.GetDefaultDataFolder() + sep + dataFileName);
 							}
 						}
@@ -1603,7 +1595,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 				}
 
 				// Add data files to archive
-				for (auto& df : dataFiles) {
+				for (auto &df : dataFiles) {
 					wxString dataFilePath = wxString::FromUTF8(GetProjectPath() + sep + "ShapeData" + sep + df);
 					wxFileInputStream dataFileStream(dataFilePath);
 					if (!dataFileStream.IsOk()) {
@@ -1948,7 +1940,7 @@ bool OutfitStudioFrame::SaveProject() {
 	project->ClearBoneScale();
 
 	std::vector<mesh*> shapeMeshes;
-	for (auto& s : project->GetWorkNif()->GetShapes()) {
+	for (auto &s : project->GetWorkNif()->GetShapes()) {
 		if (!project->IsBaseShape(s)) {
 			mesh* m = glView->GetMesh(s->name.get());
 			if (m)
@@ -1959,7 +1951,7 @@ bool OutfitStudioFrame::SaveProject() {
 	project->UpdateNifNormals(project->GetWorkNif(), shapeMeshes);
 
 	std::string error = project->Save(project->mFileName, project->mOutfitName, project->mDataDir, project->mBaseFile,
-	                                  project->mGamePath, project->mGameFile, project->mGenWeights, project->mCopyRef);
+		project->mGamePath, project->mGameFile, project->mGenWeights, project->mCopyRef);
 
 	if (!error.empty()) {
 		wxLogError(error.c_str());
@@ -2119,7 +2111,7 @@ bool OutfitStudioFrame::SaveProjectAs() {
 	project->ClearBoneScale();
 
 	std::vector<mesh*> shapeMeshes;
-	for (auto& s : project->GetWorkNif()->GetShapes()) {
+	for (auto &s : project->GetWorkNif()->GetShapes()) {
 		if (!project->IsBaseShape(s)) {
 			mesh* m = glView->GetMesh(s->name.get());
 			if (m)
@@ -2130,7 +2122,7 @@ bool OutfitStudioFrame::SaveProjectAs() {
 	project->UpdateNifNormals(project->GetWorkNif(), shapeMeshes);
 
 	std::string error = project->Save(sliderSetFile, strOutfitName, strDataDir, strBaseFile,
-	                                  strGamePath, strGameFile, genWeights, copyRef);
+		strGamePath, strGameFile, genWeights, copyRef);
 
 	if (error.empty()) {
 		SetPendingChanges(false);
@@ -2169,7 +2161,7 @@ bool OutfitStudioFrame::LoadProject(const std::string& fileName, const std::stri
 
 	if (outfit.empty()) {
 		wxArrayString choices;
-		for (auto& s : setnames)
+		for (auto &s : setnames)
 			choices.Add(wxString::FromUTF8(s));
 
 		if (choices.GetCount() > 1) {
@@ -2286,7 +2278,7 @@ void OutfitStudioFrame::CreateSetSliders() {
 
 	sliderScroll->Freeze();
 	sliderScroll->DestroyChildren();
-	for (auto& sd : sliderDisplays)
+	for (auto &sd : sliderDisplays)
 		delete sd.second;
 
 	sliderDisplays.clear();
@@ -2295,9 +2287,9 @@ void OutfitStudioFrame::CreateSetSliders() {
 
 	wxSizer* rootSz = sliderScroll->GetSizer();
 
-	for (size_t i = 0; i < project->SliderCount(); i++) {
+	for (size_t i = 0; i < project->SliderCount(); i++)  {
 		UpdateProgress(inc, _("Loading slider: ") + project->GetSliderName(i));
-		if (project->SliderClamp(i)) // clamp sliders are a special case, usually an incorrect scale
+		if (project->SliderClamp(i))    // clamp sliders are a special case, usually an incorrect scale
 			continue;
 
 		createSliderGUI(project->GetSliderName(i), i, sliderScroll, rootSz);
@@ -2401,8 +2393,7 @@ std::string OutfitStudioFrame::NewSlider(const std::string& suggestedName, bool 
 			sliderName = wxGetTextFromUser(_("Enter a name for the new slider:"), _("Create New Slider"), fillName, this).ToUTF8();
 			if (sliderName.empty())
 				return sliderName;
-		}
-		while (project->ValidSlider(sliderName));
+		} while (project->ValidSlider(sliderName));
 	}
 	else
 		sliderName = fillName;
@@ -2436,7 +2427,7 @@ void OutfitStudioFrame::ApplySliders(bool recalcBVH) {
 	std::vector<Vector3> verts;
 	std::vector<Vector2> uvs;
 
-	for (auto& shape : project->GetWorkNif()->GetShapes()) {
+	for (auto &shape : project->GetWorkNif()->GetShapes()) {
 		project->GetLiveVerts(shape, verts, &uvs);
 		glView->UpdateMeshVertices(shape->name.get(), &verts, recalcBVH, true, false, &uvs);
 	}
@@ -2536,8 +2527,8 @@ void OutfitStudioFrame::UpdateBoneCounts() {
 	project->GetActiveBones(boneNames);
 
 	size_t selectedBoneCount = 0;
-	for (auto& s : selectedItems) {
-		for (auto& bone : boneNames) {
+	for (auto &s : selectedItems) {
+		for (auto &bone : boneNames) {
 			if (project->GetWorkAnim()->HasWeights(s->GetShape()->name.get(), bone)) {
 				selectedBoneCount++;
 			}
@@ -2555,7 +2546,7 @@ void OutfitStudioFrame::HighlightBoneNamesWithWeights() {
 		outfitBones->SetItemTextColour(item, wxColour(255, 255, 255));
 
 		auto boneName = outfitBones->GetItemText(item).ToStdString();
-		for (auto& i : selectedItems) {
+		for (auto &i : selectedItems) {
 			if (project->GetWorkAnim()->HasWeights(i->GetShape()->name.get(), boneName)) {
 				outfitBones->SetItemTextColour(item, wxColour(0, 255, 0));
 			}
@@ -2565,11 +2556,11 @@ void OutfitStudioFrame::HighlightBoneNamesWithWeights() {
 	}
 }
 
-void OutfitStudioFrame::GetNormalizeBones(std::vector<std::string>* normBones, std::vector<std::string>* notNormBones) {
+void OutfitStudioFrame::GetNormalizeBones(std::vector<std::string> *normBones, std::vector<std::string> *notNormBones) {
 	std::vector<std::string> activeBones;
 	project->GetActiveBones(activeBones);
 
-	for (auto& boneName : activeBones) {
+	for (auto &boneName : activeBones) {
 		if (lastNormalizeBones.find(boneName) != lastNormalizeBones.end()) {
 			if (normBones)
 				normBones->push_back(boneName);
@@ -2587,7 +2578,7 @@ std::vector<std::string> OutfitStudioFrame::GetSelectedBones() {
 
 	std::vector<std::string> boneList;
 
-	for (auto& selBone : lastSelectedBones) {
+	for (auto &selBone : lastSelectedBones) {
 		if (std::find(activeBones.begin(), activeBones.end(), selBone) != activeBones.end()) {
 			boneList.push_back(selBone);
 		}
@@ -2604,7 +2595,7 @@ void OutfitStudioFrame::CalcAutoXMirrorBone() {
 	project->GetActiveBones(bones);
 
 	int bestFlips = 0;
-	for (const std::string& b : bones) {
+	for (const std::string &b : bones) {
 		if (abLen != b.length())
 			continue;
 
@@ -2698,17 +2689,17 @@ void OutfitStudioFrame::UpdateShapeSource(NiShape* shape) {
 		project->UpdateShapeFromMesh(shape, m);
 }
 
-void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject* usp, bool bIsUndo) {
+void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject *usp, bool bIsUndo) {
 	if (!usp->sliderName.empty()) {
 		float sliderscale = 1 / usp->sliderscale;
-		for (auto& uss : usp->usss) {
-			mesh* m = glView->GetMesh(uss.shapeName);
+		for (auto &uss : usp->usss) {
+			mesh *m = glView->GetMesh(uss.shapeName);
 			if (!m)
 				continue;
 
 			std::unordered_map<uint16_t, Vector3> strokeDiff;
 
-			for (auto& ps : uss.pointStartState) {
+			for (auto &ps : uss.pointStartState) {
 				auto pe = uss.pointEndState.find(ps.first);
 				if (pe == uss.pointEndState.end())
 					continue;
@@ -2724,17 +2715,17 @@ void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject* usp, bool bIsUndo)
 	}
 	else {
 		if (usp->undoType == UT_WEIGHT) {
-			for (auto& uss : usp->usss) {
-				mesh* m = glView->GetMesh(uss.shapeName);
+			for (auto &uss : usp->usss) {
+				mesh *m = glView->GetMesh(uss.shapeName);
 				if (!m)
 					continue;
 
-				for (auto& bw : uss.boneWeights) {
+				for (auto &bw : uss.boneWeights) {
 					if (bw.weights.empty()) continue;
 					project->GetWorkAnim()->AddShapeBone(m->shapeName, bw.boneName);
 					auto weights = project->GetWorkAnim()->GetWeightsPtr(m->shapeName, bw.boneName);
 					if (!weights) continue;
-					for (auto& p : bw.weights) {
+					for (auto &p : bw.weights) {
 						float val = bIsUndo ? p.second.startVal : p.second.endVal;
 						if (val == 0.0f)
 							weights->erase(p.first);
@@ -2751,8 +2742,8 @@ void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject* usp, bool bIsUndo)
 			}
 		}
 		else if (usp->undoType == UT_COLOR) {
-			for (auto& uss : usp->usss) {
-				mesh* m = glView->GetMesh(uss.shapeName);
+			for (auto &uss : usp->usss) {
+				mesh *m = glView->GetMesh(uss.shapeName);
 				if (!m)
 					continue;
 
@@ -2763,14 +2754,14 @@ void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject* usp, bool bIsUndo)
 				std::vector<Color4> vcolors = (*colorPtr);
 
 				if (bIsUndo) {
-					for (auto& p : uss.pointStartState) {
+					for (auto &p : uss.pointStartState) {
 						vcolors[p.first].r = p.second.x;
 						vcolors[p.first].g = p.second.y;
 						vcolors[p.first].b = p.second.z;
 					}
 				}
 				else {
-					for (auto& p : uss.pointEndState) {
+					for (auto &p : uss.pointEndState) {
 						vcolors[p.first].r = p.second.x;
 						vcolors[p.first].g = p.second.y;
 						vcolors[p.first].b = p.second.z;
@@ -2781,8 +2772,8 @@ void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject* usp, bool bIsUndo)
 			}
 		}
 		else if (usp->undoType == UT_ALPHA) {
-			for (auto& uss : usp->usss) {
-				mesh* m = glView->GetMesh(uss.shapeName);
+			for (auto &uss : usp->usss) {
+				mesh *m = glView->GetMesh(uss.shapeName);
 				if (!m)
 					continue;
 
@@ -2793,11 +2784,11 @@ void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject* usp, bool bIsUndo)
 				std::vector<Color4> vcolors = (*colorPtr);
 
 				if (bIsUndo) {
-					for (auto& p : uss.pointStartState)
+					for (auto &p : uss.pointStartState)
 						vcolors[p.first].a = p.second.x;
 				}
 				else {
-					for (auto& p : uss.pointEndState)
+					for (auto &p : uss.pointEndState)
 						vcolors[p.first].a = p.second.x;
 				}
 
@@ -2810,7 +2801,7 @@ void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject* usp, bool bIsUndo)
 }
 
 void OutfitStudioFrame::UpdateShapeReference(NiShape* shape, NiShape* newShape) {
-	for (auto& i : selectedItems) {
+	for (auto &i : selectedItems) {
 		if (i->GetShape() == shape) {
 			i->SetShape(newShape);
 		}
@@ -2932,7 +2923,7 @@ void OutfitStudioFrame::MenuExitSliderEdit() {
 
 void OutfitStudioFrame::ScrollToActiveSlider() {
 	if (!activeSlider.empty()) {
-		for (auto& d : sliderDisplays) {
+		for (auto &d : sliderDisplays) {
 			if (d.first == activeSlider) {
 				ScrollWindowIntoView(sliderScroll, d.second->sliderPane);
 			}
@@ -3151,7 +3142,7 @@ bool OutfitStudioFrame::CheckEditableState() {
 	if (bEditSlider) {
 		if (project->SliderValue(activeSlider) == 0.0) {
 			int response = wxMessageBox(_("You are trying to edit a slider's morph with that slider set to zero.  Do you wish to set the slider to one now?"),
-			                            wxMessageBoxCaptionStr, wxYES_NO, this);
+				wxMessageBoxCaptionStr, wxYES_NO, this);
 
 			if (response == wxYES) {
 				SetSliderValue(activeSlider, 100);
@@ -3173,8 +3164,8 @@ bool OutfitStudioFrame::CheckEditableState() {
 	if (project->AllSlidersZero())
 		return true;
 
-	int response = wxMessageBox(_("You can only edit the base shape when all sliders are zero. Do you wish to set all sliders to zero now?  Note, use the pencil button next to a slider to enable editing of that slider's morph."),
-	                            wxMessageBoxCaptionStr, wxYES_NO, this);
+	int	response = wxMessageBox(_("You can only edit the base shape when all sliders are zero. Do you wish to set all sliders to zero now?  Note, use the pencil button next to a slider to enable editing of that slider's morph."),
+		wxMessageBoxCaptionStr, wxYES_NO, this);
 
 	if (response == wxYES)
 		ZeroSliders();
@@ -3286,7 +3277,7 @@ void OutfitStudioFrame::OnNewProject(wxCommandEvent& WXUNUSED(event)) {
 		XRCCTRL(wiz, "npTexFilename", wxFilePickerCtrl)->Bind(wxEVT_FILEPICKER_CHANGED, &OutfitStudioFrame::OnLoadOutfitFP_Texture, this);
 
 		wxChoice* tmplChoice = XRCCTRL(wiz, "npTemplateChoice", wxChoice);
-		for (auto& tmpl : refTemplates)
+		for (auto &tmpl : refTemplates)
 			tmplChoice->Append(tmpl.GetName());
 
 		std::string lastRefTemplate = OutfitStudioConfig["LastRefTemplate"];
@@ -3311,7 +3302,7 @@ void OutfitStudioFrame::OnNewProject(wxCommandEvent& WXUNUSED(event)) {
 	ClearProject();
 	project->ClearReference();
 	project->ClearOutfit();
-
+	
 	glView->Cleanup();
 	glView->GetUndoHistory()->ClearHistory();
 
@@ -3350,10 +3341,10 @@ void OutfitStudioFrame::OnNewProject(wxCommandEvent& WXUNUSED(event)) {
 		if (fileName.EndsWith(".osp") || fileName.EndsWith(".xml")) {
 			wxString sliderSetName = XRCCTRL(wiz, "npSliderSetName", wxChoice)->GetStringSelection();
 			wxLogMessage("Loading reference '%s' from set '%s' of file '%s'...",
-			             refShape, sliderSetName, fileName);
+				refShape, sliderSetName, fileName);
 
 			error = project->LoadReference(fileName.ToUTF8().data(),
-			                               sliderSetName.ToUTF8().data(), false, refShape.ToUTF8().data());
+				sliderSetName.ToUTF8().data(), false, refShape.ToUTF8().data());
 		}
 		else if (fileName.EndsWith(".nif")) {
 			wxLogMessage("Loading reference '%s' from '%s'...", refShape, fileName);
@@ -3391,7 +3382,7 @@ void OutfitStudioFrame::OnNewProject(wxCommandEvent& WXUNUSED(event)) {
 	UpdateProgress(80, _("Creating outfit..."));
 
 	if (XRCCTRL(wiz, "npTexAuto", wxRadioButton)->GetValue() == false)
-		project->SetTextures({XRCCTRL(wiz, "npTexFilename", wxFilePickerCtrl)->GetPath().ToUTF8().data()});
+		project->SetTextures({ XRCCTRL(wiz, "npTexFilename", wxFilePickerCtrl)->GetPath().ToUTF8().data() });
 	else
 		project->SetTextures();
 
@@ -3452,7 +3443,7 @@ void OutfitStudioFrame::OnLoadReference(wxCommandEvent& WXUNUSED(event)) {
 		XRCCTRL(dlg, "npSliderSetName", wxChoice)->Bind(wxEVT_CHOICE, &OutfitStudioFrame::OnNPWizChangeSetNameChoice, this);
 
 		wxChoice* tmplChoice = XRCCTRL(dlg, "npTemplateChoice", wxChoice);
-		for (auto& tmpl : refTemplates)
+		for (auto &tmpl : refTemplates)
 			tmplChoice->Append(tmpl.GetName());
 
 		std::string lastRefTemplate = OutfitStudioConfig["LastRefTemplate"];
@@ -3472,7 +3463,6 @@ void OutfitStudioFrame::OnLoadReference(wxCommandEvent& WXUNUSED(event)) {
 
 	UpdateProgress(10, _("Loading reference set..."));
 	bool mergeSliders = (XRCCTRL(dlg, "chkClearSliders", wxCheckBox)->IsChecked());
-	bool keepZapSliders = (XRCCTRL(dlg, "chkKeepZapSliders", wxCheckBox)->IsChecked());
 
 	int error = 0;
 	if (XRCCTRL(dlg, "npRefIsTemplate", wxRadioButton)->GetValue() == true) {
@@ -3485,9 +3475,9 @@ void OutfitStudioFrame::OnLoadReference(wxCommandEvent& WXUNUSED(event)) {
 		auto tmpl = find_if(refTemplates.begin(), refTemplates.end(), [&tmplName](const RefTemplate& rt) { return rt.GetName() == tmplName; });
 		if (tmpl != refTemplates.end()) {
 			if (wxFileName(wxString::FromUTF8(tmpl->GetSource())).IsRelative())
-				error = project->LoadReferenceTemplate(GetProjectPath() + PathSepStr + tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), tmpl->GetLoadAll(), mergeSliders, keepZapSliders);
+				error = project->LoadReferenceTemplate(GetProjectPath() + PathSepStr + tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), tmpl->GetLoadAll(), mergeSliders);
 			else
-				error = project->LoadReferenceTemplate(tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), tmpl->GetLoadAll(), mergeSliders, keepZapSliders);
+				error = project->LoadReferenceTemplate(tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), tmpl->GetLoadAll(), mergeSliders);
 		}
 		else
 			error = 1;
@@ -3499,14 +3489,14 @@ void OutfitStudioFrame::OnLoadReference(wxCommandEvent& WXUNUSED(event)) {
 		if (fileName.EndsWith(".osp") || fileName.EndsWith(".xml")) {
 			wxString sliderSetName = XRCCTRL(dlg, "npSliderSetName", wxChoice)->GetStringSelection();
 			wxLogMessage("Loading reference '%s' from set '%s' of file '%s'...",
-			             refShape, sliderSetName, fileName);
+				refShape, sliderSetName, fileName);
 
 			error = project->LoadReference(fileName.ToUTF8().data(),
-			                               sliderSetName.ToUTF8().data(), mergeSliders, refShape.ToUTF8().data(), keepZapSliders);
+				sliderSetName.ToUTF8().data(), mergeSliders, refShape.ToUTF8().data());
 		}
 		else if (fileName.EndsWith(".nif")) {
 			wxLogMessage("Loading reference '%s' from '%s'...", refShape, fileName);
-			error = project->LoadReferenceNif(fileName.ToUTF8().data(), refShape.ToUTF8().data(), mergeSliders, keepZapSliders);
+			error = project->LoadReferenceNif(fileName.ToUTF8().data(), refShape.ToUTF8().data(), mergeSliders);
 		}
 	}
 	else
@@ -3721,7 +3711,7 @@ void OutfitStudioFrame::OnLoadOutfit(wxCommandEvent& WXUNUSED(event)) {
 	wxLogMessage("Loading outfit...");
 	StartProgress(_("Loading outfit..."));
 
-	for (auto& s : project->GetWorkNif()->GetShapes()) {
+	for (auto &s : project->GetWorkNif()->GetShapes()) {
 		if (!project->IsBaseShape(s)) {
 			glView->DeleteMesh(s->name.get());
 		}
@@ -3756,7 +3746,7 @@ void OutfitStudioFrame::OnLoadOutfit(wxCommandEvent& WXUNUSED(event)) {
 	if (XRCCTRL(dlg, "npTexAuto", wxRadioButton)->GetValue() == true)
 		project->SetTextures();
 	else {
-		std::vector<std::string> texVec = {XRCCTRL(dlg, "npTexFilename", wxFilePickerCtrl)->GetPath().ToUTF8().data()};
+		std::vector<std::string> texVec = { XRCCTRL(dlg, "npTexFilename", wxFilePickerCtrl)->GetPath().ToUTF8().data() };
 		project->SetTextures(texVec);
 	}
 
@@ -3818,7 +3808,7 @@ void OutfitStudioFrame::ClearProject() {
 	if (editUV)
 		editUV->Close();
 
-	for (auto& s : project->GetWorkNif()->GetShapeNames())
+	for (auto &s : project->GetWorkNif()->GetShapeNames())
 		glView->DeleteMesh(s);
 
 	project->mFileName.clear();
@@ -3916,7 +3906,7 @@ void OutfitStudioFrame::RefreshGUIFromProj(bool render) {
 	wxTreeItemId item;
 	wxTreeItemId firstItem;
 	wxTreeItemId prevFirstSelItem;
-	for (auto& shape : shapes) {
+	for (auto &shape : shapes) {
 		auto itemData = new ShapeItemData(shape);
 		item = outfitShapes->AppendItem(outfitRoot, wxString::FromUTF8(shape->name.get()));
 		outfitShapes->SetItemState(item, 0);
@@ -4025,7 +4015,7 @@ void OutfitStudioFrame::UpdateAnimationGUI() {
 	project->GetActiveBones(activeBones);
 
 	// Re-fill mirror and pose bone lists
-	for (auto& bone : activeBones) {
+	for (auto &bone : activeBones) {
 		cXMirrorBone->AppendString(bone);
 
 		if (xMChoice >= 2 && bone == manualXMirrorBone)
@@ -4048,7 +4038,7 @@ void OutfitStudioFrame::UpdateAnimationGUI() {
 	std::string poseDataPath = GetProjectPath() + "/PoseData";
 	poseDataCollection.LoadData(poseDataPath);
 
-	for (auto& poseData : poseDataCollection.poseData) {
+	for (auto &poseData : poseDataCollection.poseData) {
 		wxString poseName = wxString::FromUTF8(poseData.name);
 		cPoseName->Append(poseName, &poseData);
 	}
@@ -4075,7 +4065,7 @@ void OutfitStudioFrame::UpdateBoneTree() {
 	std::vector<std::string> activeBones;
 	project->GetActiveBones(activeBones);
 
-	for (auto& bone : activeBones) {
+	for (auto &bone : activeBones) {
 		// Filter out bone by name
 		wxString boneStr = wxString::FromUTF8(bone);
 		if (!boneStr.Lower().Contains(filterStr))
@@ -4098,7 +4088,7 @@ void OutfitStudioFrame::UpdateBoneTree() {
 }
 
 void OutfitStudioFrame::MeshesFromProj(const bool reloadTextures) {
-	for (auto& shape : project->GetWorkNif()->GetShapes())
+	for (auto &shape : project->GetWorkNif()->GetShapes())
 		MeshFromProj(shape, reloadTextures);
 
 	if (glView->GetVertexEdit())
@@ -4121,7 +4111,7 @@ void OutfitStudioFrame::MeshFromProj(NiShape* shape, const bool reloadTextures) 
 	}
 
 	std::vector<std::string> selShapes;
-	for (auto& i : selectedItems)
+	for (auto &i : selectedItems)
 		selShapes.push_back(i->GetShape()->name.get());
 
 	glView->SetActiveShapes(selShapes);
@@ -4144,7 +4134,7 @@ void OutfitStudioFrame::UpdateMeshFromSet(NiShape* shape) {
 void OutfitStudioFrame::FillVertexColors() {
 	std::vector<std::string> shapeNames = project->GetWorkNif()->GetShapeNames();
 
-	for (auto& s : shapeNames) {
+	for (auto &s : shapeNames) {
 		mesh* m = glView->GetMesh(s);
 		if (!m)
 			continue;
@@ -4207,7 +4197,7 @@ void OutfitStudioFrame::OnSetBaseShape(wxCommandEvent& WXUNUSED(event)) {
 	wxLogMessage("Setting new base shape.");
 	project->ClearBoneScale();
 
-	for (auto& s : project->GetWorkNif()->GetShapes())
+	for (auto &s : project->GetWorkNif()->GetShapes())
 		UpdateShapeSource(s);
 
 	ZeroSliders();
@@ -4231,7 +4221,7 @@ void OutfitStudioFrame::OnImportNIF(wxCommandEvent& WXUNUSED(event)) {
 	StartProgress(_("Importing NIF file..."));
 	UpdateProgress(1, _("Importing NIF file..."));
 
-	for (auto& fileName : fileNames)
+	for (auto &fileName : fileNames)
 		project->ImportNIF(fileName.ToUTF8().data(), false);
 
 	UpdateProgress(60, _("Refreshing GUI..."));
@@ -4259,7 +4249,7 @@ void OutfitStudioFrame::OnExportNIF(wxCommandEvent& WXUNUSED(event)) {
 	project->ClearBoneScale();
 
 	std::vector<mesh*> shapeMeshes;
-	for (auto& s : project->GetWorkNif()->GetShapes()) {
+	for (auto &s : project->GetWorkNif()->GetShapes()) {
 		if (!project->IsBaseShape(s)) {
 			mesh* m = glView->GetMesh(s->name.get());
 			if (m)
@@ -4294,7 +4284,7 @@ void OutfitStudioFrame::OnExportNIFWithRef(wxCommandEvent& event) {
 	project->ClearBoneScale();
 
 	std::vector<mesh*> shapeMeshes;
-	for (auto& s : project->GetWorkNif()->GetShapeNames()) {
+	for (auto &s : project->GetWorkNif()->GetShapeNames()) {
 		mesh* m = glView->GetMesh(s);
 		if (m)
 			shapeMeshes.push_back(m);
@@ -4346,7 +4336,7 @@ void OutfitStudioFrame::OnExportShapeNIF(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	std::vector<std::string> shapes;
-	for (auto& i : selectedItems)
+	for (auto &i : selectedItems)
 		shapes.push_back(i->GetShape()->name.get());
 
 	wxLogMessage("Exporting selected shapes to NIF file '%s'.", fileName);
@@ -4366,7 +4356,7 @@ void OutfitStudioFrame::OnImportOBJ(wxCommandEvent& WXUNUSED(event)) {
 	wxArrayString fileNames;
 	importDialog.GetPaths(fileNames);
 
-	for (auto& fileName : fileNames) {
+	for (auto &fileName : fileNames) {
 		wxLogMessage("Importing shape(s) from OBJ file '%s'...", fileName);
 
 		int ret;
@@ -4391,7 +4381,7 @@ void OutfitStudioFrame::OnExportOBJ(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	bool hasSkinTrans = false;
-	for (NiShape* shape : project->GetWorkNif()->GetShapes()) {
+	for (NiShape *shape : project->GetWorkNif()->GetShapes()) {
 		if (!project->GetWorkAnim()->shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(MatTransform()))
 			hasSkinTrans = true;
 	}
@@ -4423,8 +4413,8 @@ void OutfitStudioFrame::OnExportShapeOBJ(wxCommandEvent& WXUNUSED(event)) {
 	}
 
 	bool hasSkinTrans = false;
-	for (auto& i : selectedItems) {
-		NiShape* shape = i->GetShape();
+	for (auto &i : selectedItems) {
+		NiShape *shape = i->GetShape();
 		if (!project->GetWorkAnim()->shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(MatTransform()))
 			hasSkinTrans = true;
 	}
@@ -4446,7 +4436,7 @@ void OutfitStudioFrame::OnExportShapeOBJ(wxCommandEvent& WXUNUSED(event)) {
 
 		std::vector<NiShape*> shapes;
 		shapes.reserve(selectedItems.size());
-		for (auto& i : selectedItems)
+		for (auto &i : selectedItems)
 			shapes.push_back(i->GetShape());
 
 		if (project->ExportOBJ(fileName.ToUTF8().data(), shapes, transToGlobal, Vector3(0.1f, 0.1f, 0.1f))) {
@@ -4462,7 +4452,7 @@ void OutfitStudioFrame::OnExportShapeOBJ(wxCommandEvent& WXUNUSED(event)) {
 		wxLogMessage("Exporting shape '%s' as OBJ file to '%s'.", activeItem->GetShape()->name.get(), fileName);
 		project->ClearBoneScale();
 
-		std::vector<NiShape*> shapes = {activeItem->GetShape()};
+		std::vector<NiShape*> shapes = { activeItem->GetShape() };
 		if (project->ExportOBJ(fileName.ToUTF8().data(), shapes, transToGlobal, Vector3(0.1f, 0.1f, 0.1f))) {
 			wxLogError("Failed to export OBJ file '%s'!", fileName);
 			wxMessageBox(_("Failed to export OBJ file!"), _("Error"), wxICON_ERROR);
@@ -4478,7 +4468,7 @@ void OutfitStudioFrame::OnImportFBX(wxCommandEvent& WXUNUSED(event)) {
 	wxArrayString fileNames;
 	importDialog.GetPaths(fileNames);
 
-	for (auto& fileName : fileNames) {
+	for (auto &fileName : fileNames) {
 		wxLogMessage("Importing shape(s) from FBX file '%s'...", fileName);
 
 		int ret;
@@ -4506,7 +4496,7 @@ void OutfitStudioFrame::OnExportFBX(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	bool hasSkinTrans = false;
-	for (NiShape* shape : project->GetWorkNif()->GetShapes()) {
+	for (NiShape *shape : project->GetWorkNif()->GetShapes()) {
 		if (!project->GetWorkAnim()->shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(MatTransform()))
 			hasSkinTrans = true;
 	}
@@ -4538,8 +4528,8 @@ void OutfitStudioFrame::OnExportShapeFBX(wxCommandEvent& WXUNUSED(event)) {
 	}
 
 	bool hasSkinTrans = false;
-	for (auto& i : selectedItems) {
-		NiShape* shape = i->GetShape();
+	for (auto &i : selectedItems) {
+		NiShape *shape = i->GetShape();
 		if (!project->GetWorkAnim()->shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(MatTransform()))
 			hasSkinTrans = true;
 	}
@@ -4561,7 +4551,7 @@ void OutfitStudioFrame::OnExportShapeFBX(wxCommandEvent& WXUNUSED(event)) {
 
 		std::vector<NiShape*> shapes;
 		shapes.reserve(selectedItems.size());
-		for (auto& i : selectedItems)
+		for (auto &i : selectedItems)
 			shapes.push_back(i->GetShape());
 
 		if (!project->ExportFBX(fileName.ToUTF8().data(), shapes, transToGlobal)) {
@@ -4577,7 +4567,7 @@ void OutfitStudioFrame::OnExportShapeFBX(wxCommandEvent& WXUNUSED(event)) {
 		wxLogMessage("Exporting shape '%s' as FBX file to '%s'.", activeItem->GetShape()->name.get(), fileName);
 		project->ClearBoneScale();
 
-		std::vector<NiShape*> shapes = {activeItem->GetShape()};
+		std::vector<NiShape*> shapes = { activeItem->GetShape() };
 		if (!project->ExportFBX(fileName.ToUTF8().data(), shapes, transToGlobal)) {
 			wxLogError("Failed to export FBX file '%s'!", fileName);
 			wxMessageBox(_("Failed to export FBX file!"), _("Error"), wxICON_ERROR);
@@ -4598,7 +4588,7 @@ void OutfitStudioFrame::OnImportTRIHead(wxCommandEvent& WXUNUSED(event)) {
 	sliderScroll->FitInside();
 	activeSlider.clear();
 
-	for (auto& fn : fileNames) {
+	for (auto &fn : fileNames) {
 		wxFileName fileName(fn);
 		wxLogMessage("Importing morphs from TRI (head) file '%s'...", fn);
 
@@ -4628,7 +4618,7 @@ void OutfitStudioFrame::OnImportTRIHead(wxCommandEvent& WXUNUSED(event)) {
 		RefreshGUIFromProj(false);
 
 		auto morphs = tri.GetMorphs();
-		for (auto& morph : morphs) {
+		for (auto &morph : morphs) {
 			if (!project->ValidSlider(morph.morphName)) {
 				createSliderGUI(morph.morphName, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
 				project->AddEmptySlider(morph.morphName);
@@ -4669,7 +4659,7 @@ void OutfitStudioFrame::OnExportTRIHead(wxCommandEvent& WXUNUSED(event)) {
 	if (dir.IsEmpty())
 		return;
 
-	for (auto& shape : project->GetWorkNif()->GetShapes()) {
+	for (auto &shape : project->GetWorkNif()->GetShapes()) {
 		std::string fn = dir + PathSepStr + shape->name.get() + ".tri";
 
 		wxLogMessage("Exporting TRI (head) morphs of '%s' to '%s'...", shape->name.get(), fn);
@@ -4727,7 +4717,7 @@ void OutfitStudioFrame::OnExportPhysicsData(wxCommandEvent& WXUNUSED(event)) {
 	}
 
 	wxArrayString fileNames;
-	for (auto& data : physicsData)
+	for (auto &data : physicsData)
 		fileNames.Add(wxString::FromUTF8(data.first));
 
 	wxSingleChoiceDialog physicsDataChoice(this, _("Please choose the physics data source you want to export."), _("Choose physics data"), fileNames);
@@ -4782,7 +4772,7 @@ void OutfitStudioFrame::OnMakeConvRef(wxCommandEvent& WXUNUSED(event)) {
 
 	std::vector<std::string> sliderList;
 	project->GetSliderList(sliderList);
-	for (auto& s : sliderList) {
+	for (auto &s : sliderList) {
 		if (!s.compare(finalName))
 			continue;
 		project->DeleteSlider(s);
@@ -4800,7 +4790,7 @@ void OutfitStudioFrame::OnMakeConvRef(wxCommandEvent& WXUNUSED(event)) {
 
 void OutfitStudioFrame::OnSelectSliders(wxCommandEvent& event) {
 	bool checked = event.IsChecked();
-	for (auto& sd : sliderDisplays)
+	for (auto &sd : sliderDisplays)
 		ShowSliderEffect(sd.first, checked);
 
 	ApplySliders();
@@ -4814,7 +4804,7 @@ void OutfitStudioFrame::DoFilterSliders() {
 	wxString filterStr = sliderFilter->GetValue();
 	filterStr.MakeLower();
 
-	for (auto& sd : sliderDisplays) {
+	for (auto &sd : sliderDisplays) {
 		if (!sd.second)
 			continue;
 
@@ -4885,7 +4875,7 @@ void OutfitStudioFrame::ToggleVisibility(wxTreeItemId firstItem) {
 	}
 
 	if (selectedItems.size() > 1) {
-		for (auto& i : selectedItems) {
+		for (auto &i : selectedItems) {
 			if (i->GetId().GetID() != firstItem.GetID()) {
 				std::string shapeName{outfitShapes->GetItemText(i->GetId()).ToUTF8()};
 				glView->SetShapeGhostMode(shapeName, ghost);
@@ -4936,7 +4926,7 @@ void OutfitStudioFrame::OnShapeSelect(wxTreeEvent& event) {
 	wxArrayTreeItemIds selected;
 	outfitShapes->GetSelections(selected);
 
-	for (auto& i : selected) {
+	for (auto &i : selected) {
 		if (outfitShapes->GetItemParent(i).IsOk()) {
 			auto data = (ShapeItemData*)outfitShapes->GetItemData(i);
 			if (data) {
@@ -5011,7 +5001,7 @@ void OutfitStudioFrame::OnBoneStateToggle(wxTreeEvent& event) {
 
 void OutfitStudioFrame::RefreshGUIWeightColors() {
 	// Clear vcolors of all shapes
-	for (auto& s : project->GetWorkNif()->GetShapeNames()) {
+	for (auto &s : project->GetWorkNif()->GetShapeNames()) {
 		mesh* m = glView->GetMesh(s);
 		if (m)
 			m->ColorChannelFill(1, 0.0f);
@@ -5019,7 +5009,7 @@ void OutfitStudioFrame::RefreshGUIWeightColors() {
 
 	if (!activeBone.empty()) {
 		// Show weights of selected shapes without reference
-		for (auto& s : selectedItems) {
+		for (auto &s : selectedItems) {
 			if (!project->IsBaseShape(s->GetShape())) {
 				auto weights = project->GetWorkAnim()->GetWeightsPtr(s->GetShape()->name.get(), activeBone);
 
@@ -5027,7 +5017,7 @@ void OutfitStudioFrame::RefreshGUIWeightColors() {
 				if (m) {
 					m->ColorChannelFill(1, 0.0f);
 					if (weights) {
-						for (auto& bw : *weights)
+						for (auto &bw : *weights)
 							m->vcolors[bw.first].y = bw.second;
 					}
 				}
@@ -5043,7 +5033,7 @@ void OutfitStudioFrame::RefreshGUIWeightColors() {
 			if (m) {
 				m->ColorChannelFill(1, 0.0f);
 				if (weights) {
-					for (auto& bw : *weights)
+					for (auto &bw : *weights)
 						m->vcolors[bw.first].y = bw.second;
 				}
 			}
@@ -5153,7 +5143,7 @@ void OutfitStudioFrame::OnShapeDrop(wxTreeEvent& event) {
 	// Make first child
 	if (dropItem == outfitRoot)
 		dropItem = 0;
-
+	
 	// Duplicate item
 	wxTreeItemId movedItem = outfitShapes->InsertItem(outfitRoot, dropItem, activeItem->GetShape()->name.get());
 	if (!movedItem.IsOk())
@@ -5167,7 +5157,7 @@ void OutfitStudioFrame::OnShapeDrop(wxTreeEvent& event) {
 		outfitShapes->SetItemBold(movedItem);
 		outfitShapes->SetItemTextColour(movedItem, wxColour(0, 255, 0));
 	}
-
+	
 	// Delete old item
 	outfitShapes->Delete(activeItem->GetId());
 
@@ -5450,7 +5440,7 @@ void OutfitStudioFrame::ApplySegments() {
 		SegmentItemData* segmentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(child));
 		if (segmentData) {
 			inf.segs.emplace_back();
-			NifSegmentInfo& seg = inf.segs.back();
+			NifSegmentInfo &seg = inf.segs.back();
 			seg.partID = segmentData->partID;
 			size_t childCount = segmentTree->GetChildrenCount(child);
 
@@ -5463,7 +5453,7 @@ void OutfitStudioFrame::ApplySegments() {
 				while (subChild.IsOk()) {
 					SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(subChild));
 					if (subSegmentData) {
-						NifSubSegmentInfo& sub = seg.subs[childInd++];
+						NifSubSegmentInfo &sub = seg.subs[childInd++];
 						sub.partID = subSegmentData->partID;
 						sub.userSlotID = subSegmentData->userSlotID;
 						sub.material = subSegmentData->material;
@@ -5524,9 +5514,9 @@ void OutfitStudioFrame::CreateSegmentTree(NiShape* shape) {
 			wxTreeItemId segID = segmentTree->AppendItem(segmentRoot, "Segment", -1, -1, new SegmentItemData(inf.segs[i].partID));
 			if (segID.IsOk()) {
 				for (size_t j = 0; j < inf.segs[i].subs.size(); j++) {
-					NifSubSegmentInfo& sub = inf.segs[i].subs[j];
+					NifSubSegmentInfo &sub = inf.segs[i].subs[j];
 					segmentTree->AppendItem(segID, "Sub Segment", -1, -1,
-					                        new SubSegmentItemData(sub.partID, sub.userSlotID, sub.material, sub.extraData));
+						new SubSegmentItemData(sub.partID, sub.userSlotID, sub.material, sub.extraData));
 				}
 			}
 		}
@@ -5800,15 +5790,15 @@ void OutfitStudioFrame::OnAddPartition(wxCommandEvent& WXUNUSED(event)) {
 		auto shape = activeItem->GetShape();
 		if (shape && shape->GetNumVertices() > 0) {
 			newItem = partitionTree->AppendItem(partitionRoot, "Partition", -1, -1,
-			                                    new PartitionItemData(partInd, isSkyrim ? 32 : 0));
+				new PartitionItemData(partInd, isSkyrim ? 32 : 0));
 		}
 
-		for (int& pi : triParts)
+		for (int &pi : triParts)
 			pi = partInd;
 	}
 	else
 		newItem = partitionTree->InsertItem(partitionRoot, activePartition, "Partition", -1, -1,
-		                                    new PartitionItemData(partInd, isSkyrim ? 32 : 0));
+			new PartitionItemData(partInd, isSkyrim ? 32 : 0));
 
 	if (newItem.IsOk()) {
 		partitionTree->UnselectAll();
@@ -5828,7 +5818,7 @@ void OutfitStudioFrame::OnDeletePartition(wxCommandEvent& WXUNUSED(event)) {
 
 		int newIndex = -1;
 		if (sibling.IsOk()) {
-			PartitionItemData* siblingData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(sibling));
+			PartitionItemData *siblingData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(sibling));
 			if (siblingData)
 				newIndex = siblingData->index;
 		}
@@ -5982,7 +5972,7 @@ void OutfitStudioFrame::ShowPartition(const wxTreeItemId& item, bool updateFromM
 	PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(activePartition));
 	if (partitionData) {
 		if (!updateFromMask) {
-			for (auto& s : partitionStrings) {
+			for (auto &s : partitionStrings) {
 				if (s.StartsWith(wxString::Format("%d", partitionData->type))) {
 					// Show correct data in UI
 					partitionType->Enable();
@@ -5993,7 +5983,7 @@ void OutfitStudioFrame::ShowPartition(const wxTreeItemId& item, bool updateFromM
 		else {
 			// Add triangles from mask
 			for (size_t triInd = 0; triInd < allTris.size(); ++triInd) {
-				const Triangle& tri = allTris[triInd];
+				const Triangle &tri = allTris[triInd];
 				if (mask.find(tri.p1) != mask.end() && mask.find(tri.p2) != mask.end() && mask.find(tri.p3) != mask.end())
 					triParts[triInd] = partitionData->index;
 			}
@@ -6031,7 +6021,7 @@ void OutfitStudioFrame::ShowPartition(const wxTreeItemId& item, bool updateFromM
 				if (triParts[i] != partitionData->index)
 					continue;
 
-				const Triangle& t = allTris[i];
+				const Triangle &t = allTris[i];
 				m->vcolors[t.p1].x = 1.0f;
 				m->vcolors[t.p2].x = 1.0f;
 				m->vcolors[t.p3].x = 1.0f;
@@ -6053,7 +6043,7 @@ void OutfitStudioFrame::UpdatePartitionNames() {
 		PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(child));
 		if (partitionData) {
 			bool found = false;
-			for (auto& s : partitionStrings) {
+			for (auto &s : partitionStrings) {
 				if (s.StartsWith(wxString::Format("%d", partitionData->type))) {
 					partitionTree->SetItemText(child, s);
 					found = true;
@@ -6069,7 +6059,7 @@ void OutfitStudioFrame::UpdatePartitionNames() {
 	}
 }
 
-void OutfitStudioFrame::SetSubMeshesForPartitions(mesh* m, const std::vector<int>& tp) {
+void OutfitStudioFrame::SetSubMeshesForPartitions(mesh *m, const std::vector<int> &tp) {
 	uint32_t nTris = static_cast<uint32_t>(tp.size());
 
 	// Sort triangles (via triInds) by partition number, negative partition
@@ -6109,7 +6099,7 @@ void OutfitStudioFrame::SetSubMeshesForPartitions(mesh* m, const std::vector<int
 	m->QueueUpdate(mesh::UpdateType::Indices);
 }
 
-void OutfitStudioFrame::SetNoSubMeshes(mesh* m) {
+void OutfitStudioFrame::SetNoSubMeshes(mesh *m) {
 	if (!m)
 		return;
 
@@ -6333,7 +6323,7 @@ void OutfitStudioFrame::OnClickSliderButton(wxCommandEvent& event) {
 		scale = 1.01f;
 
 	if (scale != 0.0f) {
-		for (auto& i : selectedItems) {
+		for (auto &i : selectedItems) {
 			auto shape = i->GetShape();
 			std::vector<Vector3> verts;
 			project->ScaleMorphResult(shape, activeSlider, scale);
@@ -6609,7 +6599,7 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 		xMirrorBoneLabel->Show();
 		posePane->Show();
 		bonesFilter->GetParent()->Show();
-
+		
 		glView->SetTransformMode(false);
 		SelectTool(ToolID::WeightBrush);
 		glView->SetWeightVisible();
@@ -6924,7 +6914,7 @@ void OutfitStudioFrame::ScrollWindowIntoView(wxScrolledWindow* scrolled, wxWindo
 }
 
 void OutfitStudioFrame::HighlightSlider(const std::string& name) {
-	for (auto& d : sliderDisplays) {
+	for (auto &d : sliderDisplays) {
 		if (d.first == name) {
 			d.second->hilite = true;
 			d.second->sliderPane->SetBackgroundColour(wxColour(125, 77, 138));
@@ -7012,7 +7002,7 @@ void OutfitStudioFrame::OnLoadPreset(wxCommandEvent& WXUNUSED(event)) {
 	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgChoosePreset")) {
 		presetChoice = XRCCTRL(dlg, "choicePreset", wxChoice);
 		presetChoice->AppendString("Zero All");
-		for (auto& n : names)
+		for (auto &n : names)
 			presetChoice->AppendString(n);
 
 		presetChoice->SetSelection(0);
@@ -7094,7 +7084,7 @@ void OutfitStudioFrame::OnSavePreset(wxCommandEvent& WXUNUSED(event)) {
 
 	bool addedSlider = false;
 	PresetCollection presets;
-	for (auto& s : sliders) {
+	for (auto &s : sliders) {
 		size_t index = 0;
 		if (!project->SliderIndexFromName(s, index))
 			continue;
@@ -7226,7 +7216,7 @@ void OutfitStudioFrame::OnSliderImportOSD(wxCommandEvent& WXUNUSED(event)) {
 	// Deleting sliders
 	sliderScroll->Freeze();
 	std::vector<std::string> erase;
-	for (auto& sd : sliderDisplays) {
+	for (auto &sd : sliderDisplays) {
 		sd.second->slider->SetValue(0);
 		SetSliderValue(sd.first, 0);
 		ShowSliderEffect(sd.first, true);
@@ -7245,7 +7235,7 @@ void OutfitStudioFrame::OnSliderImportOSD(wxCommandEvent& WXUNUSED(event)) {
 		project->DeleteSlider(sd.first);
 	}
 
-	for (auto& e : erase)
+	for (auto &e : erase)
 		sliderDisplays.erase(e);
 
 	MenuExitSliderEdit();
@@ -7256,10 +7246,10 @@ void OutfitStudioFrame::OnSliderImportOSD(wxCommandEvent& WXUNUSED(event)) {
 	wxString addedDiffs;
 	auto diffs = osd.GetDataDiffs();
 
-	for (auto& shape : project->GetWorkNif()->GetShapes()) {
+	for (auto &shape : project->GetWorkNif()->GetShapes()) {
 		std::string s = shape->name.get();
 		bool added = false;
-		for (auto& diff : diffs) {
+		for (auto &diff : diffs) {
 			// Diff name is supposed to begin with matching shape name
 			if (diff.first.substr(0, s.size()) != s)
 				continue;
@@ -7317,7 +7307,7 @@ void OutfitStudioFrame::OnSliderImportTRI(wxCommandEvent& WXUNUSED(event)) {
 	// Deleting sliders
 	sliderScroll->Freeze();
 	std::vector<std::string> erase;
-	for (auto& sd : sliderDisplays) {
+	for (auto &sd : sliderDisplays) {
 		sd.second->slider->SetValue(0);
 		SetSliderValue(sd.first, 0);
 		ShowSliderEffect(sd.first, true);
@@ -7336,7 +7326,7 @@ void OutfitStudioFrame::OnSliderImportTRI(wxCommandEvent& WXUNUSED(event)) {
 		project->DeleteSlider(sd.first);
 	}
 
-	for (auto& e : erase)
+	for (auto &e : erase)
 		sliderDisplays.erase(e);
 
 	MenuExitSliderEdit();
@@ -7346,13 +7336,13 @@ void OutfitStudioFrame::OnSliderImportTRI(wxCommandEvent& WXUNUSED(event)) {
 
 	wxString addedMorphs;
 	auto morphs = tri.GetMorphs();
-	for (auto& morph : morphs) {
+	for (auto &morph : morphs) {
 		auto shape = project->GetWorkNif()->FindBlockByName<NiShape>(morph.first);
 		if (!shape)
 			continue;
 
 		addedMorphs += morph.first + "\n";
-		for (auto& morphData : morph.second) {
+		for (auto &morphData : morph.second) {
 			if (!project->ValidSlider(morphData->name)) {
 				createSliderGUI(morphData->name, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
 				project->AddEmptySlider(morphData->name);
@@ -7423,7 +7413,7 @@ void OutfitStudioFrame::OnSliderExportNIF(wxCommandEvent& WXUNUSED(event)) {
 		if (dir.IsEmpty())
 			return;
 
-		for (auto& i : selectedItems) {
+		for (auto &i : selectedItems) {
 			std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + i->GetShape()->name.get() + "_" + activeSlider + ".nif";
 			wxLogMessage("Exporting NIF slider data of '%s' for shape '%s' to '%s'...", activeSlider, i->GetShape()->name.get(), targetFile);
 			project->SaveSliderNIF(activeSlider, i->GetShape(), targetFile);
@@ -7459,7 +7449,7 @@ void OutfitStudioFrame::OnSliderExportBSD(wxCommandEvent& WXUNUSED(event)) {
 		if (dir.IsEmpty())
 			return;
 
-		for (auto& i : selectedItems) {
+		for (auto &i : selectedItems) {
 			std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + i->GetShape()->name.get() + "_" + activeSlider + ".bsd";
 			wxLogMessage("Exporting BSD slider data of '%s' for shape '%s' to '%s'...", activeSlider, i->GetShape()->name.get(), targetFile);
 			project->SaveSliderBSD(activeSlider, i->GetShape(), targetFile);
@@ -7492,7 +7482,7 @@ void OutfitStudioFrame::OnSliderExportOBJ(wxCommandEvent& WXUNUSED(event)) {
 		if (dir.IsEmpty())
 			return;
 
-		for (auto& i : selectedItems) {
+		for (auto &i : selectedItems) {
 			std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + i->GetShape()->name.get() + "_" + activeSlider + ".obj";
 			wxLogMessage("Exporting OBJ slider data of '%s' for shape '%s' to '%s'...", activeSlider, i->GetShape()->name.get(), targetFile);
 			project->SaveSliderOBJ(activeSlider, i->GetShape(), targetFile);
@@ -7563,8 +7553,8 @@ void OutfitStudioFrame::OnSliderExportToOBJs(wxCommandEvent& WXUNUSED(event)) {
 	project->GetSliderList(sliderList);
 
 	wxLogMessage("Exporting sliders to OBJ files in '%s'...", dir);
-	for (auto& shape : project->GetWorkNif()->GetShapes()) {
-		for (auto& slider : sliderList) {
+	for (auto &shape : project->GetWorkNif()->GetShapes()) {
+		for (auto &slider : sliderList) {
 			std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + shape->name.get() + "_" + slider + ".obj";
 			wxLogMessage("Exporting OBJ slider data of '%s' for shape '%s' to '%s'...", slider, shape->name.get(), targetFile);
 			if (project->SaveSliderOBJ(slider, shape, targetFile, true))
@@ -7594,7 +7584,7 @@ void OutfitStudioFrame::OnClearSlider(wxCommandEvent& WXUNUSED(event)) {
 
 	auto clearSlider = [&](const std::string& sliderName) {
 		std::unordered_map<uint16_t, float> mask;
-		for (auto& i : selectedItems) {
+		for (auto &i : selectedItems) {
 			mask.clear();
 			glView->GetShapeMask(mask, i->GetShape()->name.get());
 			if (mask.size() > 0)
@@ -7606,7 +7596,7 @@ void OutfitStudioFrame::OnClearSlider(wxCommandEvent& WXUNUSED(event)) {
 
 	if (!bEditSlider) {
 		wxLogMessage("Clearing slider data of the checked sliders for the selected shapes.");
-		for (auto& sd : sliderDisplays)
+		for (auto &sd : sliderDisplays)
 			if (sd.second->sliderNameCheck->Get3StateValue() == wxCheckBoxState::wxCHK_CHECKED)
 				clearSlider(sd.first);
 	}
@@ -7642,14 +7632,13 @@ void OutfitStudioFrame::OnNewZapSlider(wxCommandEvent& WXUNUSED(event)) {
 		sliderName = wxGetTextFromUser(_("Enter a name for the new zap:"), _("Create New Zap"), fillName, this).ToUTF8();
 		if (sliderName.empty())
 			return;
-	}
-	while (project->ValidSlider(sliderName));
+	} while (project->ValidSlider(sliderName));
 
 	wxLogMessage("Creating new zap '%s'.", sliderName);
 	createSliderGUI(sliderName, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
 
 	std::unordered_map<uint16_t, float> unmasked;
-	for (auto& i : selectedItems) {
+	for (auto &i : selectedItems) {
 		unmasked.clear();
 		glView->GetShapeUnmasked(unmasked, i->GetShape()->name.get());
 		project->AddZapSlider(sliderName, unmasked, i->GetShape());
@@ -7674,8 +7663,7 @@ void OutfitStudioFrame::OnNewCombinedSlider(wxCommandEvent& WXUNUSED(event)) {
 		sliderName = wxGetTextFromUser(_("Enter a name for the new slider:"), _("Create New Slider"), fillName, this).ToUTF8();
 		if (sliderName.empty())
 			return;
-	}
-	while (project->ValidSlider(sliderName));
+	} while (project->ValidSlider(sliderName));
 
 	wxLogMessage("Creating new combined slider '%s'.", sliderName);
 	createSliderGUI(sliderName, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
@@ -7696,7 +7684,7 @@ void OutfitStudioFrame::OnSliderNegate(wxCommandEvent& WXUNUSED(event)) {
 	}
 
 	wxLogMessage("Negating slider '%s' for the selected shapes.", activeSlider);
-	for (auto& i : selectedItems)
+	for (auto &i : selectedItems)
 		project->NegateSlider(activeSlider, i->GetShape());
 
 	SetPendingChanges();
@@ -7713,11 +7701,21 @@ void OutfitStudioFrame::OnMaskAffected(wxCommandEvent& WXUNUSED(event)) {
 	}
 
 	wxLogMessage("Creating mask for affected vertices of the slider '%s'.", activeSlider);
-	for (auto& i : selectedItems)
+	for (auto &i : selectedItems)
 		project->MaskAffected(activeSlider, i->GetShape());
 }
 
+void OutfitStudioFrame::OnDeleteSlider(wxCommandEvent& WXUNUSED(event)) {
+	wxString prompt = _("Are you sure you wish to delete the selected slider(s)?");
+	int result = wxMessageBox(prompt, _("Confirm slider delete"), wxYES_NO | wxICON_WARNING, this);
+	if (result != wxYES)
+		return;
+
+	DeleteSliders();
+}
+
 void OutfitStudioFrame::DeleteSliders(bool keepZaps) {
+
 	auto deleteSlider = [&](const std::string& sliderName) {
 		wxLogMessage("Deleting slider '%s'.", sliderName);
 
@@ -7742,12 +7740,11 @@ void OutfitStudioFrame::DeleteSliders(bool keepZaps) {
 
 	if (!bEditSlider) {
 		for (auto it = sliderDisplays.begin(); it != sliderDisplays.end();) {
-			if (keepZaps && project->activeSet[it->first].bZap) {
-				++it;
-				continue;
-			}
-
 			if (it->second->sliderNameCheck->Get3StateValue() == wxCheckBoxState::wxCHK_CHECKED) {
+				if (keepZaps && project->activeSet[it->first].bZap) {
+					++it;
+					continue;
+				}
 				deleteSlider(it->first);
 				it = sliderDisplays.erase(it);
 			}
@@ -7767,15 +7764,6 @@ void OutfitStudioFrame::DeleteSliders(bool keepZaps) {
 
 	SetPendingChanges();
 	ApplySliders();
-}
-
-void OutfitStudioFrame::OnDeleteSlider(wxCommandEvent& WXUNUSED(event)) {
-	wxString prompt = _("Are you sure you wish to delete the selected slider(s)?");
-	int result = wxMessageBox(prompt, _("Confirm slider delete"), wxYES_NO | wxICON_WARNING, this);
-	if (result != wxYES)
-		return;
-
-	DeleteSliders();
 }
 
 void OutfitStudioFrame::ShowSliderProperties(const std::string& sliderName) {
@@ -7827,7 +7815,7 @@ void OutfitStudioFrame::ShowSliderProperties(const std::string& sliderName) {
 				if (i != curSlider && (project->SliderZap(i) || project->SliderHidden(i)))
 					zapToggleList->Append(wxString::FromUTF8(project->GetSliderName(i)));
 
-			for (auto& s : project->SliderZapToggles(curSlider)) {
+			for (auto &s : project->SliderZapToggles(curSlider)) {
 				int stringId = zapToggleList->FindString(s, true);
 				if (stringId != wxNOT_FOUND)
 					zapToggleList->Check(stringId);
@@ -7877,7 +7865,7 @@ void OutfitStudioFrame::ShowSliderProperties(const std::string& sliderName) {
 				wxArrayString zapToggles;
 				wxArrayInt toggled;
 				zapToggleList->GetCheckedItems(toggled);
-				for (auto& i : toggled)
+				for (auto &i : toggled)
 					zapToggles.Add(zapToggleList->GetString(i));
 
 				project->SetSliderZapToggles(curSlider, zapToggles);
@@ -7894,7 +7882,7 @@ void OutfitStudioFrame::ShowSliderProperties(const std::string& sliderName) {
 			project->SetSliderDefault(curSlider, loVal, false);
 			project->SetSliderDefault(curSlider, hiVal, true);
 
-			std::string newSliderName{edSliderName->GetValue().ToUTF8()};
+			std::string newSliderName{ edSliderName->GetValue().ToUTF8() };
 			if (sliderName != newSliderName && !project->ValidSlider(newSliderName)) {
 				project->SetSliderName(curSlider, newSliderName);
 				SliderDisplay* d = sliderDisplays[sliderName];
@@ -7944,6 +7932,7 @@ void OutfitStudioFrame::ConformSliders(NiShape* shape, const ConformOptions& opt
 		project->morpher.CopyMeshMask(m, shapeName);
 		project->ConformShape(shape, options);
 	}
+
 	if (!silent)
 		UpdateProgress(99);
 }
@@ -7960,7 +7949,7 @@ void OutfitStudioFrame::OnSliderConform(wxCommandEvent& WXUNUSED(event)) {
 		StartProgress(_("Initializing data..."));
 		project->InitConform();
 
-		for (auto& i : selectedItems)
+		for (auto &i : selectedItems)
 			ConformSliders(i->GetShape(), options);
 
 		project->morpher.ClearProximityCache();
@@ -7994,7 +7983,7 @@ void OutfitStudioFrame::OnSliderConformAll(wxCommandEvent& WXUNUSED(event)) {
 		int inc = 100 / shapes.size() - 1;
 		int pos = 0;
 
-		for (auto& shape : shapes) {
+		for (auto &shape : shapes) {
 			UpdateProgress(pos * inc, _("Conforming: ") + shape->name.get());
 			StartSubProgress(pos * inc, pos * inc + inc);
 			ConformSliders(shape, options);
@@ -8014,42 +8003,6 @@ void OutfitStudioFrame::OnSliderConformAll(wxCommandEvent& WXUNUSED(event)) {
 		UpdateProgress(100, _("Finished"));
 		EndProgress();
 	}
-}
-
-int OutfitStudioFrame::ConformShapes(std::vector<NiShape*> shapes, bool silent) {
-	if (!project->GetBaseShape())
-		return 1;
-
-	ConformOptions options;
-	if (ShowConform(options, silent)) {
-		wxLogMessage("Conforming Shapes.");
-
-		ZeroSliders();
-
-		project->InitConform();
-
-		int inc = 100 / shapes.size() - 1;
-		int pos = 0;
-
-		for (auto& shape : shapes) {
-			wxLogMessage(_("Conforming: ") + shape->name.get());
-			if (!silent)
-				StartSubProgress(pos * inc, pos * inc + inc);
-			ConformSliders(shape, options, silent);
-			pos++;
-			if (!silent)
-				EndProgress();
-		}
-
-		project->morpher.ClearProximityCache();
-		project->morpher.UnlinkRefDiffData();
-
-		SetPendingChanges();
-
-		wxLogMessage("All shapes conformed.");
-		return 0;
-	}
-	return 1;
 }
 
 bool OutfitStudioFrame::ShowConform(ConformOptions& options, bool silent) {
@@ -8136,6 +8089,42 @@ bool OutfitStudioFrame::ShowConform(ConformOptions& options, bool silent) {
 	return false;
 }
 
+int OutfitStudioFrame::ConformShapes(std::vector<NiShape*> shapes, bool silent) {
+	if (!project->GetBaseShape())
+		return 1;
+
+	ConformOptions options;
+	if (ShowConform(options, silent)) {
+		wxLogMessage("Conforming Shapes.");
+
+		ZeroSliders();
+
+		project->InitConform();
+
+		int inc = 100 / shapes.size() - 1;
+		int pos = 0;
+
+		for (auto& shape : shapes) {
+			wxLogMessage(_("Conforming: ") + shape->name.get());
+			if (!silent)
+				StartSubProgress(pos * inc, pos * inc + inc);
+			ConformSliders(shape, options, silent);
+			pos++;
+			if (!silent)
+				EndProgress();
+		}
+
+		project->morpher.ClearProximityCache();
+		project->morpher.UnlinkRefDiffData();
+
+		SetPendingChanges();
+
+		wxLogMessage("All shapes conformed.");
+		return 0;
+	}
+	return 1;
+}
+
 void OutfitStudioFrame::OnInvertUV(wxCommandEvent& event) {
 	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
@@ -8145,7 +8134,7 @@ void OutfitStudioFrame::OnInvertUV(wxCommandEvent& event) {
 	bool invertX = (event.GetId() == XRCID("uvInvertX"));
 	bool invertY = (event.GetId() == XRCID("uvInvertY"));
 
-	for (auto& i : selectedItems) {
+	for (auto &i : selectedItems) {
 		project->GetWorkNif()->InvertUVsForShape(i->GetShape(), invertX, invertY);
 	}
 
@@ -8163,7 +8152,7 @@ void OutfitStudioFrame::OnMirror(wxCommandEvent& event) {
 	bool mirrorY = (event.GetId() == XRCID("mirrorY"));
 	bool mirrorZ = (event.GetId() == XRCID("mirrorZ"));
 
-	for (auto& i : selectedItems) {
+	for (auto &i : selectedItems) {
 		project->GetWorkNif()->MirrorShape(i->GetShape(), mirrorX, mirrorY, mirrorZ);
 	}
 
@@ -8184,8 +8173,7 @@ void OutfitStudioFrame::OnRenameShape(wxCommandEvent& WXUNUSED(event)) {
 			return;
 
 		newShapeName = std::move(result);
-	}
-	while (project->IsValidShape(newShapeName));
+	} while (project->IsValidShape(newShapeName));
 
 	std::string shapeName = activeItem->GetShape()->name.get();
 	wxLogMessage("Renaming shape '%s' to '%s'.", shapeName, newShapeName);
@@ -8247,7 +8235,7 @@ void OutfitStudioFrame::OnMoveShape(wxCommandEvent& WXUNUSED(event)) {
 			std::vector<Vector3> verts;
 
 			if (!previewMove.IsZero()) {
-				UndoStateProject* curState = glView->GetUndoHistory()->GetBackState();
+				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
 				if (curState) {
 					glView->ApplyUndoState(curState, true, false);
 					glView->GetUndoHistory()->PopState();
@@ -8263,10 +8251,10 @@ void OutfitStudioFrame::OnMoveShape(wxCommandEvent& WXUNUSED(event)) {
 			bool mirrorAxisY = XRCCTRL(dlg, "mirrorAxisY", wxCheckBox)->IsChecked();
 			bool mirrorAxisZ = XRCCTRL(dlg, "mirrorAxisZ", wxCheckBox)->IsChecked();
 
-			UndoStateProject* usp = glView->GetUndoHistory()->PushState();
+			UndoStateProject *usp = glView->GetUndoHistory()->PushState();
 			usp->undoType = UT_VERTPOS;
 
-			for (auto& sel : selectedItems) {
+			for (auto &sel : selectedItems) {
 				mask.clear();
 				mptr = nullptr;
 
@@ -8368,7 +8356,7 @@ void OutfitStudioFrame::OnMoveShape(wxCommandEvent& WXUNUSED(event)) {
 
 		if (dlg.ShowModal() != wxID_OK) {
 			if (!previewMove.IsZero()) {
-				UndoStateProject* curState = glView->GetUndoHistory()->GetBackState();
+				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
 				if (curState) {
 					glView->ApplyUndoState(curState, true);
 					glView->GetUndoHistory()->PopState();
@@ -8399,7 +8387,7 @@ void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
 			std::vector<Vector3> verts;
 
 			if (previewScale != Vector3(1.0f, 1.0f, 1.0f)) {
-				UndoStateProject* curState = glView->GetUndoHistory()->GetBackState();
+				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
 				if (curState) {
 					glView->ApplyUndoState(curState, true, false);
 					glView->GetUndoHistory()->PopState();
@@ -8419,10 +8407,10 @@ void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
 				origin = mesh::VecToNifCoords(origin);
 			}
 
-			UndoStateProject* usp = glView->GetUndoHistory()->PushState();
+			UndoStateProject *usp = glView->GetUndoHistory()->PushState();
 			usp->undoType = UT_VERTPOS;
 
-			for (auto& sel : selectedItems) {
+			for (auto &sel : selectedItems) {
 				mask.clear();
 				mptr = nullptr;
 
@@ -8557,7 +8545,7 @@ void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
 
 		if (dlg.ShowModal() != wxID_OK) {
 			if (previewScale != Vector3(1.0f, 1.0f, 1.0f)) {
-				UndoStateProject* curState = glView->GetUndoHistory()->GetBackState();
+				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
 				if (curState) {
 					glView->ApplyUndoState(curState, true);
 					glView->GetUndoHistory()->PopState();
@@ -8588,7 +8576,7 @@ void OutfitStudioFrame::OnRotateShape(wxCommandEvent& WXUNUSED(event)) {
 			std::vector<Vector3> verts;
 
 			if (!previewRotation.IsZero()) {
-				UndoStateProject* curState = glView->GetUndoHistory()->GetBackState();
+				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
 				if (curState) {
 					glView->ApplyUndoState(curState, true, false);
 					glView->GetUndoHistory()->PopState();
@@ -8608,10 +8596,10 @@ void OutfitStudioFrame::OnRotateShape(wxCommandEvent& WXUNUSED(event)) {
 				origin = mesh::VecToNifCoords(origin);
 			}
 
-			UndoStateProject* usp = glView->GetUndoHistory()->PushState();
+			UndoStateProject *usp = glView->GetUndoHistory()->PushState();
 			usp->undoType = UT_VERTPOS;
 
-			for (auto& sel : selectedItems) {
+			for (auto &sel : selectedItems) {
 				mask.clear();
 				mptr = nullptr;
 
@@ -8709,7 +8697,7 @@ void OutfitStudioFrame::OnRotateShape(wxCommandEvent& WXUNUSED(event)) {
 
 		if (dlg.ShowModal() != wxID_OK) {
 			if (!previewRotation.IsZero()) {
-				UndoStateProject* curState = glView->GetUndoHistory()->GetBackState();
+				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
 				if (curState) {
 					glView->ApplyUndoState(curState, true);
 					glView->GetUndoHistory()->PopState();
@@ -8733,10 +8721,10 @@ void OutfitStudioFrame::OnDeleteVerts(wxCommandEvent& WXUNUSED(event)) {
 	}
 
 	// Prepare the undo data and determine if any shapes are being deleted.
-	UndoStateProject* usp = glView->GetUndoHistory()->PushState();
+	UndoStateProject *usp = glView->GetUndoHistory()->PushState();
 	usp->undoType = UT_MESH;
-	std::vector<NiShape*> delShapes;
-	for (auto& i : selectedItems) {
+	std::vector<NiShape *> delShapes;
+	for (auto &i : selectedItems) {
 		if (editUV && editUV->shape == i->GetShape())
 			editUV->Close();
 
@@ -8754,13 +8742,13 @@ void OutfitStudioFrame::OnDeleteVerts(wxCommandEvent& WXUNUSED(event)) {
 	if (!delShapes.empty()) {
 		if (wxMessageBox(_("Are you sure you wish to delete parts of the selected shapes?"), _("Confirm Delete"), wxYES_NO) == wxNO)
 			return;
-		for (NiShape* shape : delShapes)
+		for (NiShape *shape : delShapes)
 			project->DeleteShape(shape);
 	}
 
 	// Now do the vertex deletion
-	for (auto& uss : usp->usss) {
-		NiShape* shape = project->GetWorkNif()->FindBlockByName<NiShape>(uss.shapeName);
+	for (auto &uss : usp->usss) {
+		NiShape *shape = project->GetWorkNif()->FindBlockByName<NiShape>(uss.shapeName);
 		if (!shape)
 			continue;
 		project->ApplyShapeMeshUndo(shape, uss, false);
@@ -8798,15 +8786,14 @@ void OutfitStudioFrame::OnSeparateVerts(wxCommandEvent& WXUNUSED(event)) {
 			return;
 
 		newShapeName = std::move(result);
-	}
-	while (project->IsValidShape(newShapeName));
+	} while (project->IsValidShape(newShapeName));
 
 	if (editUV && editUV->shape == activeItem->GetShape())
 		editUV->Close();
 
 	auto newShape = project->DuplicateShape(activeItem->GetShape(), newShapeName);
 
-	UndoStateProject* usp = glView->GetUndoHistory()->PushState();
+	UndoStateProject *usp = glView->GetUndoHistory()->PushState();
 	usp->undoType = UT_MESH;
 	usp->usss.resize(2);
 	usp->usss[0].shapeName = activeItem->GetShape()->name.get();
@@ -8829,10 +8816,10 @@ void OutfitStudioFrame::OnSeparateVerts(wxCommandEvent& WXUNUSED(event)) {
 	ApplySliders();
 }
 
-void OutfitStudioFrame::CheckCopyGeo(wxDialog& dlg) {
-	wxStaticText* errors = XRCCTRL(dlg, "copyGeometryErrors", wxStaticText);
-	wxChoice* sourceChoice = XRCCTRL(dlg, "sourceChoice", wxChoice);
-	wxChoice* targetChoice = XRCCTRL(dlg, "targetChoice", wxChoice);
+void OutfitStudioFrame::CheckCopyGeo(wxDialog &dlg) {
+	wxStaticText *errors = XRCCTRL(dlg, "copyGeometryErrors", wxStaticText);
+	wxChoice *sourceChoice = XRCCTRL(dlg, "sourceChoice", wxChoice);
+	wxChoice *targetChoice = XRCCTRL(dlg, "targetChoice", wxChoice);
 
 	std::string source = sourceChoice->GetString(sourceChoice->GetSelection()).ToStdString();
 	std::string target = targetChoice->GetString(targetChoice->GetSelection()).ToStdString();
@@ -8880,8 +8867,8 @@ void OutfitStudioFrame::OnCopyGeo(wxCommandEvent& WXUNUSED(event)) {
 	if (!wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgCopyGeometry"))
 		return;
 
-	wxChoice* sourceChoice = XRCCTRL(dlg, "sourceChoice", wxChoice);
-	wxChoice* targetChoice = XRCCTRL(dlg, "targetChoice", wxChoice);
+	wxChoice *sourceChoice = XRCCTRL(dlg, "sourceChoice", wxChoice);
+	wxChoice *targetChoice = XRCCTRL(dlg, "targetChoice", wxChoice);
 	if (!sourceChoice || !targetChoice)
 		return;
 
@@ -8893,7 +8880,7 @@ void OutfitStudioFrame::OnCopyGeo(wxCommandEvent& WXUNUSED(event)) {
 	if (shapeList.size() < 2)
 		return;
 
-	for (const std::string& shape : shapeList) {
+	for (const std::string &shape : shapeList) {
 		sourceChoice->AppendString(shape);
 		targetChoice->AppendString(shape);
 		if (shape == sourceShapeName)
@@ -8921,14 +8908,14 @@ void OutfitStudioFrame::OnCopyGeo(wxCommandEvent& WXUNUSED(event)) {
 	sourceShapeName = sourceChoice->GetString(sourceChoice->GetSelection()).ToStdString();
 	std::string targetShapeName = targetChoice->GetString(targetChoice->GetSelection()).ToStdString();
 
-	NiShape* sourceShape = project->GetWorkNif()->FindBlockByName<NiShape>(sourceShapeName);
+	NiShape *sourceShape = project->GetWorkNif()->FindBlockByName<NiShape>(sourceShapeName);
 	if (!sourceShape)
 		return;
-	NiShape* targetShape = project->GetWorkNif()->FindBlockByName<NiShape>(targetShapeName);
+	NiShape *targetShape = project->GetWorkNif()->FindBlockByName<NiShape>(targetShapeName);
 	if (!targetShape)
 		return;
 
-	UndoStateProject* usp = glView->GetUndoHistory()->PushState();
+	UndoStateProject *usp = glView->GetUndoHistory()->PushState();
 	usp->undoType = UT_MESH;
 	usp->usss.resize(1);
 	usp->usss[0].shapeName = targetShapeName;
@@ -8960,8 +8947,7 @@ void OutfitStudioFrame::OnDupeShape(wxCommandEvent& WXUNUSED(event)) {
 				return;
 
 			newName = std::move(result);
-		}
-		while (project->IsValidShape(newName));
+		} while (project->IsValidShape(newName));
 
 		wxLogMessage("Duplicating shape '%s' as '%s'.", activeItem->GetShape()->name.get(), newName);
 		project->ClearBoneScale();
@@ -9003,13 +8989,13 @@ void OutfitStudioFrame::OnDeleteShape(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	std::vector<ShapeItemData> selected;
-	for (auto& i : selectedItems)
+	for (auto &i : selectedItems)
 		selected.push_back(*i);
 
 	activeItem = nullptr;
 	selectedItems.clear();
 
-	for (auto& i : selected) {
+	for (auto &i : selected) {
 		if (editUV && editUV->shape == i.GetShape())
 			editUV->Close();
 
@@ -9037,7 +9023,7 @@ void OutfitStudioFrame::OnAddBone(wxCommandEvent& WXUNUSED(event)) {
 	wxTreeCtrl* boneTree = XRCCTRL(dlg, "boneTree", wxTreeCtrl);
 
 	std::function<void(wxTreeItemId, AnimBone*)> fAddBoneChildren = [&](wxTreeItemId treeParent, AnimBone* boneParent) {
-		for (auto& cb : boneParent->children) {
+		for (auto &cb : boneParent->children) {
 			if (!cb->boneName.empty()) {
 				auto newItem = boneTree->AppendItem(treeParent, cb->boneName);
 				fAddBoneChildren(newItem, cb);
@@ -9074,18 +9060,18 @@ void OutfitStudioFrame::OnAddBone(wxCommandEvent& WXUNUSED(event)) {
 	}
 }
 
-void OutfitStudioFrame::FillParentBoneChoice(wxDialog& dlg, const std::string& selBone) {
-	wxChoice* cParentBone = XRCCTRL(dlg, "cParentBone", wxChoice);
+void OutfitStudioFrame::FillParentBoneChoice(wxDialog &dlg, const std::string &selBone) {
+	wxChoice *cParentBone = XRCCTRL(dlg, "cParentBone", wxChoice);
 	cParentBone->AppendString("(none)");
 
 	std::set<std::string> boneSet;
 	for (auto selItem : selectedItems) {
-		const std::vector<std::string>& bones = project->GetWorkAnim()->shapeBones[selItem->GetShape()->name.get()];
-		for (const std::string& b : bones)
+		const std::vector<std::string> &bones = project->GetWorkAnim()->shapeBones[selItem->GetShape()->name.get()];
+		for (const std::string &b : bones)
 			boneSet.insert(b);
 	}
 
-	for (auto& bone : boneSet) {
+	for (auto &bone : boneSet) {
 		cParentBone->AppendString(bone);
 		if (bone == selBone)
 			cParentBone->SetSelection(cParentBone->GetCount() - 1);
@@ -9102,7 +9088,7 @@ void OutfitStudioFrame::FillParentBoneChoice(wxDialog& dlg, const std::string& s
 	}
 }
 
-void OutfitStudioFrame::GetBoneDlgData(wxDialog& dlg, MatTransform& xform, std::string& parentBone) {
+void OutfitStudioFrame::GetBoneDlgData(wxDialog &dlg, MatTransform &xform, std::string &parentBone) {
 	xform.translation.x = atof(XRCCTRL(dlg, "textX", wxTextCtrl)->GetValue().c_str());
 	xform.translation.y = atof(XRCCTRL(dlg, "textY", wxTextCtrl)->GetValue().c_str());
 	xform.translation.z = atof(XRCCTRL(dlg, "textZ", wxTextCtrl)->GetValue().c_str());
@@ -9113,7 +9099,7 @@ void OutfitStudioFrame::GetBoneDlgData(wxDialog& dlg, MatTransform& xform, std::
 	rotvec.z = atof(XRCCTRL(dlg, "textRZ", wxTextCtrl)->GetValue().c_str());
 	xform.rotation = RotVecToMat(rotvec);
 
-	wxChoice* cParentBone = XRCCTRL(dlg, "cParentBone", wxChoice);
+	wxChoice *cParentBone = XRCCTRL(dlg, "cParentBone", wxChoice);
 	int pBChoice = cParentBone->GetSelection();
 	if (pBChoice != wxNOT_FOUND)
 		parentBone = cParentBone->GetString(pBChoice).ToStdString();
@@ -9167,7 +9153,7 @@ void OutfitStudioFrame::OnAddCustomBone(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnEditBone(wxCommandEvent& WXUNUSED(event)) {
-	AnimBone* bPtr = AnimSkeleton::getInstance().GetBonePtr(contextBone);
+	AnimBone *bPtr = AnimSkeleton::getInstance().GetBonePtr(contextBone);
 	if (!bPtr)
 		return;
 
@@ -9182,7 +9168,7 @@ void OutfitStudioFrame::OnEditBone(wxCommandEvent& WXUNUSED(event)) {
 	else
 		FillParentBoneChoice(dlg);
 
-	wxTextCtrl* boneNameTC = XRCCTRL(dlg, "boneName", wxTextCtrl);
+	wxTextCtrl *boneNameTC = XRCCTRL(dlg, "boneName", wxTextCtrl);
 	boneNameTC->SetValue(bPtr->boneName);
 	boneNameTC->Disable();
 
@@ -9252,7 +9238,7 @@ void OutfitStudioFrame::OnDeleteBoneFromSelected(wxCommandEvent& WXUNUSED(event)
 		std::string bone = outfitBones->GetItemText(selItems[i]);
 		wxLogMessage("Deleting weights of bone '%s' from selected shapes.", bone);
 
-		for (auto& s : selectedItems)
+		for (auto &s : selectedItems)
 			project->GetWorkAnim()->RemoveShapeBone(s->GetShape()->name.get(), bone);
 	}
 
@@ -9307,8 +9293,8 @@ bool OutfitStudioFrame::ShowWeightCopy(WeightCopyOptions& options, bool silent) 
 			XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Enable(!noTargetLimit);
 		});
 
-		wxCheckBox* cbCopySkinTrans = XRCCTRL(dlg, "cbCopySkinTrans", wxCheckBox);
-		wxCheckBox* cbTransformGeo = XRCCTRL(dlg, "cbTransformGeo", wxCheckBox);
+		wxCheckBox *cbCopySkinTrans = XRCCTRL(dlg, "cbCopySkinTrans", wxCheckBox);
+		wxCheckBox *cbTransformGeo = XRCCTRL(dlg, "cbTransformGeo", wxCheckBox);
 		if (options.showSkinTransOption) {
 			cbCopySkinTrans->SetValue(options.doSkinTransCopy);
 			cbTransformGeo->SetValue(options.doTransformGeo);
@@ -9320,7 +9306,7 @@ bool OutfitStudioFrame::ShowWeightCopy(WeightCopyOptions& options, bool silent) 
 		dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
 
 		dlg.SetSize(dlg.GetBestSize());
-
+		
 		if (silent || dlg.ShowModal() == wxID_OK) {
 			options.proximityRadius = atof(XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->GetValue().c_str());
 
@@ -9351,26 +9337,26 @@ void OutfitStudioFrame::ReselectBone() {
 	}
 }
 
-void OutfitStudioFrame::CalcCopySkinTransOption(WeightCopyOptions& options) {
+void OutfitStudioFrame::CalcCopySkinTransOption(WeightCopyOptions &options) {
 	// This function calculates whether the "copy global-to-skin transform
 	// from base shape" checkbox should be shown and what the default value
 	// for the "transform-geometry" checkbox should be
 
-	NifFile* nif = project->GetWorkNif();
-	NiShape* baseShape = project->GetBaseShape();
+	NifFile *nif = project->GetWorkNif();
+	NiShape *baseShape = project->GetBaseShape();
 	if (!baseShape)
 		return;
 
-	AnimInfo& workAnim = *project->GetWorkAnim();
+	AnimInfo &workAnim = *project->GetWorkAnim();
 
 	if (!workAnim.HasSkinnedShape(baseShape))
 		return;
 
-	const MatTransform& baseXformGlobalToSkin = workAnim.shapeSkinning[baseShape->name.get()].xformGlobalToSkin;
+	const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[baseShape->name.get()].xformGlobalToSkin;
 
 	// Check if any shape's skin CS is different from the base shape's
 	for (size_t i = 0; i < selectedItems.size(); i++) {
-		NiShape* shape = selectedItems[i]->GetShape();
+		NiShape *shape = selectedItems[i]->GetShape();
 		if (shape == baseShape)
 			continue;
 
@@ -9393,7 +9379,7 @@ void OutfitStudioFrame::CalcCopySkinTransOption(WeightCopyOptions& options) {
 	// find the average vertex position of the base shape in its own skin coordinates
 	Vector3 baseAvg;
 
-	const std::vector<Vector3>& baseVerts = *nif->GetVertsForShape(baseShape);
+	const std::vector<Vector3> &baseVerts = *nif->GetVertsForShape(baseShape);
 	for (size_t i = 0; i < baseVerts.size(); ++i)
 		baseAvg += baseVerts[i];
 
@@ -9402,15 +9388,15 @@ void OutfitStudioFrame::CalcCopySkinTransOption(WeightCopyOptions& options) {
 
 	// Now check if any shape would be better aligned by changing its global-to-skin transform
 	for (size_t i = 0; i < selectedItems.size(); i++) {
-		NiShape* shape = selectedItems[i]->GetShape();
+		NiShape *shape = selectedItems[i]->GetShape();
 		if (shape == baseShape)
 			continue;
 
-		const MatTransform& globalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
+		const MatTransform &globalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
 		if (globalToSkin.IsNearlyEqualTo(baseXformGlobalToSkin))
 			continue;
 
-		const std::vector<Vector3>& verts = *nif->GetVertsForShape(shape);
+		const std::vector<Vector3> &verts = *nif->GetVertsForShape(shape);
 		if (verts.empty())
 			continue;
 
@@ -9449,25 +9435,25 @@ void OutfitStudioFrame::OnCopyBoneWeight(wxCommandEvent& WXUNUSED(event)) {
 
 	WeightCopyOptions options;
 	CalcCopySkinTransOption(options);
-	AnimInfo& workAnim = *project->GetWorkAnim();
+	AnimInfo &workAnim = *project->GetWorkAnim();
 
 	if (ShowWeightCopy(options)) {
 		StartProgress(_("Copying bone weights..."));
 
-		UndoStateProject* usp = glView->GetUndoHistory()->PushState();
+		UndoStateProject *usp = glView->GetUndoHistory()->PushState();
 		usp->undoType = UT_WEIGHT;
 
 		std::vector<std::string> baseBones = workAnim.shapeBones[project->GetBaseShape()->name.get()];
 		std::sort(baseBones.begin(), baseBones.end());
 		std::unordered_map<uint16_t, float> mask;
 		for (size_t i = 0; i < selectedItems.size(); i++) {
-			NiShape* shape = selectedItems[i]->GetShape();
+			NiShape *shape = selectedItems[i]->GetShape();
 			if (!project->IsBaseShape(shape)) {
 				wxLogMessage("Copying bone weights to '%s'...", shape->name.get());
 
 				if (options.doSkinTransCopy) {
-					const MatTransform& baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->name.get()].xformGlobalToSkin;
-					const MatTransform& oldXformGlobalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
+					const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->name.get()].xformGlobalToSkin;
+					const MatTransform &oldXformGlobalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
 
 					if (options.doTransformGeo && !baseXformGlobalToSkin.IsNearlyEqualTo(oldXformGlobalToSkin))
 						project->ApplyTransformToShapeGeometry(shape, baseXformGlobalToSkin.ComposeTransforms(oldXformGlobalToSkin.InverseTransform()));
@@ -9613,47 +9599,47 @@ void OutfitStudioFrame::OnCopySelectedWeight(wxCommandEvent& WXUNUSED(event)) {
 	if (nSelBones < 1)
 		return;
 
-	std::unordered_set<std::string> selBones{boneList.begin(), boneList.end()};
+	std::unordered_set<std::string> selBones{ boneList.begin(), boneList.end() };
 
 	std::string bonesString;
-	for (std::string& boneName : boneList)
+	for (std::string &boneName : boneList)
 		bonesString += "'" + boneName + "' ";
 
 	std::vector<std::string> normBones, notNormBones, lockedBones;
 	GetNormalizeBones(&normBones, &notNormBones);
-	for (auto& bone : normBones)
+	for (auto &bone : normBones)
 		if (!selBones.count(bone))
 			boneList.push_back(bone);
 
 	bool bHasNormBones = static_cast<int>(boneList.size()) > nSelBones;
 	if (bHasNormBones) {
-		for (auto& bone : notNormBones)
+		for (auto &bone : notNormBones)
 			if (!selBones.count(bone))
 				lockedBones.push_back(bone);
 	}
 	else {
-		for (auto& bone : notNormBones)
+		for (auto &bone : notNormBones)
 			if (!selBones.count(bone))
 				boneList.push_back(bone);
 	}
 
 	WeightCopyOptions options;
 	CalcCopySkinTransOption(options);
-	AnimInfo& workAnim = *project->GetWorkAnim();
+	AnimInfo &workAnim = *project->GetWorkAnim();
 
 	if (ShowWeightCopy(options)) {
 		StartProgress(_("Copying selected bone weights..."));
 
-		UndoStateProject* usp = glView->GetUndoHistory()->PushState();
+		UndoStateProject *usp = glView->GetUndoHistory()->PushState();
 		usp->undoType = UT_WEIGHT;
 		std::unordered_map<uint16_t, float> mask;
 		for (size_t i = 0; i < selectedItems.size(); i++) {
-			NiShape* shape = selectedItems[i]->GetShape();
+			NiShape *shape = selectedItems[i]->GetShape();
 			if (!project->IsBaseShape(shape)) {
 				wxLogMessage("Copying selected bone weights to '%s' for %s...", shape->name.get(), bonesString);
 				if (options.doSkinTransCopy) {
-					const MatTransform& baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->name.get()].xformGlobalToSkin;
-					const MatTransform& oldXformGlobalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
+					const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->name.get()].xformGlobalToSkin;
+					const MatTransform &oldXformGlobalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
 
 					if (options.doTransformGeo && !baseXformGlobalToSkin.IsNearlyEqualTo(oldXformGlobalToSkin))
 						project->ApplyTransformToShapeGeometry(shape, baseXformGlobalToSkin.ComposeTransforms(oldXformGlobalToSkin.InverseTransform()));
@@ -9719,7 +9705,7 @@ void OutfitStudioFrame::OnTransferSelectedWeight(wxCommandEvent& WXUNUSED(event)
 		return;
 
 	std::string bonesString;
-	for (std::string& boneName : selectedBones)
+	for (std::string &boneName : selectedBones)
 		bonesString += "'" + boneName + "' ";
 
 	wxLogMessage("Transferring selected bone weights to '%s' for %s...", activeItem->GetShape()->name.get(), bonesString);
@@ -9743,7 +9729,7 @@ void OutfitStudioFrame::OnMaskWeighted(wxCommandEvent& WXUNUSED(event)) {
 		return;
 	}
 
-	for (auto& i : selectedItems) {
+	for (auto &i : selectedItems) {
 		std::string shapeName = i->GetShape()->name.get();
 		mesh* m = glView->GetMesh(shapeName);
 		if (!m)
@@ -9753,10 +9739,10 @@ void OutfitStudioFrame::OnMaskWeighted(wxCommandEvent& WXUNUSED(event)) {
 
 		auto& bones = project->GetWorkAnim()->shapeBones;
 		if (bones.find(shapeName) != bones.end()) {
-			for (auto& b : bones[shapeName]) {
+			for (auto &b : bones[shapeName]) {
 				auto weights = project->GetWorkAnim()->GetWeightsPtr(shapeName, b);
 				if (weights) {
-					for (auto& bw : *weights)
+					for (auto &bw : *weights)
 						if (bw.second > 0.0f)
 							m->vcolors[bw.first].x = 1.0f;
 				}
@@ -9773,7 +9759,7 @@ void OutfitStudioFrame::OnMaskBoneWeighted(wxCommandEvent& WXUNUSED(event)) {
 		return;
 	}
 
-	for (auto& i : selectedItems) {
+	for (auto &i : selectedItems) {
 		std::string shapeName = i->GetShape()->name.get();
 		mesh* m = glView->GetMesh(shapeName);
 		if (!m || !m->vcolors)
@@ -9781,10 +9767,10 @@ void OutfitStudioFrame::OnMaskBoneWeighted(wxCommandEvent& WXUNUSED(event)) {
 
 		m->ColorChannelFill(0, 0.0f);
 
-		for (auto& b : GetSelectedBones()) {
+		for (auto &b : GetSelectedBones()) {
 			auto weights = project->GetWorkAnim()->GetWeightsPtr(shapeName, b);
 			if (weights) {
-				for (auto& bw : *weights)
+				for (auto &bw : *weights)
 					if (bw.second > 0.0f)
 						m->vcolors[bw.first].x = 1.0f;
 			}
@@ -9874,13 +9860,13 @@ void OutfitStudioFrame::OnNPWizChangeSliderSetFile(wxFileDirPickerEvent& event) 
 		std::vector<std::string> setNames;
 		ssf.GetSetNames(setNames);
 
-		for (auto& sn : setNames)
+		for (auto &sn : setNames)
 			setNameChoice->AppendString(sn);
 
 		if (!setNames.empty()) {
 			setNameChoice->SetSelection(0);
 			ssf.SetShapes(setNames.front(), shapes);
-			for (auto& rsn : shapes)
+			for (auto &rsn : shapes)
 				refShapeChoice->AppendString(rsn);
 
 			refShapeChoice->SetSelection(0);
@@ -9894,7 +9880,7 @@ void OutfitStudioFrame::OnNPWizChangeSliderSetFile(wxFileDirPickerEvent& event) 
 		if (checkFile.Load(file))
 			return;
 
-		for (auto& rsn : checkFile.GetShapeNames())
+		for (auto &rsn : checkFile.GetShapeNames())
 			refShapeChoice->AppendString(rsn);
 
 		refShapeChoice->SetSelection(0);
@@ -9918,7 +9904,7 @@ void OutfitStudioFrame::OnNPWizChangeSetNameChoice(wxCommandEvent& event) {
 	wxChoice* refShapeChoice = (wxChoice*)XRCCTRL((*npWiz), "npRefShapeName", wxChoice);
 	refShapeChoice->Clear();
 
-	for (auto& rsn : shapes)
+	for (auto &rsn : shapes)
 		refShapeChoice->AppendString(rsn);
 
 	refShapeChoice->SetSelection(0);
@@ -9935,7 +9921,7 @@ void OutfitStudioFrame::OnLoadOutfitFP_Texture(wxFileDirPickerEvent& event) {
 }
 
 void OutfitStudioFrame::OnRecalcNormals(wxCommandEvent& WXUNUSED(event)) {
-	for (auto& s : selectedItems)
+	for (auto &s : selectedItems)
 		glView->RecalcNormals(s->GetShape()->name.get());
 
 	glView->Render();
@@ -9945,7 +9931,7 @@ void OutfitStudioFrame::OnSmoothNormalSeams(wxCommandEvent& event) {
 	bool enable = event.IsChecked();
 	glView->SetNormalSeamSmoothMode(enable);
 
-	for (auto& s : selectedItems)
+	for (auto &s : selectedItems)
 		project->activeSet.SetSmoothSeamNormals(s->GetShape()->name.get(), enable);
 
 	glView->Render();
@@ -9955,7 +9941,7 @@ void OutfitStudioFrame::OnLockNormals(wxCommandEvent& event) {
 	bool enable = event.IsChecked();
 	glView->SetLockNormalsMode(enable);
 
-	for (auto& s : selectedItems)
+	for (auto &s : selectedItems)
 		project->activeSet.SetLockNormals(s->GetShape()->name.get(), enable);
 }
 
@@ -10003,7 +9989,7 @@ void OutfitStudioFrame::OnSaveMask(wxCommandEvent& WXUNUSED(event)) {
 		auto maskData = new std::map<std::string, std::unordered_map<uint16_t, float>>();
 
 		std::vector<std::string> shapes = GetShapeList();
-		for (auto& s : shapes) {
+		for (auto &s : shapes) {
 			std::unordered_map<uint16_t, float> mask;
 			glView->GetShapeMask(mask, s);
 			(*maskData)[s] = std::move(mask);
@@ -10026,13 +10012,12 @@ void OutfitStudioFrame::OnSaveAsMask(wxCommandEvent& WXUNUSED(event)) {
 		if (maskName.empty())
 			return;
 
-	}
-	while (cMaskName->FindString(maskName) != wxNOT_FOUND);
+	} while (cMaskName->FindString(maskName) != wxNOT_FOUND);
 
 	auto maskData = new std::map<std::string, std::unordered_map<uint16_t, float>>();
 
 	std::vector<std::string> shapes = GetShapeList();
-	for (auto& s : shapes) {
+	for (auto &s : shapes) {
 		std::unordered_map<uint16_t, float> mask;
 		glView->GetShapeMask(mask, s);
 		(*maskData)[s] = std::move(mask);
@@ -10057,7 +10042,7 @@ void OutfitStudioFrame::OnPaneCollapse(wxCollapsiblePaneEvent& WXUNUSED(event)) 
 }
 
 void OutfitStudioFrame::ApplyPose() {
-	for (auto& shape : project->GetWorkNif()->GetShapes()) {
+	for (auto &shape : project->GetWorkNif()->GetShapes()) {
 		std::vector<Vector3> verts;
 		project->GetLiveVerts(shape, verts);
 		glView->UpdateMeshVertices(shape->name.get(), &verts, true, true, false);
@@ -10070,7 +10055,7 @@ void OutfitStudioFrame::ApplyPose() {
 	glView->Render();
 }
 
-AnimBone* OutfitStudioFrame::GetPoseBonePtr() {
+AnimBone *OutfitStudioFrame::GetPoseBonePtr() {
 	int selind = cPoseBone->GetSelection();
 	if (selind == wxNOT_FOUND) return nullptr;
 	std::string poseBone = cPoseBone->GetString(selind).ToStdString();
@@ -10078,7 +10063,7 @@ AnimBone* OutfitStudioFrame::GetPoseBonePtr() {
 }
 
 void OutfitStudioFrame::PoseToGUI() {
-	AnimBone* bone = GetPoseBonePtr();
+	AnimBone *bone = GetPoseBonePtr();
 	if (bone) {
 		rxPoseSlider->SetValue(bone->poseRotVec.x * 100);
 		ryPoseSlider->SetValue(bone->poseRotVec.y * 100);
@@ -10117,17 +10102,17 @@ void OutfitStudioFrame::OnPoseBoneChanged(wxCommandEvent& WXUNUSED(event)) {
 
 void OutfitStudioFrame::OnPoseValChanged(int cind, float val) {
 	// Called when any pose slider or text control is changed.
-	AnimBone* bone = GetPoseBonePtr();
+	AnimBone *bone = GetPoseBonePtr();
 	if (!bone) return;
 	if (cind < 3)
 		bone->poseRotVec[cind] = val;
 	else
-		bone->poseTranVec[cind - 3] = val;
+		bone->poseTranVec[cind-3] = val;
 	bone->UpdatePoseTransform();
 	ApplyPose();
 }
 
-void OutfitStudioFrame::OnAnyPoseSlider(wxScrollEvent& e, wxTextCtrl* t, int cind) {
+void OutfitStudioFrame::OnAnyPoseSlider(wxScrollEvent &e, wxTextCtrl *t, int cind) {
 	float val = e.GetPosition() * 0.01f;
 	t->ChangeValue(wxString() << val);
 	OnPoseValChanged(cind, val);
@@ -10136,65 +10121,55 @@ void OutfitStudioFrame::OnAnyPoseSlider(wxScrollEvent& e, wxTextCtrl* t, int cin
 void OutfitStudioFrame::OnRXPoseSlider(wxScrollEvent& e) {
 	OnAnyPoseSlider(e, rxPoseText, 0);
 }
-
 void OutfitStudioFrame::OnRYPoseSlider(wxScrollEvent& e) {
 	OnAnyPoseSlider(e, ryPoseText, 1);
 }
-
 void OutfitStudioFrame::OnRZPoseSlider(wxScrollEvent& e) {
 	OnAnyPoseSlider(e, rzPoseText, 2);
 }
-
 void OutfitStudioFrame::OnTXPoseSlider(wxScrollEvent& e) {
 	OnAnyPoseSlider(e, txPoseText, 3);
 }
-
 void OutfitStudioFrame::OnTYPoseSlider(wxScrollEvent& e) {
 	OnAnyPoseSlider(e, tyPoseText, 4);
 }
-
 void OutfitStudioFrame::OnTZPoseSlider(wxScrollEvent& e) {
 	OnAnyPoseSlider(e, tzPoseText, 5);
 }
 
-void OutfitStudioFrame::OnAnyPoseTextChanged(wxTextCtrl* t, wxSlider* s, int cind) {
+void OutfitStudioFrame::OnAnyPoseTextChanged(wxTextCtrl *t, wxSlider *s, int cind) {
 	if (!t || !s) return;
 	double val;
 	if (!t->GetValue().ToDouble(&val))
 		return;
-	s->SetValue(val * 100);
+	s->SetValue(val*100);
 	OnPoseValChanged(cind, val);
 }
 
 void OutfitStudioFrame::OnRXPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
 	OnAnyPoseTextChanged(rxPoseText, rxPoseSlider, 0);
 }
-
 void OutfitStudioFrame::OnRYPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
 	OnAnyPoseTextChanged(ryPoseText, ryPoseSlider, 1);
 }
-
 void OutfitStudioFrame::OnRZPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
 	OnAnyPoseTextChanged(rzPoseText, rzPoseSlider, 2);
 }
-
 void OutfitStudioFrame::OnTXPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
 	OnAnyPoseTextChanged(txPoseText, txPoseSlider, 3);
 }
-
 void OutfitStudioFrame::OnTYPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
 	OnAnyPoseTextChanged(tyPoseText, tyPoseSlider, 4);
 }
-
 void OutfitStudioFrame::OnTZPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
 	OnAnyPoseTextChanged(tzPoseText, tzPoseSlider, 5);
 }
 
 void OutfitStudioFrame::OnResetBonePose(wxCommandEvent& WXUNUSED(event)) {
-	AnimBone* bone = GetPoseBonePtr();
+	AnimBone *bone = GetPoseBonePtr();
 	if (!bone) return;
-	bone->poseRotVec = Vector3(0, 0, 0);
-	bone->poseTranVec = Vector3(0, 0, 0);
+	bone->poseRotVec = Vector3(0,0,0);
+	bone->poseTranVec = Vector3(0,0,0);
 	bone->UpdatePoseTransform();
 	PoseToGUI();
 	ApplyPose();
@@ -10209,8 +10184,8 @@ void OutfitStudioFrame::OnResetAllPose(wxCommandEvent& WXUNUSED(event)) {
 	std::vector<std::string> bones;
 	project->GetActiveBones(bones);
 
-	for (const std::string& boneName : bones) {
-		AnimBone* bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
+	for (const std::string &boneName : bones) {
+		AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
 		if (!bone)
 			continue;
 
@@ -10233,7 +10208,7 @@ void OutfitStudioFrame::OnPoseToMesh(wxCommandEvent& WXUNUSED(event)) {
 		if (dlg.ShowModal() != wxID_OK)
 			return;
 
-		for (auto& s : project->GetWorkNif()->GetShapes()) {
+		for (auto &s : project->GetWorkNif()->GetShapes()) {
 			UpdateShapeSource(s);
 			project->RefreshMorphShape(s);
 		}
@@ -10244,8 +10219,8 @@ void OutfitStudioFrame::OnPoseToMesh(wxCommandEvent& WXUNUSED(event)) {
 		std::vector<std::string> bones;
 		project->GetActiveBones(bones);
 
-		for (const std::string& boneName : bones) {
-			AnimBone* bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
+		for (const std::string &boneName : bones) {
+			AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
 			if (!bone)
 				continue;
 
@@ -10281,8 +10256,8 @@ void OutfitStudioFrame::OnSelectPose(wxCommandEvent& WXUNUSED(event)) {
 		std::vector<std::string> bones;
 		project->GetActiveBones(bones);
 
-		for (const auto& boneName : bones) {
-			AnimBone* bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
+		for (const auto &boneName : bones) {
+			AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
 			if (!bone)
 				continue;
 
@@ -10314,8 +10289,8 @@ void OutfitStudioFrame::OnSavePose(wxCommandEvent& WXUNUSED(event)) {
 		std::vector<std::string> bones;
 		project->GetActiveBones(bones);
 
-		for (const auto& boneName : bones) {
-			AnimBone* bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
+		for (const auto &boneName : bones) {
+			AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
 			if (!bone)
 				continue;
 
@@ -10360,16 +10335,15 @@ void OutfitStudioFrame::OnSaveAsPose(wxCommandEvent& WXUNUSED(event)) {
 		if (poseName.empty())
 			return;
 
-	}
-	while (cPoseName->FindString(poseName) != wxNOT_FOUND);
+	} while (cPoseName->FindString(poseName) != wxNOT_FOUND);
 
 	auto poseData = new PoseData(poseName.ToUTF8().data());
 
 	std::vector<std::string> bones;
 	project->GetActiveBones(bones);
 
-	for (const auto& boneName : bones) {
-		AnimBone* bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
+	for (const auto &boneName : bones) {
+		AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
 		if (!bone)
 			continue;
 
@@ -10547,7 +10521,7 @@ void wxGLPanel::SetMeshTextures(const std::string& shapeName, const std::vector<
 	mesh* m = gls.GetMesh(shapeName);
 	if (!m)
 		return;
-
+	
 	std::string vShader = Config["AppDir"] + "/res/shaders/default.vert";
 	std::string fShader = Config["AppDir"] + "/res/shaders/default.frag";
 
@@ -10564,7 +10538,7 @@ void wxGLPanel::SetMeshTextures(const std::string& shapeName, const std::vector<
 	GLMaterial* mat = gls.AddMaterial(textureFiles, vShader, fShader, reloadTextures);
 	if (mat) {
 		m->material = mat;
-
+		
 		if (hasMatFile)
 			m->UpdateFromMaterialFile(matFile);
 
@@ -10686,7 +10660,7 @@ void wxGLPanel::OnKeys(wxKeyEvent& event) {
 					uss.pointEndState[vertIndex] = newPos;
 
 					// Push changes onto undo stack and execute
-					UndoStateProject* usp = GetUndoHistory()->PushState();
+					UndoStateProject *usp = GetUndoHistory()->PushState();
 					usp->undoType = UT_VERTPOS;
 					usp->usss.push_back(std::move(uss));
 
@@ -10813,7 +10787,7 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 			brushBones.push_back(xMirrorBone);
 
 		bool bHasNormBones = false;
-		for (auto& bone : normBones) {
+		for (auto &bone : normBones) {
 			if (bone != activeBone && bone != xMirrorBone) {
 				brushBones.push_back(bone);
 				bHasNormBones = true;
@@ -10821,12 +10795,12 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 		}
 
 		if (bHasNormBones) {
-			for (auto& bone : notNormBones)
+			for (auto &bone : notNormBones)
 				if (bone != activeBone && bone != xMirrorBone)
 					lockedBones.push_back(bone);
 		}
 		else {
-			for (auto& bone : notNormBones)
+			for (auto &bone : notNormBones)
 				if (bone != activeBone && bone != xMirrorBone)
 					brushBones.push_back(bone);
 		}
@@ -10908,7 +10882,7 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 	activeBrush->setRadius(brushSize);
 
 	if (activeBrush->Type() == TBT_WEIGHT) {
-		for (auto& sel : os->GetSelectedItems()) {
+		for (auto &sel : os->GetSelectedItems()) {
 			os->project->GetWorkNif()->CreateSkinning(sel->GetShape());
 
 			int boneIndex = os->project->GetWorkAnim()->GetShapeBoneIndex(sel->GetShape()->name.get(), os->GetActiveBone());
@@ -10944,7 +10918,7 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 			if (shape)
 				workNif->GetVertsForShape(shape, basePosition);
 
-			for (auto& p : basePosition)
+			for (auto &p : basePosition)
 				p = mesh::VecToMeshCoords(p);
 
 			positionData[i] = std::move(basePosition);
@@ -10964,8 +10938,8 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 void wxGLPanel::UpdateBrushStroke(const wxPoint& screenPos) {
 	Vector3 o;
 	Vector3 n;
-	Vector3 d; // Mirror pick ray direction.
-	Vector3 s; // Mirror pick ray origin.
+	Vector3 d;	// Mirror pick ray direction.
+	Vector3 s;	// Mirror pick ray origin.
 
 	TweakPickInfo tpi;
 
@@ -11041,7 +11015,7 @@ void wxGLPanel::EndBrushStroke() {
 			}
 
 			if (!os->bEditSlider && brushType != TBT_WEIGHT && brushType != TBT_COLOR && brushType != TBT_ALPHA) {
-				for (auto& s : os->project->GetWorkNif()->GetShapes()) {
+				for (auto &s : os->project->GetWorkNif()->GetShapes()) {
 					os->UpdateShapeSource(s);
 					os->project->RefreshMorphShape(s);
 				}
@@ -11192,7 +11166,7 @@ void wxGLPanel::EndTransform() {
 
 	os->ActiveShapesUpdated(undoHistory.GetCurState());
 	if (!os->bEditSlider) {
-		for (auto& s : os->project->GetWorkNif()->GetShapes()) {
+		for (auto &s : os->project->GetWorkNif()->GetShapes()) {
 			os->UpdateShapeSource(s);
 			os->project->RefreshMorphShape(s);
 		}
@@ -11232,7 +11206,7 @@ bool wxGLPanel::StartPivotPosition(const wxPoint& screenPos) {
 	else
 		return false;
 
-	std::vector<mesh*> strokeMeshes{hitMesh};
+	std::vector<mesh*> strokeMeshes{ hitMesh };
 	activeStroke = std::make_unique<TweakStroke>(strokeMeshes, &translateBrush, *undoHistory.PushState());
 	activeStroke->beginStroke(tpi);
 
@@ -11260,7 +11234,7 @@ void wxGLPanel::EndPivotPosition() {
 
 	std::vector<mesh*> refMeshes = activeStroke->GetRefMeshes();
 	if (refMeshes.size() > 0) {
-		UndoStateShape& uss = activeStroke->usp.usss[0];
+		UndoStateShape &uss = activeStroke->usp.usss[0];
 		if (uss.pointStartState.size() > 0 && uss.pointEndState.size() > 0) {
 			Vector3& pivotStartStatePos = uss.pointStartState[0];
 			Vector3& pivotEndStatePos = uss.pointEndState[0];
@@ -11326,7 +11300,7 @@ void wxGLPanel::EndPickVertex() {
 }
 
 void wxGLPanel::ClickCollapseVertex() {
-	mesh* m = GetMesh(mouseDownMeshName);
+	mesh *m = GetMesh(mouseDownMeshName);
 	if (!m || mouseDownPoint < 0)
 		return;
 
@@ -11334,7 +11308,7 @@ void wxGLPanel::ClickCollapseVertex() {
 	if (!workNif)
 		return;
 
-	NiShape* shape = workNif->FindBlockByName<NiShape>(mouseDownMeshName);
+	NiShape *shape = workNif->FindBlockByName<NiShape>(mouseDownMeshName);
 	if (!shape)
 		return;
 
@@ -11356,7 +11330,7 @@ void wxGLPanel::ClickCollapseVertex() {
 	}
 
 	// Push changes onto undo stack and execute.
-	UndoStateProject* usp = GetUndoHistory()->PushState();
+	UndoStateProject *usp = GetUndoHistory()->PushState();
 	usp->undoType = UT_MESH;
 	usp->usss.push_back(std::move(uss));
 	ApplyUndoState(usp, false);
@@ -11399,7 +11373,7 @@ void wxGLPanel::ClickFlipEdge() {
 	if (mouseDownMeshName.empty() || mouseDownEdge.p1 < 0 || mouseDownEdge.p1 == mouseDownEdge.p2)
 		return;
 
-	NiShape* shape = os->project->GetWorkNif()->FindBlockByName<NiShape>(mouseDownMeshName);
+	NiShape *shape = os->project->GetWorkNif()->FindBlockByName<NiShape>(mouseDownMeshName);
 	if (!shape)
 		return;
 
@@ -11412,7 +11386,7 @@ void wxGLPanel::ClickFlipEdge() {
 	}
 
 	// Push changes onto undo stack and execute.
-	UndoStateProject* usp = GetUndoHistory()->PushState();
+	UndoStateProject *usp = GetUndoHistory()->PushState();
 	usp->undoType = UT_MESH;
 	usp->usss.push_back(std::move(uss));
 	ApplyUndoState(usp, false);
@@ -11424,7 +11398,7 @@ void wxGLPanel::ClickSplitEdge() {
 	if (mouseDownMeshName.empty() || mouseDownEdge.p1 < 0 || mouseDownEdge.p1 == mouseDownEdge.p2)
 		return;
 
-	mesh* m = GetMesh(mouseDownMeshName);
+	mesh *m = GetMesh(mouseDownMeshName);
 	if (!m)
 		return;
 
@@ -11432,7 +11406,7 @@ void wxGLPanel::ClickSplitEdge() {
 	if (!workNif)
 		return;
 
-	NiShape* shape = workNif->FindBlockByName<NiShape>(mouseDownMeshName);
+	NiShape *shape = workNif->FindBlockByName<NiShape>(mouseDownMeshName);
 	if (!shape)
 		return;
 
@@ -11475,7 +11449,7 @@ void wxGLPanel::ClickSplitEdge() {
 	}
 
 	// Push changes onto undo stack and execute.
-	UndoStateProject* usp = GetUndoHistory()->PushState();
+	UndoStateProject *usp = GetUndoHistory()->PushState();
 	usp->undoType = UT_MESH;
 	usp->usss.push_back(std::move(uss));
 	ApplyUndoState(usp, false);
@@ -11483,10 +11457,10 @@ void wxGLPanel::ClickSplitEdge() {
 	os->UpdateUndoTools();
 }
 
-bool wxGLPanel::RestoreMode(UndoStateProject* usp) {
+bool wxGLPanel::RestoreMode(UndoStateProject *usp) {
 	bool modeChanged = false;
 	int undoType = usp->undoType;
-	if (undoType == UT_VERTPOS && os->activeSlider != usp->sliderName) {
+	if (undoType == UT_VERTPOS  && os->activeSlider != usp->sliderName) {
 		os->EnterSliderEdit(usp->sliderName);
 		modeChanged = true;
 	}
@@ -11506,19 +11480,19 @@ bool wxGLPanel::RestoreMode(UndoStateProject* usp) {
 	return modeChanged;
 }
 
-void wxGLPanel::ApplyUndoState(UndoStateProject* usp, bool bUndo, bool bRender) {
+void wxGLPanel::ApplyUndoState(UndoStateProject *usp, bool bUndo, bool bRender) {
 	int undoType = usp->undoType;
 	if (undoType == UT_WEIGHT) {
-		for (auto& uss : usp->usss) {
-			mesh* m = GetMesh(uss.shapeName);
+		for (auto &uss : usp->usss) {
+			mesh *m = GetMesh(uss.shapeName);
 			if (!m)
 				continue;
 
-			for (auto& bw : uss.boneWeights) {
+			for (auto &bw : uss.boneWeights) {
 				if (bw.boneName != os->GetActiveBone())
 					continue;
 
-				for (auto& wIt : bw.weights)
+				for (auto &wIt : bw.weights)
 					m->vcolors[wIt.first].y = bUndo ? wIt.second.startVal : wIt.second.endVal;
 			}
 
@@ -11535,12 +11509,12 @@ void wxGLPanel::ApplyUndoState(UndoStateProject* usp, bool bUndo, bool bRender) 
 		}
 	}
 	else if (undoType == UT_MASK || undoType == UT_COLOR) {
-		for (auto& uss : usp->usss) {
-			mesh* m = GetMesh(uss.shapeName);
+		for (auto &uss : usp->usss) {
+			mesh *m = GetMesh(uss.shapeName);
 			if (!m)
 				continue;
 
-			for (auto& pit : (bUndo ? uss.pointStartState : uss.pointEndState))
+			for (auto &pit : (bUndo ? uss.pointStartState : uss.pointEndState))
 				m->vcolors[pit.first] = pit.second;
 
 			m->QueueUpdate(mesh::UpdateType::VertexColors);
@@ -11550,12 +11524,12 @@ void wxGLPanel::ApplyUndoState(UndoStateProject* usp, bool bUndo, bool bRender) 
 			os->ActiveShapesUpdated(usp, bUndo);
 	}
 	else if (undoType == UT_ALPHA) {
-		for (auto& uss : usp->usss) {
-			mesh* m = GetMesh(uss.shapeName);
+		for (auto &uss : usp->usss) {
+			mesh *m = GetMesh(uss.shapeName);
 			if (!m)
 				continue;
 
-			for (auto& pit : (bUndo ? uss.pointStartState : uss.pointEndState))
+			for (auto &pit : (bUndo ? uss.pointStartState : uss.pointEndState))
 				m->valpha[pit.first] = pit.second.x;
 
 			m->QueueUpdate(mesh::UpdateType::VertexAlpha);
@@ -11564,12 +11538,12 @@ void wxGLPanel::ApplyUndoState(UndoStateProject* usp, bool bUndo, bool bRender) 
 		os->ActiveShapesUpdated(usp, bUndo);
 	}
 	else if (undoType == UT_VERTPOS) {
-		for (auto& uss : usp->usss) {
-			mesh* m = GetMesh(uss.shapeName);
+		for (auto &uss : usp->usss) {
+			mesh *m = GetMesh(uss.shapeName);
 			if (!m)
 				continue;
 
-			for (auto& pit : (bUndo ? uss.pointStartState : uss.pointEndState))
+			for (auto &pit : (bUndo ? uss.pointStartState : uss.pointEndState))
 				m->verts[pit.first] = pit.second;
 
 			m->SmoothNormals();
@@ -11581,8 +11555,8 @@ void wxGLPanel::ApplyUndoState(UndoStateProject* usp, bool bUndo, bool bRender) 
 		os->ActiveShapesUpdated(usp, bUndo);
 
 		if (usp->sliderName.empty()) {
-			for (auto& uss : usp->usss) {
-				mesh* m = GetMesh(uss.shapeName);
+			for (auto &uss : usp->usss) {
+				mesh *m = GetMesh(uss.shapeName);
 				if (!m)
 					continue;
 
@@ -11593,8 +11567,8 @@ void wxGLPanel::ApplyUndoState(UndoStateProject* usp, bool bUndo, bool bRender) 
 		}
 	}
 	else if (undoType == UT_MESH) {
-		for (auto& uss : usp->usss) {
-			NiShape* shape = os->project->GetWorkNif()->FindBlockByName<NiShape>(uss.shapeName);
+		for (auto &uss : usp->usss) {
+			NiShape *shape = os->project->GetWorkNif()->FindBlockByName<NiShape>(uss.shapeName);
 			if (!shape)
 				continue;
 
@@ -11615,7 +11589,7 @@ void wxGLPanel::ApplyUndoState(UndoStateProject* usp, bool bUndo, bool bRender) 
 }
 
 bool wxGLPanel::UndoStroke() {
-	UndoStateProject* curState = undoHistory.GetCurState();
+	UndoStateProject *curState = undoHistory.GetCurState();
 	if (!curState)
 		return false;
 	if (RestoreMode(curState))
@@ -11629,7 +11603,7 @@ bool wxGLPanel::UndoStroke() {
 }
 
 bool wxGLPanel::RedoStroke() {
-	UndoStateProject* curState = undoHistory.GetNextState();
+	UndoStateProject *curState = undoHistory.GetNextState();
 	if (!curState)
 		return false;
 	if (RestoreMode(curState))
@@ -11834,20 +11808,20 @@ void wxGLPanel::UpdatePivot() {
 void wxGLPanel::ShowNodes(bool show) {
 	nodesMode = show;
 
-	for (auto& m : nodesPoints)
+	for (auto &m : nodesPoints)
 		m->bVisible = show;
 
-	for (auto& m : nodesLines)
+	for (auto &m : nodesLines)
 		m->bVisible = show;
 
 	gls.RenderOneFrame();
 }
 
 void wxGLPanel::UpdateNodes() {
-	for (auto& m : nodesPoints)
+	for (auto &m : nodesPoints)
 		gls.DeleteOverlay(m);
 
-	for (auto& m : nodesLines)
+	for (auto &m : nodesLines)
 		gls.DeleteOverlay(m);
 
 	nodesPoints.clear();
@@ -11886,7 +11860,7 @@ void wxGLPanel::UpdateNodes() {
 			}
 		}
 
-		for (auto& child : node->childRefs) {
+		for (auto &child : node->childRefs) {
 			auto childNode = workNif->GetHeader().GetBlock<NiNode>(child);
 			if (childNode)
 				addChildNodes(childNode, node, rootPosition, position);
@@ -11903,20 +11877,20 @@ void wxGLPanel::UpdateNodes() {
 void wxGLPanel::ShowBones(bool show) {
 	bonesMode = show;
 
-	for (auto& m : bonesPoints)
+	for (auto &m : bonesPoints)
 		m->bVisible = show;
 
-	for (auto& m : bonesLines)
+	for (auto &m : bonesLines)
 		m->bVisible = show;
 
 	gls.RenderOneFrame();
 }
 
 void wxGLPanel::UpdateBones() {
-	for (auto& m : bonesPoints)
+	for (auto &m : bonesPoints)
 		gls.DeleteOverlay(m);
 
-	for (auto& m : bonesLines)
+	for (auto &m : bonesLines)
 		gls.DeleteOverlay(m);
 
 	bonesPoints.clear();
@@ -11927,12 +11901,12 @@ void wxGLPanel::UpdateBones() {
 	std::function<bool(AnimBone*, const Vector3&)> addChildBones = [&](AnimBone* parent, const Vector3& rootPosition) {
 		bool anyBoneInSelection = false;
 
-		for (auto& cb : parent->children) {
+		for (auto &cb : parent->children) {
 			bool childBonesInSelection = addChildBones(cb, rootPosition);
 
 			if (!cb->boneName.empty()) {
 				bool boneInSelection = false;
-				for (auto& si : os->GetSelectedItems()) {
+				for (auto &si : os->GetSelectedItems()) {
 					if (workAnim->GetShapeBoneIndex(si->GetShape()->name.get(), cb->boneName) != -1) {
 						boneInSelection = true;
 						break;
@@ -11980,7 +11954,7 @@ void wxGLPanel::UpdateBones() {
 void wxGLPanel::UpdateNodeColors() {
 	std::string activeBone = os->GetActiveBone();
 
-	for (auto& m : nodesPoints) {
+	for (auto &m : nodesPoints) {
 		auto nodeName = m->shapeName.substr(2, m->shapeName.length() - 2);
 		if (nodeName == activeBone) {
 			m->color.x = 1.0f;
@@ -11996,7 +11970,7 @@ void wxGLPanel::UpdateNodeColors() {
 		}
 	}
 
-	for (auto& m : nodesLines) {
+	for (auto &m : nodesLines) {
 		auto nodeName = m->shapeName.substr(2, m->shapeName.length() - 2);
 		if (nodeName == activeBone) {
 			m->color.x = 0.7f;
@@ -12012,7 +11986,7 @@ void wxGLPanel::UpdateNodeColors() {
 		}
 	}
 
-	for (auto& m : bonesPoints) {
+	for (auto &m : bonesPoints) {
 		auto nodeName = m->shapeName.substr(3, m->shapeName.length() - 3);
 		if (nodeName == activeBone) {
 			m->color.x = 1.0f;
@@ -12028,7 +12002,7 @@ void wxGLPanel::UpdateNodeColors() {
 		}
 	}
 
-	for (auto& m : bonesLines) {
+	for (auto &m : bonesLines) {
 		auto nodeName = m->shapeName.substr(3, m->shapeName.length() - 3);
 		if (nodeName == activeBone) {
 			m->color.x = 0.7f;
@@ -12048,14 +12022,14 @@ void wxGLPanel::UpdateNodeColors() {
 void wxGLPanel::ShowFloor(bool show) {
 	floorMode = show;
 
-	for (auto& m : floorMeshes)
+	for (auto &m : floorMeshes)
 		m->bVisible = show;
 
 	gls.RenderOneFrame();
 }
 
 void wxGLPanel::UpdateFloor() {
-	for (auto& m : floorMeshes)
+	for (auto &m : floorMeshes)
 		gls.DeleteMesh(m);
 
 	floorMeshes.clear();
@@ -12144,7 +12118,7 @@ void wxGLPanel::UpdateFloor() {
 }
 
 void wxGLPanel::ShowVertexEdit(bool show) {
-	for (auto& m : gls.GetMeshes())
+	for (auto &m : gls.GetMeshes())
 		if (m)
 			m->bShowPoints = false;
 
@@ -12166,7 +12140,7 @@ void wxGLPanel::OnIdle(wxIdleEvent& WXUNUSED(event)) {
 		lbuttonDown || rbuttonDown || mbuttonDown)
 		return;
 
-	for (auto& m : BVHUpdateQueue)
+	for (auto &m : BVHUpdateQueue)
 		m->CreateBVH();
 
 	BVHUpdateQueue.clear();
@@ -12231,7 +12205,7 @@ void wxGLPanel::OnMouseWheel(wxMouseEvent& event) {
 			}
 		}
 	}
-	else if (wxGetKeyState(wxKeyCode('S'))) {
+	else if (wxGetKeyState(wxKeyCode('S')))  {
 		wxPoint p = event.GetPosition();
 
 		if (brushMode) {
@@ -12573,7 +12547,7 @@ bool DnDFile::OnDropFiles(wxCoord, wxCoord, const wxArrayString& fileNames) {
 		if (owner->activeItem && fileNames.GetCount() == 1)
 			mergeShape = owner->activeItem->GetShape();
 
-		for (auto& inputFile : fileNames) {
+		for (auto &inputFile : fileNames) {
 			wxString dataName = inputFile.AfterLast('/').AfterLast('\\');
 			dataName = dataName.BeforeLast('.');
 
@@ -12624,7 +12598,7 @@ bool DnDFile::OnDropFiles(wxCoord, wxCoord, const wxArrayString& fileNames) {
 bool DnDSliderFile::OnDropFiles(wxCoord, wxCoord, const wxArrayString& fileNames) {
 	if (owner) {
 		bool isMultiple = (fileNames.GetCount() > 1);
-		for (size_t i = 0; i < fileNames.GetCount(); i++) {
+		for (size_t i = 0; i < fileNames.GetCount(); i++)	{
 			wxString inputFile;
 			inputFile = fileNames.Item(i);
 
@@ -12681,7 +12655,7 @@ wxDragResult DnDSliderFile::OnDragOver(wxCoord x, wxCoord y, wxDragResult defRes
 		return lastResult;
 
 	if (owner) {
-		for (auto& child : owner->sliderDisplays) {
+		for (auto &child : owner->sliderDisplays) {
 			if (child.second->sliderPane->GetRect().Contains(x, y)) {
 				targetSlider = child.first;
 				lastResult = wxDragMove;

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -9447,7 +9447,7 @@ int OutfitStudioFrame::CopyBoneWeightForShapes(std::vector<NiShape*> shapes, boo
 
 		UpdateUndoTools();
 
-		UpdateProgress(90, _("Finished"));
+		UpdateProgress(100, _("Finished"));
 		EndProgress();
 	}
 

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -100,6 +100,7 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_MENU(XRCID("importNIF"), OutfitStudioFrame::OnImportNIF)
 	EVT_MENU(XRCID("exportNIF"), OutfitStudioFrame::OnExportNIF)
 	EVT_MENU(XRCID("exportNIFWithRef"), OutfitStudioFrame::OnExportNIFWithRef)
+	EVT_MENU(XRCID("bakeNifInPlace"), OutfitStudioFrame::OnBakeNifInPlace)
 	EVT_MENU(XRCID("exportShapeNIF"), OutfitStudioFrame::OnExportShapeNIF)
 
 	EVT_MENU(XRCID("importOBJ"), OutfitStudioFrame::OnImportOBJ)
@@ -4131,6 +4132,27 @@ void OutfitStudioFrame::OnExportNIFWithRef(wxCommandEvent& event) {
 	if (error) {
 		wxLogError("Failed to save NIF file '%s' with reference!", fileName);
 		wxMessageBox(wxString::Format(_("Failed to save NIF file '%s' with reference!"), fileName), _("Export Error"), wxICON_ERROR);
+	}
+}
+
+void OutfitStudioFrame::OnBakeNifInPlace(wxCommandEvent& event) {
+	if (!project->GetWorkNif()->IsValid())
+		return;
+
+	wxLogMessage("Baking nif with reference");
+	project->ClearBoneScale();
+
+	std::vector<mesh*> shapeMeshes;
+	for (auto &s : project->GetWorkNif()->GetShapeNames()) {
+		mesh* m = glView->GetMesh(s);
+		if (m)
+			shapeMeshes.push_back(m);
+	}
+
+	int error = project->BakeNifInPlace(shapeMeshes, project->GetBaseShape() != nullptr);
+	if (error) {
+		wxLogError("Failed to bake NIF");
+		wxMessageBox("Failed to bake NIF", _("Export Error"), wxICON_ERROR);
 	}
 }
 

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -83,7 +83,7 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_BUTTON(XRCID("savePose"), OutfitStudioFrame::OnSavePose)
 	EVT_BUTTON(XRCID("saveAsPose"), OutfitStudioFrame::OnSaveAsPose)
 	EVT_BUTTON(XRCID("deletePose"), OutfitStudioFrame::OnDeletePose)
-	
+
 	// The following line with "EVT_COMMAND_SCROLL(wxID_ANY" apparently
 	// suppresses all following lines with EVT_COMMAND_SCROLL.
 	EVT_COMMAND_SCROLL(wxID_ANY, OutfitStudioFrame::OnSlider)
@@ -118,7 +118,7 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 
 	EVT_MENU(XRCID("importPhysicsData"), OutfitStudioFrame::OnImportPhysicsData)
 	EVT_MENU(XRCID("exportPhysicsData"), OutfitStudioFrame::OnExportPhysicsData)
-	
+
 	EVT_MENU(XRCID("sliderLoadPreset"), OutfitStudioFrame::OnLoadPreset)
 	EVT_MENU(XRCID("sliderSavePreset"), OutfitStudioFrame::OnSavePreset)
 	EVT_MENU(XRCID("sliderConform"), OutfitStudioFrame::OnSliderConform)
@@ -143,11 +143,11 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_MENU(XRCID("sliderClear"), OutfitStudioFrame::OnClearSlider)
 	EVT_MENU(XRCID("sliderDelete"), OutfitStudioFrame::OnDeleteSlider)
 	EVT_MENU(XRCID("sliderProperties"), OutfitStudioFrame::OnSliderProperties)
-	
+
 	EVT_MENU(XRCID("btnXMirror"), OutfitStudioFrame::OnXMirror)
 	EVT_MENU(XRCID("btnConnected"), OutfitStudioFrame::OnConnectedOnly)
 	EVT_MENU(XRCID("btnBrushCollision"), OutfitStudioFrame::OnGlobalBrushCollision)
-	
+
 	EVT_MENU(XRCID("btnSelect"), OutfitStudioFrame::OnSelectTool)
 	EVT_MENU(XRCID("btnTransform"), OutfitStudioFrame::OnSelectTool)
 	EVT_MENU(XRCID("btnPivot"), OutfitStudioFrame::OnSelectTool)
@@ -176,7 +176,7 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_MENU(XRCID("btnShowNodes"), OutfitStudioFrame::OnShowNodes)
 	EVT_MENU(XRCID("btnShowBones"), OutfitStudioFrame::OnShowBones)
 	EVT_MENU(XRCID("btnShowFloor"), OutfitStudioFrame::OnShowFloor)
-	
+
 	EVT_MENU(XRCID("btnIncreaseSize"), OutfitStudioFrame::OnIncBrush)
 	EVT_MENU(XRCID("btnDecreaseSize"), OutfitStudioFrame::OnDecBrush)
 	EVT_MENU(XRCID("btnIncreaseStr"), OutfitStudioFrame::OnIncStr)
@@ -217,7 +217,7 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_MENU(XRCID("deleteBone"), OutfitStudioFrame::OnDeleteBone)
 	EVT_MENU(XRCID("deleteBoneSelected"), OutfitStudioFrame::OnDeleteBoneFromSelected)
 	EVT_MENU(XRCID("editBone"), OutfitStudioFrame::OnEditBone)
-	EVT_MENU(XRCID("copyBoneWeight"), OutfitStudioFrame::OnCopyBoneWeight)	
+	EVT_MENU(XRCID("copyBoneWeight"), OutfitStudioFrame::OnCopyBoneWeight)
 	EVT_MENU(XRCID("copySelectedWeight"), OutfitStudioFrame::OnCopySelectedWeight)
 	EVT_MENU(XRCID("transferSelectedWeight"), OutfitStudioFrame::OnTransferSelectedWeight)
 	EVT_MENU(XRCID("maskWeightedVerts"), OutfitStudioFrame::OnMaskWeighted)
@@ -266,7 +266,7 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_CHOICE(XRCID("partitionType"), OutfitStudioFrame::OnPartitionTypeChanged)
 	EVT_BUTTON(XRCID("partitionApply"), OutfitStudioFrame::OnPartitionApply)
 	EVT_BUTTON(XRCID("partitionReset"), OutfitStudioFrame::OnPartitionReset)
-	
+
 	EVT_BUTTON(XRCID("meshTabButton"), OutfitStudioFrame::OnTabButtonClick)
 	EVT_BUTTON(XRCID("boneTabButton"), OutfitStudioFrame::OnTabButtonClick)
 	EVT_BUTTON(XRCID("segmentTabButton"), OutfitStudioFrame::OnTabButtonClick)
@@ -300,7 +300,7 @@ wxIMPLEMENT_APP(OutfitStudio);
 ConfigurationManager Config;
 ConfigurationManager OutfitStudioConfig;
 
-const wxString TargetGames[] = { "Fallout3", "FalloutNewVegas", "Skyrim", "Fallout4", "SkyrimSpecialEdition", "Fallout4VR", "SkyrimVR", "Fallout 76", "Oblivion" };
+const wxString TargetGames[] = {"Fallout3", "FalloutNewVegas", "Skyrim", "Fallout4", "SkyrimSpecialEdition", "Fallout4VR", "SkyrimVR", "Fallout 76", "Oblivion"};
 const wxLanguage SupportedLangs[] = {
 	wxLANGUAGE_ENGLISH, wxLANGUAGE_AFRIKAANS, wxLANGUAGE_ARABIC, wxLANGUAGE_CATALAN, wxLANGUAGE_CZECH, wxLANGUAGE_DANISH, wxLANGUAGE_GERMAN,
 	wxLANGUAGE_GREEK, wxLANGUAGE_SPANISH, wxLANGUAGE_BASQUE, wxLANGUAGE_FINNISH, wxLANGUAGE_FRENCH, wxLANGUAGE_HINDI,
@@ -363,15 +363,24 @@ bool OutfitStudio::OnInit() {
 
 	wxString gameName = "Target game: ";
 	switch (targetGame) {
-	case FO3: gameName.Append("Fallout 3"); break;
-	case FONV: gameName.Append("Fallout New Vegas"); break;
-	case SKYRIM: gameName.Append("Skyrim"); break;
-	case FO4: gameName.Append("Fallout 4"); break;
-	case SKYRIMSE: gameName.Append("Skyrim Special Edition"); break;
-	case FO4VR: gameName.Append("Fallout 4 VR"); break;
-	case SKYRIMVR: gameName.Append("Skyrim VR"); break;
-	case FO76: gameName.Append("Fallout 76"); break;
-	case OB: gameName.Append("Oblivion"); break;
+	case FO3: gameName.Append("Fallout 3");
+		break;
+	case FONV: gameName.Append("Fallout New Vegas");
+		break;
+	case SKYRIM: gameName.Append("Skyrim");
+		break;
+	case FO4: gameName.Append("Fallout 4");
+		break;
+	case SKYRIMSE: gameName.Append("Skyrim Special Edition");
+		break;
+	case FO4VR: gameName.Append("Fallout 4 VR");
+		break;
+	case SKYRIMVR: gameName.Append("Skyrim VR");
+		break;
+	case FO76: gameName.Append("Fallout 76");
+		break;
+	case OB: gameName.Append("Oblivion");
+		break;
 	default: gameName.Append("Invalid");
 	}
 	wxLogMessage(gameName);
@@ -405,13 +414,13 @@ bool OutfitStudio::OnInit() {
 			wxMessageBox(_("No read/write permission for project path!\n\nPlease launch the program with admin elevation and make sure the project path in the settings is correct."), _("Warning"), wxICON_WARNING);
 	}
 
-	for (auto &file : cmdFiles) {
+	for (auto& file : cmdFiles) {
 		wxFileName loadFile(file);
 		if (loadFile.FileExists()) {
-			std::string fileName{ loadFile.GetFullPath().ToUTF8() };
+			std::string fileName{loadFile.GetFullPath().ToUTF8()};
 			wxString fileExt = loadFile.GetExt().MakeLower();
 			if (fileExt == "osp") {
-				std::string projectName{ cmdProject.ToUTF8() };
+				std::string projectName{cmdProject.ToUTF8()};
 				frame->LoadProject(fileName, projectName);
 				break;
 			}
@@ -634,10 +643,10 @@ bool OutfitStudio::SetDefaultConfig() {
 		}
 		else
 #endif
-		if (Config["WarnMissingGamePath"] == "true") {
-			wxLogWarning("Failed to find game install path registry key or GameDataPath in the config.");
-			wxMessageBox(_("Failed to find game install path registry key or GameDataPath in the config."), _("Warning"), wxICON_WARNING);
-		}
+			if (Config["WarnMissingGamePath"] == "true") {
+				wxLogWarning("Failed to find game install path registry key or GameDataPath in the config.");
+				wxMessageBox(_("Failed to find game install path registry key or GameDataPath in the config."), _("Warning"), wxICON_WARNING);
+			}
 	}
 	else
 		wxLogMessage("Game data path in config: %s", Config["GameDataPath"]);
@@ -918,7 +927,7 @@ void OutfitStudio::GetArchiveFiles(std::vector<std::string>& outList) {
 OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 	wxLogMessage("Loading Outfit Studio frame at X:%d Y:%d with W:%d H:%d...", pos.x, pos.y, size.GetWidth(), size.GetHeight());
 
-	wxXmlResource *xrc = wxXmlResource::Get();
+	wxXmlResource* xrc = wxXmlResource::Get();
 	if (!xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/OutfitStudio.xrc")) {
 		wxMessageBox(_("Failed to load OutfitStudio.xrc file!"), _("Error"), wxICON_ERROR);
 		Close(true);
@@ -939,7 +948,7 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/Skeleton.xrc");
 	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/Settings.xrc");
 
-	int statusWidths[] = { -1, 400, 100 };
+	int statusWidths[] = {-1, 400, 100};
 	statusBar = (wxStatusBar*)FindWindowByName("statusBar");
 	if (statusBar) {
 		statusBar->SetFieldsCount(3);
@@ -998,7 +1007,7 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 
 	outfitShapes = (wxTreeCtrl*)FindWindowByName("outfitShapes");
 	if (outfitShapes) {
-		wxImageList *visStateImages = new wxImageList(16, 16, false, 2);
+		wxImageList* visStateImages = new wxImageList(16, 16, false, 2);
 		wxBitmap visImg(wxString::FromUTF8(Config["AppDir"]) + "/res/images/icoVisible.png", wxBITMAP_TYPE_PNG);
 		wxBitmap invImg(wxString::FromUTF8(Config["AppDir"]) + "/res/images/icoInvisible.png", wxBITMAP_TYPE_PNG);
 		wxBitmap wfImg(wxString::FromUTF8(Config["AppDir"]) + "/res/images/icoWireframe.png", wxBITMAP_TYPE_PNG);
@@ -1018,7 +1027,7 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 	if (outfitBones) {
 		wxBitmap noneImg(wxString::FromUTF8(Config["AppDir"]) + "/res/images/icoNone.png", wxBITMAP_TYPE_PNG);
 		wxBitmap changeImg(wxString::FromUTF8(Config["AppDir"]) + "/res/images/icoChange.png", wxBITMAP_TYPE_PNG);
-		wxImageList *boneStateImages = new wxImageList(16, 16, false, 2);
+		wxImageList* boneStateImages = new wxImageList(16, 16, false, 2);
 		if (noneImg.IsOk())
 			boneStateImages->Add(noneImg);
 		if (changeImg.IsOk())
@@ -1110,7 +1119,7 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 	xrc->AttachUnknownControl("bonesFilter", bonesFilter, this);
 	bonesFilter->GetParent()->Hide();
 
-	project = new OutfitProject(this);	// Create empty project
+	project = new OutfitProject(this); // Create empty project
 	CreateSetSliders();
 
 	bEditSlider = false;
@@ -1156,7 +1165,7 @@ void OutfitStudioFrame::OnClose(wxCloseEvent& WXUNUSED(event)) {
 		project = nullptr;
 	}
 
-	for (auto &sd : sliderDisplays)
+	for (auto& sd : sliderDisplays)
 		delete sd.second;
 
 	if (glView)
@@ -1165,7 +1174,7 @@ void OutfitStudioFrame::OnClose(wxCloseEvent& WXUNUSED(event)) {
 	OutfitStudioConfig.ClearValueArray("ProjectHistory", "Project");
 
 	std::vector<std::map<std::string, std::string>> phArrayEntries;
-	for (auto &ph : projectHistory) {
+	for (auto& ph : projectHistory) {
 		std::map<std::string, std::string> attributeValues;
 		attributeValues["name"] = ph.projectName;
 		attributeValues["file"] = ph.fileName;
@@ -1301,7 +1310,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 			projectList->Clear();
 
 			// Add outfits that are no members to list
-			for (auto &project : projectSources) {
+			for (auto& project : projectSources) {
 				// Filter outfit by name
 				wxString projectStr = wxString::FromUTF8(project.first);
 				if (projectStr.Lower().Contains(filterStr)) {
@@ -1316,7 +1325,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 		wxDir::GetAllFiles(wxString::FromUTF8(GetProjectPath()) + "/SliderSets", &files, "*.osp");
 		wxDir::GetAllFiles(wxString::FromUTF8(GetProjectPath()) + "/SliderSets", &files, "*.xml");
 
-		for (auto &file : files) {
+		for (auto& file : files) {
 			std::string fileName{file.ToUTF8()};
 
 			SliderSetFile sliderDoc;
@@ -1327,7 +1336,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 			std::vector<std::string> setNames;
 			sliderDoc.GetSetNamesUnsorted(setNames, false);
 
-			for (auto &setName : setNames) {
+			for (auto& setName : setNames) {
 				if (projectSources.find(setName) != projectSources.end())
 					continue;
 
@@ -1386,7 +1395,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 			SliderSetFile projectFile;
 			projectFile.New(mergedFilePath);
 
-			for (auto &setName : selectedProjects) {
+			for (auto& setName : selectedProjects) {
 				if (projectSources.find(setName) == projectSources.end())
 					continue;
 
@@ -1432,8 +1441,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 
 								dataFiles.insert(set.GetDefaultDataFolder() + sep + dataFileName.substr(0, split));
 							}
-							else
-							{
+							else {
 								dataFiles.insert(set.GetDefaultDataFolder() + sep + dataFileName);
 							}
 						}
@@ -1441,7 +1449,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 				}
 
 				// Add data files to folder
-				for (auto &df : dataFiles) {
+				for (auto& df : dataFiles) {
 					wxString dataFilePath = wxString::FromUTF8(GetProjectPath() + sep + "ShapeData" + sep + df);
 					wxFileInputStream dataFileStream(dataFilePath);
 					if (!dataFileStream.IsOk()) {
@@ -1537,7 +1545,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 			wxFFileOutputStream out(fileName);
 			wxZipOutputStream zip(out);
 
-			for (auto &setName : selectedProjects) {
+			for (auto& setName : selectedProjects) {
 				if (projectSources.find(setName) == projectSources.end())
 					continue;
 
@@ -1587,8 +1595,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 
 								dataFiles.insert(set.GetDefaultDataFolder() + sep + dataFileName.substr(0, split));
 							}
-							else
-							{
+							else {
 								dataFiles.insert(set.GetDefaultDataFolder() + sep + dataFileName);
 							}
 						}
@@ -1596,7 +1603,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 				}
 
 				// Add data files to archive
-				for (auto &df : dataFiles) {
+				for (auto& df : dataFiles) {
 					wxString dataFilePath = wxString::FromUTF8(GetProjectPath() + sep + "ShapeData" + sep + df);
 					wxFileInputStream dataFileStream(dataFilePath);
 					if (!dataFileStream.IsOk()) {
@@ -1941,7 +1948,7 @@ bool OutfitStudioFrame::SaveProject() {
 	project->ClearBoneScale();
 
 	std::vector<mesh*> shapeMeshes;
-	for (auto &s : project->GetWorkNif()->GetShapes()) {
+	for (auto& s : project->GetWorkNif()->GetShapes()) {
 		if (!project->IsBaseShape(s)) {
 			mesh* m = glView->GetMesh(s->name.get());
 			if (m)
@@ -1952,7 +1959,7 @@ bool OutfitStudioFrame::SaveProject() {
 	project->UpdateNifNormals(project->GetWorkNif(), shapeMeshes);
 
 	std::string error = project->Save(project->mFileName, project->mOutfitName, project->mDataDir, project->mBaseFile,
-		project->mGamePath, project->mGameFile, project->mGenWeights, project->mCopyRef);
+	                                  project->mGamePath, project->mGameFile, project->mGenWeights, project->mCopyRef);
 
 	if (!error.empty()) {
 		wxLogError(error.c_str());
@@ -2112,7 +2119,7 @@ bool OutfitStudioFrame::SaveProjectAs() {
 	project->ClearBoneScale();
 
 	std::vector<mesh*> shapeMeshes;
-	for (auto &s : project->GetWorkNif()->GetShapes()) {
+	for (auto& s : project->GetWorkNif()->GetShapes()) {
 		if (!project->IsBaseShape(s)) {
 			mesh* m = glView->GetMesh(s->name.get());
 			if (m)
@@ -2123,7 +2130,7 @@ bool OutfitStudioFrame::SaveProjectAs() {
 	project->UpdateNifNormals(project->GetWorkNif(), shapeMeshes);
 
 	std::string error = project->Save(sliderSetFile, strOutfitName, strDataDir, strBaseFile,
-		strGamePath, strGameFile, genWeights, copyRef);
+	                                  strGamePath, strGameFile, genWeights, copyRef);
 
 	if (error.empty()) {
 		SetPendingChanges(false);
@@ -2162,7 +2169,7 @@ bool OutfitStudioFrame::LoadProject(const std::string& fileName, const std::stri
 
 	if (outfit.empty()) {
 		wxArrayString choices;
-		for (auto &s : setnames)
+		for (auto& s : setnames)
 			choices.Add(wxString::FromUTF8(s));
 
 		if (choices.GetCount() > 1) {
@@ -2279,7 +2286,7 @@ void OutfitStudioFrame::CreateSetSliders() {
 
 	sliderScroll->Freeze();
 	sliderScroll->DestroyChildren();
-	for (auto &sd : sliderDisplays)
+	for (auto& sd : sliderDisplays)
 		delete sd.second;
 
 	sliderDisplays.clear();
@@ -2288,9 +2295,9 @@ void OutfitStudioFrame::CreateSetSliders() {
 
 	wxSizer* rootSz = sliderScroll->GetSizer();
 
-	for (size_t i = 0; i < project->SliderCount(); i++)  {
+	for (size_t i = 0; i < project->SliderCount(); i++) {
 		UpdateProgress(inc, _("Loading slider: ") + project->GetSliderName(i));
-		if (project->SliderClamp(i))    // clamp sliders are a special case, usually an incorrect scale
+		if (project->SliderClamp(i)) // clamp sliders are a special case, usually an incorrect scale
 			continue;
 
 		createSliderGUI(project->GetSliderName(i), i, sliderScroll, rootSz);
@@ -2394,7 +2401,8 @@ std::string OutfitStudioFrame::NewSlider(const std::string& suggestedName, bool 
 			sliderName = wxGetTextFromUser(_("Enter a name for the new slider:"), _("Create New Slider"), fillName, this).ToUTF8();
 			if (sliderName.empty())
 				return sliderName;
-		} while (project->ValidSlider(sliderName));
+		}
+		while (project->ValidSlider(sliderName));
 	}
 	else
 		sliderName = fillName;
@@ -2428,7 +2436,7 @@ void OutfitStudioFrame::ApplySliders(bool recalcBVH) {
 	std::vector<Vector3> verts;
 	std::vector<Vector2> uvs;
 
-	for (auto &shape : project->GetWorkNif()->GetShapes()) {
+	for (auto& shape : project->GetWorkNif()->GetShapes()) {
 		project->GetLiveVerts(shape, verts, &uvs);
 		glView->UpdateMeshVertices(shape->name.get(), &verts, recalcBVH, true, false, &uvs);
 	}
@@ -2528,8 +2536,8 @@ void OutfitStudioFrame::UpdateBoneCounts() {
 	project->GetActiveBones(boneNames);
 
 	size_t selectedBoneCount = 0;
-	for (auto &s : selectedItems) {
-		for (auto &bone : boneNames) {
+	for (auto& s : selectedItems) {
+		for (auto& bone : boneNames) {
 			if (project->GetWorkAnim()->HasWeights(s->GetShape()->name.get(), bone)) {
 				selectedBoneCount++;
 			}
@@ -2547,7 +2555,7 @@ void OutfitStudioFrame::HighlightBoneNamesWithWeights() {
 		outfitBones->SetItemTextColour(item, wxColour(255, 255, 255));
 
 		auto boneName = outfitBones->GetItemText(item).ToStdString();
-		for (auto &i : selectedItems) {
+		for (auto& i : selectedItems) {
 			if (project->GetWorkAnim()->HasWeights(i->GetShape()->name.get(), boneName)) {
 				outfitBones->SetItemTextColour(item, wxColour(0, 255, 0));
 			}
@@ -2557,11 +2565,11 @@ void OutfitStudioFrame::HighlightBoneNamesWithWeights() {
 	}
 }
 
-void OutfitStudioFrame::GetNormalizeBones(std::vector<std::string> *normBones, std::vector<std::string> *notNormBones) {
+void OutfitStudioFrame::GetNormalizeBones(std::vector<std::string>* normBones, std::vector<std::string>* notNormBones) {
 	std::vector<std::string> activeBones;
 	project->GetActiveBones(activeBones);
 
-	for (auto &boneName : activeBones) {
+	for (auto& boneName : activeBones) {
 		if (lastNormalizeBones.find(boneName) != lastNormalizeBones.end()) {
 			if (normBones)
 				normBones->push_back(boneName);
@@ -2579,7 +2587,7 @@ std::vector<std::string> OutfitStudioFrame::GetSelectedBones() {
 
 	std::vector<std::string> boneList;
 
-	for (auto &selBone : lastSelectedBones) {
+	for (auto& selBone : lastSelectedBones) {
 		if (std::find(activeBones.begin(), activeBones.end(), selBone) != activeBones.end()) {
 			boneList.push_back(selBone);
 		}
@@ -2596,7 +2604,7 @@ void OutfitStudioFrame::CalcAutoXMirrorBone() {
 	project->GetActiveBones(bones);
 
 	int bestFlips = 0;
-	for (const std::string &b : bones) {
+	for (const std::string& b : bones) {
 		if (abLen != b.length())
 			continue;
 
@@ -2690,17 +2698,17 @@ void OutfitStudioFrame::UpdateShapeSource(NiShape* shape) {
 		project->UpdateShapeFromMesh(shape, m);
 }
 
-void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject *usp, bool bIsUndo) {
+void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject* usp, bool bIsUndo) {
 	if (!usp->sliderName.empty()) {
 		float sliderscale = 1 / usp->sliderscale;
-		for (auto &uss : usp->usss) {
-			mesh *m = glView->GetMesh(uss.shapeName);
+		for (auto& uss : usp->usss) {
+			mesh* m = glView->GetMesh(uss.shapeName);
 			if (!m)
 				continue;
 
 			std::unordered_map<uint16_t, Vector3> strokeDiff;
 
-			for (auto &ps : uss.pointStartState) {
+			for (auto& ps : uss.pointStartState) {
 				auto pe = uss.pointEndState.find(ps.first);
 				if (pe == uss.pointEndState.end())
 					continue;
@@ -2716,17 +2724,17 @@ void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject *usp, bool bIsUndo)
 	}
 	else {
 		if (usp->undoType == UT_WEIGHT) {
-			for (auto &uss : usp->usss) {
-				mesh *m = glView->GetMesh(uss.shapeName);
+			for (auto& uss : usp->usss) {
+				mesh* m = glView->GetMesh(uss.shapeName);
 				if (!m)
 					continue;
 
-				for (auto &bw : uss.boneWeights) {
+				for (auto& bw : uss.boneWeights) {
 					if (bw.weights.empty()) continue;
 					project->GetWorkAnim()->AddShapeBone(m->shapeName, bw.boneName);
 					auto weights = project->GetWorkAnim()->GetWeightsPtr(m->shapeName, bw.boneName);
 					if (!weights) continue;
-					for (auto &p : bw.weights) {
+					for (auto& p : bw.weights) {
 						float val = bIsUndo ? p.second.startVal : p.second.endVal;
 						if (val == 0.0f)
 							weights->erase(p.first);
@@ -2743,8 +2751,8 @@ void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject *usp, bool bIsUndo)
 			}
 		}
 		else if (usp->undoType == UT_COLOR) {
-			for (auto &uss : usp->usss) {
-				mesh *m = glView->GetMesh(uss.shapeName);
+			for (auto& uss : usp->usss) {
+				mesh* m = glView->GetMesh(uss.shapeName);
 				if (!m)
 					continue;
 
@@ -2755,14 +2763,14 @@ void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject *usp, bool bIsUndo)
 				std::vector<Color4> vcolors = (*colorPtr);
 
 				if (bIsUndo) {
-					for (auto &p : uss.pointStartState) {
+					for (auto& p : uss.pointStartState) {
 						vcolors[p.first].r = p.second.x;
 						vcolors[p.first].g = p.second.y;
 						vcolors[p.first].b = p.second.z;
 					}
 				}
 				else {
-					for (auto &p : uss.pointEndState) {
+					for (auto& p : uss.pointEndState) {
 						vcolors[p.first].r = p.second.x;
 						vcolors[p.first].g = p.second.y;
 						vcolors[p.first].b = p.second.z;
@@ -2773,8 +2781,8 @@ void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject *usp, bool bIsUndo)
 			}
 		}
 		else if (usp->undoType == UT_ALPHA) {
-			for (auto &uss : usp->usss) {
-				mesh *m = glView->GetMesh(uss.shapeName);
+			for (auto& uss : usp->usss) {
+				mesh* m = glView->GetMesh(uss.shapeName);
 				if (!m)
 					continue;
 
@@ -2785,11 +2793,11 @@ void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject *usp, bool bIsUndo)
 				std::vector<Color4> vcolors = (*colorPtr);
 
 				if (bIsUndo) {
-					for (auto &p : uss.pointStartState)
+					for (auto& p : uss.pointStartState)
 						vcolors[p.first].a = p.second.x;
 				}
 				else {
-					for (auto &p : uss.pointEndState)
+					for (auto& p : uss.pointEndState)
 						vcolors[p.first].a = p.second.x;
 				}
 
@@ -2802,7 +2810,7 @@ void OutfitStudioFrame::ActiveShapesUpdated(UndoStateProject *usp, bool bIsUndo)
 }
 
 void OutfitStudioFrame::UpdateShapeReference(NiShape* shape, NiShape* newShape) {
-	for (auto &i : selectedItems) {
+	for (auto& i : selectedItems) {
 		if (i->GetShape() == shape) {
 			i->SetShape(newShape);
 		}
@@ -2924,7 +2932,7 @@ void OutfitStudioFrame::MenuExitSliderEdit() {
 
 void OutfitStudioFrame::ScrollToActiveSlider() {
 	if (!activeSlider.empty()) {
-		for (auto &d : sliderDisplays) {
+		for (auto& d : sliderDisplays) {
 			if (d.first == activeSlider) {
 				ScrollWindowIntoView(sliderScroll, d.second->sliderPane);
 			}
@@ -3143,7 +3151,7 @@ bool OutfitStudioFrame::CheckEditableState() {
 	if (bEditSlider) {
 		if (project->SliderValue(activeSlider) == 0.0) {
 			int response = wxMessageBox(_("You are trying to edit a slider's morph with that slider set to zero.  Do you wish to set the slider to one now?"),
-				wxMessageBoxCaptionStr, wxYES_NO, this);
+			                            wxMessageBoxCaptionStr, wxYES_NO, this);
 
 			if (response == wxYES) {
 				SetSliderValue(activeSlider, 100);
@@ -3165,8 +3173,8 @@ bool OutfitStudioFrame::CheckEditableState() {
 	if (project->AllSlidersZero())
 		return true;
 
-	int	response = wxMessageBox(_("You can only edit the base shape when all sliders are zero. Do you wish to set all sliders to zero now?  Note, use the pencil button next to a slider to enable editing of that slider's morph."),
-		wxMessageBoxCaptionStr, wxYES_NO, this);
+	int response = wxMessageBox(_("You can only edit the base shape when all sliders are zero. Do you wish to set all sliders to zero now?  Note, use the pencil button next to a slider to enable editing of that slider's morph."),
+	                            wxMessageBoxCaptionStr, wxYES_NO, this);
 
 	if (response == wxYES)
 		ZeroSliders();
@@ -3278,7 +3286,7 @@ void OutfitStudioFrame::OnNewProject(wxCommandEvent& WXUNUSED(event)) {
 		XRCCTRL(wiz, "npTexFilename", wxFilePickerCtrl)->Bind(wxEVT_FILEPICKER_CHANGED, &OutfitStudioFrame::OnLoadOutfitFP_Texture, this);
 
 		wxChoice* tmplChoice = XRCCTRL(wiz, "npTemplateChoice", wxChoice);
-		for (auto &tmpl : refTemplates)
+		for (auto& tmpl : refTemplates)
 			tmplChoice->Append(tmpl.GetName());
 
 		std::string lastRefTemplate = OutfitStudioConfig["LastRefTemplate"];
@@ -3303,7 +3311,7 @@ void OutfitStudioFrame::OnNewProject(wxCommandEvent& WXUNUSED(event)) {
 	ClearProject();
 	project->ClearReference();
 	project->ClearOutfit();
-	
+
 	glView->Cleanup();
 	glView->GetUndoHistory()->ClearHistory();
 
@@ -3342,10 +3350,10 @@ void OutfitStudioFrame::OnNewProject(wxCommandEvent& WXUNUSED(event)) {
 		if (fileName.EndsWith(".osp") || fileName.EndsWith(".xml")) {
 			wxString sliderSetName = XRCCTRL(wiz, "npSliderSetName", wxChoice)->GetStringSelection();
 			wxLogMessage("Loading reference '%s' from set '%s' of file '%s'...",
-				refShape, sliderSetName, fileName);
+			             refShape, sliderSetName, fileName);
 
 			error = project->LoadReference(fileName.ToUTF8().data(),
-				sliderSetName.ToUTF8().data(), false, refShape.ToUTF8().data());
+			                               sliderSetName.ToUTF8().data(), false, refShape.ToUTF8().data());
 		}
 		else if (fileName.EndsWith(".nif")) {
 			wxLogMessage("Loading reference '%s' from '%s'...", refShape, fileName);
@@ -3383,7 +3391,7 @@ void OutfitStudioFrame::OnNewProject(wxCommandEvent& WXUNUSED(event)) {
 	UpdateProgress(80, _("Creating outfit..."));
 
 	if (XRCCTRL(wiz, "npTexAuto", wxRadioButton)->GetValue() == false)
-		project->SetTextures({ XRCCTRL(wiz, "npTexFilename", wxFilePickerCtrl)->GetPath().ToUTF8().data() });
+		project->SetTextures({XRCCTRL(wiz, "npTexFilename", wxFilePickerCtrl)->GetPath().ToUTF8().data()});
 	else
 		project->SetTextures();
 
@@ -3444,7 +3452,7 @@ void OutfitStudioFrame::OnLoadReference(wxCommandEvent& WXUNUSED(event)) {
 		XRCCTRL(dlg, "npSliderSetName", wxChoice)->Bind(wxEVT_CHOICE, &OutfitStudioFrame::OnNPWizChangeSetNameChoice, this);
 
 		wxChoice* tmplChoice = XRCCTRL(dlg, "npTemplateChoice", wxChoice);
-		for (auto &tmpl : refTemplates)
+		for (auto& tmpl : refTemplates)
 			tmplChoice->Append(tmpl.GetName());
 
 		std::string lastRefTemplate = OutfitStudioConfig["LastRefTemplate"];
@@ -3491,10 +3499,10 @@ void OutfitStudioFrame::OnLoadReference(wxCommandEvent& WXUNUSED(event)) {
 		if (fileName.EndsWith(".osp") || fileName.EndsWith(".xml")) {
 			wxString sliderSetName = XRCCTRL(dlg, "npSliderSetName", wxChoice)->GetStringSelection();
 			wxLogMessage("Loading reference '%s' from set '%s' of file '%s'...",
-				refShape, sliderSetName, fileName);
+			             refShape, sliderSetName, fileName);
 
 			error = project->LoadReference(fileName.ToUTF8().data(),
-				sliderSetName.ToUTF8().data(), mergeSliders, refShape.ToUTF8().data(), keepZapSliders);
+			                               sliderSetName.ToUTF8().data(), mergeSliders, refShape.ToUTF8().data(), keepZapSliders);
 		}
 		else if (fileName.EndsWith(".nif")) {
 			wxLogMessage("Loading reference '%s' from '%s'...", refShape, fileName);
@@ -3528,18 +3536,16 @@ void OutfitStudioFrame::OnLoadReference(wxCommandEvent& WXUNUSED(event)) {
 	EndProgress();
 }
 
-int OutfitStudioFrame::LoadReferenceTemplate(const wxString& refTemplate, bool keepZapSliders)
-{
+int OutfitStudioFrame::LoadReferenceTemplate(const wxString& refTemplate, bool keepZapSliders) {
 	NiShape* baseShape = project->GetBaseShape();
 	if (baseShape)
 		glView->DeleteMesh(baseShape->name.get());
-	
+
 	int error;
 	wxLogMessage("Loading reference template '%s'...", refTemplate);
 	std::string tmplName{refTemplate.ToUTF8()};
 	auto tmpl = find_if(refTemplates.begin(), refTemplates.end(), [&tmplName](const RefTemplate& rt) { return rt.GetName() == tmplName; });
-	if (tmpl != refTemplates.end())
-	{
+	if (tmpl != refTemplates.end()) {
 		if (wxFileName(wxString::FromUTF8(tmpl->GetSource())).IsRelative())
 			error = project->LoadReferenceTemplate(GetProjectPath() + PathSepStr + tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), tmpl->GetLoadAll(), false, keepZapSliders, true);
 		else
@@ -3548,9 +3554,9 @@ int OutfitStudioFrame::LoadReferenceTemplate(const wxString& refTemplate, bool k
 	else
 		error = 1;
 
-	if(!error) {
+	if (!error) {
 		// since some reference files have multiple shapes, just update all textures
-		for(auto &s : project->GetWorkNif()->GetShapes())
+		for (auto& s : project->GetWorkNif()->GetShapes())
 			project->SetTextures(s);
 
 		RefreshGUIFromProj();
@@ -3560,10 +3566,9 @@ int OutfitStudioFrame::LoadReferenceTemplate(const wxString& refTemplate, bool k
 	return error;
 }
 
-void OutfitStudioFrame::LoadDialogChoice(wxDialog& dlg, const char* dlgProperty) const
-{
+void OutfitStudioFrame::LoadDialogChoice(wxDialog& dlg, const char* dlgProperty) const {
 	wxChoice* choice = XRCCTRL(dlg, dlgProperty, wxChoice);
-	for (auto &tmpl : refTemplates)
+	for (auto& tmpl : refTemplates)
 		choice->Append(tmpl.GetName());
 
 	std::string lastValue = OutfitStudioConfig[dlgProperty];
@@ -3571,18 +3576,16 @@ void OutfitStudioFrame::LoadDialogChoice(wxDialog& dlg, const char* dlgProperty)
 		choice->Select(0);
 }
 
-void OutfitStudioFrame::LoadDialogText(wxDialog& dlg, const char* dlgProperty) const
-{
+void OutfitStudioFrame::LoadDialogText(wxDialog& dlg, const char* dlgProperty) const {
 	wxTextCtrl* tmplChoice = XRCCTRL(dlg, dlgProperty, wxTextCtrl);
 	std::string lastValue = OutfitStudioConfig[dlgProperty];
 	tmplChoice->SetValue(lastValue);
 }
 
-bool OutfitStudioFrame::AlertProgressError(int error, const wxString& title, const wxString& message)
-{
+bool OutfitStudioFrame::AlertProgressError(int error, const wxString& title, const wxString& message) {
 	if (error == 0)
 		return false;
-	
+
 	wxLogError(message);
 	wxMessageBox(message, _(title), wxICON_ERROR);
 	EndProgress();
@@ -3626,13 +3629,12 @@ void OutfitStudioFrame::OnConvertBodyReference(wxCommandEvent& WXUNUSED(event)) 
 	Config.SaveConfig(Config["AppDir"] + "/Config.xml");
 
 	UpdateProgress(1, _("Updating Project Output Settings"));
-	
+
 	wxStringTokenizer tkz(removeFromProjectText, wxT(","));
 	bool modifiedName = false;
-	while ( tkz.HasMoreTokens() )
-	{
-	    wxString token = tkz.GetNextToken();
-		if(!modifiedName && !appendToProjectText.IsEmpty() && project->mFileName.Contains(token)) {
+	while (tkz.HasMoreTokens()) {
+		wxString token = tkz.GetNextToken();
+		if (!modifiedName && !appendToProjectText.IsEmpty() && project->mFileName.Contains(token)) {
 			project->mFileName.Replace(token, appendToProjectText);
 			modifiedName = true;
 		}
@@ -3643,33 +3645,32 @@ void OutfitStudioFrame::OnConvertBodyReference(wxCommandEvent& WXUNUSED(event)) 
 		project->mDataDir.Replace(token, "");
 		project->mBaseFile.Replace(token, "");
 	}
-	if(!appendToProjectText.IsEmpty())
-	{
-		if(project->mOutfitName[0] != ' ')
+	if (!appendToProjectText.IsEmpty()) {
+		if (project->mOutfitName[0] != ' ')
 			project->mOutfitName.Prepend(' ');
-		if(project->mDataDir[0] != ' ')
+		if (project->mDataDir[0] != ' ')
 			project->mDataDir.Prepend(' ');
-		if(project->mBaseFile[0] != ' ')
+		if (project->mBaseFile[0] != ' ')
 			project->mBaseFile.Prepend(' ');
 		project->mOutfitName.Prepend(appendToProjectText);
 		project->mDataDir.Prepend(appendToProjectText);
 		project->mBaseFile.Prepend(appendToProjectText);
-		
+
 		project->outfitName = project->mOutfitName.ToStdString();
 		UpdateTitle();
 	}
-	
+
 	project->DeleteShape(project->GetBaseShape());
 	auto shapes = project->GetWorkNif()->GetShapes(); // get outfit shapes
 
 	UpdateProgress(5, _("Loading conversion reference..."));
 	if (AlertProgressError(LoadReferenceTemplate(conversionRefTemplate, keepZapSliders), "Load Error", "Failed to load conversion reference"))
 		return;
-	
+
 	UpdateProgress(10, _("Conforming outfit parts..."));
 	if (AlertProgressError(ConformShapes(shapes, true), "Conform Error", "Failed to conform shapes"))
 		return;
-	
+
 	UpdateProgress(25, _("Updating conversion Slider..."));
 	SetSliderValue(project->activeSet.size() - 1, 100);
 	ApplySliders();
@@ -3689,10 +3690,10 @@ void OutfitStudioFrame::OnConvertBodyReference(wxCommandEvent& WXUNUSED(event)) 
 	UpdateProgress(80, _("Conforming outfit parts..."));
 	if (AlertProgressError(ConformShapes(shapes, true), "Conform Error", "Failed to conform shapes"))
 		return;
-	
+
 	RefreshGUIFromProj();
 	ApplySliders();
-	
+
 	wxLogMessage("Finished conversion.");
 	UpdateProgress(100, _("Finished"));
 	EndProgress();
@@ -3702,8 +3703,7 @@ void OutfitStudioFrame::OnLoadOutfit(wxCommandEvent& WXUNUSED(event)) {
 	wxDialog dlg;
 	int result = wxID_CANCEL;
 
-	if (wxXmlResource::Get()->LoadObject((wxObject*)&dlg, this, "dlgLoadOutfit", "wxDialog"))
-	{
+	if (wxXmlResource::Get()->LoadObject((wxObject*)&dlg, this, "dlgLoadOutfit", "wxDialog")) {
 		XRCCTRL(dlg, "npWorkFilename", wxFilePickerCtrl)->Bind(wxEVT_FILEPICKER_CHANGED, &OutfitStudioFrame::OnLoadOutfitFP_File, this);
 		XRCCTRL(dlg, "npTexFilename", wxFilePickerCtrl)->Bind(wxEVT_FILEPICKER_CHANGED, &OutfitStudioFrame::OnLoadOutfitFP_Texture, this);
 		if (project->GetWorkNif()->IsValid())
@@ -3721,10 +3721,8 @@ void OutfitStudioFrame::OnLoadOutfit(wxCommandEvent& WXUNUSED(event)) {
 	wxLogMessage("Loading outfit...");
 	StartProgress(_("Loading outfit..."));
 
-	for (auto &s : project->GetWorkNif()->GetShapes())
-	{
-		if (!project->IsBaseShape(s))
-		{
+	for (auto& s : project->GetWorkNif()->GetShapes()) {
+		if (!project->IsBaseShape(s)) {
 			glView->DeleteMesh(s->name.get());
 		}
 	}
@@ -3733,11 +3731,9 @@ void OutfitStudioFrame::OnLoadOutfit(wxCommandEvent& WXUNUSED(event)) {
 	UpdateProgress(1, _("Loading outfit..."));
 
 	int ret = 0;
-	if (XRCCTRL(dlg, "npWorkFile", wxRadioButton)->GetValue() == true)
-	{
+	if (XRCCTRL(dlg, "npWorkFile", wxRadioButton)->GetValue() == true) {
 		wxString fileName = XRCCTRL(dlg, "npWorkFilename", wxFilePickerCtrl)->GetPath();
-		if (fileName.Lower().EndsWith(".nif"))
-		{
+		if (fileName.Lower().EndsWith(".nif")) {
 			if (!keepShapes)
 				ret = project->ImportNIF(fileName.ToUTF8().data(), true, outfitName);
 			else
@@ -3751,8 +3747,7 @@ void OutfitStudioFrame::OnLoadOutfit(wxCommandEvent& WXUNUSED(event)) {
 	else
 		project->ClearOutfit();
 
-	if (ret)
-	{
+	if (ret) {
 		EndProgress();
 		RefreshGUIFromProj();
 		return;
@@ -3760,9 +3755,8 @@ void OutfitStudioFrame::OnLoadOutfit(wxCommandEvent& WXUNUSED(event)) {
 
 	if (XRCCTRL(dlg, "npTexAuto", wxRadioButton)->GetValue() == true)
 		project->SetTextures();
-	else
-	{
-		std::vector<std::string> texVec = { XRCCTRL(dlg, "npTexFilename", wxFilePickerCtrl)->GetPath().ToUTF8().data() };
+	else {
+		std::vector<std::string> texVec = {XRCCTRL(dlg, "npTexFilename", wxFilePickerCtrl)->GetPath().ToUTF8().data()};
 		project->SetTextures(texVec);
 	}
 
@@ -3810,8 +3804,7 @@ void OutfitStudioFrame::UpdateReferenceTemplates() {
 	refTemplates.clear();
 
 	std::string fileName = GetProjectPath() + "/RefTemplates.xml";
-	if (wxFileName::IsFileReadable(fileName))
-	{
+	if (wxFileName::IsFileReadable(fileName)) {
 		RefTemplateFile refTemplateFile(fileName);
 		refTemplateFile.GetAll(refTemplates);
 	}
@@ -3825,7 +3818,7 @@ void OutfitStudioFrame::ClearProject() {
 	if (editUV)
 		editUV->Close();
 
-	for (auto &s : project->GetWorkNif()->GetShapeNames())
+	for (auto& s : project->GetWorkNif()->GetShapeNames())
 		glView->DeleteMesh(s);
 
 	project->mFileName.clear();
@@ -3887,15 +3880,12 @@ void OutfitStudioFrame::RefreshGUIFromProj(bool render) {
 	selectedItems.clear();
 	std::vector<ShapeItemState> prevStates;
 
-	if (outfitRoot.IsOk())
-	{
+	if (outfitRoot.IsOk()) {
 		wxTreeItemIdValue cookie;
 		wxTreeItemId child = outfitShapes->GetFirstChild(outfitRoot, cookie);
-		while (child.IsOk())
-		{
+		while (child.IsOk()) {
 			auto itemData = (ShapeItemData*)outfitShapes->GetItemData(child);
-			if (itemData)
-			{
+			if (itemData) {
 				ShapeItemState prevState;
 				prevState.shape = itemData->GetShape();
 				prevState.state = outfitShapes->GetItemState(child);
@@ -3916,8 +3906,7 @@ void OutfitStudioFrame::RefreshGUIFromProj(bool render) {
 	}
 
 	auto shapes = project->GetWorkNif()->GetShapes();
-	if (shapes.size() > 0)
-	{
+	if (shapes.size() > 0) {
 		if (shapes.size() == 1 && project->IsBaseShape(shapes.front()))
 			outfitRoot = outfitShapes->AppendItem(shapesRoot, "Reference Only");
 		else
@@ -3927,30 +3916,25 @@ void OutfitStudioFrame::RefreshGUIFromProj(bool render) {
 	wxTreeItemId item;
 	wxTreeItemId firstItem;
 	wxTreeItemId prevFirstSelItem;
-	for (auto &shape : shapes)
-	{
+	for (auto& shape : shapes) {
 		auto itemData = new ShapeItemData(shape);
 		item = outfitShapes->AppendItem(outfitRoot, wxString::FromUTF8(shape->name.get()));
 		outfitShapes->SetItemState(item, 0);
 		outfitShapes->SetItemData(item, itemData);
 
-		if (project->IsBaseShape(shape))
-		{
+		if (project->IsBaseShape(shape)) {
 			outfitShapes->SetItemBold(item);
 			outfitShapes->SetItemTextColour(item, wxColour(0, 255, 0));
 		}
 
-		auto it = std::find_if(prevStates.begin(), prevStates.end(), [&shape](const ShapeItemState& state)
-		{
+		auto it = std::find_if(prevStates.begin(), prevStates.end(), [&shape](const ShapeItemState& state) {
 			return state.shape == shape;
 		});
 
-		if (it != prevStates.end())
-		{
+		if (it != prevStates.end()) {
 			outfitShapes->SetItemState(item, it->state);
 
-			if (it->selected)
-			{
+			if (it->selected) {
 				outfitShapes->SelectItem(item);
 				selectedItems.push_back(itemData);
 
@@ -3977,18 +3961,15 @@ void OutfitStudioFrame::RefreshGUIFromProj(bool render) {
 
 	UpdateAnimationGUI();
 
-	if (outfitRoot.IsOk())
-	{
+	if (outfitRoot.IsOk()) {
 		wxTreeItemIdValue cookie;
 		wxTreeItemId child = outfitShapes->GetFirstChild(outfitRoot, cookie);
-		while (child.IsOk())
-		{
+		while (child.IsOk()) {
 			bool vis = true;
 			bool ghost = false;
 
 			int state = outfitShapes->GetItemState(child);
-			switch (state)
-			{
+			switch (state) {
 			case 1:
 				vis = false;
 				ghost = false;
@@ -4044,8 +4025,7 @@ void OutfitStudioFrame::UpdateAnimationGUI() {
 	project->GetActiveBones(activeBones);
 
 	// Re-fill mirror and pose bone lists
-	for (auto &bone : activeBones)
-	{
+	for (auto& bone : activeBones) {
 		cXMirrorBone->AppendString(bone);
 
 		if (xMChoice >= 2 && bone == manualXMirrorBone)
@@ -4068,8 +4048,7 @@ void OutfitStudioFrame::UpdateAnimationGUI() {
 	std::string poseDataPath = GetProjectPath() + "/PoseData";
 	poseDataCollection.LoadData(poseDataPath);
 
-	for (auto &poseData : poseDataCollection.poseData)
-	{
+	for (auto& poseData : poseDataCollection.poseData) {
 		wxString poseName = wxString::FromUTF8(poseData.name);
 		cPoseName->Append(poseName, &poseData);
 	}
@@ -4096,8 +4075,7 @@ void OutfitStudioFrame::UpdateBoneTree() {
 	std::vector<std::string> activeBones;
 	project->GetActiveBones(activeBones);
 
-	for (auto &bone : activeBones)
-	{
+	for (auto& bone : activeBones) {
 		// Filter out bone by name
 		wxString boneStr = wxString::FromUTF8(bone);
 		if (!boneStr.Lower().Contains(filterStr))
@@ -4106,8 +4084,7 @@ void OutfitStudioFrame::UpdateBoneTree() {
 		wxTreeItemId item = outfitBones->AppendItem(bonesRoot, boneStr);
 		outfitBones->SetItemState(item, lastNormalizeBones.count(bone) != 0 ? 1 : 0);
 
-		if (lastSelectedBones.count(bone) != 0)
-		{
+		if (lastSelectedBones.count(bone) != 0) {
 			outfitBones->SelectItem(item);
 			if (activeBone.empty())
 				activeBone = bone;
@@ -4121,7 +4098,7 @@ void OutfitStudioFrame::UpdateBoneTree() {
 }
 
 void OutfitStudioFrame::MeshesFromProj(const bool reloadTextures) {
-	for (auto &shape : project->GetWorkNif()->GetShapes())
+	for (auto& shape : project->GetWorkNif()->GetShapes())
 		MeshFromProj(shape, reloadTextures);
 
 	if (glView->GetVertexEdit())
@@ -4132,8 +4109,7 @@ void OutfitStudioFrame::MeshFromProj(NiShape* shape, const bool reloadTextures) 
 	if (editUV)
 		editUV->Close();
 
-	if (extInitialized)
-	{
+	if (extInitialized) {
 		glView->DeleteMesh(shape->name.get());
 		glView->AddMeshFromNif(project->GetWorkNif(), shape->name.get());
 
@@ -4145,7 +4121,7 @@ void OutfitStudioFrame::MeshFromProj(NiShape* shape, const bool reloadTextures) 
 	}
 
 	std::vector<std::string> selShapes;
-	for (auto &i : selectedItems)
+	for (auto& i : selectedItems)
 		selShapes.push_back(i->GetShape()->name.get());
 
 	glView->SetActiveShapes(selShapes);
@@ -4159,8 +4135,7 @@ void OutfitStudioFrame::MeshFromProj(NiShape* shape, const bool reloadTextures) 
 void OutfitStudioFrame::UpdateMeshFromSet(NiShape* shape) {
 	std::string shapeName = shape->name.get();
 	mesh* m = glView->GetMesh(shapeName);
-	if (m)
-	{
+	if (m) {
 		m->smoothSeamNormals = project->activeSet.GetSmoothSeamNormals(shapeName);
 		m->lockNormals = project->activeSet.GetLockNormals(shapeName);
 	}
@@ -4169,8 +4144,7 @@ void OutfitStudioFrame::UpdateMeshFromSet(NiShape* shape) {
 void OutfitStudioFrame::FillVertexColors() {
 	std::vector<std::string> shapeNames = project->GetWorkNif()->GetShapeNames();
 
-	for (auto &s : shapeNames)
-	{
+	for (auto& s : shapeNames) {
 		mesh* m = glView->GetMesh(s);
 		if (!m)
 			continue;
@@ -4179,10 +4153,8 @@ void OutfitStudioFrame::FillVertexColors() {
 		m->AlphaFill(1.0f);
 
 		const std::vector<Color4>* vcolors = project->GetWorkNif()->GetColorsForShape(s);
-		if (vcolors)
-		{
-			for (size_t v = 0; v < vcolors->size(); v++)
-			{
+		if (vcolors) {
+			for (size_t v = 0; v < vcolors->size(); v++) {
 				m->vcolors[v].x = vcolors->at(v).r;
 				m->vcolors[v].y = vcolors->at(v).g;
 				m->vcolors[v].z = vcolors->at(v).b;
@@ -4223,13 +4195,11 @@ void OutfitStudioFrame::OnSSSGenWeightsFalse(wxCommandEvent& event) {
 	XRCCTRL(*win, "m_lowHighInfo", wxStaticText)->SetLabel(".nif");
 }
 
-void OutfitStudioFrame::OnSaveSliderSet(wxCommandEvent& WXUNUSED(event))
-{
+void OutfitStudioFrame::OnSaveSliderSet(wxCommandEvent& WXUNUSED(event)) {
 	SaveProject();
 }
 
-void OutfitStudioFrame::OnSaveSliderSetAs(wxCommandEvent& WXUNUSED(event))
-{
+void OutfitStudioFrame::OnSaveSliderSetAs(wxCommandEvent& WXUNUSED(event)) {
 	SaveProjectAs();
 }
 
@@ -4237,12 +4207,11 @@ void OutfitStudioFrame::OnSetBaseShape(wxCommandEvent& WXUNUSED(event)) {
 	wxLogMessage("Setting new base shape.");
 	project->ClearBoneScale();
 
-	for (auto &s : project->GetWorkNif()->GetShapes())
+	for (auto& s : project->GetWorkNif()->GetShapes())
 		UpdateShapeSource(s);
 
 	ZeroSliders();
-	if (!activeSlider.empty())
-	{
+	if (!activeSlider.empty()) {
 		bEditSlider = false;
 		SliderDisplay* d = sliderDisplays[activeSlider];
 		d->slider->SetFocus();
@@ -4262,7 +4231,7 @@ void OutfitStudioFrame::OnImportNIF(wxCommandEvent& WXUNUSED(event)) {
 	StartProgress(_("Importing NIF file..."));
 	UpdateProgress(1, _("Importing NIF file..."));
 
-	for (auto &fileName : fileNames)
+	for (auto& fileName : fileNames)
 		project->ImportNIF(fileName.ToUTF8().data(), false);
 
 	UpdateProgress(60, _("Refreshing GUI..."));
@@ -4290,10 +4259,8 @@ void OutfitStudioFrame::OnExportNIF(wxCommandEvent& WXUNUSED(event)) {
 	project->ClearBoneScale();
 
 	std::vector<mesh*> shapeMeshes;
-	for (auto &s : project->GetWorkNif()->GetShapes())
-	{
-		if (!project->IsBaseShape(s))
-		{
+	for (auto& s : project->GetWorkNif()->GetShapes()) {
+		if (!project->IsBaseShape(s)) {
 			mesh* m = glView->GetMesh(s->name.get());
 			if (m)
 				shapeMeshes.push_back(m);
@@ -4301,8 +4268,7 @@ void OutfitStudioFrame::OnExportNIF(wxCommandEvent& WXUNUSED(event)) {
 	}
 
 	int error = project->ExportNIF(fileName.ToUTF8().data(), shapeMeshes);
-	if (error)
-	{
+	if (error) {
 		wxLogError("Failed to save NIF file '%s'!", fileName);
 		wxMessageBox(wxString::Format(_("Failed to save NIF file '%s'!"), fileName), _("Export Error"), wxICON_ERROR);
 	}
@@ -4312,8 +4278,7 @@ void OutfitStudioFrame::OnExportNIFWithRef(wxCommandEvent& event) {
 	if (!project->GetWorkNif()->IsValid())
 		return;
 
-	if (!project->GetBaseShape())
-	{
+	if (!project->GetBaseShape()) {
 		OnExportNIF(event);
 		return;
 	}
@@ -4329,23 +4294,20 @@ void OutfitStudioFrame::OnExportNIFWithRef(wxCommandEvent& event) {
 	project->ClearBoneScale();
 
 	std::vector<mesh*> shapeMeshes;
-	for (auto &s : project->GetWorkNif()->GetShapeNames())
-	{
+	for (auto& s : project->GetWorkNif()->GetShapeNames()) {
 		mesh* m = glView->GetMesh(s);
 		if (m)
 			shapeMeshes.push_back(m);
 	}
 
 	int error = project->ExportNIF(fileName.ToUTF8().data(), shapeMeshes, true);
-	if (error)
-	{
+	if (error) {
 		wxLogError("Failed to save NIF file '%s' with reference!", fileName);
 		wxMessageBox(wxString::Format(_("Failed to save NIF file '%s' with reference!"), fileName), _("Export Error"), wxICON_ERROR);
 	}
 }
 
-int OutfitStudioFrame::BakeConversionReference() const
-{
+int OutfitStudioFrame::BakeConversionReference() const {
 	if (!project->GetWorkNif()->IsValid())
 		return 1;
 
@@ -4353,8 +4315,7 @@ int OutfitStudioFrame::BakeConversionReference() const
 	project->ClearBoneScale();
 
 	std::vector<mesh*> shapeMeshes;
-	for (auto &s : project->GetWorkNif()->GetShapeNames())
-	{
+	for (auto& s : project->GetWorkNif()->GetShapeNames()) {
 		mesh* m = glView->GetMesh(s);
 		if (m)
 			shapeMeshes.push_back(m);
@@ -4363,19 +4324,16 @@ int OutfitStudioFrame::BakeConversionReference() const
 	return project->BakeConversionReference(shapeMeshes, project->GetBaseShape() != nullptr);
 }
 
-void OutfitStudioFrame::OnBakeConversionReference(wxCommandEvent& event)
-{
+void OutfitStudioFrame::OnBakeConversionReference(wxCommandEvent& event) {
 	int error = BakeConversionReference();
-	if (error)
-	{
+	if (error) {
 		wxLogError("Failed to bake conversion reference");
 		wxMessageBox("Failed to bake conversion reference", _("Bake Error"), wxICON_ERROR);
 	}
 }
 
 void OutfitStudioFrame::OnExportShapeNIF(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
@@ -4388,14 +4346,13 @@ void OutfitStudioFrame::OnExportShapeNIF(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	std::vector<std::string> shapes;
-	for (auto &i : selectedItems)
+	for (auto& i : selectedItems)
 		shapes.push_back(i->GetShape()->name.get());
 
 	wxLogMessage("Exporting selected shapes to NIF file '%s'.", fileName);
 	project->ClearBoneScale();
 
-	if (project->ExportShapeNIF(fileName.ToUTF8().data(), shapes))
-	{
+	if (project->ExportShapeNIF(fileName.ToUTF8().data(), shapes)) {
 		wxLogError("Failed to export selected shapes to NIF file '%s'!", fileName);
 		wxMessageBox(_("Failed to export selected shapes to NIF file!"), _("Error"), wxICON_ERROR);
 	}
@@ -4409,8 +4366,7 @@ void OutfitStudioFrame::OnImportOBJ(wxCommandEvent& WXUNUSED(event)) {
 	wxArrayString fileNames;
 	importDialog.GetPaths(fileNames);
 
-	for (auto &fileName : fileNames)
-	{
+	for (auto& fileName : fileNames) {
 		wxLogMessage("Importing shape(s) from OBJ file '%s'...", fileName);
 
 		int ret;
@@ -4435,14 +4391,12 @@ void OutfitStudioFrame::OnExportOBJ(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	bool hasSkinTrans = false;
-	for (NiShape *shape : project->GetWorkNif()->GetShapes())
-	{
+	for (NiShape* shape : project->GetWorkNif()->GetShapes()) {
 		if (!project->GetWorkAnim()->shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(MatTransform()))
 			hasSkinTrans = true;
 	}
 	bool transToGlobal = false;
-	if (hasSkinTrans)
-	{
+	if (hasSkinTrans) {
 		int res = wxMessageBox(_("Some of the shapes have skin coordinate systems that are not the same as the global coordinate system.  Should the geometry be transformed to global coordinates in the OBJ?  (This is not recommended.)"), _("Transform to global"), wxYES_NO | wxCANCEL);
 		if (res == wxCANCEL)
 			return;
@@ -4456,38 +4410,33 @@ void OutfitStudioFrame::OnExportOBJ(wxCommandEvent& WXUNUSED(event)) {
 	wxLogMessage("Exporting project to OBJ file '%s'...", fileName);
 	project->ClearBoneScale();
 
-	if (project->ExportOBJ(fileName.ToUTF8().data(), project->GetWorkNif()->GetShapes(), transToGlobal, Vector3(0.1f, 0.1f, 0.1f)))
-	{
+	if (project->ExportOBJ(fileName.ToUTF8().data(), project->GetWorkNif()->GetShapes(), transToGlobal, Vector3(0.1f, 0.1f, 0.1f))) {
 		wxLogError("Failed to export OBJ file '%s'!", fileName);
 		wxMessageBox(_("Failed to export OBJ file!"), _("Export Error"), wxICON_ERROR);
 	}
 }
 
 void OutfitStudioFrame::OnExportShapeOBJ(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
 
 	bool hasSkinTrans = false;
-	for (auto &i : selectedItems)
-	{
-		NiShape *shape = i->GetShape();
+	for (auto& i : selectedItems) {
+		NiShape* shape = i->GetShape();
 		if (!project->GetWorkAnim()->shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(MatTransform()))
 			hasSkinTrans = true;
 	}
 	bool transToGlobal = false;
-	if (hasSkinTrans)
-	{
+	if (hasSkinTrans) {
 		int res = wxMessageBox(_("Some of the shapes have skin coordinate systems that are not the same as the global coordinate system.  Should the geometry be transformed to global coordinates in the OBJ?"), _("Transform to global"), wxYES_NO | wxCANCEL);
 		if (res == wxCANCEL)
 			return;
 		transToGlobal = (res == wxYES);
 	}
 
-	if (selectedItems.size() > 1)
-	{
+	if (selectedItems.size() > 1) {
 		wxString fileName = wxFileSelector(_("Export selected shapes as an .obj file"), wxEmptyString, wxEmptyString, ".obj", "OBJ Files (*.obj)|*.obj", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
 		if (fileName.IsEmpty())
 			return;
@@ -4497,17 +4446,15 @@ void OutfitStudioFrame::OnExportShapeOBJ(wxCommandEvent& WXUNUSED(event)) {
 
 		std::vector<NiShape*> shapes;
 		shapes.reserve(selectedItems.size());
-		for (auto &i : selectedItems)
+		for (auto& i : selectedItems)
 			shapes.push_back(i->GetShape());
 
-		if (project->ExportOBJ(fileName.ToUTF8().data(), shapes, transToGlobal, Vector3(0.1f, 0.1f, 0.1f)))
-		{
+		if (project->ExportOBJ(fileName.ToUTF8().data(), shapes, transToGlobal, Vector3(0.1f, 0.1f, 0.1f))) {
 			wxLogError("Failed to export OBJ file '%s'!", fileName);
 			wxMessageBox(_("Failed to export OBJ file!"), _("Error"), wxICON_ERROR);
 		}
 	}
-	else
-	{
+	else {
 		wxString fileName = wxFileSelector(_("Export shape as an .obj file"), wxEmptyString, wxString(activeItem->GetShape()->name.get() + ".obj"), ".obj", "OBJ Files (*.obj)|*.obj", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
 		if (fileName.IsEmpty())
 			return;
@@ -4515,9 +4462,8 @@ void OutfitStudioFrame::OnExportShapeOBJ(wxCommandEvent& WXUNUSED(event)) {
 		wxLogMessage("Exporting shape '%s' as OBJ file to '%s'.", activeItem->GetShape()->name.get(), fileName);
 		project->ClearBoneScale();
 
-		std::vector<NiShape*> shapes = { activeItem->GetShape() };
-		if (project->ExportOBJ(fileName.ToUTF8().data(), shapes, transToGlobal, Vector3(0.1f, 0.1f, 0.1f)))
-		{
+		std::vector<NiShape*> shapes = {activeItem->GetShape()};
+		if (project->ExportOBJ(fileName.ToUTF8().data(), shapes, transToGlobal, Vector3(0.1f, 0.1f, 0.1f))) {
 			wxLogError("Failed to export OBJ file '%s'!", fileName);
 			wxMessageBox(_("Failed to export OBJ file!"), _("Error"), wxICON_ERROR);
 		}
@@ -4532,8 +4478,7 @@ void OutfitStudioFrame::OnImportFBX(wxCommandEvent& WXUNUSED(event)) {
 	wxArrayString fileNames;
 	importDialog.GetPaths(fileNames);
 
-	for (auto &fileName : fileNames)
-	{
+	for (auto& fileName : fileNames) {
 		wxLogMessage("Importing shape(s) from FBX file '%s'...", fileName);
 
 		int ret;
@@ -4561,14 +4506,12 @@ void OutfitStudioFrame::OnExportFBX(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	bool hasSkinTrans = false;
-	for (NiShape *shape : project->GetWorkNif()->GetShapes())
-	{
+	for (NiShape* shape : project->GetWorkNif()->GetShapes()) {
 		if (!project->GetWorkAnim()->shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(MatTransform()))
 			hasSkinTrans = true;
 	}
 	bool transToGlobal = false;
-	if (hasSkinTrans)
-	{
+	if (hasSkinTrans) {
 		int res = wxMessageBox(_("Some of the shapes have skin coordinate systems that are not the same as the global coordinate system.  Should the geometry be transformed to global coordinates in the FBX?  (This is not recommended.)"), _("Transform to global"), wxYES_NO | wxCANCEL);
 		if (res == wxCANCEL)
 			return;
@@ -4582,38 +4525,33 @@ void OutfitStudioFrame::OnExportFBX(wxCommandEvent& WXUNUSED(event)) {
 	wxLogMessage("Exporting project to OBJ file '%s'...", fileName);
 	project->ClearBoneScale();
 
-	if (!project->ExportFBX(fileName.ToUTF8().data(), project->GetWorkNif()->GetShapes(), transToGlobal))
-	{
+	if (!project->ExportFBX(fileName.ToUTF8().data(), project->GetWorkNif()->GetShapes(), transToGlobal)) {
 		wxLogError("Failed to export FBX file '%s'!", fileName);
 		wxMessageBox(_("Failed to export FBX file!"), _("Export Error"), wxICON_ERROR);
 	}
 }
 
 void OutfitStudioFrame::OnExportShapeFBX(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
 
 	bool hasSkinTrans = false;
-	for (auto &i : selectedItems)
-	{
-		NiShape *shape = i->GetShape();
+	for (auto& i : selectedItems) {
+		NiShape* shape = i->GetShape();
 		if (!project->GetWorkAnim()->shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(MatTransform()))
 			hasSkinTrans = true;
 	}
 	bool transToGlobal = false;
-	if (hasSkinTrans)
-	{
+	if (hasSkinTrans) {
 		int res = wxMessageBox(_("Some of the shapes have skin coordinate systems that are not the same as the global coordinate system.  Should the geometry be transformed to global coordinates in the FBX?"), _("Transform to global"), wxYES_NO | wxCANCEL);
 		if (res == wxCANCEL)
 			return;
 		transToGlobal = (res == wxYES);
 	}
 
-	if (selectedItems.size() > 1)
-	{
+	if (selectedItems.size() > 1) {
 		wxString fileName = wxFileSelector(_("Export selected shapes as an .fbx file"), wxEmptyString, wxEmptyString, ".fbx", "FBX Files (*.fbx)|*.fbx", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
 		if (fileName.IsEmpty())
 			return;
@@ -4623,17 +4561,15 @@ void OutfitStudioFrame::OnExportShapeFBX(wxCommandEvent& WXUNUSED(event)) {
 
 		std::vector<NiShape*> shapes;
 		shapes.reserve(selectedItems.size());
-		for (auto &i : selectedItems)
+		for (auto& i : selectedItems)
 			shapes.push_back(i->GetShape());
 
-		if (!project->ExportFBX(fileName.ToUTF8().data(), shapes, transToGlobal))
-		{
+		if (!project->ExportFBX(fileName.ToUTF8().data(), shapes, transToGlobal)) {
 			wxLogError("Failed to export FBX file '%s'!", fileName);
 			wxMessageBox(_("Failed to export FBX file!"), _("Error"), wxICON_ERROR);
 		}
 	}
-	else
-	{
+	else {
 		wxString fileName = wxFileSelector(_("Export shape as an .fbx file"), wxEmptyString, wxString(activeItem->GetShape()->name.get() + ".fbx"), ".fbx", "FBX Files (*.fbx)|*.fbx", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
 		if (fileName.IsEmpty())
 			return;
@@ -4641,9 +4577,8 @@ void OutfitStudioFrame::OnExportShapeFBX(wxCommandEvent& WXUNUSED(event)) {
 		wxLogMessage("Exporting shape '%s' as FBX file to '%s'.", activeItem->GetShape()->name.get(), fileName);
 		project->ClearBoneScale();
 
-		std::vector<NiShape*> shapes = { activeItem->GetShape() };
-		if (!project->ExportFBX(fileName.ToUTF8().data(), shapes, transToGlobal))
-		{
+		std::vector<NiShape*> shapes = {activeItem->GetShape()};
+		if (!project->ExportFBX(fileName.ToUTF8().data(), shapes, transToGlobal)) {
 			wxLogError("Failed to export FBX file '%s'!", fileName);
 			wxMessageBox(_("Failed to export FBX file!"), _("Error"), wxICON_ERROR);
 		}
@@ -4663,22 +4598,19 @@ void OutfitStudioFrame::OnImportTRIHead(wxCommandEvent& WXUNUSED(event)) {
 	sliderScroll->FitInside();
 	activeSlider.clear();
 
-	for (auto &fn : fileNames)
-	{
+	for (auto& fn : fileNames) {
 		wxFileName fileName(fn);
 		wxLogMessage("Importing morphs from TRI (head) file '%s'...", fn);
 
 		TriHeadFile tri;
-		if (!tri.Read(fn.ToUTF8().data()))
-		{
+		if (!tri.Read(fn.ToUTF8().data())) {
 			wxLogError("Failed to load TRI file '%s'!", fn);
 			wxMessageBox(_("Failed to load TRI file!"), _("Error"), wxICON_ERROR);
 			return;
 		}
 
 		std::string shapeName{fileName.GetName().ToUTF8()};
-		while (project->IsValidShape(shapeName))
-		{
+		while (project->IsValidShape(shapeName)) {
 			std::string result{wxGetTextFromUser(_("Please enter a new unique name for the shape."), _("Rename Shape"), shapeName, this).ToUTF8()};
 			if (result.empty())
 				continue;
@@ -4696,10 +4628,8 @@ void OutfitStudioFrame::OnImportTRIHead(wxCommandEvent& WXUNUSED(event)) {
 		RefreshGUIFromProj(false);
 
 		auto morphs = tri.GetMorphs();
-		for (auto &morph : morphs)
-		{
-			if (!project->ValidSlider(morph.morphName))
-			{
+		for (auto& morph : morphs) {
+			if (!project->ValidSlider(morph.morphName)) {
 				createSliderGUI(morph.morphName, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
 				project->AddEmptySlider(morph.morphName);
 				ShowSliderEffect(morph.morphName);
@@ -4725,14 +4655,12 @@ void OutfitStudioFrame::OnImportTRIHead(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnExportTRIHead(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetWorkNif()->IsValid())
-	{
+	if (!project->GetWorkNif()->IsValid()) {
 		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
 		return;
 	}
 
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
@@ -4741,13 +4669,11 @@ void OutfitStudioFrame::OnExportTRIHead(wxCommandEvent& WXUNUSED(event)) {
 	if (dir.IsEmpty())
 		return;
 
-	for (auto &shape : project->GetWorkNif()->GetShapes())
-	{
+	for (auto& shape : project->GetWorkNif()->GetShapes()) {
 		std::string fn = dir + PathSepStr + shape->name.get() + ".tri";
 
 		wxLogMessage("Exporting TRI (head) morphs of '%s' to '%s'...", shape->name.get(), fn);
-		if (!project->WriteHeadTRI(shape, fn))
-		{
+		if (!project->WriteHeadTRI(shape, fn)) {
 			wxLogError("Failed to export TRI file to '%s'!", fn);
 			wxMessageBox(_("Failed to export TRI file!"), _("Error"), wxICON_ERROR);
 		}
@@ -4755,14 +4681,12 @@ void OutfitStudioFrame::OnExportTRIHead(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnExportShapeTRIHead(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetWorkNif()->IsValid())
-	{
+	if (!project->GetWorkNif()->IsValid()) {
 		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
 		return;
 	}
 
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
@@ -4772,8 +4696,7 @@ void OutfitStudioFrame::OnExportShapeTRIHead(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	wxLogMessage("Exporting TRI (head) morphs to '%s'...", fn);
-	if (!project->WriteHeadTRI(activeItem->GetShape(), fn.ToUTF8().data()))
-	{
+	if (!project->WriteHeadTRI(activeItem->GetShape(), fn.ToUTF8().data())) {
 		wxLogError("Failed to export TRI file to '%s'!", fn);
 		wxMessageBox(_("Failed to export TRI file!"), _("Error"), wxICON_ERROR);
 	}
@@ -4785,8 +4708,7 @@ void OutfitStudioFrame::OnImportPhysicsData(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	auto physicsBlock = std::make_unique<BSClothExtraData>();
-	if (!physicsBlock->FromHKX(fileName.ToUTF8().data()))
-	{
+	if (!physicsBlock->FromHKX(fileName.ToUTF8().data())) {
 		wxLogError("Failed to import physics data file '%s'!", fileName);
 		wxMessageBox(wxString::Format(_("Failed to import physics data file '%s'!"), fileName), _("Import Error"), wxICON_ERROR);
 	}
@@ -4799,14 +4721,13 @@ void OutfitStudioFrame::OnImportPhysicsData(wxCommandEvent& WXUNUSED(event)) {
 
 void OutfitStudioFrame::OnExportPhysicsData(wxCommandEvent& WXUNUSED(event)) {
 	auto& physicsData = project->GetClothData();
-	if (physicsData.empty())
-	{
+	if (physicsData.empty()) {
 		wxMessageBox(_("There is no physics data loaded!"), _("Info"), wxICON_INFORMATION);
 		return;
 	}
 
 	wxArrayString fileNames;
-	for (auto &data : physicsData)
+	for (auto& data : physicsData)
 		fileNames.Add(wxString::FromUTF8(data.first));
 
 	wxSingleChoiceDialog physicsDataChoice(this, _("Please choose the physics data source you want to export."), _("Choose physics data"), fileNames);
@@ -4816,14 +4737,12 @@ void OutfitStudioFrame::OnExportPhysicsData(wxCommandEvent& WXUNUSED(event)) {
 	int sel = physicsDataChoice.GetSelection();
 	std::string selString{fileNames[sel].ToUTF8()};
 
-	if (!selString.empty())
-	{
+	if (!selString.empty()) {
 		wxString fileName = wxFileSelector(_("Export physics data"), wxEmptyString, wxEmptyString, ".hkx", "*.hkx", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
 		if (fileName.IsEmpty())
 			return;
 
-		if (!physicsData[selString]->ToHKX(fileName.ToUTF8().data()))
-		{
+		if (!physicsData[selString]->ToHKX(fileName.ToUTF8().data())) {
 			wxLogError("Failed to save physics data file '%s'!", fileName);
 			wxMessageBox(wxString::Format(_("Failed to save physics data file '%s'!"), fileName), _("Export Error"), wxICON_ERROR);
 		}
@@ -4831,8 +4750,7 @@ void OutfitStudioFrame::OnExportPhysicsData(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnMakeConvRef(wxCommandEvent& WXUNUSED(event)) {
-	if (project->AllSlidersZero())
-	{
+	if (project->AllSlidersZero()) {
 		wxMessageBox(_("This function requires at least one slider position to be non-zero."));
 		return;
 	}
@@ -4854,8 +4772,7 @@ void OutfitStudioFrame::OnMakeConvRef(wxCommandEvent& WXUNUSED(event)) {
 	project->AddCombinedSlider(finalName);
 
 	auto baseShape = project->GetBaseShape();
-	if (baseShape)
-	{
+	if (baseShape) {
 		mesh* m = glView->GetMesh(baseShape->name.get());
 		if (m)
 			project->UpdateShapeFromMesh(baseShape, m);
@@ -4865,8 +4782,7 @@ void OutfitStudioFrame::OnMakeConvRef(wxCommandEvent& WXUNUSED(event)) {
 
 	std::vector<std::string> sliderList;
 	project->GetSliderList(sliderList);
-	for (auto &s : sliderList)
-	{
+	for (auto& s : sliderList) {
 		if (!s.compare(finalName))
 			continue;
 		project->DeleteSlider(s);
@@ -4884,14 +4800,13 @@ void OutfitStudioFrame::OnMakeConvRef(wxCommandEvent& WXUNUSED(event)) {
 
 void OutfitStudioFrame::OnSelectSliders(wxCommandEvent& event) {
 	bool checked = event.IsChecked();
-	for (auto &sd : sliderDisplays)
+	for (auto& sd : sliderDisplays)
 		ShowSliderEffect(sd.first, checked);
 
 	ApplySliders();
 }
 
-void OutfitStudioFrame::OnSliderFilterChanged(wxCommandEvent& WXUNUSED(event))
-{
+void OutfitStudioFrame::OnSliderFilterChanged(wxCommandEvent& WXUNUSED(event)) {
 	DoFilterSliders();
 }
 
@@ -4899,8 +4814,7 @@ void OutfitStudioFrame::DoFilterSliders() {
 	wxString filterStr = sliderFilter->GetValue();
 	filterStr.MakeLower();
 
-	for (auto &sd : sliderDisplays)
-	{
+	for (auto& sd : sliderDisplays) {
 		if (!sd.second)
 			continue;
 
@@ -4915,8 +4829,7 @@ void OutfitStudioFrame::DoFilterSliders() {
 	sliderScroll->FitInside();
 }
 
-void OutfitStudioFrame::OnBonesFilterChanged(wxCommandEvent& WXUNUSED(event))
-{
+void OutfitStudioFrame::OnBonesFilterChanged(wxCommandEvent& WXUNUSED(event)) {
 	UpdateBoneTree();
 }
 
@@ -4939,19 +4852,15 @@ void OutfitStudioFrame::ToggleVisibility(wxTreeItemId firstItem) {
 	bool ghost = false;
 	int state = 0;
 
-	if (!firstItem.IsOk())
-	{
-		if (!selectedItems.empty())
-		{
+	if (!firstItem.IsOk()) {
+		if (!selectedItems.empty()) {
 			firstItem = selectedItems.front()->GetId();
 		}
 	}
 
-	if (firstItem.IsOk())
-	{
+	if (firstItem.IsOk()) {
 		state = outfitShapes->GetItemState(firstItem);
-		switch (state)
-		{
+		switch (state) {
 		case 0:
 			vis = false;
 			ghost = false;
@@ -4975,12 +4884,9 @@ void OutfitStudioFrame::ToggleVisibility(wxTreeItemId firstItem) {
 		outfitShapes->SetItemState(firstItem, state);
 	}
 
-	if (selectedItems.size() > 1)
-	{
-		for (auto &i : selectedItems)
-		{
-			if (i->GetId().GetID() != firstItem.GetID())
-			{
+	if (selectedItems.size() > 1) {
+		for (auto& i : selectedItems) {
+			if (i->GetId().GetID() != firstItem.GetID()) {
 				std::string shapeName{outfitShapes->GetItemText(i->GetId()).ToUTF8()};
 				glView->SetShapeGhostMode(shapeName, ghost);
 				glView->ShowShape(shapeName, vis);
@@ -4999,27 +4905,23 @@ void OutfitStudioFrame::OnShapeVisToggle(wxTreeEvent& event) {
 
 void OutfitStudioFrame::OnShapeSelect(wxTreeEvent& event) {
 	wxTreeItemId item = event.GetItem();
-	if (!item.IsOk())
-	{
+	if (!item.IsOk()) {
 		event.Veto();
 		return;
 	}
 
-	if (selectionLocked)
-	{
+	if (selectionLocked) {
 		event.Veto();
 		return;
 	}
 
-	if (outfitShapes->GetItemParent(item).IsOk())
-	{
+	if (outfitShapes->GetItemParent(item).IsOk()) {
 		if (outfitShapes->IsSelected(item))
 			activeItem = (ShapeItemData*)outfitShapes->GetItemData(item);
 		else
 			activeItem = nullptr;
 	}
-	else
-	{
+	else {
 		wxTreeItemIdValue cookie;
 		wxTreeItemId subitem = outfitShapes->GetFirstChild(item, cookie);
 		if (subitem.IsOk() && outfitShapes->IsSelected(subitem))
@@ -5034,13 +4936,10 @@ void OutfitStudioFrame::OnShapeSelect(wxTreeEvent& event) {
 	wxArrayTreeItemIds selected;
 	outfitShapes->GetSelections(selected);
 
-	for (auto &i : selected)
-	{
-		if (outfitShapes->GetItemParent(i).IsOk())
-		{
+	for (auto& i : selected) {
+		if (outfitShapes->GetItemParent(i).IsOk()) {
 			auto data = (ShapeItemData*)outfitShapes->GetItemData(i);
-			if (data)
-			{
+			if (data) {
 				shapeNames.push_back(data->GetShape()->name.get());
 				selectedItems.push_back(data);
 
@@ -5048,15 +4947,12 @@ void OutfitStudioFrame::OnShapeSelect(wxTreeEvent& event) {
 					activeItem = data;
 			}
 		}
-		else
-		{
+		else {
 			wxTreeItemIdValue cookie;
 			wxTreeItemId subitem = outfitShapes->GetFirstChild(i, cookie);
-			if (subitem.IsOk())
-			{
+			if (subitem.IsOk()) {
 				auto data = (ShapeItemData*)outfitShapes->GetItemData(subitem);
-				if (data)
-				{
+				if (data) {
 					shapeNames.push_back(data->GetShape()->name.get());
 					selectedItems.push_back(data);
 
@@ -5096,8 +4992,7 @@ void OutfitStudioFrame::ToggleBoneState(wxTreeItemId item) {
 	std::string text = outfitBones->GetItemText(item).ToStdString();
 	int state = outfitBones->GetItemState(item);
 
-	switch (state)
-	{
+	switch (state) {
 	case 0:
 		outfitBones->SetItemState(item, 1);
 		lastNormalizeBones.insert(text);
@@ -5116,29 +5011,23 @@ void OutfitStudioFrame::OnBoneStateToggle(wxTreeEvent& event) {
 
 void OutfitStudioFrame::RefreshGUIWeightColors() {
 	// Clear vcolors of all shapes
-	for (auto &s : project->GetWorkNif()->GetShapeNames())
-	{
+	for (auto& s : project->GetWorkNif()->GetShapeNames()) {
 		mesh* m = glView->GetMesh(s);
 		if (m)
 			m->ColorChannelFill(1, 0.0f);
 	}
 
-	if (!activeBone.empty())
-	{
+	if (!activeBone.empty()) {
 		// Show weights of selected shapes without reference
-		for (auto &s : selectedItems)
-		{
-			if (!project->IsBaseShape(s->GetShape()))
-			{
+		for (auto& s : selectedItems) {
+			if (!project->IsBaseShape(s->GetShape())) {
 				auto weights = project->GetWorkAnim()->GetWeightsPtr(s->GetShape()->name.get(), activeBone);
 
 				mesh* m = glView->GetMesh(s->GetShape()->name.get());
-				if (m)
-				{
+				if (m) {
 					m->ColorChannelFill(1, 0.0f);
-					if (weights)
-					{
-						for (auto &bw : *weights)
+					if (weights) {
+						for (auto& bw : *weights)
 							m->vcolors[bw.first].y = bw.second;
 					}
 				}
@@ -5147,17 +5036,14 @@ void OutfitStudioFrame::RefreshGUIWeightColors() {
 
 		// Always show weights of reference shape
 		NiShape* baseShape = project->GetBaseShape();
-		if (baseShape)
-		{
+		if (baseShape) {
 			auto weights = project->GetWorkAnim()->GetWeightsPtr(baseShape->name.get(), activeBone);
 
 			mesh* m = glView->GetMesh(baseShape->name.get());
-			if (m)
-			{
+			if (m) {
 				m->ColorChannelFill(1, 0.0f);
-				if (weights)
-				{
-					for (auto &bw : *weights)
+				if (weights) {
+					for (auto& bw : *weights)
 						m->vcolors[bw.first].y = bw.second;
 				}
 			}
@@ -5184,16 +5070,13 @@ void OutfitStudioFrame::OnBoneSelect(wxTreeEvent& event) {
 	activeBone.clear();
 	std::string selBone = outfitBones->GetItemText(item);
 
-	if (!outfitBones->IsSelected(item))
-	{
-		if (!selected.IsEmpty())
-		{
+	if (!outfitBones->IsSelected(item)) {
+		if (!selected.IsEmpty()) {
 			std::string frontBone = outfitBones->GetItemText(selected.front());
 			activeBone = frontBone;
 		}
 	}
-	else
-	{
+	else {
 		activeBone = selBone;
 		if (selected.GetCount() == 1)
 			lastSelectedBones.clear();
@@ -5201,8 +5084,7 @@ void OutfitStudioFrame::OnBoneSelect(wxTreeEvent& event) {
 
 	wxTreeItemIdValue cookie;
 	wxTreeItemId itemTree = outfitBones->GetFirstChild(bonesRoot, cookie);
-	while (itemTree.IsOk())
-	{
+	while (itemTree.IsOk()) {
 		std::string boneName = outfitBones->GetItemText(itemTree).ToStdString();
 		if (outfitBones->IsSelected(itemTree))
 			lastSelectedBones.insert(boneName);
@@ -5231,23 +5113,19 @@ void OutfitStudioFrame::OnCheckTreeSel(wxTreeEvent& event) {
 
 void OutfitStudioFrame::OnShapeContext(wxTreeEvent& event) {
 	wxTreeItemId item = event.GetItem();
-	if (outfitShapes->GetItemParent(item).IsOk())
-	{
+	if (outfitShapes->GetItemParent(item).IsOk()) {
 		outfitShapes->SelectItem(item);
 
 		wxMenu* menu = wxXmlResource::Get()->LoadMenu("menuMeshContext");
-		if (menu)
-		{
+		if (menu) {
 			PopupMenu(menu);
 			delete menu;
 		}
 	}
 }
 
-void OutfitStudioFrame::OnShapeDrag(wxTreeEvent& event)
-{
-	if (activeItem)
-	{
+void OutfitStudioFrame::OnShapeDrag(wxTreeEvent& event) {
+	if (activeItem) {
 		wxPoint p;
 		wxGetMousePosition(&p.x, &p.y);
 		p = outfitShapes->ScreenToClient(p);
@@ -5256,8 +5134,7 @@ void OutfitStudioFrame::OnShapeDrag(wxTreeEvent& event)
 		outfitShapes->HitTest(p, outflags);
 
 		int mask = wxTREE_HITTEST_ONITEMINDENT | wxTREE_HITTEST_ONITEMSTATEICON;
-		if ((outflags & mask) == 0)
-		{
+		if ((outflags & mask) == 0) {
 			outfitShapes->SetCursor(wxCURSOR_HAND);
 			event.Allow();
 		}
@@ -5286,8 +5163,7 @@ void OutfitStudioFrame::OnShapeDrop(wxTreeEvent& event) {
 	auto dropData = new ShapeItemData(activeItem->GetShape());
 	outfitShapes->SetItemState(movedItem, 0);
 	outfitShapes->SetItemData(movedItem, dropData);
-	if (project->IsBaseShape(dropData->GetShape()))
-	{
+	if (project->IsBaseShape(dropData->GetShape())) {
 		outfitShapes->SetItemBold(movedItem);
 		outfitShapes->SetItemTextColour(movedItem, wxColour(0, 255, 0));
 	}
@@ -5306,8 +5182,7 @@ void OutfitStudioFrame::OnBoneContext(wxTreeEvent& event) {
 	if (itemId.IsOk())
 		contextBone = outfitBones->GetItemText(itemId);
 	wxMenu* menu = wxXmlResource::Get()->LoadMenu("menuBoneContext");
-	if (menu)
-	{
+	if (menu) {
 		PopupMenu(menu);
 		delete menu;
 	}
@@ -5316,15 +5191,13 @@ void OutfitStudioFrame::OnBoneContext(wxTreeEvent& event) {
 void OutfitStudioFrame::OnBoneTreeContext(wxCommandEvent& WXUNUSED(event)) {
 	contextBone.clear();
 	wxMenu* menu = wxXmlResource::Get()->LoadMenu("menuBoneTreeContext");
-	if (menu)
-	{
+	if (menu) {
 		PopupMenu(menu);
 		delete menu;
 	}
 }
 
-void OutfitStudioFrame::OnSegmentSelect(wxTreeEvent& event)
-{
+void OutfitStudioFrame::OnSegmentSelect(wxTreeEvent& event) {
 	ShowSegment(event.GetItem());
 }
 
@@ -5341,8 +5214,7 @@ void OutfitStudioFrame::OnSegmentContext(wxTreeEvent& event) {
 	else
 		menu = wxXmlResource::Get()->LoadMenu("menuSegmentContext");
 
-	if (menu)
-	{
+	if (menu) {
 		PopupMenu(menu);
 		delete menu;
 	}
@@ -5350,8 +5222,7 @@ void OutfitStudioFrame::OnSegmentContext(wxTreeEvent& event) {
 
 void OutfitStudioFrame::OnSegmentTreeContext(wxCommandEvent& WXUNUSED(event)) {
 	wxMenu* menu = wxXmlResource::Get()->LoadMenu("menuSegmentTreeContext");
-	if (menu)
-	{
+	if (menu) {
 		PopupMenu(menu);
 		delete menu;
 	}
@@ -5361,15 +5232,13 @@ int OutfitStudioFrame::CalcMaxSegPartID() {
 	int maxid = -1;
 	wxTreeItemIdValue cookie;
 	wxTreeItemId child = segmentTree->GetFirstChild(segmentRoot, cookie);
-	while (child.IsOk())
-	{
+	while (child.IsOk()) {
 		SegmentItemData* segmentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(child));
 		if (segmentData)
 			maxid = std::max(maxid, segmentData->partID);
 		wxTreeItemIdValue subCookie;
 		wxTreeItemId subChild = segmentTree->GetFirstChild(child, subCookie);
-		while (subChild.IsOk())
-		{
+		while (subChild.IsOk()) {
 			SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(subChild));
 			if (subSegmentData)
 				maxid = std::max(maxid, subSegmentData->partID);
@@ -5383,8 +5252,7 @@ int OutfitStudioFrame::CalcMaxSegPartID() {
 void OutfitStudioFrame::OnAddSegment(wxCommandEvent& WXUNUSED(event)) {
 	int newPartID = CalcMaxSegPartID() + 1;
 	wxTreeItemId newItem;
-	if (!activeSegment.IsOk() || segmentTree->GetChildrenCount(segmentRoot) <= 0)
-	{
+	if (!activeSegment.IsOk() || segmentTree->GetChildrenCount(segmentRoot) <= 0) {
 		// The new segment is the only partition: assign all triangles.
 		for (size_t i = 0; i < triSParts.size(); ++i)
 			triSParts[i] = newPartID;
@@ -5394,8 +5262,7 @@ void OutfitStudioFrame::OnAddSegment(wxCommandEvent& WXUNUSED(event)) {
 	else
 		newItem = segmentTree->InsertItem(segmentRoot, activeSegment, "Segment", -1, -1, new SegmentItemData(newPartID));
 
-	if (newItem.IsOk())
-	{
+	if (newItem.IsOk()) {
 		segmentTree->UnselectAll();
 		segmentTree->SelectItem(newItem);
 	}
@@ -5408,10 +5275,8 @@ void OutfitStudioFrame::OnAddSubSegment(wxCommandEvent& WXUNUSED(event)) {
 	int newPartID = CalcMaxSegPartID() + 1;
 	wxTreeItemId newItem;
 	wxTreeItemId parent = segmentTree->GetItemParent(activeSegment);
-	if (parent == segmentRoot)
-	{
-		if (segmentTree->GetChildrenCount(activeSegment) <= 0)
-		{
+	if (parent == segmentRoot) {
+		if (segmentTree->GetChildrenCount(activeSegment) <= 0) {
 			// The new subsegment will be the only child: assign all of
 			// the segment's triangles to it.
 			SegmentItemData* segmentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(activeSegment));
@@ -5426,8 +5291,7 @@ void OutfitStudioFrame::OnAddSubSegment(wxCommandEvent& WXUNUSED(event)) {
 	else
 		newItem = segmentTree->InsertItem(parent, activeSegment, "Sub Segment", -1, -1, new SubSegmentItemData(newPartID, 0, 0xFFFFFFFF));
 
-	if (newItem.IsOk())
-	{
+	if (newItem.IsOk()) {
 		segmentTree->UnselectAll();
 		segmentTree->SelectItem(newItem);
 	}
@@ -5438,15 +5302,13 @@ void OutfitStudioFrame::OnAddSubSegment(wxCommandEvent& WXUNUSED(event)) {
 
 void OutfitStudioFrame::OnDeleteSegment(wxCommandEvent& WXUNUSED(event)) {
 	SegmentItemData* segmentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(activeSegment));
-	if (segmentData)
-	{
+	if (segmentData) {
 		// Collect list of partition IDs that will be disappearing.
 		std::vector<bool> oldPartIDs(CalcMaxSegPartID() + 1, false);
 		oldPartIDs[segmentData->partID] = true;
 		wxTreeItemIdValue cookie;
 		wxTreeItemId child = segmentTree->GetFirstChild(activeSegment, cookie);
-		while (child.IsOk())
-		{
+		while (child.IsOk()) {
 			SubSegmentItemData* childData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(child));
 			if (childData)
 				oldPartIDs[childData->partID] = true;
@@ -5458,15 +5320,13 @@ void OutfitStudioFrame::OnDeleteSegment(wxCommandEvent& WXUNUSED(event)) {
 		wxTreeItemId sibling = segmentTree->GetPrevSibling(activeSegment);
 		if (!sibling.IsOk())
 			sibling = segmentTree->GetNextSibling(activeSegment);
-		if (sibling.IsOk())
-		{
+		if (sibling.IsOk()) {
 			SegmentItemData* siblingData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(sibling));
 			if (siblingData)
 				newPartID = siblingData->partID;
 
 			child = segmentTree->GetFirstChild(sibling, cookie);
-			if (child.IsOk())
-			{
+			if (child.IsOk()) {
 				SubSegmentItemData* childData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(child));
 				if (childData)
 					newPartID = childData->partID;
@@ -5493,8 +5353,7 @@ void OutfitStudioFrame::OnDeleteSegment(wxCommandEvent& WXUNUSED(event)) {
 void OutfitStudioFrame::OnDeleteSubSegment(wxCommandEvent& WXUNUSED(event)) {
 	SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(activeSegment));
 	wxTreeItemId newSelItem;
-	if (subSegmentData)
-	{
+	if (subSegmentData) {
 		int oldPartID = subSegmentData->partID, newPartID = -1;
 
 		// Find a partition to assign triangles to.
@@ -5502,18 +5361,15 @@ void OutfitStudioFrame::OnDeleteSubSegment(wxCommandEvent& WXUNUSED(event)) {
 		if (!sibling.IsOk())
 			sibling = segmentTree->GetNextSibling(activeSegment);
 
-		if (sibling.IsOk())
-		{
+		if (sibling.IsOk()) {
 			SubSegmentItemData* siblingData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(sibling));
 			if (siblingData)
 				newPartID = siblingData->partID;
 			newSelItem = sibling;
 		}
-		else
-		{
+		else {
 			wxTreeItemId parent = segmentTree->GetItemParent(activeSegment);
-			if (parent.IsOk())
-			{
+			if (parent.IsOk()) {
 				SegmentItemData* parentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(parent));
 				if (parentData)
 					newPartID = parentData->partID;
@@ -5538,18 +5394,14 @@ void OutfitStudioFrame::OnDeleteSubSegment(wxCommandEvent& WXUNUSED(event)) {
 void OutfitStudioFrame::OnSegmentSlotChanged(wxCommandEvent& event) {
 	wxChoice* segmentSlot = (wxChoice*)event.GetEventObject();
 
-	if (activeSegment.IsOk() && segmentTree->GetItemParent(activeSegment).IsOk())
-	{
+	if (activeSegment.IsOk() && segmentTree->GetItemParent(activeSegment).IsOk()) {
 		SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(activeSegment));
-		if (subSegmentData)
-		{
+		if (subSegmentData) {
 			subSegmentData->userSlotID = 0;
 
-			if (segmentSlot->GetSelection() > 0)
-			{
+			if (segmentSlot->GetSelection() > 0) {
 				wxString slotSel = segmentSlot->GetStringSelection();
-				if (slotSel.length() >= 2)
-				{
+				if (slotSel.length() >= 2) {
 					unsigned long slot = 0;
 					slotSel.Mid(0, 2).ToULong(&slot);
 
@@ -5567,11 +5419,9 @@ void OutfitStudioFrame::OnSegmentSlotChanged(wxCommandEvent& event) {
 void OutfitStudioFrame::OnSegmentTypeChanged(wxCommandEvent& event) {
 	wxChoice* segmentType = (wxChoice*)event.GetEventObject();
 
-	if (activeSegment.IsOk() && segmentTree->GetItemParent(activeSegment).IsOk())
-	{
+	if (activeSegment.IsOk() && segmentTree->GetItemParent(activeSegment).IsOk()) {
 		SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(activeSegment));
-		if (subSegmentData)
-		{
+		if (subSegmentData) {
 			unsigned long type = 0xFFFFFFFF;
 
 			wxString hashSel = segmentType->GetStringSelection();
@@ -5586,8 +5436,7 @@ void OutfitStudioFrame::OnSegmentTypeChanged(wxCommandEvent& event) {
 	}
 }
 
-void OutfitStudioFrame::OnSegmentApply(wxCommandEvent& WXUNUSED(event))
-{
+void OutfitStudioFrame::OnSegmentApply(wxCommandEvent& WXUNUSED(event)) {
 	ApplySegments();
 }
 
@@ -5597,29 +5446,24 @@ void OutfitStudioFrame::ApplySegments() {
 	wxTreeItemIdValue cookie;
 	wxTreeItemId child = segmentTree->GetFirstChild(segmentRoot, cookie);
 
-	while (child.IsOk())
-	{
+	while (child.IsOk()) {
 		SegmentItemData* segmentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(child));
-		if (segmentData)
-		{
+		if (segmentData) {
 			inf.segs.emplace_back();
-			NifSegmentInfo &seg = inf.segs.back();
+			NifSegmentInfo& seg = inf.segs.back();
 			seg.partID = segmentData->partID;
 			size_t childCount = segmentTree->GetChildrenCount(child);
 
-			if (childCount > 0)
-			{
+			if (childCount > 0) {
 				seg.subs.resize(childCount);
 				int childInd = 0;
 
 				wxTreeItemIdValue subCookie;
 				wxTreeItemId subChild = segmentTree->GetFirstChild(child, subCookie);
-				while (subChild.IsOk())
-				{
+				while (subChild.IsOk()) {
 					SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(subChild));
-					if (subSegmentData)
-					{
-						NifSubSegmentInfo &sub = seg.subs[childInd++];
+					if (subSegmentData) {
+						NifSubSegmentInfo& sub = seg.subs[childInd++];
 						sub.partID = subSegmentData->partID;
 						sub.userSlotID = subSegmentData->userSlotID;
 						sub.material = subSegmentData->material;
@@ -5644,13 +5488,11 @@ void OutfitStudioFrame::ApplySegments() {
 	SetPendingChanges();
 }
 
-void OutfitStudioFrame::OnSegmentReset(wxCommandEvent& WXUNUSED(event))
-{
+void OutfitStudioFrame::OnSegmentReset(wxCommandEvent& WXUNUSED(event)) {
 	ResetSegments();
 }
 
-void OutfitStudioFrame::ResetSegments()
-{
+void OutfitStudioFrame::ResetSegments() {
 	if (activeItem)
 		CreateSegmentTree(activeItem->GetShape());
 	else
@@ -5669,8 +5511,7 @@ void OutfitStudioFrame::OnSegmentEditSSF(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::CreateSegmentTree(NiShape* shape) {
-	if (segmentTree->GetChildrenCount(segmentRoot) > 0)
-	{
+	if (segmentTree->GetChildrenCount(segmentRoot) > 0) {
 		triSParts.clear(); // DeleteChildren calls OnSegmentSelect
 		segmentTree->DeleteChildren(segmentRoot);
 	}
@@ -5678,16 +5519,12 @@ void OutfitStudioFrame::CreateSegmentTree(NiShape* shape) {
 	segmentTabButton->SetPendingChanges(false);
 
 	NifSegmentationInfo inf;
-	if (project->GetWorkNif()->GetShapeSegments(shape, inf, triSParts))
-	{
-		for (size_t i = 0; i < inf.segs.size(); i++)
-		{
+	if (project->GetWorkNif()->GetShapeSegments(shape, inf, triSParts)) {
+		for (size_t i = 0; i < inf.segs.size(); i++) {
 			wxTreeItemId segID = segmentTree->AppendItem(segmentRoot, "Segment", -1, -1, new SegmentItemData(inf.segs[i].partID));
-			if (segID.IsOk())
-			{
-				for (size_t j = 0; j < inf.segs[i].subs.size(); j++)
-				{
-					NifSubSegmentInfo &sub = inf.segs[i].subs[j];
+			if (segID.IsOk()) {
+				for (size_t j = 0; j < inf.segs[i].subs.size(); j++) {
+					NifSubSegmentInfo& sub = inf.segs[i].subs[j];
 					segmentTree->AppendItem(segID, "Sub Segment", -1, -1,
 					                        new SubSegmentItemData(sub.partID, sub.userSlotID, sub.material, sub.extraData));
 				}
@@ -5714,8 +5551,7 @@ void OutfitStudioFrame::ShowSegment(const wxTreeItemId& item, bool updateFromMas
 	std::unordered_map<uint16_t, float> mask;
 	wxChoice* segmentType = nullptr;
 	wxChoice* segmentSlot = nullptr;
-	if (!updateFromMask)
-	{
+	if (!updateFromMask) {
 		segmentType = (wxChoice*)FindWindowByName("segmentType");
 		segmentType->Disable();
 		segmentType->SetSelection(0);
@@ -5744,31 +5580,24 @@ void OutfitStudioFrame::ShowSegment(const wxTreeItemId& item, bool updateFromMas
 	std::vector<bool> selPartIDs(CalcMaxSegPartID() + 1, false);
 
 	SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(activeSegment));
-	if (subSegmentData)
-	{
+	if (subSegmentData) {
 		// Active segment is a subsegment
 		selPartIDs[subSegmentData->partID] = true;
 
-		if (updateFromMask)
-		{
+		if (updateFromMask) {
 			// Add triangles from mask
-			for (size_t t = 0; t < tris.size(); t++)
-			{
+			for (size_t t = 0; t < tris.size(); t++) {
 				if (mask.find(tris[t].p1) != mask.end() && mask.find(tris[t].p2) != mask.end() && mask.find(tris[t].p3) != mask.end())
 					triSParts[t] = subSegmentData->partID;
 			}
 		}
-		else
-		{
-			if (subSegmentData->material != 0xFFFFFFFF)
-			{
+		else {
+			if (subSegmentData->material != 0xFFFFFFFF) {
 				bool typeFound = false;
 				auto typeHash = wxString::Format("0x%08x", subSegmentData->material);
-				for (uint32_t i = 0; i < segmentType->GetCount(); i++)
-				{
+				for (uint32_t i = 0; i < segmentType->GetCount(); i++) {
 					auto typeString = segmentType->GetString(i);
-					if (typeString.Contains(typeHash))
-					{
+					if (typeString.Contains(typeHash)) {
 						segmentType->SetSelection((int)i);
 						typeFound = true;
 						break;
@@ -5781,12 +5610,10 @@ void OutfitStudioFrame::ShowSegment(const wxTreeItemId& item, bool updateFromMas
 
 			segmentType->Enable();
 
-			for (uint32_t i = 0; i < segmentSlot->GetCount(); i++)
-			{
+			for (uint32_t i = 0; i < segmentSlot->GetCount(); i++) {
 				wxString slotPrefix = wxString::Format("%d - ", subSegmentData->userSlotID);
 				auto slotString = segmentSlot->GetString(i);
-				if (slotString.StartsWith(slotPrefix))
-				{
+				if (slotString.StartsWith(slotPrefix)) {
 					segmentSlot->SetSelection((int)i);
 					break;
 				}
@@ -5795,11 +5622,9 @@ void OutfitStudioFrame::ShowSegment(const wxTreeItemId& item, bool updateFromMas
 			segmentSlot->Enable();
 		}
 	}
-	else
-	{
+	else {
 		SegmentItemData* segmentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(activeSegment));
-		if (segmentData)
-		{
+		if (segmentData) {
 			// Active segment is a normal segment
 			// Collect list of partition IDs for segment and children.
 			// Also find partition ID of last child, or segment if none.
@@ -5807,22 +5632,18 @@ void OutfitStudioFrame::ShowSegment(const wxTreeItemId& item, bool updateFromMas
 			int destPartID = segmentData->partID;
 			wxTreeItemIdValue subCookie;
 			wxTreeItemId child = segmentTree->GetFirstChild(activeSegment, subCookie);
-			while (child.IsOk())
-			{
+			while (child.IsOk()) {
 				SubSegmentItemData* childData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(child));
-				if (childData)
-				{
+				if (childData) {
 					selPartIDs[childData->partID] = true;
 					destPartID = childData->partID;
 				}
 				child = segmentTree->GetNextChild(activeSegment, subCookie);
 			}
 
-			if (updateFromMask)
-			{
+			if (updateFromMask) {
 				// Add triangles from mask
-				for (size_t t = 0; t < tris.size(); t++)
-				{
+				for (size_t t = 0; t < tris.size(); t++) {
 					if (mask.find(tris[t].p1) != mask.end() && mask.find(tris[t].p2) != mask.end() && mask.find(tris[t].p3) != mask.end() && (triSParts[t] < 0 || !selPartIDs[triSParts[t]]))
 						triSParts[t] = destPartID;
 				}
@@ -5832,23 +5653,19 @@ void OutfitStudioFrame::ShowSegment(const wxTreeItemId& item, bool updateFromMas
 
 	// Display segmentation colors depending on what is selected
 	mesh* m = glView->GetMesh(activeItem->GetShape()->name.get());
-	if (m)
-	{
+	if (m) {
 		SetSubMeshesForPartitions(m, triSParts);
 
 		// Set colors for segments
 		int nsm = m->subMeshes.size();
 		m->subMeshesColor.resize(nsm);
-		for (int pi = 0; pi < nsm; ++pi)
-		{
-			if (selPartIDs[pi])
-			{
+		for (int pi = 0; pi < nsm; ++pi) {
+			if (selPartIDs[pi]) {
 				m->subMeshesColor[pi].x = 1.0f;
 				m->subMeshesColor[pi].y = 0.0f;
 				m->subMeshesColor[pi].z = 0.0f;
 			}
-			else
-			{
+			else {
 				float colorValue = (pi + 1.0f) / (nsm + 1);
 				m->subMeshesColor[pi] = glView->CreateColorRamp(colorValue);
 			}
@@ -5857,8 +5674,7 @@ void OutfitStudioFrame::ShowSegment(const wxTreeItemId& item, bool updateFromMas
 		// Set mask
 		m->ColorFill(Vector3(0.0f, 0.0f, 0.0f));
 
-		for (size_t i = 0; i < triSParts.size(); ++i)
-		{
+		for (size_t i = 0; i < triSParts.size(); ++i) {
 			if (triSParts[i] < 0 || !selPartIDs[triSParts[i]])
 				continue;
 
@@ -5879,31 +5695,25 @@ void OutfitStudioFrame::UpdateSegmentNames() {
 	wxTreeItemIdValue cookie;
 	wxTreeItemId child = segmentTree->GetFirstChild(segmentRoot, cookie);
 
-	while (child.IsOk())
-	{
+	while (child.IsOk()) {
 		segmentTree->SetItemText(child, wxString::Format("Segment #%d", segmentIndex));
 
 		int subSegmentIndex = 0;
 		wxTreeItemIdValue subCookie;
 		wxTreeItemId subChild = segmentTree->GetFirstChild(child, subCookie);
 
-		while (subChild.IsOk())
-		{
+		while (subChild.IsOk()) {
 			std::string subSegmentName = "Default";
 			std::string subSegmentSlot = "";
 
 			auto subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(subChild));
-			if (subSegmentData)
-			{
-				if (subSegmentData->material != 0xFFFFFFFF)
-				{
+			if (subSegmentData) {
+				if (subSegmentData->material != 0xFFFFFFFF) {
 					bool typeFound = false;
 					auto typeHash = wxString::Format("0x%08x", subSegmentData->material);
-					for (uint32_t i = 0; i < segmentType->GetCount(); i++)
-					{
+					for (uint32_t i = 0; i < segmentType->GetCount(); i++) {
 						auto typeString = segmentType->GetString(i);
-						if (typeString.Contains(typeHash))
-						{
+						if (typeString.Contains(typeHash)) {
 							subSegmentName = typeString.BeforeLast('|');
 							typeFound = true;
 							break;
@@ -5914,15 +5724,12 @@ void OutfitStudioFrame::UpdateSegmentNames() {
 						subSegmentName = typeHash;
 				}
 
-				if (subSegmentData->userSlotID >= 30)
-				{
+				if (subSegmentData->userSlotID >= 30) {
 					wxString slotPrefix = wxString::Format("%d - ", subSegmentData->userSlotID);
 
-					for (uint32_t i = 0; i < segmentSlot->GetCount(); i++)
-					{
+					for (uint32_t i = 0; i < segmentSlot->GetCount(); i++) {
 						auto slotString = segmentSlot->GetString(i);
-						if (slotString.StartsWith(slotPrefix))
-						{
+						if (slotString.StartsWith(slotPrefix)) {
 							subSegmentSlot = wxString::Format("(Slot %s)", slotString);
 							break;
 						}
@@ -5941,8 +5748,7 @@ void OutfitStudioFrame::UpdateSegmentNames() {
 	}
 }
 
-void OutfitStudioFrame::OnPartitionSelect(wxTreeEvent& event)
-{
+void OutfitStudioFrame::OnPartitionSelect(wxTreeEvent& event) {
 	ShowPartition(event.GetItem());
 }
 
@@ -5957,8 +5763,7 @@ void OutfitStudioFrame::OnPartitionContext(wxTreeEvent& event) {
 	if (partitionData)
 		menu = wxXmlResource::Get()->LoadMenu("menuPartitionContext");
 
-	if (menu)
-	{
+	if (menu) {
 		PopupMenu(menu);
 		delete menu;
 	}
@@ -5966,8 +5771,7 @@ void OutfitStudioFrame::OnPartitionContext(wxTreeEvent& event) {
 
 void OutfitStudioFrame::OnPartitionTreeContext(wxCommandEvent& WXUNUSED(event)) {
 	wxMenu* menu = wxXmlResource::Get()->LoadMenu("menuPartitionTreeContext");
-	if (menu)
-	{
+	if (menu) {
 		PopupMenu(menu);
 		delete menu;
 	}
@@ -5980,8 +5784,7 @@ void OutfitStudioFrame::OnAddPartition(wxCommandEvent& WXUNUSED(event)) {
 	std::set<int> partInds;
 	wxTreeItemIdValue cookie;
 	wxTreeItemId child = partitionTree->GetFirstChild(partitionRoot, cookie);
-	while (child.IsOk())
-	{
+	while (child.IsOk()) {
 		PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(child));
 		if (partitionData)
 			partInds.insert(partitionData->index);
@@ -5993,24 +5796,21 @@ void OutfitStudioFrame::OnAddPartition(wxCommandEvent& WXUNUSED(event)) {
 
 	// Create partition item
 	wxTreeItemId newItem;
-	if (!activePartition.IsOk() || partitionTree->GetChildrenCount(partitionRoot) <= 0)
-	{
+	if (!activePartition.IsOk() || partitionTree->GetChildrenCount(partitionRoot) <= 0) {
 		auto shape = activeItem->GetShape();
-		if (shape && shape->GetNumVertices() > 0)
-		{
+		if (shape && shape->GetNumVertices() > 0) {
 			newItem = partitionTree->AppendItem(partitionRoot, "Partition", -1, -1,
 			                                    new PartitionItemData(partInd, isSkyrim ? 32 : 0));
 		}
 
-		for (int &pi : triParts)
+		for (int& pi : triParts)
 			pi = partInd;
 	}
 	else
 		newItem = partitionTree->InsertItem(partitionRoot, activePartition, "Partition", -1, -1,
 		                                    new PartitionItemData(partInd, isSkyrim ? 32 : 0));
 
-	if (newItem.IsOk())
-	{
+	if (newItem.IsOk()) {
 		partitionTree->UnselectAll();
 		partitionTree->SelectItem(newItem);
 	}
@@ -6021,16 +5821,14 @@ void OutfitStudioFrame::OnAddPartition(wxCommandEvent& WXUNUSED(event)) {
 
 void OutfitStudioFrame::OnDeletePartition(wxCommandEvent& WXUNUSED(event)) {
 	PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(activePartition));
-	if (partitionData)
-	{
+	if (partitionData) {
 		wxTreeItemId sibling = partitionTree->GetPrevSibling(activePartition);
 		if (!sibling.IsOk())
 			sibling = partitionTree->GetNextSibling(activePartition);
 
 		int newIndex = -1;
-		if (sibling.IsOk())
-		{
-			PartitionItemData *siblingData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(sibling));
+		if (sibling.IsOk()) {
+			PartitionItemData* siblingData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(sibling));
 			if (siblingData)
 				newIndex = siblingData->index;
 		}
@@ -6038,16 +5836,14 @@ void OutfitStudioFrame::OnDeletePartition(wxCommandEvent& WXUNUSED(event)) {
 			if (triParts[i] == partitionData->index)
 				triParts[i] = newIndex;
 
-		if (sibling.IsOk())
-		{
+		if (sibling.IsOk()) {
 			partitionTree->UnselectAll();
 			partitionTree->Delete(activePartition);
 			partitionTree->SelectItem(sibling);
 
 			ShowPartition(sibling);
 		}
-		else
-		{
+		else {
 			partitionTree->Delete(activePartition);
 			activePartition.Unset();
 		}
@@ -6060,11 +5856,9 @@ void OutfitStudioFrame::OnDeletePartition(wxCommandEvent& WXUNUSED(event)) {
 void OutfitStudioFrame::OnPartitionTypeChanged(wxCommandEvent& event) {
 	wxChoice* partitionType = (wxChoice*)event.GetEventObject();
 
-	if (activePartition.IsOk() && partitionTree->GetItemParent(activePartition).IsOk())
-	{
+	if (activePartition.IsOk() && partitionTree->GetItemParent(activePartition).IsOk()) {
 		PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(activePartition));
-		if (partitionData)
-		{
+		if (partitionData) {
 			unsigned long type = 0;
 			partitionType->GetStringSelection().ToULong(&type);
 			partitionData->type = type;
@@ -6075,8 +5869,7 @@ void OutfitStudioFrame::OnPartitionTypeChanged(wxCommandEvent& event) {
 	partitionTabButton->SetPendingChanges();
 }
 
-void OutfitStudioFrame::OnPartitionApply(wxCommandEvent& WXUNUSED(event))
-{
+void OutfitStudioFrame::OnPartitionApply(wxCommandEvent& WXUNUSED(event)) {
 	ApplyPartitions();
 }
 
@@ -6091,14 +5884,11 @@ void OutfitStudioFrame::ApplyPartitions() {
 	wxTreeItemIdValue cookie;
 	wxTreeItemId child = partitionTree->GetFirstChild(partitionRoot, cookie);
 
-	while (child.IsOk())
-	{
+	while (child.IsOk()) {
 		PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(child));
-		if (partitionData)
-		{
+		if (partitionData) {
 			const int index = partitionData->index;
-			if (index >= partitionInfo.size())
-			{
+			if (index >= partitionInfo.size()) {
 				partitionInfo.resize(index + 1);
 				delPartFlags.resize(index + 1, true);
 			}
@@ -6123,13 +5913,11 @@ void OutfitStudioFrame::ApplyPartitions() {
 	SetPendingChanges();
 }
 
-void OutfitStudioFrame::OnPartitionReset(wxCommandEvent& WXUNUSED(event))
-{
+void OutfitStudioFrame::OnPartitionReset(wxCommandEvent& WXUNUSED(event)) {
 	ResetPartitions();
 }
 
-void OutfitStudioFrame::ResetPartitions()
-{
+void OutfitStudioFrame::ResetPartitions() {
 	if (activeItem)
 		CreatePartitionTree(activeItem->GetShape());
 	else
@@ -6137,8 +5925,7 @@ void OutfitStudioFrame::ResetPartitions()
 }
 
 void OutfitStudioFrame::CreatePartitionTree(NiShape* shape) {
-	if (partitionTree->GetChildrenCount(partitionRoot) > 0)
-	{
+	if (partitionTree->GetChildrenCount(partitionRoot) > 0) {
 		triParts.clear(); // DeleteChildren calls OnPartitionSelect
 		partitionTree->DeleteChildren(partitionRoot);
 	}
@@ -6146,10 +5933,8 @@ void OutfitStudioFrame::CreatePartitionTree(NiShape* shape) {
 	partitionTabButton->SetPendingChanges(false);
 
 	NiVector<BSDismemberSkinInstance::PartitionInfo> partitionInfo;
-	if (project->GetWorkNif()->GetShapePartitions(shape, partitionInfo, triParts))
-	{
-		for (int i = 0; i < partitionInfo.size(); i++)
-		{
+	if (project->GetWorkNif()->GetShapePartitions(shape, partitionInfo, triParts)) {
+		for (int i = 0; i < partitionInfo.size(); i++) {
 			partitionTree->AppendItem(partitionRoot, "Partition", -1, -1, new PartitionItemData(i, partitionInfo[i].partID));
 		}
 	}
@@ -6173,8 +5958,7 @@ void OutfitStudioFrame::ShowPartition(const wxTreeItemId& item, bool updateFromM
 	std::unordered_map<uint16_t, float> mask;
 	wxChoice* partitionType = nullptr;
 	wxArrayString partitionStrings;
-	if (!updateFromMask)
-	{
+	if (!updateFromMask) {
 		partitionType = (wxChoice*)FindWindowByName("partitionType");
 		partitionType->Disable();
 		partitionType->SetSelection(0);
@@ -6196,26 +5980,20 @@ void OutfitStudioFrame::ShowPartition(const wxTreeItemId& item, bool updateFromM
 		return;
 
 	PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(activePartition));
-	if (partitionData)
-	{
-		if (!updateFromMask)
-		{
-			for (auto &s : partitionStrings)
-			{
-				if (s.StartsWith(wxString::Format("%d", partitionData->type)))
-				{
+	if (partitionData) {
+		if (!updateFromMask) {
+			for (auto& s : partitionStrings) {
+				if (s.StartsWith(wxString::Format("%d", partitionData->type))) {
 					// Show correct data in UI
 					partitionType->Enable();
 					partitionType->SetStringSelection(s);
 				}
 			}
 		}
-		else
-		{
+		else {
 			// Add triangles from mask
-			for (size_t triInd = 0; triInd < allTris.size(); ++triInd)
-			{
-				const Triangle &tri = allTris[triInd];
+			for (size_t triInd = 0; triInd < allTris.size(); ++triInd) {
+				const Triangle& tri = allTris[triInd];
 				if (mask.find(tri.p1) != mask.end() && mask.find(tri.p2) != mask.end() && mask.find(tri.p3) != mask.end())
 					triParts[triInd] = partitionData->index;
 			}
@@ -6224,25 +6002,21 @@ void OutfitStudioFrame::ShowPartition(const wxTreeItemId& item, bool updateFromM
 
 	// Display partition colors depending on what is selected
 	mesh* m = glView->GetMesh(activeItem->GetShape()->name.get());
-	if (m)
-	{
+	if (m) {
 		SetSubMeshesForPartitions(m, triParts);
 
 		// Set colors for non-selected partitions
 		int nsm = m->subMeshes.size();
 		m->subMeshesColor.resize(nsm);
 
-		for (int pi = 0; pi < nsm; ++pi)
-		{
+		for (int pi = 0; pi < nsm; ++pi) {
 			float colorValue = (pi + 1.0f) / (nsm + 1);
 			m->subMeshesColor[pi] = glView->CreateColorRamp(colorValue);
 		}
 
 		// Set color for selected partition
-		if (partitionData)
-		{
-			if (nsm > partitionData->index)
-			{
+		if (partitionData) {
+			if (nsm > partitionData->index) {
 				m->subMeshesColor[partitionData->index].x = 1.0f;
 				m->subMeshesColor[partitionData->index].y = 0.0f;
 				m->subMeshesColor[partitionData->index].z = 0.0f;
@@ -6252,14 +6026,12 @@ void OutfitStudioFrame::ShowPartition(const wxTreeItemId& item, bool updateFromM
 		// Set mask
 		m->ColorFill(Vector3(0.0f, 0.0f, 0.0f));
 
-		if (partitionData)
-		{
-			for (size_t i = 0; i < allTris.size(); ++i)
-			{
+		if (partitionData) {
+			for (size_t i = 0; i < allTris.size(); ++i) {
 				if (triParts[i] != partitionData->index)
 					continue;
 
-				const Triangle &t = allTris[i];
+				const Triangle& t = allTris[i];
 				m->vcolors[t.p1].x = 1.0f;
 				m->vcolors[t.p2].x = 1.0f;
 				m->vcolors[t.p3].x = 1.0f;
@@ -6277,16 +6049,12 @@ void OutfitStudioFrame::UpdatePartitionNames() {
 	wxTreeItemIdValue cookie;
 	wxTreeItemId child = partitionTree->GetFirstChild(partitionRoot, cookie);
 
-	while (child.IsOk())
-	{
+	while (child.IsOk()) {
 		PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(child));
-		if (partitionData)
-		{
+		if (partitionData) {
 			bool found = false;
-			for (auto &s : partitionStrings)
-			{
-				if (s.StartsWith(wxString::Format("%d", partitionData->type)))
-				{
+			for (auto& s : partitionStrings) {
+				if (s.StartsWith(wxString::Format("%d", partitionData->type))) {
 					partitionTree->SetItemText(child, s);
 					found = true;
 					break;
@@ -6301,7 +6069,7 @@ void OutfitStudioFrame::UpdatePartitionNames() {
 	}
 }
 
-void OutfitStudioFrame::SetSubMeshesForPartitions(mesh *m, const std::vector<int> &tp) {
+void OutfitStudioFrame::SetSubMeshesForPartitions(mesh* m, const std::vector<int>& tp) {
 	uint32_t nTris = static_cast<uint32_t>(tp.size());
 
 	// Sort triangles (via triInds) by partition number, negative partition
@@ -6310,8 +6078,7 @@ void OutfitStudioFrame::SetSubMeshesForPartitions(mesh *m, const std::vector<int
 	for (uint32_t ti = 0; ti < nTris; ++ti)
 		triInds[ti] = ti;
 
-	std::stable_sort(triInds.begin(), triInds.end(), [&tp](int i, int j)
-	{
+	std::stable_sort(triInds.begin(), triInds.end(), [&tp](int i, int j) {
 		return tp[j] < 0 || tp[i] < tp[j];
 	});
 
@@ -6323,13 +6090,11 @@ void OutfitStudioFrame::SetSubMeshesForPartitions(mesh *m, const std::vector<int
 	m->subMeshes.clear();
 	m->subMeshesColor.clear();
 
-	for (uint32_t ti = 0; ti < nTris; ++ti)
-	{
+	for (uint32_t ti = 0; ti < nTris; ++ti) {
 		while (tp[triInds[ti]] >= static_cast<int>(m->subMeshes.size()))
 			m->subMeshes.emplace_back(ti, 0);
 
-		if (tp[triInds[ti]] < 0)
-		{
+		if (tp[triInds[ti]] < 0) {
 			m->subMeshes.emplace_back(ti, 0);
 			break;
 		}
@@ -6344,7 +6109,7 @@ void OutfitStudioFrame::SetSubMeshesForPartitions(mesh *m, const std::vector<int
 	m->QueueUpdate(mesh::UpdateType::Indices);
 }
 
-void OutfitStudioFrame::SetNoSubMeshes(mesh *m) {
+void OutfitStudioFrame::SetNoSubMeshes(mesh* m) {
 	if (!m)
 		return;
 
@@ -6413,14 +6178,11 @@ void OutfitStudioFrame::OnSelectTool(wxCommandEvent& event) {
 		SelectTool(ToolID::Any);
 
 	// Remember last standard tool used in regular tabs
-	if (meshTabButton->GetCheck() || lightsTabButton->GetCheck())
-	{
+	if (meshTabButton->GetCheck() || lightsTabButton->GetCheck()) {
 		auto activeBrush = glView->GetActiveBrush();
-		if (activeBrush)
-		{
+		if (activeBrush) {
 			int brushType = activeBrush->Type();
-			if (brushType == TBT_STANDARD || brushType == TBT_MASK || brushType == TBT_MOVE)
-			{
+			if (brushType == TBT_STANDARD || brushType == TBT_MASK || brushType == TBT_MOVE) {
 				glView->SetLastTool(glView->GetActiveTool());
 			}
 		}
@@ -6448,13 +6210,11 @@ void OutfitStudioFrame::OnTogglePerspective(wxCommandEvent& event) {
 }
 
 void OutfitStudioFrame::OnToggleRotationCenter(wxCommandEvent& WXUNUSED(event)) {
-	if (glView->rotationCenterMode != RotationCenterMode::Zero)
-	{
+	if (glView->rotationCenterMode != RotationCenterMode::Zero) {
 		glView->rotationCenterMode = RotationCenterMode::Zero;
 		glView->gls.camRotOffset.Zero();
 	}
-	else
-	{
+	else {
 		glView->rotationCenterMode = RotationCenterMode::MeshCenter;
 		glView->gls.camRotOffset = glView->gls.GetActiveCenter();
 	}
@@ -6483,8 +6243,7 @@ void OutfitStudioFrame::OnShowFloor(wxCommandEvent& event) {
 	glView->ShowFloor(enabled);
 }
 
-void OutfitStudioFrame::OnBrushSettings(wxCommandEvent& WXUNUSED(event))
-{
+void OutfitStudioFrame::OnBrushSettings(wxCommandEvent& WXUNUSED(event)) {
 	if (brushSettingsPopup)
 		CloseBrushSettings();
 	else
@@ -6560,8 +6319,7 @@ void OutfitStudioFrame::OnClickSliderButton(wxCommandEvent& event) {
 
 	wxString buttonName = btn->GetName();
 	std::string clickedName{buttonName.BeforeLast('|').ToUTF8()};
-	if (clickedName.empty())
-	{
+	if (clickedName.empty()) {
 		event.Skip();
 		return;
 	}
@@ -6574,10 +6332,8 @@ void OutfitStudioFrame::OnClickSliderButton(wxCommandEvent& event) {
 	else if (buttonNameId == "btnPlus")
 		scale = 1.01f;
 
-	if (scale != 0.0f)
-	{
-		for (auto &i : selectedItems)
-		{
+	if (scale != 0.0f) {
+		for (auto& i : selectedItems) {
 			auto shape = i->GetShape();
 			std::vector<Vector3> verts;
 			project->ScaleMorphResult(shape, activeSlider, scale);
@@ -6587,8 +6343,7 @@ void OutfitStudioFrame::OnClickSliderButton(wxCommandEvent& event) {
 		return;
 	}
 
-	if (buttonNameId == "btnSliderProp")
-	{
+	if (buttonNameId == "btnSliderProp") {
 		ShowSliderProperties(clickedName);
 		return;
 	}
@@ -6628,28 +6383,24 @@ void OutfitStudioFrame::OnReadoutChange(wxCommandEvent& event) {
 void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 	int id = event.GetId();
 
-	if (currentTabButton && currentTabButton->HasPendingChanges())
-	{
+	if (currentTabButton && currentTabButton->HasPendingChanges()) {
 		wxMessageDialog dlg(this, _("Your changes were not applied yet. Do you want to apply or reset them?"), _("Pending Changes"), wxYES_NO | wxCANCEL | wxICON_WARNING | wxCANCEL_DEFAULT);
 		dlg.SetYesNoCancelLabels(_("Apply"), _("Reset"), _("Cancel"));
 
 		int res = dlg.ShowModal();
-		if (res == wxID_YES)
-		{
+		if (res == wxID_YES) {
 			if (currentTabButton == partitionTabButton)
 				ApplyPartitions();
 			else if (currentTabButton == segmentTabButton)
 				ApplySegments();
 		}
-		else if (res == wxID_NO)
-		{
+		else if (res == wxID_NO) {
 			if (currentTabButton == partitionTabButton)
 				ResetPartitions();
 			else if (currentTabButton == segmentTabButton)
 				ResetSegments();
 		}
-		else
-		{
+		else {
 			event.Skip();
 			return;
 		}
@@ -6658,8 +6409,7 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 	if (id != meshTabButton->GetId())
 		masksPane->Hide();
 
-	if (id != segmentTabButton->GetId())
-	{
+	if (id != segmentTabButton->GetId()) {
 		wxStaticText* segmentTypeLabel = (wxStaticText*)FindWindowByName("segmentTypeLabel");
 		wxChoice* segmentType = (wxChoice*)FindWindowByName("segmentType");
 		wxStaticText* segmentSlotLabel = (wxStaticText*)FindWindowByName("segmentSlotLabel");
@@ -6699,8 +6449,7 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 		toolBarH->EnableTool(XRCID("btnSelect"), true);
 	}
 
-	if (id != partitionTabButton->GetId())
-	{
+	if (id != partitionTabButton->GetId()) {
 		wxStaticText* partitionTypeLabel = (wxStaticText*)FindWindowByName("partitionTypeLabel");
 		wxChoice* partitionType = (wxChoice*)FindWindowByName("partitionType");
 		wxButton* partitionApply = (wxButton*)FindWindowByName("partitionApply");
@@ -6730,8 +6479,7 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 		toolBarH->EnableTool(XRCID("btnSelect"), true);
 	}
 
-	if (id != boneTabButton->GetId())
-	{
+	if (id != boneTabButton->GetId()) {
 		boneScale->Show(false);
 		cXMirrorBone->Show(false);
 
@@ -6753,8 +6501,7 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 
 		project->ClearBoneScale();
 
-		if (project->bPose)
-		{
+		if (project->bPose) {
 			project->bPose = false;
 			ApplyPose();
 		}
@@ -6762,16 +6509,14 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 		glView->SetWeightVisible(false);
 	}
 
-	if (id != colorsTabButton->GetId())
-	{
+	if (id != colorsTabButton->GetId()) {
 		glView->SetColorsVisible(false);
 
 		if (colorSettings->IsShown())
 			glView->ClearColors();
 	}
 
-	if (id != boneTabButton->GetId() || id != colorsTabButton->GetId())
-	{
+	if (id != boneTabButton->GetId() || id != colorsTabButton->GetId()) {
 		glView->SetTransformMode(false);
 
 		menuBar->Check(XRCID("btnInflateBrush"), true);
@@ -6808,8 +6553,7 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 		toolBarH->EnableTool(XRCID("btnSplitEdgeTool"), true);
 	}
 
-	if (id == meshTabButton->GetId())
-	{
+	if (id == meshTabButton->GetId()) {
 		currentTabButton = meshTabButton;
 
 		outfitBones->Hide();
@@ -6830,8 +6574,7 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 		SetNoSubMeshes();
 		SelectTool(glView->GetLastTool());
 	}
-	else if (id == boneTabButton->GetId())
-	{
+	else if (id == boneTabButton->GetId()) {
 		currentTabButton = boneTabButton;
 
 		outfitShapes->Hide();
@@ -6866,7 +6609,7 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 		xMirrorBoneLabel->Show();
 		posePane->Show();
 		bonesFilter->GetParent()->Show();
-	
+
 		glView->SetTransformMode(false);
 		SelectTool(ToolID::WeightBrush);
 		glView->SetWeightVisible();
@@ -6914,8 +6657,7 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 		ReselectBone();
 		glView->GetUndoHistory()->ClearHistory();
 	}
-	else if (id == colorsTabButton->GetId())
-	{
+	else if (id == colorsTabButton->GetId()) {
 		currentTabButton = colorsTabButton;
 
 		outfitShapes->Hide();
@@ -6975,8 +6717,7 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 
 		SetNoSubMeshes();
 	}
-	else if (id == segmentTabButton->GetId())
-	{
+	else if (id == segmentTabButton->GetId()) {
 		currentTabButton = segmentTabButton;
 
 		outfitShapes->Hide();
@@ -7055,8 +6796,7 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 
 		ShowSegment(segmentTree->GetSelection());
 	}
-	else if (id == partitionTabButton->GetId())
-	{
+	else if (id == partitionTabButton->GetId()) {
 		currentTabButton = partitionTabButton;
 
 		outfitShapes->Hide();
@@ -7125,8 +6865,7 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 
 		ShowPartition(partitionTree->GetSelection());
 	}
-	else if (id == lightsTabButton->GetId())
-	{
+	else if (id == lightsTabButton->GetId()) {
 		currentTabButton = lightsTabButton;
 
 		outfitShapes->Hide();
@@ -7185,15 +6924,12 @@ void OutfitStudioFrame::ScrollWindowIntoView(wxScrolledWindow* scrolled, wxWindo
 }
 
 void OutfitStudioFrame::HighlightSlider(const std::string& name) {
-	for (auto &d : sliderDisplays)
-	{
-		if (d.first == name)
-		{
+	for (auto& d : sliderDisplays) {
+		if (d.first == name) {
 			d.second->hilite = true;
 			d.second->sliderPane->SetBackgroundColour(wxColour(125, 77, 138));
 		}
-		else
-		{
+		else {
 			d.second->hilite = false;
 			d.second->sliderPane->SetBackgroundColour(wxColour(64, 64, 64));
 			d.second->slider->Disable();
@@ -7203,12 +6939,9 @@ void OutfitStudioFrame::HighlightSlider(const std::string& name) {
 	sliderScroll->Refresh();
 }
 
-void OutfitStudioFrame::ZeroSliders()
-{
-	if (!project->AllSlidersZero())
-	{
-		for (size_t s = 0; s < project->SliderCount(); s++)
-		{
+void OutfitStudioFrame::ZeroSliders() {
+	if (!project->AllSlidersZero()) {
+		for (size_t s = 0; s < project->SliderCount(); s++) {
 			if (project->SliderClamp(s))
 				continue;
 
@@ -7239,14 +6972,12 @@ void OutfitStudioFrame::OnSlider(wxScrollEvent& event) {
 		sliderName == "tzPoseSlider")
 		return;
 
-	if (sliderName != "boneScale")
-	{
+	if (sliderName != "boneScale") {
 		project->ClearBoneScale(false);
 		boneScale->SetValue(0);
 	}
 
-	if (sliderName == "boneScale")
-	{
+	if (sliderName == "boneScale") {
 		if (!activeBone.empty())
 			project->ApplyBoneScale(activeBone, event.GetPosition(), true);
 
@@ -7278,11 +7009,10 @@ void OutfitStudioFrame::OnLoadPreset(wxCommandEvent& WXUNUSED(event)) {
 	presets.LoadPresets(GetProjectPath() + "/SliderPresets", choice, names, true);
 	presets.GetPresetNames(names);
 
-	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgChoosePreset"))
-	{
+	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgChoosePreset")) {
 		presetChoice = XRCCTRL(dlg, "choicePreset", wxChoice);
 		presetChoice->AppendString("Zero All");
-		for (auto &n : names)
+		for (auto& n : names)
 			presetChoice->AppendString(n);
 
 		presetChoice->SetSelection(0);
@@ -7300,8 +7030,7 @@ void OutfitStudioFrame::OnLoadPreset(wxCommandEvent& WXUNUSED(event)) {
 
 		ZeroSliders();
 
-		if (choice == "Zero All")
-		{
+		if (choice == "Zero All") {
 			wxLogMessage("Sliders were reset to zero.");
 			return;
 		}
@@ -7310,8 +7039,7 @@ void OutfitStudioFrame::OnLoadPreset(wxCommandEvent& WXUNUSED(event)) {
 
 		float v;
 		bool r;
-		for (size_t i = 0; i < project->SliderCount(); i++)
-		{
+		for (size_t i = 0; i < project->SliderCount(); i++) {
 			if (!presets.GetSliderExists(choice, project->GetSliderName(i)))
 				continue;
 
@@ -7339,8 +7067,7 @@ void OutfitStudioFrame::OnLoadPreset(wxCommandEvent& WXUNUSED(event)) {
 void OutfitStudioFrame::OnSavePreset(wxCommandEvent& WXUNUSED(event)) {
 	std::vector<std::string> sliders;
 	project->GetSliderList(sliders);
-	if (sliders.empty())
-	{
+	if (sliders.empty()) {
 		wxMessageBox(_("There are no sliders loaded!"), _("Error"), wxICON_ERROR, this);
 		return;
 	}
@@ -7367,8 +7094,7 @@ void OutfitStudioFrame::OnSavePreset(wxCommandEvent& WXUNUSED(event)) {
 
 	bool addedSlider = false;
 	PresetCollection presets;
-	for (auto &s : sliders)
-	{
+	for (auto& s : sliders) {
 		size_t index = 0;
 		if (!project->SliderIndexFromName(s, index))
 			continue;
@@ -7389,29 +7115,25 @@ void OutfitStudioFrame::OnSavePreset(wxCommandEvent& WXUNUSED(event)) {
 			addedSlider = true;
 	}
 
-	if (!addedSlider)
-	{
+	if (!addedSlider) {
 		wxLogMessage("No changes were made to the sliders, so no preset was saved!");
 		wxMessageBox(_("No changes were made to the sliders, so no preset was saved!"), _("Info"), wxICON_INFORMATION, this);
 		return;
 	}
 
 	int error = presets.SavePreset(fileName, presetName, "OutfitStudioFrame", groups);
-	if (error)
-	{
+	if (error) {
 		wxLogError("Failed to save preset (%d)!", error);
 		wxMessageBox(wxString::Format(_("Failed to save preset (%d)!"), error), _("Error"), wxICON_ERROR, this);
 	}
 }
 
 void OutfitStudioFrame::OnSliderImportNIF(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
-	if (!bEditSlider)
-	{
+	if (!bEditSlider) {
 		wxMessageBox(_("There is no slider in edit mode to import data to!"), _("Error"));
 		return;
 	}
@@ -7421,8 +7143,7 @@ void OutfitStudioFrame::OnSliderImportNIF(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	wxLogMessage("Importing slider to '%s' for shape '%s' from NIF file '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
-	if (!project->SetSliderFromNIF(activeSlider, activeItem->GetShape(), fn.ToUTF8().data()))
-	{
+	if (!project->SetSliderFromNIF(activeSlider, activeItem->GetShape(), fn.ToUTF8().data())) {
 		wxLogError("No mesh found in the .nif file that matches currently selected shape!");
 		wxMessageBox(_("No mesh found in the .nif file that matches currently selected shape!"), _("Error"), wxICON_ERROR);
 		return;
@@ -7433,13 +7154,11 @@ void OutfitStudioFrame::OnSliderImportNIF(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnSliderImportBSD(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
-	if (!bEditSlider)
-	{
+	if (!bEditSlider) {
 		wxMessageBox(_("There is no slider in edit mode to import data to!"), _("Error"));
 		return;
 	}
@@ -7456,13 +7175,11 @@ void OutfitStudioFrame::OnSliderImportBSD(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnSliderImportOBJ(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
-	if (!bEditSlider)
-	{
+	if (!bEditSlider) {
 		wxMessageBox(_("There is no slider in edit mode to import data to!"), _("Error"));
 		return;
 	}
@@ -7472,8 +7189,7 @@ void OutfitStudioFrame::OnSliderImportOBJ(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	wxLogMessage("Importing slider to '%s' for shape '%s' from OBJ file '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
-	if (!project->SetSliderFromOBJ(activeSlider, activeItem->GetShape(), fn.ToUTF8().data()))
-	{
+	if (!project->SetSliderFromOBJ(activeSlider, activeItem->GetShape(), fn.ToUTF8().data())) {
 		wxLogError("Vertex count of .obj file mesh does not match currently selected shape!");
 		wxMessageBox(_("Vertex count of .obj file mesh does not match currently selected shape!"), _("Error"), wxICON_ERROR);
 		return;
@@ -7484,8 +7200,7 @@ void OutfitStudioFrame::OnSliderImportOBJ(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnSliderImportOSD(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetWorkNif()->IsValid())
-	{
+	if (!project->GetWorkNif()->IsValid()) {
 		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
 		return;
 	}
@@ -7502,8 +7217,7 @@ void OutfitStudioFrame::OnSliderImportOSD(wxCommandEvent& WXUNUSED(event)) {
 	wxLogMessage("Importing morphs from OSD file '%s'...", fn);
 
 	OSDataFile osd;
-	if (!osd.Read(fn.ToUTF8().data()))
-	{
+	if (!osd.Read(fn.ToUTF8().data())) {
 		wxLogError("Failed to import OSD file '%s'!", fn);
 		wxMessageBox(_("Failed to import OSD file!"), _("Error"), wxICON_ERROR);
 		return;
@@ -7512,8 +7226,7 @@ void OutfitStudioFrame::OnSliderImportOSD(wxCommandEvent& WXUNUSED(event)) {
 	// Deleting sliders
 	sliderScroll->Freeze();
 	std::vector<std::string> erase;
-	for (auto &sd : sliderDisplays)
-	{
+	for (auto& sd : sliderDisplays) {
 		sd.second->slider->SetValue(0);
 		SetSliderValue(sd.first, 0);
 		ShowSliderEffect(sd.first, true);
@@ -7532,7 +7245,7 @@ void OutfitStudioFrame::OnSliderImportOSD(wxCommandEvent& WXUNUSED(event)) {
 		project->DeleteSlider(sd.first);
 	}
 
-	for (auto &e : erase)
+	for (auto& e : erase)
 		sliderDisplays.erase(e);
 
 	MenuExitSliderEdit();
@@ -7543,19 +7256,16 @@ void OutfitStudioFrame::OnSliderImportOSD(wxCommandEvent& WXUNUSED(event)) {
 	wxString addedDiffs;
 	auto diffs = osd.GetDataDiffs();
 
-	for (auto &shape : project->GetWorkNif()->GetShapes())
-	{
+	for (auto& shape : project->GetWorkNif()->GetShapes()) {
 		std::string s = shape->name.get();
 		bool added = false;
-		for (auto &diff : diffs)
-		{
+		for (auto& diff : diffs) {
 			// Diff name is supposed to begin with matching shape name
 			if (diff.first.substr(0, s.size()) != s)
 				continue;
 
 			std::string diffName = diff.first.substr(s.length(), diff.first.length() - s.length() + 1);
-			if (!project->ValidSlider(diffName))
-			{
+			if (!project->ValidSlider(diffName)) {
 				createSliderGUI(diffName, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
 				project->AddEmptySlider(diffName);
 				ShowSliderEffect(diffName);
@@ -7581,8 +7291,7 @@ void OutfitStudioFrame::OnSliderImportOSD(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnSliderImportTRI(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetWorkNif()->IsValid())
-	{
+	if (!project->GetWorkNif()->IsValid()) {
 		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
 		return;
 	}
@@ -7599,8 +7308,7 @@ void OutfitStudioFrame::OnSliderImportTRI(wxCommandEvent& WXUNUSED(event)) {
 	wxLogMessage("Importing morphs from TRI file '%s'...", fn);
 
 	TriFile tri;
-	if (!tri.Read(fn.ToUTF8().data()))
-	{
+	if (!tri.Read(fn.ToUTF8().data())) {
 		wxLogError("Failed to load TRI file '%s'!", fn);
 		wxMessageBox(_("Failed to load TRI file!"), _("Error"), wxICON_ERROR);
 		return;
@@ -7609,8 +7317,7 @@ void OutfitStudioFrame::OnSliderImportTRI(wxCommandEvent& WXUNUSED(event)) {
 	// Deleting sliders
 	sliderScroll->Freeze();
 	std::vector<std::string> erase;
-	for (auto &sd : sliderDisplays)
-	{
+	for (auto& sd : sliderDisplays) {
 		sd.second->slider->SetValue(0);
 		SetSliderValue(sd.first, 0);
 		ShowSliderEffect(sd.first, true);
@@ -7629,7 +7336,7 @@ void OutfitStudioFrame::OnSliderImportTRI(wxCommandEvent& WXUNUSED(event)) {
 		project->DeleteSlider(sd.first);
 	}
 
-	for (auto &e : erase)
+	for (auto& e : erase)
 		sliderDisplays.erase(e);
 
 	MenuExitSliderEdit();
@@ -7639,17 +7346,14 @@ void OutfitStudioFrame::OnSliderImportTRI(wxCommandEvent& WXUNUSED(event)) {
 
 	wxString addedMorphs;
 	auto morphs = tri.GetMorphs();
-	for (auto &morph : morphs)
-	{
+	for (auto& morph : morphs) {
 		auto shape = project->GetWorkNif()->FindBlockByName<NiShape>(morph.first);
 		if (!shape)
 			continue;
 
 		addedMorphs += morph.first + "\n";
-		for (auto &morphData : morph.second)
-		{
-			if (!project->ValidSlider(morphData->name))
-			{
+		for (auto& morphData : morph.second) {
+			if (!project->ValidSlider(morphData->name)) {
 				createSliderGUI(morphData->name, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
 				project->AddEmptySlider(morphData->name);
 				ShowSliderEffect(morphData->name);
@@ -7658,8 +7362,7 @@ void OutfitStudioFrame::OnSliderImportTRI(wxCommandEvent& WXUNUSED(event)) {
 			std::unordered_map<uint16_t, Vector3> diff(morphData->offsets.begin(), morphData->offsets.end());
 			project->SetSliderFromDiff(morphData->name, shape, diff);
 
-			if (morphData->type == MORPHTYPE_UV)
-			{
+			if (morphData->type == MORPHTYPE_UV) {
 				size_t sliderIndex = 0;
 				if (!project->SliderIndexFromName(morphData->name, sliderIndex))
 					continue;
@@ -7681,13 +7384,11 @@ void OutfitStudioFrame::OnSliderImportTRI(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnSliderImportFBX(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
-	if (!bEditSlider)
-	{
+	if (!bEditSlider) {
 		wxMessageBox(_("There is no slider in edit mode to import data to!"), _("Error"));
 		return;
 	}
@@ -7697,8 +7398,7 @@ void OutfitStudioFrame::OnSliderImportFBX(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	wxLogMessage("Importing slider to '%s' for shape '%s' from FBX file '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
-	if (!project->SetSliderFromFBX(activeSlider, activeItem->GetShape(), fn.ToUTF8().data()))
-	{
+	if (!project->SetSliderFromFBX(activeSlider, activeItem->GetShape(), fn.ToUTF8().data())) {
 		wxLogError("Vertex count of .obj file mesh does not match currently selected shape!");
 		wxMessageBox(_("Vertex count of .obj file mesh does not match currently selected shape!"), _("Error"), wxICON_ERROR);
 		return;
@@ -7709,39 +7409,33 @@ void OutfitStudioFrame::OnSliderImportFBX(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnSliderExportNIF(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
-	if (!bEditSlider)
-	{
+	if (!bEditSlider) {
 		wxMessageBox(_("There is no slider in edit mode to export data from!"), _("Error"));
 		return;
 	}
 
-	if (selectedItems.size() > 1)
-	{
+	if (selectedItems.size() > 1) {
 		wxString dir = wxDirSelector(_("Export .nif slider data to directory"), wxEmptyString, wxDD_DEFAULT_STYLE, wxDefaultPosition, this);
 		if (dir.IsEmpty())
 			return;
 
-		for (auto &i : selectedItems)
-		{
+		for (auto& i : selectedItems) {
 			std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + i->GetShape()->name.get() + "_" + activeSlider + ".nif";
 			wxLogMessage("Exporting NIF slider data of '%s' for shape '%s' to '%s'...", activeSlider, i->GetShape()->name.get(), targetFile);
 			project->SaveSliderNIF(activeSlider, i->GetShape(), targetFile);
 		}
 	}
-	else
-	{
+	else {
 		wxString fn = wxFileSelector(_("Export .nif slider data"), wxEmptyString, wxEmptyString, ".nif", "*.nif", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
 		if (fn.IsEmpty())
 			return;
 
 		wxLogMessage("Exporting NIF slider data of '%s' for shape '%s' to '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
-		if (project->SaveSliderNIF(activeSlider, activeItem->GetShape(), fn.ToUTF8().data()))
-		{
+		if (project->SaveSliderNIF(activeSlider, activeItem->GetShape(), fn.ToUTF8().data())) {
 			wxLogError("Failed to export NIF file '%s'!", fn);
 			wxMessageBox(_("Failed to export NIF file!"), _("Error"), wxICON_ERROR);
 		}
@@ -7751,32 +7445,27 @@ void OutfitStudioFrame::OnSliderExportNIF(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnSliderExportBSD(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
-	if (!bEditSlider)
-	{
+	if (!bEditSlider) {
 		wxMessageBox(_("There is no slider in edit mode to export data from!"), _("Error"));
 		return;
 	}
 
-	if (selectedItems.size() > 1)
-	{
+	if (selectedItems.size() > 1) {
 		wxString dir = wxDirSelector(_("Export .bsd slider data to directory"), wxEmptyString, wxDD_DEFAULT_STYLE, wxDefaultPosition, this);
 		if (dir.IsEmpty())
 			return;
 
-		for (auto &i : selectedItems)
-		{
+		for (auto& i : selectedItems) {
 			std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + i->GetShape()->name.get() + "_" + activeSlider + ".bsd";
 			wxLogMessage("Exporting BSD slider data of '%s' for shape '%s' to '%s'...", activeSlider, i->GetShape()->name.get(), targetFile);
 			project->SaveSliderBSD(activeSlider, i->GetShape(), targetFile);
 		}
 	}
-	else
-	{
+	else {
 		wxString fn = wxFileSelector(_("Export .bsd slider data"), wxEmptyString, wxEmptyString, ".bsd", "*.bsd", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
 		if (fn.IsEmpty())
 			return;
@@ -7789,39 +7478,33 @@ void OutfitStudioFrame::OnSliderExportBSD(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnSliderExportOBJ(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
-	if (!bEditSlider)
-	{
+	if (!bEditSlider) {
 		wxMessageBox(_("There is no slider in edit mode to export data from!"), _("Error"));
 		return;
 	}
 
-	if (selectedItems.size() > 1)
-	{
+	if (selectedItems.size() > 1) {
 		wxString dir = wxDirSelector(_("Export .obj slider data to directory"), wxEmptyString, wxDD_DEFAULT_STYLE, wxDefaultPosition, this);
 		if (dir.IsEmpty())
 			return;
 
-		for (auto &i : selectedItems)
-		{
+		for (auto& i : selectedItems) {
 			std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + i->GetShape()->name.get() + "_" + activeSlider + ".obj";
 			wxLogMessage("Exporting OBJ slider data of '%s' for shape '%s' to '%s'...", activeSlider, i->GetShape()->name.get(), targetFile);
 			project->SaveSliderOBJ(activeSlider, i->GetShape(), targetFile);
 		}
 	}
-	else
-	{
+	else {
 		wxString fn = wxFileSelector(_("Export .obj slider data"), wxEmptyString, wxEmptyString, ".obj", "*.obj", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
 		if (fn.IsEmpty())
 			return;
 
 		wxLogMessage("Exporting OBJ slider data of '%s' for shape '%s' to '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
-		if (project->SaveSliderOBJ(activeSlider, activeItem->GetShape(), fn.ToUTF8().data()))
-		{
+		if (project->SaveSliderOBJ(activeSlider, activeItem->GetShape(), fn.ToUTF8().data())) {
 			wxLogError("Failed to export OBJ file '%s'!", fn);
 			wxMessageBox(_("Failed to export OBJ file!"), _("Error"), wxICON_ERROR);
 		}
@@ -7831,8 +7514,7 @@ void OutfitStudioFrame::OnSliderExportOBJ(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnSliderExportOSD(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetWorkNif()->IsValid())
-	{
+	if (!project->GetWorkNif()->IsValid()) {
 		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
 		return;
 	}
@@ -7842,8 +7524,7 @@ void OutfitStudioFrame::OnSliderExportOSD(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	wxLogMessage("Exporting OSD file to '%s'...", fn);
-	if (!project->SaveSliderData(fn.ToUTF8().data()))
-	{
+	if (!project->SaveSliderData(fn.ToUTF8().data())) {
 		wxLogError("Failed to export OSD file to '%s'!", fn);
 		wxMessageBox(_("Failed to export OSD file!"), _("Error"), wxICON_ERROR);
 		return;
@@ -7851,8 +7532,7 @@ void OutfitStudioFrame::OnSliderExportOSD(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnSliderExportTRI(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetWorkNif()->IsValid())
-	{
+	if (!project->GetWorkNif()->IsValid()) {
 		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
 		return;
 	}
@@ -7862,8 +7542,7 @@ void OutfitStudioFrame::OnSliderExportTRI(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	wxLogMessage("Exporting TRI morphs to '%s'...", fn);
-	if (!project->WriteMorphTRI(fn.ToUTF8().data()))
-	{
+	if (!project->WriteMorphTRI(fn.ToUTF8().data())) {
 		wxLogError("Failed to export TRI file to '%s'!", fn);
 		wxMessageBox(_("Failed to export TRI file!"), _("Error"), wxICON_ERROR);
 		return;
@@ -7871,8 +7550,7 @@ void OutfitStudioFrame::OnSliderExportTRI(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnSliderExportToOBJs(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetWorkNif()->IsValid())
-	{
+	if (!project->GetWorkNif()->IsValid()) {
 		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
 		return;
 	}
@@ -7885,10 +7563,8 @@ void OutfitStudioFrame::OnSliderExportToOBJs(wxCommandEvent& WXUNUSED(event)) {
 	project->GetSliderList(sliderList);
 
 	wxLogMessage("Exporting sliders to OBJ files in '%s'...", dir);
-	for (auto &shape : project->GetWorkNif()->GetShapes())
-	{
-		for (auto &slider : sliderList)
-		{
+	for (auto& shape : project->GetWorkNif()->GetShapes()) {
+		for (auto& slider : sliderList) {
 			std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + shape->name.get() + "_" + slider + ".obj";
 			wxLogMessage("Exporting OBJ slider data of '%s' for shape '%s' to '%s'...", slider, shape->name.get(), targetFile);
 			if (project->SaveSliderOBJ(slider, shape, targetFile, true))
@@ -7898,20 +7574,17 @@ void OutfitStudioFrame::OnSliderExportToOBJs(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnClearSlider(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
 
 	int result;
-	if (selectedItems.size() > 1)
-	{
+	if (selectedItems.size() > 1) {
 		wxString prompt = _("Are you sure you wish to clear the unmasked slider data for the selected shapes?  This action cannot be undone.");
 		result = wxMessageBox(prompt, _("Confirm data erase"), wxYES_NO | wxICON_WARNING, this);
 	}
-	else
-	{
+	else {
 		wxString prompt = wxString::Format(_("Are you sure you wish to clear the unmasked slider data for the shape '%s'?  This action cannot be undone."), activeItem->GetShape()->name.get());
 		result = wxMessageBox(prompt, _("Confirm data erase"), wxYES_NO | wxICON_WARNING, this);
 	}
@@ -7919,11 +7592,9 @@ void OutfitStudioFrame::OnClearSlider(wxCommandEvent& WXUNUSED(event)) {
 	if (result != wxYES)
 		return;
 
-	auto clearSlider = [&](const std::string& sliderName)
-	{
+	auto clearSlider = [&](const std::string& sliderName) {
 		std::unordered_map<uint16_t, float> mask;
-		for (auto &i : selectedItems)
-		{
+		for (auto& i : selectedItems) {
 			mask.clear();
 			glView->GetShapeMask(mask, i->GetShape()->name.get());
 			if (mask.size() > 0)
@@ -7933,15 +7604,13 @@ void OutfitStudioFrame::OnClearSlider(wxCommandEvent& WXUNUSED(event)) {
 		}
 	};
 
-	if (!bEditSlider)
-	{
+	if (!bEditSlider) {
 		wxLogMessage("Clearing slider data of the checked sliders for the selected shapes.");
-		for (auto &sd : sliderDisplays)
+		for (auto& sd : sliderDisplays)
 			if (sd.second->sliderNameCheck->Get3StateValue() == wxCheckBoxState::wxCHK_CHECKED)
 				clearSlider(sd.first);
 	}
-	else
-	{
+	else {
 		wxLogMessage("Clearing slider data of '%s' for the selected shapes.", activeSlider);
 		clearSlider(activeSlider);
 	}
@@ -7950,14 +7619,12 @@ void OutfitStudioFrame::OnClearSlider(wxCommandEvent& WXUNUSED(event)) {
 	ApplySliders();
 }
 
-void OutfitStudioFrame::OnNewSlider(wxCommandEvent& WXUNUSED(event))
-{
+void OutfitStudioFrame::OnNewSlider(wxCommandEvent& WXUNUSED(event)) {
 	NewSlider();
 }
 
 void OutfitStudioFrame::OnNewZapSlider(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
@@ -7971,19 +7638,18 @@ void OutfitStudioFrame::OnNewZapSlider(wxCommandEvent& WXUNUSED(event)) {
 		fillName = wxString::Format("%s %d", baseName, ++count).ToUTF8();
 
 	std::string sliderName;
-	do
-	{
+	do {
 		sliderName = wxGetTextFromUser(_("Enter a name for the new zap:"), _("Create New Zap"), fillName, this).ToUTF8();
 		if (sliderName.empty())
 			return;
-	} while (project->ValidSlider(sliderName));
+	}
+	while (project->ValidSlider(sliderName));
 
 	wxLogMessage("Creating new zap '%s'.", sliderName);
 	createSliderGUI(sliderName, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
 
 	std::unordered_map<uint16_t, float> unmasked;
-	for (auto &i : selectedItems)
-	{
+	for (auto& i : selectedItems) {
 		unmasked.clear();
 		glView->GetShapeUnmasked(unmasked, i->GetShape()->name.get());
 		project->AddZapSlider(sliderName, unmasked, i->GetShape());
@@ -8004,12 +7670,12 @@ void OutfitStudioFrame::OnNewCombinedSlider(wxCommandEvent& WXUNUSED(event)) {
 		fillName = wxString::Format("%s %d", baseName, ++count).ToUTF8();
 
 	std::string sliderName;
-	do
-	{
+	do {
 		sliderName = wxGetTextFromUser(_("Enter a name for the new slider:"), _("Create New Slider"), fillName, this).ToUTF8();
 		if (sliderName.empty())
 			return;
-	} while (project->ValidSlider(sliderName));
+	}
+	while (project->ValidSlider(sliderName));
 
 	wxLogMessage("Creating new combined slider '%s'.", sliderName);
 	createSliderGUI(sliderName, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
@@ -8020,45 +7686,39 @@ void OutfitStudioFrame::OnNewCombinedSlider(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnSliderNegate(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
-	if (!bEditSlider)
-	{
+	if (!bEditSlider) {
 		wxMessageBox(_("There is no slider in edit mode to negate!"), _("Error"));
 		return;
 	}
 
 	wxLogMessage("Negating slider '%s' for the selected shapes.", activeSlider);
-	for (auto &i : selectedItems)
+	for (auto& i : selectedItems)
 		project->NegateSlider(activeSlider, i->GetShape());
 
 	SetPendingChanges();
 }
 
 void OutfitStudioFrame::OnMaskAffected(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
-	if (!bEditSlider)
-	{
+	if (!bEditSlider) {
 		wxMessageBox(_("There is no slider in edit mode to create a mask from!"), _("Error"));
 		return;
 	}
 
 	wxLogMessage("Creating mask for affected vertices of the slider '%s'.", activeSlider);
-	for (auto &i : selectedItems)
+	for (auto& i : selectedItems)
 		project->MaskAffected(activeSlider, i->GetShape());
 }
 
-void OutfitStudioFrame::DeleteSliders(bool keepZaps)
-{
-	auto deleteSlider = [&](const std::string& sliderName)
-	{
+void OutfitStudioFrame::DeleteSliders(bool keepZaps) {
+	auto deleteSlider = [&](const std::string& sliderName) {
 		wxLogMessage("Deleting slider '%s'.", sliderName);
 
 		SliderDisplay* sd = sliderDisplays[sliderName];
@@ -8080,18 +7740,14 @@ void OutfitStudioFrame::DeleteSliders(bool keepZaps)
 		project->DeleteSlider(sliderName);
 	};
 
-	if (!bEditSlider)
-	{
-		for (auto it = sliderDisplays.begin(); it != sliderDisplays.end();)
-		{
-			if(keepZaps && project->activeSet[it->first].bZap)
-			{
+	if (!bEditSlider) {
+		for (auto it = sliderDisplays.begin(); it != sliderDisplays.end();) {
+			if (keepZaps && project->activeSet[it->first].bZap) {
 				++it;
 				continue;
 			}
-		
-			if (it->second->sliderNameCheck->Get3StateValue() == wxCheckBoxState::wxCHK_CHECKED)
-			{
+
+			if (it->second->sliderNameCheck->Get3StateValue() == wxCheckBoxState::wxCHK_CHECKED) {
 				deleteSlider(it->first);
 				it = sliderDisplays.erase(it);
 			}
@@ -8099,8 +7755,7 @@ void OutfitStudioFrame::DeleteSliders(bool keepZaps)
 				++it;
 		}
 	}
-	else
-	{
+	else {
 		deleteSlider(activeSlider);
 		sliderDisplays.erase(activeSlider);
 
@@ -8129,8 +7784,7 @@ void OutfitStudioFrame::ShowSliderProperties(const std::string& sliderName) {
 		return;
 
 	wxDialog dlg;
-	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgSliderProp"))
-	{
+	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgSliderProp")) {
 		wxTextCtrl* edSliderName = XRCCTRL(dlg, "edSliderName", wxTextCtrl);
 		wxStaticText* lbValLo = XRCCTRL(dlg, "lbValLo", wxStaticText);
 		wxStaticText* lbValHi = XRCCTRL(dlg, "lbValHi", wxStaticText);
@@ -8159,8 +7813,7 @@ void OutfitStudioFrame::ShowSliderProperties(const std::string& sliderName) {
 		if (project->SliderUV(curSlider))
 			chkUV->SetValue(true);
 
-		if (project->SliderZap(curSlider))
-		{
+		if (project->SliderZap(curSlider)) {
 			lbValLo->Hide();
 			lbValHi->Hide();
 			edValLo->Hide();
@@ -8174,19 +7827,16 @@ void OutfitStudioFrame::ShowSliderProperties(const std::string& sliderName) {
 				if (i != curSlider && (project->SliderZap(i) || project->SliderHidden(i)))
 					zapToggleList->Append(wxString::FromUTF8(project->GetSliderName(i)));
 
-			for (auto &s : project->SliderZapToggles(curSlider))
-			{
+			for (auto& s : project->SliderZapToggles(curSlider)) {
 				int stringId = zapToggleList->FindString(s, true);
 				if (stringId != wxNOT_FOUND)
 					zapToggleList->Check(stringId);
 			}
 		}
-		else
-		{
+		else {
 			cbValZapped->Hide();
 
-			if (!project->mGenWeights)
-			{
+			if (!project->mGenWeights) {
 				lbValLo->Hide();
 				edValLo->Hide();
 				lbValHi->SetLabel("Default");
@@ -8198,8 +7848,7 @@ void OutfitStudioFrame::ShowSliderProperties(const std::string& sliderName) {
 		else
 			cbValZapped->Set3StateValue(wxCheckBoxState::wxCHK_UNCHECKED);
 
-		chkZap->Bind(wxEVT_CHECKBOX, [&](wxCommandEvent& event)
-		{
+		chkZap->Bind(wxEVT_CHECKBOX, [&](wxCommandEvent& event) {
 			bool checked = event.IsChecked();
 
 			lbValLo->Show(!checked);
@@ -8214,17 +7863,13 @@ void OutfitStudioFrame::ShowSliderProperties(const std::string& sliderName) {
 
 		XRCCTRL(dlg, "wxID_CANCEL", wxButton)->SetFocus();
 
-		if (dlg.ShowModal() == wxID_OK)
-		{
-			if (chkZap->IsChecked())
-			{
-				if (cbValZapped->IsChecked())
-				{
+		if (dlg.ShowModal() == wxID_OK) {
+			if (chkZap->IsChecked()) {
+				if (cbValZapped->IsChecked()) {
 					loVal = 100;
 					hiVal = 100;
 				}
-				else
-				{
+				else {
 					loVal = 0;
 					hiVal = 0;
 				}
@@ -8232,13 +7877,12 @@ void OutfitStudioFrame::ShowSliderProperties(const std::string& sliderName) {
 				wxArrayString zapToggles;
 				wxArrayInt toggled;
 				zapToggleList->GetCheckedItems(toggled);
-				for (auto &i : toggled)
+				for (auto& i : toggled)
 					zapToggles.Add(zapToggleList->GetString(i));
 
 				project->SetSliderZapToggles(curSlider, zapToggles);
 			}
-			else
-			{
+			else {
 				edValLo->GetValue().ToLong(&loVal);
 				edValHi->GetValue().ToLong(&hiVal);
 			}
@@ -8250,9 +7894,8 @@ void OutfitStudioFrame::ShowSliderProperties(const std::string& sliderName) {
 			project->SetSliderDefault(curSlider, loVal, false);
 			project->SetSliderDefault(curSlider, hiVal, true);
 
-			std::string newSliderName{ edSliderName->GetValue().ToUTF8() };
-			if (sliderName != newSliderName && !project->ValidSlider(newSliderName))
-			{
+			std::string newSliderName{edSliderName->GetValue().ToUTF8()};
+			if (sliderName != newSliderName && !project->ValidSlider(newSliderName)) {
 				project->SetSliderName(curSlider, newSliderName);
 				SliderDisplay* d = sliderDisplays[sliderName];
 				sliderDisplays[newSliderName] = d;
@@ -8279,8 +7922,7 @@ void OutfitStudioFrame::ShowSliderProperties(const std::string& sliderName) {
 }
 
 void OutfitStudioFrame::OnSliderProperties(wxCommandEvent& WXUNUSED(event)) {
-	if (!bEditSlider)
-	{
+	if (!bEditSlider) {
 		wxMessageBox(_("There is no slider in edit mode to show properties for!"), _("Error"));
 		return;
 	}
@@ -8294,16 +7936,15 @@ void OutfitStudioFrame::ConformSliders(NiShape* shape, const ConformOptions& opt
 
 	std::string shapeName = shape->name.get();
 	wxLogMessage("Conforming '%s'...", shapeName);
-	if(!silent)
+	if (!silent)
 		UpdateProgress(50, _("Conforming: ") + shapeName);
 
 	mesh* m = glView->GetMesh(shapeName);
-	if (m)
-	{
+	if (m) {
 		project->morpher.CopyMeshMask(m, shapeName);
 		project->ConformShape(shape, options);
 	}
-	if(!silent)
+	if (!silent)
 		UpdateProgress(99);
 }
 
@@ -8312,15 +7953,14 @@ void OutfitStudioFrame::OnSliderConform(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	ConformOptions options;
-	if (ShowConform(options))
-	{
+	if (ShowConform(options)) {
 		wxLogMessage("Conforming...");
 		ZeroSliders();
 
 		StartProgress(_("Initializing data..."));
 		project->InitConform();
 
-		for (auto &i : selectedItems)
+		for (auto& i : selectedItems)
 			ConformSliders(i->GetShape(), options);
 
 		project->morpher.ClearProximityCache();
@@ -8342,8 +7982,7 @@ void OutfitStudioFrame::OnSliderConformAll(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	ConformOptions options;
-	if (ShowConform(options))
-	{
+	if (ShowConform(options)) {
 		wxLogMessage("Conforming all shapes...");
 		ZeroSliders();
 
@@ -8355,8 +7994,7 @@ void OutfitStudioFrame::OnSliderConformAll(wxCommandEvent& WXUNUSED(event)) {
 		int inc = 100 / shapes.size() - 1;
 		int pos = 0;
 
-		for (auto &shape : shapes)
-		{
+		for (auto& shape : shapes) {
 			UpdateProgress(pos * inc, _("Conforming: ") + shape->name.get());
 			StartSubProgress(pos * inc, pos * inc + inc);
 			ConformSliders(shape, options);
@@ -8383,10 +8021,9 @@ int OutfitStudioFrame::ConformShapes(std::vector<NiShape*> shapes, bool silent) 
 		return 1;
 
 	ConformOptions options;
-	if (ShowConform(options, silent))
-	{
+	if (ShowConform(options, silent)) {
 		wxLogMessage("Conforming Shapes.");
-	
+
 		ZeroSliders();
 
 		project->InitConform();
@@ -8394,14 +8031,13 @@ int OutfitStudioFrame::ConformShapes(std::vector<NiShape*> shapes, bool silent) 
 		int inc = 100 / shapes.size() - 1;
 		int pos = 0;
 
-		for (auto &shape : shapes)
-		{
+		for (auto& shape : shapes) {
 			wxLogMessage(_("Conforming: ") + shape->name.get());
-			if(!silent)
+			if (!silent)
 				StartSubProgress(pos * inc, pos * inc + inc);
 			ConformSliders(shape, options, silent);
 			pos++;
-			if(!silent)
+			if (!silent)
 				EndProgress();
 		}
 
@@ -8418,41 +8054,34 @@ int OutfitStudioFrame::ConformShapes(std::vector<NiShape*> shapes, bool silent) 
 
 bool OutfitStudioFrame::ShowConform(ConformOptions& options, bool silent) {
 	wxDialog dlg;
-	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgConforming"))
-	{
-		XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->Bind(wxEVT_SLIDER, [&dlg](wxCommandEvent&)
-		{
+	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgConforming")) {
+		XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->Bind(wxEVT_SLIDER, [&dlg](wxCommandEvent&) {
 			float changed = XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->GetValue() / 1000.0f;
 			XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", changed));
 		});
 
-		XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->Bind(wxEVT_TEXT, [&dlg](wxCommandEvent&)
-		{
+		XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->Bind(wxEVT_TEXT, [&dlg](wxCommandEvent&) {
 			float changed = atof(XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->GetValue().c_str());
 			XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->SetValue(changed * 1000);
 		});
 
-		XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Bind(wxEVT_SLIDER, [&dlg](wxCommandEvent&)
-		{
+		XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Bind(wxEVT_SLIDER, [&dlg](wxCommandEvent&) {
 			int changed = XRCCTRL(dlg, "maxResultsSlider", wxSlider)->GetValue();
 			XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->ChangeValue(wxString::Format("%d", changed));
 		});
 
-		XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->Bind(wxEVT_CHECKBOX, [&dlg](wxCommandEvent&)
-		{
+		XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->Bind(wxEVT_CHECKBOX, [&dlg](wxCommandEvent&) {
 			bool noTargetLimit = XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->IsChecked();
 			XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->Enable(!noTargetLimit);
 			XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Enable(!noTargetLimit);
 
-			if (noTargetLimit)
-			{
+			if (noTargetLimit) {
 				XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->ChangeValue("5.00000");
 				XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->SetValue(5000);
 			}
 		});
 
-		XRCCTRL(dlg, "presetDefault", wxButton)->Bind(wxEVT_BUTTON, [&dlg](wxCommandEvent&)
-		{
+		XRCCTRL(dlg, "presetDefault", wxButton)->Bind(wxEVT_BUTTON, [&dlg](wxCommandEvent&) {
 			XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->SetValue(false);
 			XRCCTRL(dlg, "noSqueeze", wxCheckBox)->SetValue(false);
 			XRCCTRL(dlg, "solidMode", wxCheckBox)->SetValue(false);
@@ -8464,8 +8093,7 @@ bool OutfitStudioFrame::ShowConform(ConformOptions& options, bool silent) {
 			XRCCTRL(dlg, "maxResultsSlider", wxSlider)->SetValue(10);
 		});
 
-		XRCCTRL(dlg, "presetEvenMovement", wxButton)->Bind(wxEVT_BUTTON, [&dlg](wxCommandEvent&)
-		{
+		XRCCTRL(dlg, "presetEvenMovement", wxButton)->Bind(wxEVT_BUTTON, [&dlg](wxCommandEvent&) {
 			XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->SetValue(true);
 			XRCCTRL(dlg, "noSqueeze", wxCheckBox)->SetValue(true);
 			XRCCTRL(dlg, "solidMode", wxCheckBox)->SetValue(false);
@@ -8475,8 +8103,7 @@ bool OutfitStudioFrame::ShowConform(ConformOptions& options, bool silent) {
 			XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->SetValue(5000);
 		});
 
-		XRCCTRL(dlg, "presetSolidObject", wxButton)->Bind(wxEVT_BUTTON, [&dlg](wxCommandEvent&)
-		{
+		XRCCTRL(dlg, "presetSolidObject", wxButton)->Bind(wxEVT_BUTTON, [&dlg](wxCommandEvent&) {
 			XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->SetValue(true);
 			XRCCTRL(dlg, "noSqueeze", wxCheckBox)->SetValue(false);
 			XRCCTRL(dlg, "solidMode", wxCheckBox)->SetValue(true);
@@ -8488,8 +8115,7 @@ bool OutfitStudioFrame::ShowConform(ConformOptions& options, bool silent) {
 
 		dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
 
-		if (silent || dlg.ShowModal() == wxID_OK)
-		{
+		if (silent || dlg.ShowModal() == wxID_OK) {
 			options.proximityRadius = atof(XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->GetValue().c_str());
 
 			bool noTargetLimit = XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->IsChecked();
@@ -8511,8 +8137,7 @@ bool OutfitStudioFrame::ShowConform(ConformOptions& options, bool silent) {
 }
 
 void OutfitStudioFrame::OnInvertUV(wxCommandEvent& event) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
@@ -8520,8 +8145,7 @@ void OutfitStudioFrame::OnInvertUV(wxCommandEvent& event) {
 	bool invertX = (event.GetId() == XRCID("uvInvertX"));
 	bool invertY = (event.GetId() == XRCID("uvInvertY"));
 
-	for (auto &i : selectedItems)
-	{
+	for (auto& i : selectedItems) {
 		project->GetWorkNif()->InvertUVsForShape(i->GetShape(), invertX, invertY);
 	}
 
@@ -8530,8 +8154,7 @@ void OutfitStudioFrame::OnInvertUV(wxCommandEvent& event) {
 }
 
 void OutfitStudioFrame::OnMirror(wxCommandEvent& event) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
@@ -8540,8 +8163,7 @@ void OutfitStudioFrame::OnMirror(wxCommandEvent& event) {
 	bool mirrorY = (event.GetId() == XRCID("mirrorY"));
 	bool mirrorZ = (event.GetId() == XRCID("mirrorZ"));
 
-	for (auto &i : selectedItems)
-	{
+	for (auto& i : selectedItems) {
 		project->GetWorkNif()->MirrorShape(i->GetShape(), mirrorX, mirrorY, mirrorZ);
 	}
 
@@ -8550,21 +8172,20 @@ void OutfitStudioFrame::OnMirror(wxCommandEvent& event) {
 }
 
 void OutfitStudioFrame::OnRenameShape(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
 
 	std::string newShapeName;
-	do
-	{
+	do {
 		std::string result{wxGetTextFromUser(_("Please enter a new unique name for the shape."), _("Rename Shape")).ToUTF8()};
 		if (result.empty())
 			return;
 
 		newShapeName = std::move(result);
-	} while (project->IsValidShape(newShapeName));
+	}
+	while (project->IsValidShape(newShapeName));
 
 	std::string shapeName = activeItem->GetShape()->name.get();
 	wxLogMessage("Renaming shape '%s' to '%s'.", shapeName, newShapeName);
@@ -8576,8 +8197,7 @@ void OutfitStudioFrame::OnRenameShape(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnSetReference(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
@@ -8595,10 +8215,8 @@ void OutfitStudioFrame::OnSetReference(wxCommandEvent& WXUNUSED(event)) {
 	SetPendingChanges();
 }
 
-void OutfitStudioFrame::OnEnterClose(wxKeyEvent& event)
-{
-	if (event.GetKeyCode() == WXK_RETURN)
-	{
+void OutfitStudioFrame::OnEnterClose(wxKeyEvent& event) {
+	if (event.GetKeyCode() == WXK_RETURN) {
 		wxDialog* parent = (wxDialog*)((wxWindow*)event.GetEventObject())->GetParent();
 		if (!parent)
 			return;
@@ -8611,8 +8229,7 @@ void OutfitStudioFrame::OnEnterClose(wxKeyEvent& event)
 }
 
 void OutfitStudioFrame::OnMoveShape(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
@@ -8621,21 +8238,17 @@ void OutfitStudioFrame::OnMoveShape(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	wxDialog dlg;
-	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgMoveShape"))
-	{
+	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgMoveShape")) {
 		Vector3 previewMove;
 
-		auto updateMovePreview = [&]()
-		{
+		auto updateMovePreview = [&]() {
 			std::unordered_map<uint16_t, float> mask;
 			std::unordered_map<uint16_t, float>* mptr = nullptr;
 			std::vector<Vector3> verts;
 
-			if (!previewMove.IsZero())
-			{
-				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
-				if (curState)
-				{
+			if (!previewMove.IsZero()) {
+				UndoStateProject* curState = glView->GetUndoHistory()->GetBackState();
+				if (curState) {
 					glView->ApplyUndoState(curState, true, false);
 					glView->GetUndoHistory()->PopState();
 				}
@@ -8650,11 +8263,10 @@ void OutfitStudioFrame::OnMoveShape(wxCommandEvent& WXUNUSED(event)) {
 			bool mirrorAxisY = XRCCTRL(dlg, "mirrorAxisY", wxCheckBox)->IsChecked();
 			bool mirrorAxisZ = XRCCTRL(dlg, "mirrorAxisZ", wxCheckBox)->IsChecked();
 
-			UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+			UndoStateProject* usp = glView->GetUndoHistory()->PushState();
 			usp->undoType = UT_VERTPOS;
 
-			for (auto &sel : selectedItems)
-			{
+			for (auto& sel : selectedItems) {
 				mask.clear();
 				mptr = nullptr;
 
@@ -8668,8 +8280,7 @@ void OutfitStudioFrame::OnMoveShape(wxCommandEvent& WXUNUSED(event)) {
 				UndoStateShape uss;
 				uss.shapeName = shape->name.get();
 
-				for (size_t i = 0; i < verts.size(); i++)
-				{
+				for (size_t i = 0; i < verts.size(); i++) {
 					Vector3& vertPos = verts[i];
 					Vector3 diff = changed;
 
@@ -8694,8 +8305,7 @@ void OutfitStudioFrame::OnMoveShape(wxCommandEvent& WXUNUSED(event)) {
 				usp->usss.push_back(std::move(uss));
 			}
 
-			if (bEditSlider)
-			{
+			if (bEditSlider) {
 				usp->sliderName = activeSlider;
 
 				float sliderscale = project->SliderValue(activeSlider);
@@ -8713,8 +8323,7 @@ void OutfitStudioFrame::OnMoveShape(wxCommandEvent& WXUNUSED(event)) {
 				glView->ShowTransformTool();
 		};
 
-		auto sliderMoved = [&](wxCommandEvent&)
-		{
+		auto sliderMoved = [&](wxCommandEvent&) {
 			Vector3 slider;
 			slider.x = XRCCTRL(dlg, "msSliderX", wxSlider)->GetValue() / 1000.0f;
 			slider.y = XRCCTRL(dlg, "msSliderY", wxSlider)->GetValue() / 1000.0f;
@@ -8727,8 +8336,7 @@ void OutfitStudioFrame::OnMoveShape(wxCommandEvent& WXUNUSED(event)) {
 			updateMovePreview();
 		};
 
-		auto textChanged = [&](wxCommandEvent&)
-		{
+		auto textChanged = [&](wxCommandEvent&) {
 			Vector3 changed;
 			changed.x = atof(XRCCTRL(dlg, "msTextX", wxTextCtrl)->GetValue().c_str());
 			changed.y = atof(XRCCTRL(dlg, "msTextY", wxTextCtrl)->GetValue().c_str());
@@ -8741,8 +8349,7 @@ void OutfitStudioFrame::OnMoveShape(wxCommandEvent& WXUNUSED(event)) {
 			updateMovePreview();
 		};
 
-		auto mirrorAxisChanged = [&](wxCommandEvent&)
-		{
+		auto mirrorAxisChanged = [&](wxCommandEvent&) {
 			updateMovePreview();
 		};
 
@@ -8759,13 +8366,10 @@ void OutfitStudioFrame::OnMoveShape(wxCommandEvent& WXUNUSED(event)) {
 		XRCCTRL(dlg, "mirrorAxisZ", wxCheckBox)->Bind(wxEVT_CHECKBOX, mirrorAxisChanged);
 		dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
 
-		if (dlg.ShowModal() != wxID_OK)
-		{
-			if (!previewMove.IsZero())
-			{
-				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
-				if (curState)
-				{
+		if (dlg.ShowModal() != wxID_OK) {
+			if (!previewMove.IsZero()) {
+				UndoStateProject* curState = glView->GetUndoHistory()->GetBackState();
+				if (curState) {
 					glView->ApplyUndoState(curState, true);
 					glView->GetUndoHistory()->PopState();
 				}
@@ -8777,8 +8381,7 @@ void OutfitStudioFrame::OnMoveShape(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
@@ -8787,21 +8390,17 @@ void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	wxDialog dlg;
-	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgScaleShape"))
-	{
+	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgScaleShape")) {
 		Vector3 previewScale(1.0f, 1.0f, 1.0f);
 
-		auto updateScalePreview = [&]()
-		{
+		auto updateScalePreview = [&]() {
 			std::unordered_map<uint16_t, float> mask;
 			std::unordered_map<uint16_t, float>* mptr = nullptr;
 			std::vector<Vector3> verts;
 
-			if (previewScale != Vector3(1.0f, 1.0f, 1.0f))
-			{
-				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
-				if (curState)
-				{
+			if (previewScale != Vector3(1.0f, 1.0f, 1.0f)) {
+				UndoStateProject* curState = glView->GetUndoHistory()->GetBackState();
+				if (curState) {
 					glView->ApplyUndoState(curState, true, false);
 					glView->GetUndoHistory()->PopState();
 				}
@@ -8814,18 +8413,16 @@ void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
 
 			Vector3 origin;
 			int originSelection = XRCCTRL(dlg, "origin", wxChoice)->GetCurrentSelection();
-			if (originSelection == 1)
-			{
+			if (originSelection == 1) {
 				// Center of selected shape(s), respecting mask
 				origin = glView->gls.GetActiveCenter();
 				origin = mesh::VecToNifCoords(origin);
 			}
 
-			UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+			UndoStateProject* usp = glView->GetUndoHistory()->PushState();
 			usp->undoType = UT_VERTPOS;
 
-			for (auto &sel : selectedItems)
-			{
+			for (auto& sel : selectedItems) {
 				mask.clear();
 				mptr = nullptr;
 
@@ -8844,8 +8441,7 @@ void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
 				xform.PushScale(scale.x, scale.y, scale.z);
 				xform.PushTranslate(origin * -1.0f);
 
-				for (size_t i = 0; i < verts.size(); i++)
-				{
+				for (size_t i = 0; i < verts.size(); i++) {
 					Vector3& vertPos = verts[i];
 					Vector3 diff = xform * vertPos - vertPos;
 
@@ -8863,8 +8459,7 @@ void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
 				usp->usss.push_back(std::move(uss));
 			}
 
-			if (bEditSlider)
-			{
+			if (bEditSlider) {
 				usp->sliderName = activeSlider;
 
 				float sliderscale = project->SliderValue(activeSlider);
@@ -8882,13 +8477,11 @@ void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
 				glView->ShowTransformTool();
 		};
 
-		auto sliderMoved = [&](wxCommandEvent& event)
-		{
+		auto sliderMoved = [&](wxCommandEvent& event) {
 			Vector3 scale(1.0f, 1.0f, 1.0f);
 
 			bool uniform = XRCCTRL(dlg, "ssUniform", wxCheckBox)->IsChecked();
-			if (uniform)
-			{
+			if (uniform) {
 				float uniformValue = ((wxSlider*)event.GetEventObject())->GetValue() / 1000.0f;
 				scale = Vector3(uniformValue, uniformValue, uniformValue);
 
@@ -8896,8 +8489,7 @@ void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
 				XRCCTRL(dlg, "ssSliderY", wxSlider)->SetValue(scale.y * 1000);
 				XRCCTRL(dlg, "ssSliderZ", wxSlider)->SetValue(scale.z * 1000);
 			}
-			else
-			{
+			else {
 				scale.x = XRCCTRL(dlg, "ssSliderX", wxSlider)->GetValue() / 1000.0f;
 				scale.y = XRCCTRL(dlg, "ssSliderY", wxSlider)->GetValue() / 1000.0f;
 				scale.z = XRCCTRL(dlg, "ssSliderZ", wxSlider)->GetValue() / 1000.0f;
@@ -8910,13 +8502,11 @@ void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
 			updateScalePreview();
 		};
 
-		auto textChanged = [&](wxCommandEvent& event)
-		{
+		auto textChanged = [&](wxCommandEvent& event) {
 			Vector3 scale(1.0f, 1.0f, 1.0f);
 
 			bool uniform = XRCCTRL(dlg, "ssUniform", wxCheckBox)->IsChecked();
-			if (uniform)
-			{
+			if (uniform) {
 				float uniformValue = atof(((wxTextCtrl*)event.GetEventObject())->GetValue().c_str());
 				scale = Vector3(uniformValue, uniformValue, uniformValue);
 
@@ -8924,27 +8514,23 @@ void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
 				XRCCTRL(dlg, "ssTextY", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.y));
 				XRCCTRL(dlg, "ssTextZ", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.z));
 			}
-			else
-			{
+			else {
 				scale.x = atof(XRCCTRL(dlg, "ssTextX", wxTextCtrl)->GetValue().c_str());
 				scale.y = atof(XRCCTRL(dlg, "ssTextY", wxTextCtrl)->GetValue().c_str());
 				scale.z = atof(XRCCTRL(dlg, "ssTextZ", wxTextCtrl)->GetValue().c_str());
 			}
 
-			if (scale.x < 0.01f)
-			{
+			if (scale.x < 0.01f) {
 				scale.x = 0.01f;
 				XRCCTRL(dlg, "ssTextX", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.x));
 			}
 
-			if (scale.y < 0.01f)
-			{
+			if (scale.y < 0.01f) {
 				scale.y = 0.01f;
 				XRCCTRL(dlg, "ssTextY", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.y));
 			}
 
-			if (scale.z < 0.01f)
-			{
+			if (scale.z < 0.01f) {
 				scale.z = 0.01f;
 				XRCCTRL(dlg, "ssTextZ", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.z));
 			}
@@ -8956,8 +8542,7 @@ void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
 			updateScalePreview();
 		};
 
-		auto originChanged = [&](wxCommandEvent&)
-		{
+		auto originChanged = [&](wxCommandEvent&) {
 			updateScalePreview();
 		};
 
@@ -8970,13 +8555,10 @@ void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
 		XRCCTRL(dlg, "origin", wxChoice)->Bind(wxEVT_CHOICE, originChanged);
 		dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
 
-		if (dlg.ShowModal() != wxID_OK)
-		{
-			if (previewScale != Vector3(1.0f, 1.0f, 1.0f))
-			{
-				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
-				if (curState)
-				{
+		if (dlg.ShowModal() != wxID_OK) {
+			if (previewScale != Vector3(1.0f, 1.0f, 1.0f)) {
+				UndoStateProject* curState = glView->GetUndoHistory()->GetBackState();
+				if (curState) {
 					glView->ApplyUndoState(curState, true);
 					glView->GetUndoHistory()->PopState();
 				}
@@ -8988,8 +8570,7 @@ void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnRotateShape(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
@@ -8998,21 +8579,17 @@ void OutfitStudioFrame::OnRotateShape(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	wxDialog dlg;
-	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgRotateShape"))
-	{
+	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgRotateShape")) {
 		Vector3 previewRotation;
 
-		auto updateRotationPreview = [&]()
-		{
+		auto updateRotationPreview = [&]() {
 			std::unordered_map<uint16_t, float> mask;
 			std::unordered_map<uint16_t, float>* mptr = nullptr;
 			std::vector<Vector3> verts;
 
-			if (!previewRotation.IsZero())
-			{
-				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
-				if (curState)
-				{
+			if (!previewRotation.IsZero()) {
+				UndoStateProject* curState = glView->GetUndoHistory()->GetBackState();
+				if (curState) {
 					glView->ApplyUndoState(curState, true, false);
 					glView->GetUndoHistory()->PopState();
 				}
@@ -9025,18 +8602,16 @@ void OutfitStudioFrame::OnRotateShape(wxCommandEvent& WXUNUSED(event)) {
 
 			Vector3 origin;
 			int originSelection = XRCCTRL(dlg, "origin", wxChoice)->GetCurrentSelection();
-			if (originSelection == 1)
-			{
+			if (originSelection == 1) {
 				// Center of selected shape(s), respecting mask
 				origin = glView->gls.GetActiveCenter();
 				origin = mesh::VecToNifCoords(origin);
 			}
 
-			UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+			UndoStateProject* usp = glView->GetUndoHistory()->PushState();
 			usp->undoType = UT_VERTPOS;
 
-			for (auto &sel : selectedItems)
-			{
+			for (auto& sel : selectedItems) {
 				mask.clear();
 				mptr = nullptr;
 
@@ -9057,8 +8632,7 @@ void OutfitStudioFrame::OnRotateShape(wxCommandEvent& WXUNUSED(event)) {
 				xform.PushRotate(angle.z * DEG2RAD, Vector3(0.0f, 0.0f, 1.0f));
 				xform.PushTranslate(origin * -1.0f);
 
-				for (size_t i = 0; i < verts.size(); i++)
-				{
+				for (size_t i = 0; i < verts.size(); i++) {
 					Vector3& vertPos = verts[i];
 					Vector3 diff = xform * vertPos - vertPos;
 
@@ -9076,8 +8650,7 @@ void OutfitStudioFrame::OnRotateShape(wxCommandEvent& WXUNUSED(event)) {
 				usp->usss.push_back(std::move(uss));
 			}
 
-			if (bEditSlider)
-			{
+			if (bEditSlider) {
 				usp->sliderName = activeSlider;
 
 				float sliderscale = project->SliderValue(activeSlider);
@@ -9095,8 +8668,7 @@ void OutfitStudioFrame::OnRotateShape(wxCommandEvent& WXUNUSED(event)) {
 				glView->ShowTransformTool();
 		};
 
-		auto sliderMoved = [&](wxCommandEvent&)
-		{
+		auto sliderMoved = [&](wxCommandEvent&) {
 			Vector3 angle;
 			angle.x = XRCCTRL(dlg, "rsSliderX", wxSlider)->GetValue() / 100.0f;
 			angle.y = XRCCTRL(dlg, "rsSliderY", wxSlider)->GetValue() / 100.0f;
@@ -9109,8 +8681,7 @@ void OutfitStudioFrame::OnRotateShape(wxCommandEvent& WXUNUSED(event)) {
 			updateRotationPreview();
 		};
 
-		auto textChanged = [&](wxCommandEvent&)
-		{
+		auto textChanged = [&](wxCommandEvent&) {
 			Vector3 angle;
 			angle.x = atof(XRCCTRL(dlg, "rsTextX", wxTextCtrl)->GetValue().c_str());
 			angle.y = atof(XRCCTRL(dlg, "rsTextY", wxTextCtrl)->GetValue().c_str());
@@ -9123,8 +8694,7 @@ void OutfitStudioFrame::OnRotateShape(wxCommandEvent& WXUNUSED(event)) {
 			updateRotationPreview();
 		};
 
-		auto originChanged = [&](wxCommandEvent&)
-		{
+		auto originChanged = [&](wxCommandEvent&) {
 			updateRotationPreview();
 		};
 
@@ -9137,13 +8707,10 @@ void OutfitStudioFrame::OnRotateShape(wxCommandEvent& WXUNUSED(event)) {
 		XRCCTRL(dlg, "origin", wxChoice)->Bind(wxEVT_CHOICE, originChanged);
 		dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
 
-		if (dlg.ShowModal() != wxID_OK)
-		{
-			if (!previewRotation.IsZero())
-			{
-				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
-				if (curState)
-				{
+		if (dlg.ShowModal() != wxID_OK) {
+			if (!previewRotation.IsZero()) {
+				UndoStateProject* curState = glView->GetUndoHistory()->GetBackState();
+				if (curState) {
 					glView->ApplyUndoState(curState, true);
 					glView->GetUndoHistory()->PopState();
 				}
@@ -9155,24 +8722,21 @@ void OutfitStudioFrame::OnRotateShape(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnDeleteVerts(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
 
-	if (bEditSlider)
-	{
+	if (bEditSlider) {
 		wxMessageBox(_("You're currently editing slider data, please exit the slider's edit mode (pencil button) and try again."));
 		return;
 	}
 
 	// Prepare the undo data and determine if any shapes are being deleted.
-	UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+	UndoStateProject* usp = glView->GetUndoHistory()->PushState();
 	usp->undoType = UT_MESH;
-	std::vector<NiShape *> delShapes;
-	for (auto &i : selectedItems)
-	{
+	std::vector<NiShape*> delShapes;
+	for (auto& i : selectedItems) {
 		if (editUV && editUV->shape == i->GetShape())
 			editUV->Close();
 
@@ -9187,18 +8751,16 @@ void OutfitStudioFrame::OnDeleteVerts(wxCommandEvent& WXUNUSED(event)) {
 	}
 
 	// Confirm deleting shapes; then delete them.
-	if (!delShapes.empty())
-	{
+	if (!delShapes.empty()) {
 		if (wxMessageBox(_("Are you sure you wish to delete parts of the selected shapes?"), _("Confirm Delete"), wxYES_NO) == wxNO)
 			return;
-		for (NiShape *shape : delShapes)
+		for (NiShape* shape : delShapes)
 			project->DeleteShape(shape);
 	}
 
 	// Now do the vertex deletion
-	for (auto &uss : usp->usss)
-	{
-		NiShape *shape = project->GetWorkNif()->FindBlockByName<NiShape>(uss.shapeName);
+	for (auto& uss : usp->usss) {
+		NiShape* shape = project->GetWorkNif()->FindBlockByName<NiShape>(uss.shapeName);
 		if (!shape)
 			continue;
 		project->ApplyShapeMeshUndo(shape, uss, false);
@@ -9214,14 +8776,12 @@ void OutfitStudioFrame::OnDeleteVerts(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnSeparateVerts(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
 
-	if (bEditSlider)
-	{
+	if (bEditSlider) {
 		wxMessageBox(_("You're currently editing slider data, please exit the slider's edit mode (pencil button) and try again."));
 		return;
 	}
@@ -9232,21 +8792,21 @@ void OutfitStudioFrame::OnSeparateVerts(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	std::string newShapeName;
-	do
-	{
+	do {
 		std::string result{wxGetTextFromUser(_("Please enter a unique name for the new separated shape."), _("Separate Vertices...")).ToUTF8()};
 		if (result.empty())
 			return;
 
 		newShapeName = std::move(result);
-	} while (project->IsValidShape(newShapeName));
+	}
+	while (project->IsValidShape(newShapeName));
 
 	if (editUV && editUV->shape == activeItem->GetShape())
 		editUV->Close();
 
 	auto newShape = project->DuplicateShape(activeItem->GetShape(), newShapeName);
 
-	UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+	UndoStateProject* usp = glView->GetUndoHistory()->PushState();
 	usp->undoType = UT_MESH;
 	usp->usss.resize(2);
 	usp->usss[0].shapeName = activeItem->GetShape()->name.get();
@@ -9269,10 +8829,10 @@ void OutfitStudioFrame::OnSeparateVerts(wxCommandEvent& WXUNUSED(event)) {
 	ApplySliders();
 }
 
-void OutfitStudioFrame::CheckCopyGeo(wxDialog &dlg) {
-	wxStaticText *errors = XRCCTRL(dlg, "copyGeometryErrors", wxStaticText);
-	wxChoice *sourceChoice = XRCCTRL(dlg, "sourceChoice", wxChoice);
-	wxChoice *targetChoice = XRCCTRL(dlg, "targetChoice", wxChoice);
+void OutfitStudioFrame::CheckCopyGeo(wxDialog& dlg) {
+	wxStaticText* errors = XRCCTRL(dlg, "copyGeometryErrors", wxStaticText);
+	wxChoice* sourceChoice = XRCCTRL(dlg, "sourceChoice", wxChoice);
+	wxChoice* targetChoice = XRCCTRL(dlg, "targetChoice", wxChoice);
 
 	std::string source = sourceChoice->GetString(sourceChoice->GetSelection()).ToStdString();
 	std::string target = targetChoice->GetString(targetChoice->GetSelection()).ToStdString();
@@ -9281,8 +8841,7 @@ void OutfitStudioFrame::CheckCopyGeo(wxDialog &dlg) {
 	project->CheckMerge(source, target, e);
 	XRCCTRL(dlg, "wxID_OK", wxButton)->Enable(e.canMerge);
 
-	if (e.canMerge)
-	{
+	if (e.canMerge) {
 		errors->SetLabel(_("No errors found!"));
 		dlg.SetSize(dlg.GetBestSize());
 		return;
@@ -9312,8 +8871,7 @@ void OutfitStudioFrame::CheckCopyGeo(wxDialog &dlg) {
 }
 
 void OutfitStudioFrame::OnCopyGeo(wxCommandEvent& WXUNUSED(event)) {
-	if (bEditSlider)
-	{
+	if (bEditSlider) {
 		wxMessageBox(_("You're currently editing slider data, please exit the slider's edit mode (pencil button) and try again."));
 		return;
 	}
@@ -9322,8 +8880,8 @@ void OutfitStudioFrame::OnCopyGeo(wxCommandEvent& WXUNUSED(event)) {
 	if (!wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgCopyGeometry"))
 		return;
 
-	wxChoice *sourceChoice = XRCCTRL(dlg, "sourceChoice", wxChoice);
-	wxChoice *targetChoice = XRCCTRL(dlg, "targetChoice", wxChoice);
+	wxChoice* sourceChoice = XRCCTRL(dlg, "sourceChoice", wxChoice);
+	wxChoice* targetChoice = XRCCTRL(dlg, "targetChoice", wxChoice);
 	if (!sourceChoice || !targetChoice)
 		return;
 
@@ -9335,8 +8893,7 @@ void OutfitStudioFrame::OnCopyGeo(wxCommandEvent& WXUNUSED(event)) {
 	if (shapeList.size() < 2)
 		return;
 
-	for (const std::string &shape : shapeList)
-	{
+	for (const std::string& shape : shapeList) {
 		sourceChoice->AppendString(shape);
 		targetChoice->AppendString(shape);
 		if (shape == sourceShapeName)
@@ -9350,12 +8907,10 @@ void OutfitStudioFrame::OnCopyGeo(wxCommandEvent& WXUNUSED(event)) {
 	else
 		targetChoice->SetSelection(0);
 
-	sourceChoice->Bind(wxEVT_CHOICE, [this,&dlg](wxCommandEvent&)
-	{
+	sourceChoice->Bind(wxEVT_CHOICE, [this,&dlg](wxCommandEvent&) {
 		CheckCopyGeo(dlg);
 	});
-	targetChoice->Bind(wxEVT_CHOICE, [this,&dlg](wxCommandEvent&)
-	{
+	targetChoice->Bind(wxEVT_CHOICE, [this,&dlg](wxCommandEvent&) {
 		CheckCopyGeo(dlg);
 	});
 	CheckCopyGeo(dlg);
@@ -9366,14 +8921,14 @@ void OutfitStudioFrame::OnCopyGeo(wxCommandEvent& WXUNUSED(event)) {
 	sourceShapeName = sourceChoice->GetString(sourceChoice->GetSelection()).ToStdString();
 	std::string targetShapeName = targetChoice->GetString(targetChoice->GetSelection()).ToStdString();
 
-	NiShape *sourceShape = project->GetWorkNif()->FindBlockByName<NiShape>(sourceShapeName);
+	NiShape* sourceShape = project->GetWorkNif()->FindBlockByName<NiShape>(sourceShapeName);
 	if (!sourceShape)
 		return;
-	NiShape *targetShape = project->GetWorkNif()->FindBlockByName<NiShape>(targetShapeName);
+	NiShape* targetShape = project->GetWorkNif()->FindBlockByName<NiShape>(targetShapeName);
 	if (!targetShape)
 		return;
 
-	UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+	UndoStateProject* usp = glView->GetUndoHistory()->PushState();
 	usp->undoType = UT_MESH;
 	usp->usss.resize(1);
 	usp->usss[0].shapeName = targetShapeName;
@@ -9393,29 +8948,26 @@ void OutfitStudioFrame::OnCopyGeo(wxCommandEvent& WXUNUSED(event)) {
 void OutfitStudioFrame::OnDupeShape(wxCommandEvent& WXUNUSED(event)) {
 	std::string newName;
 	wxTreeItemId subitem;
-	if (activeItem)
-	{
-		if (!outfitRoot.IsOk())
-		{
+	if (activeItem) {
+		if (!outfitRoot.IsOk()) {
 			wxMessageBox(_("You can only copy shapes into an outfit, and there is no outfit in the current project. Load one first!"));
 			return;
 		}
 
-		do
-		{
+		do {
 			std::string result{wxGetTextFromUser(_("Please enter a unique name for the duplicated shape."), _("Duplicate Shape")).ToUTF8()};
 			if (result.empty())
 				return;
 
 			newName = std::move(result);
-		} while (project->IsValidShape(newName));
+		}
+		while (project->IsValidShape(newName));
 
 		wxLogMessage("Duplicating shape '%s' as '%s'.", activeItem->GetShape()->name.get(), newName);
 		project->ClearBoneScale();
 
 		auto shape = project->DuplicateShape(activeItem->GetShape(), newName);
-		if (shape)
-		{
+		if (shape) {
 			glView->AddMeshFromNif(project->GetWorkNif(), newName);
 			UpdateMeshFromSet(shape);
 			project->SetTextures(shape);
@@ -9436,15 +8988,13 @@ void OutfitStudioFrame::OnDupeShape(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnDeleteShape(wxCommandEvent& WXUNUSED(event)) {
-	if (bEditSlider)
-	{
+	if (bEditSlider) {
 		wxCommandEvent evt;
 		OnDeleteSlider(evt);
 		return;
 	}
 
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
@@ -9453,14 +9003,13 @@ void OutfitStudioFrame::OnDeleteShape(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	std::vector<ShapeItemData> selected;
-	for (auto &i : selectedItems)
+	for (auto& i : selectedItems)
 		selected.push_back(*i);
 
 	activeItem = nullptr;
 	selectedItems.clear();
 
-	for (auto &i : selected)
-	{
+	for (auto& i : selected) {
 		if (editUV && editUV->shape == i.GetShape())
 			editUV->Close();
 
@@ -9487,12 +9036,9 @@ void OutfitStudioFrame::OnAddBone(wxCommandEvent& WXUNUSED(event)) {
 
 	wxTreeCtrl* boneTree = XRCCTRL(dlg, "boneTree", wxTreeCtrl);
 
-	std::function<void(wxTreeItemId, AnimBone*)> fAddBoneChildren = [&](wxTreeItemId treeParent, AnimBone* boneParent)
-	{
-		for (auto &cb : boneParent->children)
-		{
-			if (!cb->boneName.empty())
-			{
+	std::function<void(wxTreeItemId, AnimBone*)> fAddBoneChildren = [&](wxTreeItemId treeParent, AnimBone* boneParent) {
+		for (auto& cb : boneParent->children) {
+			if (!cb->boneName.empty()) {
 				auto newItem = boneTree->AppendItem(treeParent, cb->boneName);
 				fAddBoneChildren(newItem, cb);
 				if (cb->boneName == contextBone)
@@ -9507,12 +9053,10 @@ void OutfitStudioFrame::OnAddBone(wxCommandEvent& WXUNUSED(event)) {
 	wxTreeItemId rt = boneTree->AddRoot(rb->boneName);
 	fAddBoneChildren(rt, rb);
 
-	if (dlg.ShowModal() == wxID_OK)
-	{
+	if (dlg.ShowModal() == wxID_OK) {
 		wxArrayTreeItemIds sel;
 		boneTree->GetSelections(sel);
-		for (size_t i = 0; i < sel.size(); i++)
-		{
+		for (size_t i = 0; i < sel.size(); i++) {
 			std::string bone = boneTree->GetItemText(sel[i]);
 			wxLogMessage("Adding bone '%s' to project.", bone);
 
@@ -9530,40 +9074,35 @@ void OutfitStudioFrame::OnAddBone(wxCommandEvent& WXUNUSED(event)) {
 	}
 }
 
-void OutfitStudioFrame::FillParentBoneChoice(wxDialog &dlg, const std::string &selBone) {
-	wxChoice *cParentBone = XRCCTRL(dlg, "cParentBone", wxChoice);
+void OutfitStudioFrame::FillParentBoneChoice(wxDialog& dlg, const std::string& selBone) {
+	wxChoice* cParentBone = XRCCTRL(dlg, "cParentBone", wxChoice);
 	cParentBone->AppendString("(none)");
 
 	std::set<std::string> boneSet;
-	for (auto selItem : selectedItems)
-	{
-		const std::vector<std::string> &bones = project->GetWorkAnim()->shapeBones[selItem->GetShape()->name.get()];
-		for (const std::string &b : bones)
+	for (auto selItem : selectedItems) {
+		const std::vector<std::string>& bones = project->GetWorkAnim()->shapeBones[selItem->GetShape()->name.get()];
+		for (const std::string& b : bones)
 			boneSet.insert(b);
 	}
 
-	for (auto &bone : boneSet)
-	{
+	for (auto& bone : boneSet) {
 		cParentBone->AppendString(bone);
 		if (bone == selBone)
 			cParentBone->SetSelection(cParentBone->GetCount() - 1);
 	}
 
-	if (cParentBone->GetSelection() == wxNOT_FOUND)
-	{
-		if (selBone.empty())
-		{
+	if (cParentBone->GetSelection() == wxNOT_FOUND) {
+		if (selBone.empty()) {
 			cParentBone->SetSelection(0);
 		}
-		else
-		{
+		else {
 			cParentBone->AppendString(selBone);
 			cParentBone->SetSelection(cParentBone->GetCount() - 1);
 		}
 	}
 }
 
-void OutfitStudioFrame::GetBoneDlgData(wxDialog &dlg, MatTransform &xform, std::string &parentBone) {
+void OutfitStudioFrame::GetBoneDlgData(wxDialog& dlg, MatTransform& xform, std::string& parentBone) {
 	xform.translation.x = atof(XRCCTRL(dlg, "textX", wxTextCtrl)->GetValue().c_str());
 	xform.translation.y = atof(XRCCTRL(dlg, "textY", wxTextCtrl)->GetValue().c_str());
 	xform.translation.z = atof(XRCCTRL(dlg, "textZ", wxTextCtrl)->GetValue().c_str());
@@ -9574,7 +9113,7 @@ void OutfitStudioFrame::GetBoneDlgData(wxDialog &dlg, MatTransform &xform, std::
 	rotvec.z = atof(XRCCTRL(dlg, "textRZ", wxTextCtrl)->GetValue().c_str());
 	xform.rotation = RotVecToMat(rotvec);
 
-	wxChoice *cParentBone = XRCCTRL(dlg, "cParentBone", wxChoice);
+	wxChoice* cParentBone = XRCCTRL(dlg, "cParentBone", wxChoice);
 	int pBChoice = cParentBone->GetSelection();
 	if (pBChoice != wxNOT_FOUND)
 		parentBone = cParentBone->GetString(pBChoice).ToStdString();
@@ -9595,18 +9134,15 @@ void OutfitStudioFrame::OnAddCustomBone(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	wxString bone = XRCCTRL(dlg, "boneName", wxTextCtrl)->GetValue();
-	if (bone.empty())
-	{
+	if (bone.empty()) {
 		wxMessageBox(_("No bone name was entered!"), _("Error"), wxICON_INFORMATION, this);
 		return;
 	}
 
 	wxTreeItemIdValue cookie;
 	wxTreeItemId item = outfitBones->GetFirstChild(bonesRoot, cookie);
-	while (item.IsOk())
-	{
-		if (outfitBones->GetItemText(item) == bone)
-		{
+	while (item.IsOk()) {
+		if (outfitBones->GetItemText(item) == bone) {
 			wxMessageBox(wxString::Format(_("Bone '%s' already exists in the project!"), bone), _("Error"), wxICON_INFORMATION, this);
 			return;
 		}
@@ -9631,7 +9167,7 @@ void OutfitStudioFrame::OnAddCustomBone(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnEditBone(wxCommandEvent& WXUNUSED(event)) {
-	AnimBone *bPtr = AnimSkeleton::getInstance().GetBonePtr(contextBone);
+	AnimBone* bPtr = AnimSkeleton::getInstance().GetBonePtr(contextBone);
 	if (!bPtr)
 		return;
 
@@ -9646,7 +9182,7 @@ void OutfitStudioFrame::OnEditBone(wxCommandEvent& WXUNUSED(event)) {
 	else
 		FillParentBoneChoice(dlg);
 
-	wxTextCtrl *boneNameTC = XRCCTRL(dlg, "boneName", wxTextCtrl);
+	wxTextCtrl* boneNameTC = XRCCTRL(dlg, "boneName", wxTextCtrl);
 	boneNameTC->SetValue(bPtr->boneName);
 	boneNameTC->Disable();
 
@@ -9658,8 +9194,7 @@ void OutfitStudioFrame::OnEditBone(wxCommandEvent& WXUNUSED(event)) {
 	XRCCTRL(dlg, "textRY", wxTextCtrl)->SetValue(wxString() << rotvec.y);
 	XRCCTRL(dlg, "textRZ", wxTextCtrl)->SetValue(wxString() << rotvec.z);
 
-	if (bPtr->isStandardBone)
-	{
+	if (bPtr->isStandardBone) {
 		dlg.SetLabel("View Standard Bone");
 		XRCCTRL(dlg, "textX", wxTextCtrl)->Disable();
 		XRCCTRL(dlg, "textY", wxTextCtrl)->Disable();
@@ -9670,8 +9205,7 @@ void OutfitStudioFrame::OnEditBone(wxCommandEvent& WXUNUSED(event)) {
 		XRCCTRL(dlg, "cParentBone", wxChoice)->Disable();
 		XRCCTRL(dlg, "wxID_OK", wxButton)->Disable();
 	}
-	else
-	{
+	else {
 		dlg.SetLabel("Edit Custom Bone");
 	}
 
@@ -9691,8 +9225,7 @@ void OutfitStudioFrame::OnEditBone(wxCommandEvent& WXUNUSED(event)) {
 void OutfitStudioFrame::OnDeleteBone(wxCommandEvent& WXUNUSED(event)) {
 	wxArrayTreeItemIds selItems;
 	outfitBones->GetSelections(selItems);
-	for (size_t i = 0; i < selItems.size(); i++)
-	{
+	for (size_t i = 0; i < selItems.size(); i++) {
 		std::string bone = outfitBones->GetItemText(selItems[i]);
 		wxLogMessage("Deleting bone '%s' from project.", bone);
 
@@ -9715,12 +9248,11 @@ void OutfitStudioFrame::OnDeleteBone(wxCommandEvent& WXUNUSED(event)) {
 void OutfitStudioFrame::OnDeleteBoneFromSelected(wxCommandEvent& WXUNUSED(event)) {
 	wxArrayTreeItemIds selItems;
 	outfitBones->GetSelections(selItems);
-	for (size_t i = 0; i < selItems.size(); i++)
-	{
+	for (size_t i = 0; i < selItems.size(); i++) {
 		std::string bone = outfitBones->GetItemText(selItems[i]);
 		wxLogMessage("Deleting weights of bone '%s' from selected shapes.", bone);
 
-		for (auto &s : selectedItems)
+		for (auto& s : selectedItems)
 			project->GetWorkAnim()->RemoveShapeBone(s->GetShape()->name.get(), bone);
 	}
 
@@ -9734,8 +9266,7 @@ void OutfitStudioFrame::OnDeleteBoneFromSelected(wxCommandEvent& WXUNUSED(event)
 
 bool OutfitStudioFrame::HasUnweightedCheck() {
 	std::vector<std::string> unweighted;
-	if (project->HasUnweighted(&unweighted))
-	{
+	if (project->HasUnweighted(&unweighted)) {
 		std::string shapesJoin = JoinStrings(unweighted, "; ");
 		wxLogWarning(wxString::Format("Unweighted vertices found on shapes: %s", shapesJoin));
 
@@ -9749,43 +9280,36 @@ bool OutfitStudioFrame::HasUnweightedCheck() {
 
 bool OutfitStudioFrame::ShowWeightCopy(WeightCopyOptions& options, bool silent) {
 	wxDialog dlg;
-	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgCopyWeights"))
-	{
-		XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->Bind(wxEVT_SLIDER, [&dlg](wxCommandEvent&)
-		{
+	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgCopyWeights")) {
+		XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->Bind(wxEVT_SLIDER, [&dlg](wxCommandEvent&) {
 			float changed = XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->GetValue() / 1000.0f;
 			XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", changed));
 		});
 
-		XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->Bind(wxEVT_TEXT, [&dlg](wxCommandEvent&)
-		{
+		XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->Bind(wxEVT_TEXT, [&dlg](wxCommandEvent&) {
 			float changed = atof(XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->GetValue().c_str());
 			XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->SetValue(changed * 1000);
 		});
 
-		XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Bind(wxEVT_SLIDER, [&dlg](wxCommandEvent&)
-		{
+		XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Bind(wxEVT_SLIDER, [&dlg](wxCommandEvent&) {
 			int changed = XRCCTRL(dlg, "maxResultsSlider", wxSlider)->GetValue();
 			XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->ChangeValue(wxString::Format("%d", changed));
 		});
 
-		XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->Bind(wxEVT_TEXT, [&dlg](wxCommandEvent&)
-		{
+		XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->Bind(wxEVT_TEXT, [&dlg](wxCommandEvent&) {
 			int changed = atol(XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->GetValue().c_str());
 			XRCCTRL(dlg, "maxResultsSlider", wxSlider)->SetValue(changed);
 		});
 
-		XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->Bind(wxEVT_CHECKBOX, [&dlg](wxCommandEvent&)
-		{
+		XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->Bind(wxEVT_CHECKBOX, [&dlg](wxCommandEvent&) {
 			bool noTargetLimit = XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->IsChecked();
 			XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->Enable(!noTargetLimit);
 			XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Enable(!noTargetLimit);
 		});
 
-		wxCheckBox *cbCopySkinTrans = XRCCTRL(dlg, "cbCopySkinTrans", wxCheckBox);
-		wxCheckBox *cbTransformGeo = XRCCTRL(dlg, "cbTransformGeo", wxCheckBox);
-		if (options.showSkinTransOption)
-		{
+		wxCheckBox* cbCopySkinTrans = XRCCTRL(dlg, "cbCopySkinTrans", wxCheckBox);
+		wxCheckBox* cbTransformGeo = XRCCTRL(dlg, "cbTransformGeo", wxCheckBox);
+		if (options.showSkinTransOption) {
 			cbCopySkinTrans->SetValue(options.doSkinTransCopy);
 			cbTransformGeo->SetValue(options.doTransformGeo);
 			cbCopySkinTrans->Show();
@@ -9796,9 +9320,8 @@ bool OutfitStudioFrame::ShowWeightCopy(WeightCopyOptions& options, bool silent) 
 		dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
 
 		dlg.SetSize(dlg.GetBestSize());
-	
-		if (silent || dlg.ShowModal() == wxID_OK)
-		{
+
+		if (silent || dlg.ShowModal() == wxID_OK) {
 			options.proximityRadius = atof(XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->GetValue().c_str());
 
 			bool noTargetLimit = XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->IsChecked();
@@ -9807,8 +9330,7 @@ bool OutfitStudioFrame::ShowWeightCopy(WeightCopyOptions& options, bool silent) 
 			else
 				options.maxResults = std::numeric_limits<int>::max();
 
-			if (options.showSkinTransOption)
-			{
+			if (options.showSkinTransOption) {
 				options.doSkinTransCopy = cbCopySkinTrans->IsChecked();
 				options.doTransformGeo = cbTransformGeo->IsChecked();
 			}
@@ -9823,42 +9345,39 @@ bool OutfitStudioFrame::ShowWeightCopy(WeightCopyOptions& options, bool silent) 
 void OutfitStudioFrame::ReselectBone() {
 	wxArrayTreeItemIds selItems;
 	outfitBones->GetSelections(selItems);
-	if (!selItems.empty())
-	{
+	if (!selItems.empty()) {
 		wxTreeEvent treeEvent(wxEVT_TREE_SEL_CHANGED, outfitBones, selItems.front());
 		OnBoneSelect(treeEvent);
 	}
 }
 
-void OutfitStudioFrame::CalcCopySkinTransOption(WeightCopyOptions &options) {
+void OutfitStudioFrame::CalcCopySkinTransOption(WeightCopyOptions& options) {
 	// This function calculates whether the "copy global-to-skin transform
 	// from base shape" checkbox should be shown and what the default value
 	// for the "transform-geometry" checkbox should be
 
-	NifFile *nif = project->GetWorkNif();
-	NiShape *baseShape = project->GetBaseShape();
+	NifFile* nif = project->GetWorkNif();
+	NiShape* baseShape = project->GetBaseShape();
 	if (!baseShape)
 		return;
 
-	AnimInfo &workAnim = *project->GetWorkAnim();
+	AnimInfo& workAnim = *project->GetWorkAnim();
 
 	if (!workAnim.HasSkinnedShape(baseShape))
 		return;
 
-	const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[baseShape->name.get()].xformGlobalToSkin;
+	const MatTransform& baseXformGlobalToSkin = workAnim.shapeSkinning[baseShape->name.get()].xformGlobalToSkin;
 
 	// Check if any shape's skin CS is different from the base shape's
-	for (size_t i = 0; i < selectedItems.size(); i++)
-	{
-		NiShape *shape = selectedItems[i]->GetShape();
+	for (size_t i = 0; i < selectedItems.size(); i++) {
+		NiShape* shape = selectedItems[i]->GetShape();
 		if (shape == baseShape)
 			continue;
 
 		if (!workAnim.HasSkinnedShape(shape))
 			continue;
 
-		if (!workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(baseXformGlobalToSkin))
-		{
+		if (!workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(baseXformGlobalToSkin)) {
 			options.showSkinTransOption = true;
 			break;
 		}
@@ -9874,7 +9393,7 @@ void OutfitStudioFrame::CalcCopySkinTransOption(WeightCopyOptions &options) {
 	// find the average vertex position of the base shape in its own skin coordinates
 	Vector3 baseAvg;
 
-	const std::vector<Vector3> &baseVerts = *nif->GetVertsForShape(baseShape);
+	const std::vector<Vector3>& baseVerts = *nif->GetVertsForShape(baseShape);
 	for (size_t i = 0; i < baseVerts.size(); ++i)
 		baseAvg += baseVerts[i];
 
@@ -9882,17 +9401,16 @@ void OutfitStudioFrame::CalcCopySkinTransOption(WeightCopyOptions &options) {
 		baseAvg /= static_cast<uint32_t>(baseVerts.size());
 
 	// Now check if any shape would be better aligned by changing its global-to-skin transform
-	for (size_t i = 0; i < selectedItems.size(); i++)
-	{
-		NiShape *shape = selectedItems[i]->GetShape();
+	for (size_t i = 0; i < selectedItems.size(); i++) {
+		NiShape* shape = selectedItems[i]->GetShape();
 		if (shape == baseShape)
 			continue;
 
-		const MatTransform &globalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
+		const MatTransform& globalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
 		if (globalToSkin.IsNearlyEqualTo(baseXformGlobalToSkin))
 			continue;
 
-		const std::vector<Vector3> &verts = *nif->GetVertsForShape(shape);
+		const std::vector<Vector3>& verts = *nif->GetVertsForShape(shape);
 		if (verts.empty())
 			continue;
 
@@ -9901,8 +9419,7 @@ void OutfitStudioFrame::CalcCopySkinTransOption(WeightCopyOptions &options) {
 		MatTransform skinToBaseSkin = baseXformGlobalToSkin.ComposeTransforms(skinToGlobal);
 
 		Vector3 oldAvg, newAvg;
-		for (size_t j = 0; j < verts.size(); ++j)
-		{
+		for (size_t j = 0; j < verts.size(); ++j) {
 			oldAvg += skinToBaseSkin.ApplyTransform(verts[j]);
 			newAvg += verts[j];
 		}
@@ -9912,8 +9429,7 @@ void OutfitStudioFrame::CalcCopySkinTransOption(WeightCopyOptions &options) {
 
 		// Check whether old or new is closer to the base shape.
 		// If new is farther away, then transforming the geometry would be a good idea
-		if (newAvg.DistanceTo(baseAvg) > oldAvg.DistanceTo(baseAvg))
-		{
+		if (newAvg.DistanceTo(baseAvg) > oldAvg.DistanceTo(baseAvg)) {
 			options.doTransformGeo = true;
 			break;
 		}
@@ -9921,43 +9437,37 @@ void OutfitStudioFrame::CalcCopySkinTransOption(WeightCopyOptions &options) {
 }
 
 void OutfitStudioFrame::OnCopyBoneWeight(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
 
-	if (!project->GetBaseShape())
-	{
+	if (!project->GetBaseShape()) {
 		wxMessageBox(_("There is no reference shape!"), _("Error"));
 		return;
 	}
 
 	WeightCopyOptions options;
 	CalcCopySkinTransOption(options);
-	AnimInfo &workAnim = *project->GetWorkAnim();
+	AnimInfo& workAnim = *project->GetWorkAnim();
 
-	if (ShowWeightCopy(options))
-	{
+	if (ShowWeightCopy(options)) {
 		StartProgress(_("Copying bone weights..."));
 
-		UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+		UndoStateProject* usp = glView->GetUndoHistory()->PushState();
 		usp->undoType = UT_WEIGHT;
 
 		std::vector<std::string> baseBones = workAnim.shapeBones[project->GetBaseShape()->name.get()];
 		std::sort(baseBones.begin(), baseBones.end());
 		std::unordered_map<uint16_t, float> mask;
-		for (size_t i = 0; i < selectedItems.size(); i++)
-		{
-			NiShape *shape = selectedItems[i]->GetShape();
-			if (!project->IsBaseShape(shape))
-			{
+		for (size_t i = 0; i < selectedItems.size(); i++) {
+			NiShape* shape = selectedItems[i]->GetShape();
+			if (!project->IsBaseShape(shape)) {
 				wxLogMessage("Copying bone weights to '%s'...", shape->name.get());
 
-				if (options.doSkinTransCopy)
-				{
-					const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->name.get()].xformGlobalToSkin;
-					const MatTransform &oldXformGlobalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
+				if (options.doSkinTransCopy) {
+					const MatTransform& baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->name.get()].xformGlobalToSkin;
+					const MatTransform& oldXformGlobalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
 
 					if (options.doTransformGeo && !baseXformGlobalToSkin.IsNearlyEqualTo(oldXformGlobalToSkin))
 						project->ApplyTransformToShapeGeometry(shape, baseXformGlobalToSkin.ComposeTransforms(oldXformGlobalToSkin.InverseTransform()));
@@ -10002,18 +9512,14 @@ void OutfitStudioFrame::OnCopyBoneWeight(wxCommandEvent& WXUNUSED(event)) {
 	UpdateAnimationGUI();
 }
 
-void OutfitStudioFrame::MaskWeightedOnShape(std::string& shapeName) const
-{
+void OutfitStudioFrame::MaskWeightedOnShape(std::string& shapeName) const {
 	mesh* m = glView->GetMesh(shapeName);
 	auto& bones = project->GetWorkAnim()->shapeBones;
-	if (bones.find(shapeName) != bones.end())
-	{
-		for (auto &b : bones[shapeName])
-		{
+	if (bones.find(shapeName) != bones.end()) {
+		for (auto& b : bones[shapeName]) {
 			auto weights = project->GetWorkAnim()->GetWeightsPtr(shapeName, b);
-			if (weights)
-			{
-				for (auto &bw : *weights)
+			if (weights) {
+				for (auto& bw : *weights)
 					if (bw.second > 0.0f)
 						m->vcolors[bw.first].x = 1.0f;
 			}
@@ -10024,37 +9530,33 @@ void OutfitStudioFrame::MaskWeightedOnShape(std::string& shapeName) const
 
 int OutfitStudioFrame::CopyBoneWeightForShapes(std::vector<NiShape*> shapes, int addedRadius, bool maskWeighted, bool silent) {
 
-	if (!project->GetBaseShape())
-	{
+	if (!project->GetBaseShape()) {
 		wxLogMessage("There is no reference shape!");
 		return 1;
 	}
 
 	WeightCopyOptions options;
 	CalcCopySkinTransOption(options);
-	AnimInfo &workAnim = *project->GetWorkAnim();
+	AnimInfo& workAnim = *project->GetWorkAnim();
 
-	if (ShowWeightCopy(options, silent))
-	{
-		UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+	if (ShowWeightCopy(options, silent)) {
+		UndoStateProject* usp = glView->GetUndoHistory()->PushState();
 		usp->undoType = UT_WEIGHT;
 
 		std::vector<std::string> baseBones = workAnim.shapeBones[project->GetBaseShape()->name.get()];
 		std::sort(baseBones.begin(), baseBones.end());
 		std::unordered_map<uint16_t, float> mask;
-		for (size_t i = 0; i < shapes.size(); i++)
-		{
-			NiShape *shape = shapes[i];
+		for (size_t i = 0; i < shapes.size(); i++) {
+			NiShape* shape = shapes[i];
 			if (project->IsBaseShape(shape))
 				continue;
 
 			auto& shapeName = shape->name.get();
 			wxLogMessage("Copying bone weights to '%s'...", shapeName);
 
-			if (options.doSkinTransCopy)
-			{
-				const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->name.get()].xformGlobalToSkin;
-				const MatTransform &oldXformGlobalToSkin = workAnim.shapeSkinning[shapeName].xformGlobalToSkin;
+			if (options.doSkinTransCopy) {
+				const MatTransform& baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->name.get()].xformGlobalToSkin;
+				const MatTransform& oldXformGlobalToSkin = workAnim.shapeSkinning[shapeName].xformGlobalToSkin;
 
 				if (options.doTransformGeo && !baseXformGlobalToSkin.IsNearlyEqualTo(oldXformGlobalToSkin))
 					project->ApplyTransformToShapeGeometry(shape, baseXformGlobalToSkin.ComposeTransforms(oldXformGlobalToSkin.InverseTransform()));
@@ -10067,7 +9569,7 @@ int OutfitStudioFrame::CopyBoneWeightForShapes(std::vector<NiShape*> shapes, int
 			usp->usss.back().shapeName = shapeName;
 
 			mask.clear();
-			if(maskWeighted) {
+			if (maskWeighted) {
 				MaskWeightedOnShape(shapeName);
 			}
 			glView->GetShapeMask(mask, shapeName);
@@ -10096,14 +9598,12 @@ int OutfitStudioFrame::CopyBoneWeightForShapes(std::vector<NiShape*> shapes, int
 }
 
 void OutfitStudioFrame::OnCopySelectedWeight(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
 
-	if (!project->GetBaseShape())
-	{
+	if (!project->GetBaseShape()) {
 		wxMessageBox(_("There is no reference shape!"), _("Error"));
 		return;
 	}
@@ -10113,53 +9613,47 @@ void OutfitStudioFrame::OnCopySelectedWeight(wxCommandEvent& WXUNUSED(event)) {
 	if (nSelBones < 1)
 		return;
 
-	std::unordered_set<std::string> selBones{ boneList.begin(), boneList.end() };
+	std::unordered_set<std::string> selBones{boneList.begin(), boneList.end()};
 
 	std::string bonesString;
-	for (std::string &boneName : boneList)
+	for (std::string& boneName : boneList)
 		bonesString += "'" + boneName + "' ";
 
 	std::vector<std::string> normBones, notNormBones, lockedBones;
 	GetNormalizeBones(&normBones, &notNormBones);
-	for (auto &bone : normBones)
+	for (auto& bone : normBones)
 		if (!selBones.count(bone))
 			boneList.push_back(bone);
 
 	bool bHasNormBones = static_cast<int>(boneList.size()) > nSelBones;
-	if (bHasNormBones)
-	{
-		for (auto &bone : notNormBones)
+	if (bHasNormBones) {
+		for (auto& bone : notNormBones)
 			if (!selBones.count(bone))
 				lockedBones.push_back(bone);
 	}
-	else
-	{
-		for (auto &bone : notNormBones)
+	else {
+		for (auto& bone : notNormBones)
 			if (!selBones.count(bone))
 				boneList.push_back(bone);
 	}
 
 	WeightCopyOptions options;
 	CalcCopySkinTransOption(options);
-	AnimInfo &workAnim = *project->GetWorkAnim();
+	AnimInfo& workAnim = *project->GetWorkAnim();
 
-	if (ShowWeightCopy(options))
-	{
+	if (ShowWeightCopy(options)) {
 		StartProgress(_("Copying selected bone weights..."));
 
-		UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+		UndoStateProject* usp = glView->GetUndoHistory()->PushState();
 		usp->undoType = UT_WEIGHT;
 		std::unordered_map<uint16_t, float> mask;
-		for (size_t i = 0; i < selectedItems.size(); i++)
-		{
-			NiShape *shape = selectedItems[i]->GetShape();
-			if (!project->IsBaseShape(shape))
-			{
+		for (size_t i = 0; i < selectedItems.size(); i++) {
+			NiShape* shape = selectedItems[i]->GetShape();
+			if (!project->IsBaseShape(shape)) {
 				wxLogMessage("Copying selected bone weights to '%s' for %s...", shape->name.get(), bonesString);
-				if (options.doSkinTransCopy)
-				{
-					const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->name.get()].xformGlobalToSkin;
-					const MatTransform &oldXformGlobalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
+				if (options.doSkinTransCopy) {
+					const MatTransform& baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->name.get()].xformGlobalToSkin;
+					const MatTransform& oldXformGlobalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
 
 					if (options.doTransformGeo && !baseXformGlobalToSkin.IsNearlyEqualTo(oldXformGlobalToSkin))
 						project->ApplyTransformToShapeGeometry(shape, baseXformGlobalToSkin.ComposeTransforms(oldXformGlobalToSkin.InverseTransform()));
@@ -10197,29 +9691,25 @@ void OutfitStudioFrame::OnCopySelectedWeight(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnTransferSelectedWeight(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
 
 	auto baseShape = project->GetBaseShape();
-	if (!baseShape)
-	{
+	if (!baseShape) {
 		wxMessageBox(_("There is no reference shape!"), _("Error"));
 		return;
 	}
 
-	if (project->IsBaseShape(activeItem->GetShape()))
-	{
+	if (project->IsBaseShape(activeItem->GetShape())) {
 		wxMessageBox(_("Sorry, you can't copy weights from the reference shape to itself."), _("Error"));
 		return;
 	}
 
 	int baseVertCount = project->GetVertexCount(baseShape);
 	int workVertCount = project->GetVertexCount(activeItem->GetShape());
-	if (baseVertCount != workVertCount)
-	{
+	if (baseVertCount != workVertCount) {
 		wxMessageBox(_("The vertex count of the reference and chosen shape is not the same!"), _("Error"));
 		return;
 	}
@@ -10229,7 +9719,7 @@ void OutfitStudioFrame::OnTransferSelectedWeight(wxCommandEvent& WXUNUSED(event)
 		return;
 
 	std::string bonesString;
-	for (std::string &boneName : selectedBones)
+	for (std::string& boneName : selectedBones)
 		bonesString += "'" + boneName + "' ";
 
 	wxLogMessage("Transferring selected bone weights to '%s' for %s...", activeItem->GetShape()->name.get(), bonesString);
@@ -10248,14 +9738,12 @@ void OutfitStudioFrame::OnTransferSelectedWeight(wxCommandEvent& WXUNUSED(event)
 }
 
 void OutfitStudioFrame::OnMaskWeighted(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
 
-	for (auto &i : selectedItems)
-	{
+	for (auto& i : selectedItems) {
 		std::string shapeName = i->GetShape()->name.get();
 		mesh* m = glView->GetMesh(shapeName);
 		if (!m)
@@ -10264,14 +9752,11 @@ void OutfitStudioFrame::OnMaskWeighted(wxCommandEvent& WXUNUSED(event)) {
 		m->ColorChannelFill(0, 0.0f);
 
 		auto& bones = project->GetWorkAnim()->shapeBones;
-		if (bones.find(shapeName) != bones.end())
-		{
-			for (auto &b : bones[shapeName])
-			{
+		if (bones.find(shapeName) != bones.end()) {
+			for (auto& b : bones[shapeName]) {
 				auto weights = project->GetWorkAnim()->GetWeightsPtr(shapeName, b);
-				if (weights)
-				{
-					for (auto &bw : *weights)
+				if (weights) {
+					for (auto& bw : *weights)
 						if (bw.second > 0.0f)
 							m->vcolors[bw.first].x = 1.0f;
 				}
@@ -10283,14 +9768,12 @@ void OutfitStudioFrame::OnMaskWeighted(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnMaskBoneWeighted(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
 
-	for (auto &i : selectedItems)
-	{
+	for (auto& i : selectedItems) {
 		std::string shapeName = i->GetShape()->name.get();
 		mesh* m = glView->GetMesh(shapeName);
 		if (!m || !m->vcolors)
@@ -10298,12 +9781,10 @@ void OutfitStudioFrame::OnMaskBoneWeighted(wxCommandEvent& WXUNUSED(event)) {
 
 		m->ColorChannelFill(0, 0.0f);
 
-		for (auto &b : GetSelectedBones())
-		{
+		for (auto& b : GetSelectedBones()) {
 			auto weights = project->GetWorkAnim()->GetWeightsPtr(shapeName, b);
-			if (weights)
-			{
-				for (auto &bw : *weights)
+			if (weights) {
+				for (auto& bw : *weights)
 					if (bw.second > 0.0f)
 						m->vcolors[bw.first].x = 1.0f;
 			}
@@ -10339,15 +9820,13 @@ void OutfitStudioFrame::OnRemoveSkinning(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnShapeProperties(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
 
 	auto shape = activeItem->GetShape();
-	if (shape)
-	{
+	if (shape) {
 		ShapeProperties prop(this, project->GetWorkNif(), shape);
 		prop.ShowModal();
 	}
@@ -10387,8 +9866,7 @@ void OutfitStudioFrame::OnNPWizChangeSliderSetFile(wxFileDirPickerEvent& event) 
 	setNameChoice->Clear();
 	refShapeChoice->Clear();
 
-	if (fn.rfind(".osp") != std::string::npos || fn.rfind(".xml") != std::string::npos)
-	{
+	if (fn.rfind(".osp") != std::string::npos || fn.rfind(".xml") != std::string::npos) {
 		SliderSetFile ssf(fn);
 		if (ssf.fail())
 			return;
@@ -10396,21 +9874,19 @@ void OutfitStudioFrame::OnNPWizChangeSliderSetFile(wxFileDirPickerEvent& event) 
 		std::vector<std::string> setNames;
 		ssf.GetSetNames(setNames);
 
-		for (auto &sn : setNames)
+		for (auto& sn : setNames)
 			setNameChoice->AppendString(sn);
 
-		if (!setNames.empty())
-		{
+		if (!setNames.empty()) {
 			setNameChoice->SetSelection(0);
 			ssf.SetShapes(setNames.front(), shapes);
-			for (auto &rsn : shapes)
+			for (auto& rsn : shapes)
 				refShapeChoice->AppendString(rsn);
 
 			refShapeChoice->SetSelection(0);
 		}
 	}
-	else if (fn.rfind(".nif") != std::string::npos)
-	{
+	else if (fn.rfind(".nif") != std::string::npos) {
 		std::fstream file;
 		PlatformUtil::OpenFileStream(file, fn, std::ios::in | std::ios::binary);
 
@@ -10418,7 +9894,7 @@ void OutfitStudioFrame::OnNPWizChangeSliderSetFile(wxFileDirPickerEvent& event) 
 		if (checkFile.Load(file))
 			return;
 
-		for (auto &rsn : checkFile.GetShapeNames())
+		for (auto& rsn : checkFile.GetShapeNames())
 			refShapeChoice->AppendString(rsn);
 
 		refShapeChoice->SetSelection(0);
@@ -10442,7 +9918,7 @@ void OutfitStudioFrame::OnNPWizChangeSetNameChoice(wxCommandEvent& event) {
 	wxChoice* refShapeChoice = (wxChoice*)XRCCTRL((*npWiz), "npRefShapeName", wxChoice);
 	refShapeChoice->Clear();
 
-	for (auto &rsn : shapes)
+	for (auto& rsn : shapes)
 		refShapeChoice->AppendString(rsn);
 
 	refShapeChoice->SetSelection(0);
@@ -10459,7 +9935,7 @@ void OutfitStudioFrame::OnLoadOutfitFP_Texture(wxFileDirPickerEvent& event) {
 }
 
 void OutfitStudioFrame::OnRecalcNormals(wxCommandEvent& WXUNUSED(event)) {
-	for (auto &s : selectedItems)
+	for (auto& s : selectedItems)
 		glView->RecalcNormals(s->GetShape()->name.get());
 
 	glView->Render();
@@ -10469,7 +9945,7 @@ void OutfitStudioFrame::OnSmoothNormalSeams(wxCommandEvent& event) {
 	bool enable = event.IsChecked();
 	glView->SetNormalSeamSmoothMode(enable);
 
-	for (auto &s : selectedItems)
+	for (auto& s : selectedItems)
 		project->activeSet.SetSmoothSeamNormals(s->GetShape()->name.get(), enable);
 
 	glView->Render();
@@ -10479,7 +9955,7 @@ void OutfitStudioFrame::OnLockNormals(wxCommandEvent& event) {
 	bool enable = event.IsChecked();
 	glView->SetLockNormalsMode(enable);
 
-	for (auto &s : selectedItems)
+	for (auto& s : selectedItems)
 		project->activeSet.SetLockNormals(s->GetShape()->name.get(), enable);
 }
 
@@ -10487,20 +9963,17 @@ void OutfitStudioFrame::OnEditUV(wxCommandEvent& WXUNUSED(event)) {
 	if (editUV)
 		return;
 
-	if (!activeItem)
-	{
+	if (!activeItem) {
 		wxMessageBox(_("There is no shape selected!"), _("Error"));
 		return;
 	}
 
 	auto shape = activeItem->GetShape();
 	mesh* m = glView->GetMesh(shape->name.get());
-	if (shape && m)
-	{
+	if (shape && m) {
 		editUV = new EditUV(this, project->GetWorkNif(), shape, m, activeSlider);
 
-		editUV->Bind(wxEVT_CLOSE_WINDOW, [&](wxCloseEvent& event)
-		{
+		editUV->Bind(wxEVT_CLOSE_WINDOW, [&](wxCloseEvent& event) {
 			editUV = nullptr;
 			event.Skip();
 		});
@@ -10513,11 +9986,9 @@ void OutfitStudioFrame::OnEditUV(wxCommandEvent& WXUNUSED(event)) {
 void OutfitStudioFrame::OnSelectMask(wxCommandEvent& WXUNUSED(event)) {
 	wxChoice* cMaskName = (wxChoice*)FindWindowByName("cMaskName");
 	int maskSel = cMaskName->GetSelection();
-	if (maskSel != wxNOT_FOUND)
-	{
+	if (maskSel != wxNOT_FOUND) {
 		auto maskData = (std::map<std::string, std::unordered_map<uint16_t, float>>*)cMaskName->GetClientData(maskSel);
-		for (auto mask : (*maskData))
-		{
+		for (auto mask : (*maskData)) {
 			glView->SetShapeMask(mask.second, mask.first);
 		}
 	}
@@ -10528,13 +9999,11 @@ void OutfitStudioFrame::OnSelectMask(wxCommandEvent& WXUNUSED(event)) {
 void OutfitStudioFrame::OnSaveMask(wxCommandEvent& WXUNUSED(event)) {
 	wxChoice* cMaskName = (wxChoice*)FindWindowByName("cMaskName");
 	int maskSel = cMaskName->GetSelection();
-	if (maskSel != wxNOT_FOUND)
-	{
+	if (maskSel != wxNOT_FOUND) {
 		auto maskData = new std::map<std::string, std::unordered_map<uint16_t, float>>();
 
 		std::vector<std::string> shapes = GetShapeList();
-		for (auto &s : shapes)
-		{
+		for (auto& s : shapes) {
 			std::unordered_map<uint16_t, float> mask;
 			glView->GetShapeMask(mask, s);
 			(*maskData)[s] = std::move(mask);
@@ -10542,8 +10011,7 @@ void OutfitStudioFrame::OnSaveMask(wxCommandEvent& WXUNUSED(event)) {
 
 		cMaskName->SetClientData(maskSel, maskData);
 	}
-	else
-	{
+	else {
 		wxCommandEvent evt;
 		OnSaveAsMask(evt);
 	}
@@ -10553,19 +10021,18 @@ void OutfitStudioFrame::OnSaveAsMask(wxCommandEvent& WXUNUSED(event)) {
 	wxChoice* cMaskName = (wxChoice*)FindWindowByName("cMaskName");
 
 	wxString maskName;
-	do
-	{
+	do {
 		maskName = wxGetTextFromUser(_("Please enter a new unique name for the mask."), _("New Mask"));
 		if (maskName.empty())
 			return;
 
-	} while (cMaskName->FindString(maskName) != wxNOT_FOUND);
+	}
+	while (cMaskName->FindString(maskName) != wxNOT_FOUND);
 
 	auto maskData = new std::map<std::string, std::unordered_map<uint16_t, float>>();
 
 	std::vector<std::string> shapes = GetShapeList();
-	for (auto &s : shapes)
-	{
+	for (auto& s : shapes) {
 		std::unordered_map<uint16_t, float> mask;
 		glView->GetShapeMask(mask, s);
 		(*maskData)[s] = std::move(mask);
@@ -10579,8 +10046,7 @@ void OutfitStudioFrame::OnSaveAsMask(wxCommandEvent& WXUNUSED(event)) {
 void OutfitStudioFrame::OnDeleteMask(wxCommandEvent& WXUNUSED(event)) {
 	wxChoice* cMaskName = (wxChoice*)FindWindowByName("cMaskName");
 	int maskSel = cMaskName->GetSelection();
-	if (maskSel != wxNOT_FOUND)
-	{
+	if (maskSel != wxNOT_FOUND) {
 		cMaskName->Delete(maskSel);
 	}
 }
@@ -10591,14 +10057,12 @@ void OutfitStudioFrame::OnPaneCollapse(wxCollapsiblePaneEvent& WXUNUSED(event)) 
 }
 
 void OutfitStudioFrame::ApplyPose() {
-	for (auto &shape : project->GetWorkNif()->GetShapes())
-	{
+	for (auto& shape : project->GetWorkNif()->GetShapes()) {
 		std::vector<Vector3> verts;
 		project->GetLiveVerts(shape, verts);
 		glView->UpdateMeshVertices(shape->name.get(), &verts, true, true, false);
 	}
-	if (!activeBone.empty())
-	{
+	if (!activeBone.empty()) {
 		int boneScalePos = boneScale->GetValue();
 		if (boneScalePos != 0)
 			project->ApplyBoneScale(activeBone, boneScalePos);
@@ -10606,7 +10070,7 @@ void OutfitStudioFrame::ApplyPose() {
 	glView->Render();
 }
 
-AnimBone *OutfitStudioFrame::GetPoseBonePtr() {
+AnimBone* OutfitStudioFrame::GetPoseBonePtr() {
 	int selind = cPoseBone->GetSelection();
 	if (selind == wxNOT_FOUND) return nullptr;
 	std::string poseBone = cPoseBone->GetString(selind).ToStdString();
@@ -10614,9 +10078,8 @@ AnimBone *OutfitStudioFrame::GetPoseBonePtr() {
 }
 
 void OutfitStudioFrame::PoseToGUI() {
-	AnimBone *bone = GetPoseBonePtr();
-	if (bone)
-	{
+	AnimBone* bone = GetPoseBonePtr();
+	if (bone) {
 		rxPoseSlider->SetValue(bone->poseRotVec.x * 100);
 		ryPoseSlider->SetValue(bone->poseRotVec.y * 100);
 		rzPoseSlider->SetValue(bone->poseRotVec.z * 100);
@@ -10630,8 +10093,7 @@ void OutfitStudioFrame::PoseToGUI() {
 		tyPoseText->ChangeValue(wxString() << bone->poseTranVec.y);
 		tzPoseText->ChangeValue(wxString() << bone->poseTranVec.z);
 	}
-	else
-	{
+	else {
 		rxPoseSlider->SetValue(0);
 		ryPoseSlider->SetValue(0);
 		rzPoseSlider->SetValue(0);
@@ -10649,93 +10111,90 @@ void OutfitStudioFrame::PoseToGUI() {
 		cbPose->SetValue(project->bPose);
 }
 
-void OutfitStudioFrame::OnPoseBoneChanged(wxCommandEvent& WXUNUSED(event))
-{
+void OutfitStudioFrame::OnPoseBoneChanged(wxCommandEvent& WXUNUSED(event)) {
 	PoseToGUI();
 }
 
 void OutfitStudioFrame::OnPoseValChanged(int cind, float val) {
 	// Called when any pose slider or text control is changed.
-	AnimBone *bone = GetPoseBonePtr();
+	AnimBone* bone = GetPoseBonePtr();
 	if (!bone) return;
 	if (cind < 3)
 		bone->poseRotVec[cind] = val;
 	else
-		bone->poseTranVec[cind-3] = val;
+		bone->poseTranVec[cind - 3] = val;
 	bone->UpdatePoseTransform();
 	ApplyPose();
 }
 
-void OutfitStudioFrame::OnAnyPoseSlider(wxScrollEvent &e, wxTextCtrl *t, int cind) {
+void OutfitStudioFrame::OnAnyPoseSlider(wxScrollEvent& e, wxTextCtrl* t, int cind) {
 	float val = e.GetPosition() * 0.01f;
 	t->ChangeValue(wxString() << val);
 	OnPoseValChanged(cind, val);
 }
 
-void OutfitStudioFrame::OnRXPoseSlider(wxScrollEvent& e)
-{
+void OutfitStudioFrame::OnRXPoseSlider(wxScrollEvent& e) {
 	OnAnyPoseSlider(e, rxPoseText, 0);
 }
-void OutfitStudioFrame::OnRYPoseSlider(wxScrollEvent& e)
-{
+
+void OutfitStudioFrame::OnRYPoseSlider(wxScrollEvent& e) {
 	OnAnyPoseSlider(e, ryPoseText, 1);
 }
-void OutfitStudioFrame::OnRZPoseSlider(wxScrollEvent& e)
-{
+
+void OutfitStudioFrame::OnRZPoseSlider(wxScrollEvent& e) {
 	OnAnyPoseSlider(e, rzPoseText, 2);
 }
-void OutfitStudioFrame::OnTXPoseSlider(wxScrollEvent& e)
-{
+
+void OutfitStudioFrame::OnTXPoseSlider(wxScrollEvent& e) {
 	OnAnyPoseSlider(e, txPoseText, 3);
 }
-void OutfitStudioFrame::OnTYPoseSlider(wxScrollEvent& e)
-{
+
+void OutfitStudioFrame::OnTYPoseSlider(wxScrollEvent& e) {
 	OnAnyPoseSlider(e, tyPoseText, 4);
 }
-void OutfitStudioFrame::OnTZPoseSlider(wxScrollEvent& e)
-{
+
+void OutfitStudioFrame::OnTZPoseSlider(wxScrollEvent& e) {
 	OnAnyPoseSlider(e, tzPoseText, 5);
 }
 
-void OutfitStudioFrame::OnAnyPoseTextChanged(wxTextCtrl *t, wxSlider *s, int cind) {
+void OutfitStudioFrame::OnAnyPoseTextChanged(wxTextCtrl* t, wxSlider* s, int cind) {
 	if (!t || !s) return;
 	double val;
 	if (!t->GetValue().ToDouble(&val))
 		return;
-	s->SetValue(val*100);
+	s->SetValue(val * 100);
 	OnPoseValChanged(cind, val);
 }
 
-void OutfitStudioFrame::OnRXPoseTextChanged(wxCommandEvent& WXUNUSED(event))
-{
+void OutfitStudioFrame::OnRXPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
 	OnAnyPoseTextChanged(rxPoseText, rxPoseSlider, 0);
 }
-void OutfitStudioFrame::OnRYPoseTextChanged(wxCommandEvent& WXUNUSED(event))
-{
+
+void OutfitStudioFrame::OnRYPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
 	OnAnyPoseTextChanged(ryPoseText, ryPoseSlider, 1);
 }
-void OutfitStudioFrame::OnRZPoseTextChanged(wxCommandEvent& WXUNUSED(event))
-{
+
+void OutfitStudioFrame::OnRZPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
 	OnAnyPoseTextChanged(rzPoseText, rzPoseSlider, 2);
 }
-void OutfitStudioFrame::OnTXPoseTextChanged(wxCommandEvent& WXUNUSED(event))
-{
+
+void OutfitStudioFrame::OnTXPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
 	OnAnyPoseTextChanged(txPoseText, txPoseSlider, 3);
 }
-void OutfitStudioFrame::OnTYPoseTextChanged(wxCommandEvent& WXUNUSED(event))
-{
+
+void OutfitStudioFrame::OnTYPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
 	OnAnyPoseTextChanged(tyPoseText, tyPoseSlider, 4);
 }
-void OutfitStudioFrame::OnTZPoseTextChanged(wxCommandEvent& WXUNUSED(event))
-{
+
+void OutfitStudioFrame::OnTZPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
 	OnAnyPoseTextChanged(tzPoseText, tzPoseSlider, 5);
 }
 
 void OutfitStudioFrame::OnResetBonePose(wxCommandEvent& WXUNUSED(event)) {
-	AnimBone *bone = GetPoseBonePtr();
+	AnimBone* bone = GetPoseBonePtr();
 	if (!bone) return;
-	bone->poseRotVec = Vector3(0,0,0);
-	bone->poseTranVec = Vector3(0,0,0);
+	bone->poseRotVec = Vector3(0, 0, 0);
+	bone->poseTranVec = Vector3(0, 0, 0);
 	bone->UpdatePoseTransform();
 	PoseToGUI();
 	ApplyPose();
@@ -10750,9 +10209,8 @@ void OutfitStudioFrame::OnResetAllPose(wxCommandEvent& WXUNUSED(event)) {
 	std::vector<std::string> bones;
 	project->GetActiveBones(bones);
 
-	for (const std::string &boneName : bones)
-	{
-		AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
+	for (const std::string& boneName : bones) {
+		AnimBone* bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
 		if (!bone)
 			continue;
 
@@ -10768,17 +10226,14 @@ void OutfitStudioFrame::OnResetAllPose(wxCommandEvent& WXUNUSED(event)) {
 	ApplyPose();
 }
 
-void OutfitStudioFrame::OnPoseToMesh(wxCommandEvent& WXUNUSED(event))
-{
-	if (project->bPose)
-	{
+void OutfitStudioFrame::OnPoseToMesh(wxCommandEvent& WXUNUSED(event)) {
+	if (project->bPose) {
 		wxMessageDialog dlg(this, _("Permanently apply the pose to the mesh?"), _("Apply Pose to Mesh"), wxOK | wxCANCEL | wxICON_WARNING | wxCANCEL_DEFAULT);
 		dlg.SetOKCancelLabels(_("Apply"), _("Cancel"));
 		if (dlg.ShowModal() != wxID_OK)
 			return;
 
-		for (auto &s : project->GetWorkNif()->GetShapes())
-		{
+		for (auto& s : project->GetWorkNif()->GetShapes()) {
 			UpdateShapeSource(s);
 			project->RefreshMorphShape(s);
 		}
@@ -10789,9 +10244,8 @@ void OutfitStudioFrame::OnPoseToMesh(wxCommandEvent& WXUNUSED(event))
 		std::vector<std::string> bones;
 		project->GetActiveBones(bones);
 
-		for (const std::string &boneName : bones)
-		{
-			AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
+		for (const std::string& boneName : bones) {
+			AnimBone* bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
 			if (!bone)
 				continue;
 
@@ -10821,27 +10275,23 @@ void OutfitStudioFrame::OnPoseCheckBox(wxCommandEvent& e) {
 void OutfitStudioFrame::OnSelectPose(wxCommandEvent& WXUNUSED(event)) {
 	wxChoice* cPoseName = (wxChoice*)FindWindowByName("cPoseName");
 	int poseSel = cPoseName->GetSelection();
-	if (poseSel != wxNOT_FOUND)
-	{
+	if (poseSel != wxNOT_FOUND) {
 		auto poseData = reinterpret_cast<PoseData*>(cPoseName->GetClientData(poseSel));
 
 		std::vector<std::string> bones;
 		project->GetActiveBones(bones);
 
-		for (const auto &boneName : bones)
-		{
-			AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
+		for (const auto& boneName : bones) {
+			AnimBone* bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
 			if (!bone)
 				continue;
 
 			auto poseBoneData = std::find_if(poseData->boneData.begin(), poseData->boneData.end(), [&boneName](const PoseBoneData& rt) { return rt.name == boneName; });
-			if (poseBoneData != poseData->boneData.end())
-			{
+			if (poseBoneData != poseData->boneData.end()) {
 				bone->poseRotVec = poseBoneData->rotation;
 				bone->poseTranVec = poseBoneData->translation;
 			}
-			else
-			{
+			else {
 				bone->poseRotVec = Vector3(0.0f, 0.0f, 0.0f);
 				bone->poseTranVec = Vector3(0.0f, 0.0f, 0.0f);
 			}
@@ -10857,17 +10307,15 @@ void OutfitStudioFrame::OnSelectPose(wxCommandEvent& WXUNUSED(event)) {
 void OutfitStudioFrame::OnSavePose(wxCommandEvent& WXUNUSED(event)) {
 	wxChoice* cPoseName = (wxChoice*)FindWindowByName("cPoseName");
 	int poseSel = cPoseName->GetSelection();
-	if (poseSel != wxNOT_FOUND)
-	{
+	if (poseSel != wxNOT_FOUND) {
 		auto poseData = reinterpret_cast<PoseData*>(cPoseName->GetClientData(poseSel));
 		poseData->boneData.clear();
 
 		std::vector<std::string> bones;
 		project->GetActiveBones(bones);
 
-		for (const auto &boneName : bones)
-		{
-			AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
+		for (const auto& boneName : bones) {
+			AnimBone* bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
 			if (!bone)
 				continue;
 
@@ -10897,8 +10345,7 @@ void OutfitStudioFrame::OnSavePose(wxCommandEvent& WXUNUSED(event)) {
 		poseDataFile.SetData(poses);
 		poseDataFile.Save();
 	}
-	else
-	{
+	else {
 		wxCommandEvent evt;
 		OnSaveAsPose(evt);
 	}
@@ -10908,22 +10355,21 @@ void OutfitStudioFrame::OnSaveAsPose(wxCommandEvent& WXUNUSED(event)) {
 	wxChoice* cPoseName = (wxChoice*)FindWindowByName("cPoseName");
 
 	wxString poseName;
-	do
-	{
+	do {
 		poseName = wxGetTextFromUser(_("Please enter a new unique name for the pose."), _("New Pose"));
 		if (poseName.empty())
 			return;
 
-	} while (cPoseName->FindString(poseName) != wxNOT_FOUND);
+	}
+	while (cPoseName->FindString(poseName) != wxNOT_FOUND);
 
 	auto poseData = new PoseData(poseName.ToUTF8().data());
 
 	std::vector<std::string> bones;
 	project->GetActiveBones(bones);
 
-	for (const auto &boneName : bones)
-	{
-		AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
+	for (const auto& boneName : bones) {
+		AnimBone* bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
 		if (!bone)
 			continue;
 
@@ -10958,8 +10404,7 @@ void OutfitStudioFrame::OnSaveAsPose(wxCommandEvent& WXUNUSED(event)) {
 void OutfitStudioFrame::OnDeletePose(wxCommandEvent& WXUNUSED(event)) {
 	wxChoice* cPoseName = (wxChoice*)FindWindowByName("cPoseName");
 	int poseSel = cPoseName->GetSelection();
-	if (poseSel != wxNOT_FOUND)
-	{
+	if (poseSel != wxNOT_FOUND) {
 		auto poseData = reinterpret_cast<PoseData*>(cPoseName->GetClientData(poseSel));
 
 		wxString prompt = wxString::Format(_("Are you sure you wish to delete the pose '%s'?"), cPoseName->GetStringSelection());
@@ -10990,11 +10435,10 @@ wxBEGIN_EVENT_TABLE(wxGLPanel, wxGLCanvas)
 	EVT_CHAR_HOOK(wxGLPanel::OnKeys)
 	EVT_IDLE(wxGLPanel::OnIdle)
 	EVT_MOUSE_CAPTURE_LOST(wxGLPanel::OnCaptureLost)
-	wxEND_EVENT_TABLE()
+wxEND_EVENT_TABLE()
 
 wxGLPanel::wxGLPanel(wxWindow* parent, const wxSize& size, const wxGLAttributes& attribs)
-	: wxGLCanvas(parent, attribs, wxID_ANY, wxDefaultPosition, size, wxFULL_REPAINT_ON_RESIZE)
-{
+	: wxGLCanvas(parent, attribs, wxID_ANY, wxDefaultPosition, size, wxFULL_REPAINT_ON_RESIZE) {
 
 	context = std::make_unique<wxGLContext>(this, nullptr, &GLSurface::GetGLContextAttribs());
 }
@@ -11005,8 +10449,7 @@ wxGLPanel::~wxGLPanel() {
 }
 
 void wxGLPanel::OnShown() {
-	if (!context->IsOK())
-	{
+	if (!context->IsOK()) {
 		wxLogError("Outfit Studio: OpenGL context is not OK.");
 		wxMessageBox(_("Outfit Studio: OpenGL context is not OK."), _("OpenGL Error"), wxICON_ERROR, os);
 	}
@@ -11040,16 +10483,14 @@ void wxGLPanel::OnShown() {
 
 	UpdateLights(ambient, frontal, directional0, directional1, directional2, directional0Dir, directional1Dir, directional2Dir);
 
-	if (Config.Exists("Rendering/ColorBackground"))
-	{
+	if (Config.Exists("Rendering/ColorBackground")) {
 		int colorBackgroundR = Config.GetIntValue("Rendering/ColorBackground.r");
 		int colorBackgroundG = Config.GetIntValue("Rendering/ColorBackground.g");
 		int colorBackgroundB = Config.GetIntValue("Rendering/ColorBackground.b");
 		gls.SetBackgroundColor(Vector3(colorBackgroundR / 255.0f, colorBackgroundG / 255.0f, colorBackgroundB / 255.0f));
 	}
 
-	if (Config.Exists("Rendering/ColorWire"))
-	{
+	if (Config.Exists("Rendering/ColorWire")) {
 		int colorWireR = Config.GetIntValue("Rendering/ColorWire.r");
 		int colorWireG = Config.GetIntValue("Rendering/ColorWire.g");
 		int colorWireB = Config.GetIntValue("Rendering/ColorWire.b");
@@ -11065,16 +10506,14 @@ void wxGLPanel::OnShown() {
 	Render();
 }
 
-void wxGLPanel::SetNotifyWindow(wxWindow* win)
-{
+void wxGLPanel::SetNotifyWindow(wxWindow* win) {
 	os = dynamic_cast<OutfitStudioFrame*>(win);
 }
 
 void wxGLPanel::AddMeshFromNif(NifFile* nif, const std::string& shapeName) {
 	std::vector<std::string> shapeList = nif->GetShapeNames();
 
-	for (size_t i = 0; i < shapeList.size(); i++)
-	{
+	for (size_t i = 0; i < shapeList.size(); i++) {
 		if (!shapeName.empty() && shapeList[i] != shapeName)
 			continue;
 
@@ -11083,12 +10522,10 @@ void wxGLPanel::AddMeshFromNif(NifFile* nif, const std::string& shapeName) {
 			continue;
 
 		NiShape* shape = nif->FindBlockByName<NiShape>(shapeList[i]);
-		if (shape && shape->IsSkinned())
-		{
+		if (shape && shape->IsSkinned()) {
 			// Overwrite skin matrix with the one from AnimInfo
 			const auto skinning = os->project->GetWorkAnim()->shapeSkinning.find(shapeList[i]);
-			if (skinning != os->project->GetWorkAnim()->shapeSkinning.end())
-			{
+			if (skinning != os->project->GetWorkAnim()->shapeSkinning.end()) {
 				MatTransform gts = skinning->second.xformGlobalToSkin;
 				gts.translation = mesh::VecToMeshCoords(gts.translation);
 				m->matModel = glm::inverse(mesh::TransformToMatrix4(gts));
@@ -11099,8 +10536,7 @@ void wxGLPanel::AddMeshFromNif(NifFile* nif, const std::string& shapeName) {
 		m->BuildEdgeList();
 		m->ColorFill(Vector3());
 
-		if (extInitialized)
-		{
+		if (extInitialized) {
 			gls.SetContext();
 			m->CreateBuffers();
 		}
@@ -11116,22 +10552,19 @@ void wxGLPanel::SetMeshTextures(const std::string& shapeName, const std::vector<
 	std::string fShader = Config["AppDir"] + "/res/shaders/default.frag";
 
 	auto targetGame = (TargetGame)Config.GetIntValue("TargetGame");
-	if (targetGame == FO4 || targetGame == FO4VR || targetGame == FO76)
-	{
+	if (targetGame == FO4 || targetGame == FO4VR || targetGame == FO76) {
 		vShader = Config["AppDir"] + "/res/shaders/fo4_default.vert";
 		fShader = Config["AppDir"] + "/res/shaders/fo4_default.frag";
 	}
-	else if (targetGame == OB)
-	{
+	else if (targetGame == OB) {
 		vShader = Config["AppDir"] + "/res/shaders/ob_default.vert";
 		fShader = Config["AppDir"] + "/res/shaders/ob_default.frag";
 	}
 
 	GLMaterial* mat = gls.AddMaterial(textureFiles, vShader, fShader, reloadTextures);
-	if (mat)
-	{
+	if (mat) {
 		m->material = mat;
-	
+
 		if (hasMatFile)
 			m->UpdateFromMaterialFile(matFile);
 
@@ -11141,8 +10574,7 @@ void wxGLPanel::SetMeshTextures(const std::string& shapeName, const std::vector<
 
 void wxGLPanel::UpdateMeshVertices(const std::string& shapeName, std::vector<Vector3>* verts, bool updateBVH, bool recalcNormals, bool render, std::vector<Vector2>* uvs) {
 	mesh* m = gls.GetMesh(shapeName);
-	if (m)
-	{
+	if (m) {
 		gls.Update(m, verts, uvs);
 
 		if (updateBVH)
@@ -11156,31 +10588,26 @@ void wxGLPanel::UpdateMeshVertices(const std::string& shapeName, std::vector<Vec
 		gls.RenderOneFrame();
 }
 
-void wxGLPanel::RecalculateMeshBVH(const std::string& shapeName)
-{
+void wxGLPanel::RecalculateMeshBVH(const std::string& shapeName) {
 	gls.RecalculateMeshBVH(shapeName);
 }
 
-void wxGLPanel::ShowShape(const std::string& shapeName, bool show)
-{
+void wxGLPanel::ShowShape(const std::string& shapeName, bool show) {
 	gls.SetMeshVisibility(shapeName, show);
 }
 
-void wxGLPanel::SetActiveShapes(const std::vector<std::string>& shapeNames)
-{
+void wxGLPanel::SetActiveShapes(const std::vector<std::string>& shapeNames) {
 	gls.SetActiveMeshes(shapeNames);
 }
 
-void wxGLPanel::SetSelectedShape(const std::string& shapeName)
-{
+void wxGLPanel::SetSelectedShape(const std::string& shapeName) {
 	gls.SetSelectedMesh(shapeName);
 }
 
 void wxGLPanel::SetActiveTool(ToolID brushID) {
 	activeTool = brushID;
 
-	switch (brushID)
-	{
+	switch (brushID) {
 	case ToolID::MaskBrush:
 		activeBrush = &maskBrush;
 		break;
@@ -11214,16 +10641,13 @@ void wxGLPanel::SetActiveTool(ToolID brushID) {
 	}
 }
 
-void wxGLPanel::SetLastTool(ToolID tool)
-{
+void wxGLPanel::SetLastTool(ToolID tool) {
 	lastTool = tool;
 }
 
 void wxGLPanel::OnKeys(wxKeyEvent& event) {
-	if (!event.HasAnyModifiers())
-	{
-		if (event.GetUnicodeKey() == 'V')
-		{
+	if (!event.HasAnyModifiers()) {
+		if (event.GetUnicodeKey() == 'V') {
 			wxPoint cursorPos(event.GetPosition());
 
 			int vertIndex;
@@ -11231,8 +10655,7 @@ void wxGLPanel::OnKeys(wxKeyEvent& event) {
 				return;
 
 			wxDialog dlg;
-			if (wxXmlResource::Get()->LoadDialog(&dlg, os, "dlgMoveVertex"))
-			{
+			if (wxXmlResource::Get()->LoadDialog(&dlg, os, "dlgMoveVertex")) {
 				NiShape* shape = os->activeItem->GetShape();
 
 				std::vector<Vector3> verts;
@@ -11243,8 +10666,7 @@ void wxGLPanel::OnKeys(wxKeyEvent& event) {
 				XRCCTRL(dlg, "posY", wxTextCtrl)->SetLabel(wxString::Format("%0.5f", oldPos.y));
 				XRCCTRL(dlg, "posZ", wxTextCtrl)->SetLabel(wxString::Format("%0.5f", oldPos.z));
 
-				if (dlg.ShowModal() == wxID_OK)
-				{
+				if (dlg.ShowModal() == wxID_OK) {
 					Vector3 newPos;
 					newPos.x = atof(XRCCTRL(dlg, "posX", wxTextCtrl)->GetValue().c_str());
 					newPos.y = atof(XRCCTRL(dlg, "posY", wxTextCtrl)->GetValue().c_str());
@@ -11264,12 +10686,11 @@ void wxGLPanel::OnKeys(wxKeyEvent& event) {
 					uss.pointEndState[vertIndex] = newPos;
 
 					// Push changes onto undo stack and execute
-					UndoStateProject *usp = GetUndoHistory()->PushState();
+					UndoStateProject* usp = GetUndoHistory()->PushState();
 					usp->undoType = UT_VERTPOS;
 					usp->usss.push_back(std::move(uss));
 
-					if (os->bEditSlider)
-					{
+					if (os->bEditSlider) {
 						usp->sliderName = os->activeSlider;
 
 						float sliderscale = os->project->SliderValue(os->activeSlider);
@@ -11307,28 +10728,21 @@ void wxGLPanel::OnKeys(wxKeyEvent& event) {
 			os->SelectTool(ToolID::ColorBrush);
 		else if (event.GetUnicodeKey() == '9')
 			os->SelectTool(ToolID::AlphaBrush);
-		else if (event.GetKeyCode() == WXK_SPACE)
-		{
-			if (event.ControlDown())
-			{
-				if (!os->activeSlider.empty())
-				{
+		else if (event.GetKeyCode() == WXK_SPACE) {
+			if (event.ControlDown()) {
+				if (!os->activeSlider.empty()) {
 					os->ExitSliderEdit();
 				}
-				else
-				{
+				else {
 					os->EnterSliderEdit();
 					os->ScrollToActiveSlider();
 				}
 			}
-			else
-			{
-				if (os->brushSettingsPopup)
-				{
+			else {
+				if (os->brushSettingsPopup) {
 					os->CloseBrushSettings();
 				}
-				else
-				{
+				else {
 					bool transient = Config.GetBoolValue("Input/BrushSettingsNearCursor");
 					os->PopupBrushSettings(transient);
 				}
@@ -11343,8 +10757,7 @@ void wxGLPanel::OnKeys(wxKeyEvent& event) {
 
 bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 	// Check if brush strokes are currently allowed
-	if (activeBrush == &weightBrush)
-	{
+	if (activeBrush == &weightBrush) {
 		std::string activeBone = os->GetActiveBone();
 		if (activeBone.empty())
 			return false;
@@ -11363,8 +10776,7 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 	if (!os->CheckEditableState())
 		return false;
 
-	if (activeBrush->isMirrored())
-	{
+	if (activeBrush->isMirrored()) {
 		if (!gls.CollideMeshes(screenPos.x, screenPos.y, o, n, true, nullptr, bGlobalBrushCollision, &tpi.facetM))
 			tpi.facetM = -1;
 	}
@@ -11380,20 +10792,16 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 
 	savedBrush = activeBrush;
 
-	if (wxGetKeyState(WXK_CONTROL))
-	{
-		if (wxGetKeyState(WXK_ALT) && !segmentMode)
-		{
+	if (wxGetKeyState(WXK_CONTROL)) {
+		if (wxGetKeyState(WXK_ALT) && !segmentMode) {
 			UnMaskBrush.setStrength(-maskBrush.getStrength());
 			activeBrush = &UnMaskBrush;
 		}
-		else
-		{
+		else {
 			activeBrush = &maskBrush;
 		}
 	}
-	else if (activeBrush == &weightBrush)
-	{
+	else if (activeBrush == &weightBrush) {
 		std::vector<std::string> normBones, notNormBones, brushBones, lockedBones;
 		os->GetNormalizeBones(&normBones, &notNormBones);
 
@@ -11405,30 +10813,25 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 			brushBones.push_back(xMirrorBone);
 
 		bool bHasNormBones = false;
-		for (auto &bone : normBones)
-		{
-			if (bone != activeBone && bone != xMirrorBone)
-			{
+		for (auto& bone : normBones) {
+			if (bone != activeBone && bone != xMirrorBone) {
 				brushBones.push_back(bone);
 				bHasNormBones = true;
 			}
 		}
 
-		if (bHasNormBones)
-		{
-			for (auto &bone : notNormBones)
+		if (bHasNormBones) {
+			for (auto& bone : notNormBones)
 				if (bone != activeBone && bone != xMirrorBone)
 					lockedBones.push_back(bone);
 		}
-		else
-		{
-			for (auto &bone : notNormBones)
+		else {
+			for (auto& bone : notNormBones)
 				if (bone != activeBone && bone != xMirrorBone)
 					brushBones.push_back(bone);
 		}
 
-		if (wxGetKeyState(WXK_ALT))
-		{
+		if (wxGetKeyState(WXK_ALT)) {
 			unweightBrush.animInfo = os->project->GetWorkAnim();
 			unweightBrush.boneNames = brushBones;
 			unweightBrush.lockedBoneNames = lockedBones;
@@ -11440,8 +10843,7 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 			unweightBrush.setConnected(weightBrush.isConnected());
 			activeBrush = &unweightBrush;
 		}
-		else if (wxGetKeyState(WXK_SHIFT))
-		{
+		else if (wxGetKeyState(WXK_SHIFT)) {
 			smoothWeightBrush.animInfo = os->project->GetWorkAnim();
 			smoothWeightBrush.boneNames = brushBones;
 			smoothWeightBrush.lockedBoneNames = lockedBones;
@@ -11453,8 +10855,7 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 			smoothWeightBrush.setConnected(weightBrush.isConnected());
 			activeBrush = &smoothWeightBrush;
 		}
-		else
-		{
+		else {
 			weightBrush.animInfo = os->project->GetWorkAnim();
 			weightBrush.boneNames = brushBones;
 			weightBrush.lockedBoneNames = lockedBones;
@@ -11462,51 +10863,43 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 			weightBrush.bXMirrorBone = !xMirrorBone.empty();
 		}
 	}
-	else if (wxGetKeyState(WXK_ALT) && !segmentMode)
-	{
-		if (activeBrush == &standardBrush)
-		{
+	else if (wxGetKeyState(WXK_ALT) && !segmentMode) {
+		if (activeBrush == &standardBrush) {
 			deflateBrush.setMirror(activeBrush->isMirrored());
 			deflateBrush.setConnected(activeBrush->isConnected());
 			activeBrush = &deflateBrush;
 		}
-		else if (activeBrush == &deflateBrush)
-		{
+		else if (activeBrush == &deflateBrush) {
 			standardBrush.setMirror(activeBrush->isMirrored());
 			standardBrush.setConnected(activeBrush->isConnected());
 			activeBrush = &standardBrush;
 		}
-		else if (activeBrush == &maskBrush)
-		{
+		else if (activeBrush == &maskBrush) {
 			UnMaskBrush.setStrength(-activeBrush->getStrength());
 			UnMaskBrush.setMirror(activeBrush->isMirrored());
 			UnMaskBrush.setConnected(activeBrush->isConnected());
 			activeBrush = &UnMaskBrush;
 		}
-		else if (activeBrush == &colorBrush)
-		{
+		else if (activeBrush == &colorBrush) {
 			uncolorBrush.setStrength(-activeBrush->getStrength());
 			uncolorBrush.setMirror(activeBrush->isMirrored());
 			uncolorBrush.setConnected(activeBrush->isConnected());
 			activeBrush = &uncolorBrush;
 		}
-		else if (activeBrush == &alphaBrush)
-		{
+		else if (activeBrush == &alphaBrush) {
 			unalphaBrush.setStrength(-activeBrush->getStrength());
 			unalphaBrush.setMirror(activeBrush->isMirrored());
 			unalphaBrush.setConnected(activeBrush->isConnected());
 			activeBrush = &unalphaBrush;
 		}
 	}
-	else if (activeBrush == &maskBrush && wxGetKeyState(WXK_SHIFT))
-	{
+	else if (activeBrush == &maskBrush && wxGetKeyState(WXK_SHIFT)) {
 		smoothMaskBrush.setStrength(activeBrush->getStrength() * 15.0f);
 		smoothMaskBrush.setMirror(activeBrush->isMirrored());
 		smoothMaskBrush.setConnected(activeBrush->isConnected());
 		activeBrush = &smoothMaskBrush;
 	}
-	else if (activeBrush != &weightBrush && activeBrush != &maskBrush && wxGetKeyState(WXK_SHIFT))
-	{
+	else if (activeBrush != &weightBrush && activeBrush != &maskBrush && wxGetKeyState(WXK_SHIFT)) {
 		smoothBrush.setMirror(activeBrush->isMirrored());
 		smoothBrush.setConnected(activeBrush->isConnected());
 		activeBrush = &smoothBrush;
@@ -11514,10 +10907,8 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 
 	activeBrush->setRadius(brushSize);
 
-	if (activeBrush->Type() == TBT_WEIGHT)
-	{
-		for (auto &sel : os->GetSelectedItems())
-		{
+	if (activeBrush->Type() == TBT_WEIGHT) {
+		for (auto& sel : os->GetSelectedItems()) {
 			os->project->GetWorkNif()->CreateSkinning(sel->GetShape());
 
 			int boneIndex = os->project->GetWorkAnim()->GetShapeBoneIndex(sel->GetShape()->name.get(), os->GetActiveBone());
@@ -11528,8 +10919,7 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 
 	activeStroke = std::make_unique<TweakStroke>(gls.GetActiveMeshes(), activeBrush, *undoHistory.PushState());
 
-	if (os->bEditSlider)
-	{
+	if (os->bEditSlider) {
 		activeStroke->usp.sliderName = os->activeSlider;
 		float sliderscale = os->project->SliderValue(os->activeSlider);
 		if (sliderscale == 0.0)
@@ -11538,15 +10928,13 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 		activeStroke->usp.sliderscale = sliderscale;
 	}
 
-	if (activeBrush->Type() == TBT_UNDIFF)
-	{
+	if (activeBrush->Type() == TBT_UNDIFF) {
 		std::vector<mesh*> refMeshes = activeStroke->GetRefMeshes();
 
 		std::vector<std::vector<Vector3>> positionData;
 		positionData.resize(refMeshes.size());
 
-		for (size_t i = 0; i < refMeshes.size(); i++)
-		{
+		for (size_t i = 0; i < refMeshes.size(); i++) {
 			// Get base vertex positions, not current mesh position
 			mesh* m = refMeshes[i];
 			std::vector<Vector3> basePosition;
@@ -11556,7 +10944,7 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 			if (shape)
 				workNif->GetVertsForShape(shape, basePosition);
 
-			for (auto &p : basePosition)
+			for (auto& p : basePosition)
 				p = mesh::VecToMeshCoords(p);
 
 			positionData[i] = std::move(basePosition);
@@ -11576,31 +10964,27 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 void wxGLPanel::UpdateBrushStroke(const wxPoint& screenPos) {
 	Vector3 o;
 	Vector3 n;
-	Vector3 d;	// Mirror pick ray direction.
-	Vector3 s;	// Mirror pick ray origin.
+	Vector3 d; // Mirror pick ray direction.
+	Vector3 s; // Mirror pick ray origin.
 
 	TweakPickInfo tpi;
 
-	if (activeStroke)
-	{
+	if (activeStroke) {
 		bool hit = gls.UpdateCursor(screenPos.x, screenPos.y, bGlobalBrushCollision);
 		gls.RenderOneFrame();
 
-		if (activeBrush->Type() == TBT_MOVE)
-		{
+		if (activeBrush->Type() == TBT_MOVE) {
 			Vector3 pn;
 			float pd;
 			((TB_Move*)activeBrush)->GetWorkingPlane(pn, pd);
 			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, pn, pd);
 		}
-		else
-		{
+		else {
 			if (!hit)
 				return;
 
 			gls.CollideMeshes(screenPos.x, screenPos.y, tpi.origin, tpi.normal, false, nullptr, bGlobalBrushCollision, &tpi.facet);
-			if (activeBrush->isMirrored())
-			{
+			if (activeBrush->isMirrored()) {
 				if (!gls.CollideMeshes(screenPos.x, screenPos.y, o, n, true, nullptr, bGlobalBrushCollision, &tpi.facetM))
 					tpi.facetM = -1;
 			}
@@ -11615,11 +10999,9 @@ void wxGLPanel::UpdateBrushStroke(const wxPoint& screenPos) {
 		tpi.view = v;
 		activeStroke->updateStroke(tpi);
 
-		if (activeBrush->Type() == TBT_WEIGHT)
-		{
+		if (activeBrush->Type() == TBT_WEIGHT) {
 			std::string selectedBone = os->GetActiveBone();
-			if (!selectedBone.empty())
-			{
+			if (!selectedBone.empty()) {
 				os->ActiveShapesUpdated(undoHistory.GetCurState(), false);
 
 				int boneScalePos = os->boneScale->GetValue();
@@ -11631,30 +11013,24 @@ void wxGLPanel::UpdateBrushStroke(const wxPoint& screenPos) {
 		if (transformMode)
 			ShowTransformTool();
 
-		if (segmentMode)
-		{
+		if (segmentMode) {
 			os->ShowSegment(nullptr, true);
 			os->ShowPartition(nullptr, true);
 		}
 	}
 }
 
-void wxGLPanel::EndBrushStroke()
-{
-	if (activeStroke)
-	{
+void wxGLPanel::EndBrushStroke() {
+	if (activeStroke) {
 		activeStroke->endStroke();
 
 		int brushType = activeStroke->BrushType();
-		if (brushType != TBT_MASK)
-		{
+		if (brushType != TBT_MASK) {
 			os->ActiveShapesUpdated(undoHistory.GetCurState());
 
-			if (brushType == TBT_WEIGHT)
-			{
+			if (brushType == TBT_WEIGHT) {
 				std::string selectedBone = os->GetActiveBone();
-				if (!selectedBone.empty())
-				{
+				if (!selectedBone.empty()) {
 					int boneScalePos = os->boneScale->GetValue();
 					if (boneScalePos != 0)
 						os->project->ApplyBoneScale(selectedBone, boneScalePos, true);
@@ -11664,10 +11040,8 @@ void wxGLPanel::EndBrushStroke()
 				}
 			}
 
-			if (!os->bEditSlider && brushType != TBT_WEIGHT && brushType != TBT_COLOR && brushType != TBT_ALPHA)
-			{
-				for (auto &s : os->project->GetWorkNif()->GetShapes())
-				{
+			if (!os->bEditSlider && brushType != TBT_WEIGHT && brushType != TBT_COLOR && brushType != TBT_ALPHA) {
+				for (auto& s : os->project->GetWorkNif()->GetShapes()) {
 					os->UpdateShapeSource(s);
 					os->project->RefreshMorphShape(s);
 				}
@@ -11680,8 +11054,7 @@ void wxGLPanel::EndBrushStroke()
 		if (transformMode)
 			ShowTransformTool();
 
-		if (segmentMode)
-		{
+		if (segmentMode) {
 			os->ShowSegment(nullptr, true);
 			os->ShowPartition(nullptr, true);
 
@@ -11706,11 +11079,9 @@ bool wxGLPanel::StartTransform(const wxPoint& screenPos) {
 	tpi.center = xformCenter;
 
 	std::string mname = hitMesh->shapeName;
-	if (mname.find("Move") != std::string::npos)
-	{
+	if (mname.find("Move") != std::string::npos) {
 		translateBrush.SetXFormType(0);
-		switch (mname[0])
-		{
+		switch (mname[0]) {
 		case 'X':
 			tpi.view = Vector3(1.0f, 0.0f, 0.0f);
 			tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
@@ -11725,11 +11096,9 @@ bool wxGLPanel::StartTransform(const wxPoint& screenPos) {
 			break;
 		}
 	}
-	else if (mname.find("Rotate") != std::string::npos)
-	{
+	else if (mname.find("Rotate") != std::string::npos) {
 		translateBrush.SetXFormType(1);
-		switch (mname[0])
-		{
+		switch (mname[0]) {
 		case 'X':
 			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(1.0f, 0.0f, 0.0f), tpi.center.x);
 			//tpi.view = Vector3(0.0f, 1.0f, 0.0f);
@@ -11747,13 +11116,10 @@ bool wxGLPanel::StartTransform(const wxPoint& screenPos) {
 			break;
 		}
 	}
-	else if (mname.find("Scale") != std::string::npos)
-	{
-		if (mname.find("Uniform") == std::string::npos)
-		{
+	else if (mname.find("Scale") != std::string::npos) {
+		if (mname.find("Uniform") == std::string::npos) {
 			translateBrush.SetXFormType(2);
-			switch (mname[0])
-			{
+			switch (mname[0]) {
 			case 'X':
 				tpi.view = Vector3(1.0f, 0.0f, 0.0f);
 				tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
@@ -11768,8 +11134,7 @@ bool wxGLPanel::StartTransform(const wxPoint& screenPos) {
 				break;
 			}
 		}
-		else
-		{
+		else {
 			translateBrush.SetXFormType(3);
 			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(1.0f, 0.0f, 0.0f), tpi.center.x);
 			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(0.0f, 1.0f, 0.0f), tpi.center.y);
@@ -11782,8 +11147,7 @@ bool wxGLPanel::StartTransform(const wxPoint& screenPos) {
 
 	activeStroke = std::make_unique<TweakStroke>(gls.GetActiveMeshes(), &translateBrush, *undoHistory.PushState());
 
-	if (os->bEditSlider)
-	{
+	if (os->bEditSlider) {
 		activeStroke->usp.sliderName = os->activeSlider;
 
 		float sliderscale = os->project->SliderValue(os->activeSlider);
@@ -11827,10 +11191,8 @@ void wxGLPanel::EndTransform() {
 	activeStroke = nullptr;
 
 	os->ActiveShapesUpdated(undoHistory.GetCurState());
-	if (!os->bEditSlider)
-	{
-		for (auto &s : os->project->GetWorkNif()->GetShapes())
-		{
+	if (!os->bEditSlider) {
+		for (auto& s : os->project->GetWorkNif()->GetShapes()) {
 			os->UpdateShapeSource(s);
 			os->project->RefreshMorphShape(s);
 		}
@@ -11850,11 +11212,9 @@ bool wxGLPanel::StartPivotPosition(const wxPoint& screenPos) {
 	tpi.center = pivotPosition;
 
 	std::string mname = hitMesh->shapeName;
-	if (mname.find("PivotMesh") != std::string::npos)
-	{
+	if (mname.find("PivotMesh") != std::string::npos) {
 		translateBrush.SetXFormType(0);
-		switch (mname[0])
-		{
+		switch (mname[0]) {
 		case 'X':
 			tpi.view = Vector3(1.0f, 0.0f, 0.0f);
 			tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
@@ -11872,7 +11232,7 @@ bool wxGLPanel::StartPivotPosition(const wxPoint& screenPos) {
 	else
 		return false;
 
-	std::vector<mesh*> strokeMeshes{ hitMesh };
+	std::vector<mesh*> strokeMeshes{hitMesh};
 	activeStroke = std::make_unique<TweakStroke>(strokeMeshes, &translateBrush, *undoHistory.PushState());
 	activeStroke->beginStroke(tpi);
 
@@ -11899,11 +11259,9 @@ void wxGLPanel::EndPivotPosition() {
 	activeStroke->endStroke();
 
 	std::vector<mesh*> refMeshes = activeStroke->GetRefMeshes();
-	if (refMeshes.size() > 0)
-	{
-		UndoStateShape &uss = activeStroke->usp.usss[0];
-		if (uss.pointStartState.size() > 0 && uss.pointEndState.size() > 0)
-		{
+	if (refMeshes.size() > 0) {
+		UndoStateShape& uss = activeStroke->usp.usss[0];
+		if (uss.pointStartState.size() > 0 && uss.pointEndState.size() > 0) {
 			Vector3& pivotStartStatePos = uss.pointStartState[0];
 			Vector3& pivotEndStatePos = uss.pointEndState[0];
 			Vector3 pivotDiff = pivotEndStatePos - pivotStartStatePos;
@@ -11920,11 +11278,9 @@ bool wxGLPanel::SelectVertex(const wxPoint& screenPos) {
 	if (!gls.GetCursorVertex(screenPos.x, screenPos.y, &vertIndex))
 		return false;
 
-	if (os->activeItem)
-	{
+	if (os->activeItem) {
 		mesh* m = GetMesh(os->activeItem->GetShape()->name.get());
-		if (m)
-		{
+		if (m) {
 			if (wxGetKeyState(WXK_CONTROL))
 				m->vcolors[vertIndex].x = 1.0f;
 			else if (!segmentMode)
@@ -11970,7 +11326,7 @@ void wxGLPanel::EndPickVertex() {
 }
 
 void wxGLPanel::ClickCollapseVertex() {
-	mesh *m = GetMesh(mouseDownMeshName);
+	mesh* m = GetMesh(mouseDownMeshName);
 	if (!m || mouseDownPoint < 0)
 		return;
 
@@ -11978,7 +11334,7 @@ void wxGLPanel::ClickCollapseVertex() {
 	if (!workNif)
 		return;
 
-	NiShape *shape = workNif->FindBlockByName<NiShape>(mouseDownMeshName);
+	NiShape* shape = workNif->FindBlockByName<NiShape>(mouseDownMeshName);
 	if (!shape)
 		return;
 
@@ -11994,14 +11350,13 @@ void wxGLPanel::ClickCollapseVertex() {
 	// Prepare list of changes
 	UndoStateShape uss;
 	uss.shapeName = mouseDownMeshName;
-	if (!os->project->PrepareCollapseVertex(shape, uss, verts))
-	{
+	if (!os->project->PrepareCollapseVertex(shape, uss, verts)) {
 		wxMessageBox(_("The vertex picked has more than three connections."), _("Error"), wxICON_ERROR, os);
 		return;
 	}
 
 	// Push changes onto undo stack and execute.
-	UndoStateProject *usp = GetUndoHistory()->PushState();
+	UndoStateProject* usp = GetUndoHistory()->PushState();
 	usp->undoType = UT_MESH;
 	usp->usss.push_back(std::move(uss));
 	ApplyUndoState(usp, false);
@@ -12044,21 +11399,20 @@ void wxGLPanel::ClickFlipEdge() {
 	if (mouseDownMeshName.empty() || mouseDownEdge.p1 < 0 || mouseDownEdge.p1 == mouseDownEdge.p2)
 		return;
 
-	NiShape *shape = os->project->GetWorkNif()->FindBlockByName<NiShape>(mouseDownMeshName);
+	NiShape* shape = os->project->GetWorkNif()->FindBlockByName<NiShape>(mouseDownMeshName);
 	if (!shape)
 		return;
 
 	// Prepare list of changes
 	UndoStateShape uss;
 	uss.shapeName = mouseDownMeshName;
-	if (!os->project->PrepareFlipEdge(shape, uss, mouseDownEdge))
-	{
+	if (!os->project->PrepareFlipEdge(shape, uss, mouseDownEdge)) {
 		wxMessageBox(_("The edge picked is on the surface boundary.  Pick an interior edge."), _("Error"), wxICON_ERROR, os);
 		return;
 	}
 
 	// Push changes onto undo stack and execute.
-	UndoStateProject *usp = GetUndoHistory()->PushState();
+	UndoStateProject* usp = GetUndoHistory()->PushState();
 	usp->undoType = UT_MESH;
 	usp->usss.push_back(std::move(uss));
 	ApplyUndoState(usp, false);
@@ -12070,7 +11424,7 @@ void wxGLPanel::ClickSplitEdge() {
 	if (mouseDownMeshName.empty() || mouseDownEdge.p1 < 0 || mouseDownEdge.p1 == mouseDownEdge.p2)
 		return;
 
-	mesh *m = GetMesh(mouseDownMeshName);
+	mesh* m = GetMesh(mouseDownMeshName);
 	if (!m)
 		return;
 
@@ -12078,7 +11432,7 @@ void wxGLPanel::ClickSplitEdge() {
 	if (!workNif)
 		return;
 
-	NiShape *shape = workNif->FindBlockByName<NiShape>(mouseDownMeshName);
+	NiShape* shape = workNif->FindBlockByName<NiShape>(mouseDownMeshName);
 	if (!shape)
 		return;
 
@@ -12088,14 +11442,12 @@ void wxGLPanel::ClickSplitEdge() {
 	if (workNif->GetHeader().GetVersion().IsFO4() || workNif->GetHeader().GetVersion().IsFO76())
 		maxTriIndex = std::numeric_limits<uint32_t>().max();
 
-	if (shape->GetNumVertices() > maxVertIndex - 2)
-	{
+	if (shape->GetNumVertices() > maxVertIndex - 2) {
 		wxMessageBox(_("The shape has reached the vertex count limit."), _("Error"), wxICON_ERROR, os);
 		return;
 	}
 
-	if (shape->GetNumTriangles() > maxTriIndex - 2)
-	{
+	if (shape->GetNumTriangles() > maxTriIndex - 2) {
 		wxMessageBox(_("The shape has reached the triangle count limit."), _("Error"), wxICON_ERROR, os);
 		return;
 	}
@@ -12117,14 +11469,13 @@ void wxGLPanel::ClickSplitEdge() {
 	// Prepare list of changes
 	UndoStateShape uss;
 	uss.shapeName = mouseDownMeshName;
-	if (!os->project->PrepareSplitEdge(shape, uss, p1s, p2s))
-	{
+	if (!os->project->PrepareSplitEdge(shape, uss, p1s, p2s)) {
 		wxMessageBox(_("The edge picked has multiple triangles of the same orientation.  Correct the orientations before splitting."), _("Error"), wxICON_ERROR, os);
 		return;
 	}
 
 	// Push changes onto undo stack and execute.
-	UndoStateProject *usp = GetUndoHistory()->PushState();
+	UndoStateProject* usp = GetUndoHistory()->PushState();
 	usp->undoType = UT_MESH;
 	usp->usss.push_back(std::move(uss));
 	ApplyUndoState(usp, false);
@@ -12132,49 +11483,42 @@ void wxGLPanel::ClickSplitEdge() {
 	os->UpdateUndoTools();
 }
 
-bool wxGLPanel::RestoreMode(UndoStateProject *usp) {
+bool wxGLPanel::RestoreMode(UndoStateProject* usp) {
 	bool modeChanged = false;
 	int undoType = usp->undoType;
-	if (undoType == UT_VERTPOS  && os->activeSlider != usp->sliderName)
-	{
+	if (undoType == UT_VERTPOS && os->activeSlider != usp->sliderName) {
 		os->EnterSliderEdit(usp->sliderName);
 		modeChanged = true;
 	}
-	if ((undoType != UT_VERTPOS || usp->sliderName.empty()) && os->bEditSlider)
-	{
+	if ((undoType != UT_VERTPOS || usp->sliderName.empty()) && os->bEditSlider) {
 		os->ExitSliderEdit();
 		modeChanged = true;
 	}
-	if (undoType == UT_VERTPOS && !usp->sliderName.empty() && usp->sliderscale != os->project->SliderValue(usp->sliderName))
-	{
+	if (undoType == UT_VERTPOS && !usp->sliderName.empty() && usp->sliderscale != os->project->SliderValue(usp->sliderName)) {
 		os->SetSliderValue(usp->sliderName, usp->sliderscale * 100);
 		os->ApplySliders();
 		modeChanged = true;
 	}
-	if (undoType == UT_VERTPOS && usp->sliderName.empty() && !os->project->AllSlidersZero())
-	{
+	if (undoType == UT_VERTPOS && usp->sliderName.empty() && !os->project->AllSlidersZero()) {
 		os->ZeroSliders();
 		modeChanged = true;
 	}
 	return modeChanged;
 }
 
-void wxGLPanel::ApplyUndoState(UndoStateProject *usp, bool bUndo, bool bRender) {
+void wxGLPanel::ApplyUndoState(UndoStateProject* usp, bool bUndo, bool bRender) {
 	int undoType = usp->undoType;
-	if (undoType == UT_WEIGHT)
-	{
-		for (auto &uss : usp->usss)
-		{
-			mesh *m = GetMesh(uss.shapeName);
+	if (undoType == UT_WEIGHT) {
+		for (auto& uss : usp->usss) {
+			mesh* m = GetMesh(uss.shapeName);
 			if (!m)
 				continue;
 
-			for (auto &bw : uss.boneWeights)
-			{
+			for (auto& bw : uss.boneWeights) {
 				if (bw.boneName != os->GetActiveBone())
 					continue;
 
-				for (auto &wIt : bw.weights)
+				for (auto& wIt : bw.weights)
 					m->vcolors[wIt.first].y = bUndo ? wIt.second.startVal : wIt.second.endVal;
 			}
 
@@ -12184,22 +11528,19 @@ void wxGLPanel::ApplyUndoState(UndoStateProject *usp, bool bUndo, bool bRender) 
 		os->ActiveShapesUpdated(usp, bUndo);
 
 		std::string activeBone = os->GetActiveBone();
-		if (!activeBone.empty())
-		{
+		if (!activeBone.empty()) {
 			int boneScalePos = os->boneScale->GetValue();
 			if (boneScalePos != 0)
 				os->project->ApplyBoneScale(activeBone, boneScalePos, true);
 		}
 	}
-	else if (undoType == UT_MASK || undoType == UT_COLOR)
-	{
-		for (auto &uss : usp->usss)
-		{
-			mesh *m = GetMesh(uss.shapeName);
+	else if (undoType == UT_MASK || undoType == UT_COLOR) {
+		for (auto& uss : usp->usss) {
+			mesh* m = GetMesh(uss.shapeName);
 			if (!m)
 				continue;
 
-			for (auto &pit : (bUndo ? uss.pointStartState : uss.pointEndState))
+			for (auto& pit : (bUndo ? uss.pointStartState : uss.pointEndState))
 				m->vcolors[pit.first] = pit.second;
 
 			m->QueueUpdate(mesh::UpdateType::VertexColors);
@@ -12208,15 +11549,13 @@ void wxGLPanel::ApplyUndoState(UndoStateProject *usp, bool bUndo, bool bRender) 
 		if (undoType != UT_MASK)
 			os->ActiveShapesUpdated(usp, bUndo);
 	}
-	else if (undoType == UT_ALPHA)
-	{
-		for (auto &uss : usp->usss)
-		{
-			mesh *m = GetMesh(uss.shapeName);
+	else if (undoType == UT_ALPHA) {
+		for (auto& uss : usp->usss) {
+			mesh* m = GetMesh(uss.shapeName);
 			if (!m)
 				continue;
 
-			for (auto &pit : (bUndo ? uss.pointStartState : uss.pointEndState))
+			for (auto& pit : (bUndo ? uss.pointStartState : uss.pointEndState))
 				m->valpha[pit.first] = pit.second.x;
 
 			m->QueueUpdate(mesh::UpdateType::VertexAlpha);
@@ -12224,15 +11563,13 @@ void wxGLPanel::ApplyUndoState(UndoStateProject *usp, bool bUndo, bool bRender) 
 
 		os->ActiveShapesUpdated(usp, bUndo);
 	}
-	else if (undoType == UT_VERTPOS)
-	{
-		for (auto &uss : usp->usss)
-		{
-			mesh *m = GetMesh(uss.shapeName);
+	else if (undoType == UT_VERTPOS) {
+		for (auto& uss : usp->usss) {
+			mesh* m = GetMesh(uss.shapeName);
 			if (!m)
 				continue;
 
-			for (auto &pit : (bUndo ? uss.pointStartState : uss.pointEndState))
+			for (auto& pit : (bUndo ? uss.pointStartState : uss.pointEndState))
 				m->verts[pit.first] = pit.second;
 
 			m->SmoothNormals();
@@ -12243,11 +11580,9 @@ void wxGLPanel::ApplyUndoState(UndoStateProject *usp, bool bUndo, bool bRender) 
 
 		os->ActiveShapesUpdated(usp, bUndo);
 
-		if (usp->sliderName.empty())
-		{
-			for (auto &uss : usp->usss)
-			{
-				mesh *m = GetMesh(uss.shapeName);
+		if (usp->sliderName.empty()) {
+			for (auto& uss : usp->usss) {
+				mesh* m = GetMesh(uss.shapeName);
 				if (!m)
 					continue;
 
@@ -12257,11 +11592,9 @@ void wxGLPanel::ApplyUndoState(UndoStateProject *usp, bool bUndo, bool bRender) 
 			}
 		}
 	}
-	else if (undoType == UT_MESH)
-	{
-		for (auto &uss : usp->usss)
-		{
-			NiShape *shape = os->project->GetWorkNif()->FindBlockByName<NiShape>(uss.shapeName);
+	else if (undoType == UT_MESH) {
+		for (auto& uss : usp->usss) {
+			NiShape* shape = os->project->GetWorkNif()->FindBlockByName<NiShape>(uss.shapeName);
 			if (!shape)
 				continue;
 
@@ -12273,8 +11606,7 @@ void wxGLPanel::ApplyUndoState(UndoStateProject *usp, bool bUndo, bool bRender) 
 		os->ApplySliders();
 	}
 
-	if (bRender)
-	{
+	if (bRender) {
 		if (transformMode)
 			ShowTransformTool();
 		else
@@ -12283,7 +11615,7 @@ void wxGLPanel::ApplyUndoState(UndoStateProject *usp, bool bUndo, bool bRender) 
 }
 
 bool wxGLPanel::UndoStroke() {
-	UndoStateProject *curState = undoHistory.GetCurState();
+	UndoStateProject* curState = undoHistory.GetCurState();
 	if (!curState)
 		return false;
 	if (RestoreMode(curState))
@@ -12297,7 +11629,7 @@ bool wxGLPanel::UndoStroke() {
 }
 
 bool wxGLPanel::RedoStroke() {
-	UndoStateProject *curState = undoHistory.GetNextState();
+	UndoStateProject* curState = undoHistory.GetNextState();
 	if (!curState)
 		return false;
 	if (RestoreMode(curState))
@@ -12310,10 +11642,8 @@ bool wxGLPanel::RedoStroke() {
 	return true;
 }
 
-void wxGLPanel::ShowRotationCenter(bool show)
-{
-	if (show)
-	{
+void wxGLPanel::ShowRotationCenter(bool show) {
+	if (show) {
 		RotationCenterMesh = gls.AddVis3dSphere(gls.camRotOffset, 0.15f, Vector3(1.0f, 0.0f, 1.0f), "RotationCenterMesh");
 		RotationCenterMesh->prop.alpha = 0.5f;
 		RotationCenterMesh->bVisible = true;
@@ -12330,10 +11660,8 @@ void wxGLPanel::ShowRotationCenter(bool show)
 		RotationCenterMeshRingZ->prop.alpha = 0.5f;
 		RotationCenterMeshRingZ->bVisible = true;
 	}
-	else
-	{
-		if (RotationCenterMesh)
-		{
+	else {
+		if (RotationCenterMesh) {
 			RotationCenterMesh->bVisible = false;
 			RotationCenterMeshRingX->bVisible = false;
 			RotationCenterMeshRingY->bVisible = false;
@@ -12348,8 +11676,7 @@ void wxGLPanel::ShowTransformTool(bool show) {
 	else
 		xformCenter = gls.GetActiveCenter();
 
-	if (show)
-	{
+	if (show) {
 		XMoveMesh = gls.AddVis3dArrow(xformCenter, Vector3(1.0f, 0.0f, 0.0f), 0.04f, 0.15f, 1.75f, Vector3(1.0f, 0.0f, 0.0f), "XMoveMesh");
 		YMoveMesh = gls.AddVis3dArrow(xformCenter, Vector3(0.0f, 1.0f, 0.0f), 0.04f, 0.15f, 1.75f, Vector3(0.0f, 1.0f, 0.0f), "YMoveMesh");
 		ZMoveMesh = gls.AddVis3dArrow(xformCenter, Vector3(0.0f, 0.0f, 1.0f), 0.04f, 0.15f, 1.75f, Vector3(0.0f, 0.0f, 1.0f), "ZMoveMesh");
@@ -12376,18 +11703,15 @@ void wxGLPanel::ShowTransformTool(bool show) {
 		ZScaleMesh->bVisible = true;
 		ScaleUniformMesh->bVisible = true;
 
-		if (XPivotMesh)
-		{
+		if (XPivotMesh) {
 			XPivotMesh->bVisible = false;
 			YPivotMesh->bVisible = false;
 			ZPivotMesh->bVisible = false;
 			PivotCenterMesh->bVisible = false;
 		}
 	}
-	else
-	{
-		if (XMoveMesh)
-		{
+	else {
+		if (XMoveMesh) {
 			XMoveMesh->bVisible = false;
 			YMoveMesh->bVisible = false;
 			ZMoveMesh->bVisible = false;
@@ -12400,8 +11724,7 @@ void wxGLPanel::ShowTransformTool(bool show) {
 			ScaleUniformMesh->bVisible = false;
 		}
 
-		if (XPivotMesh && pivotMode)
-		{
+		if (XPivotMesh && pivotMode) {
 			XPivotMesh->bVisible = true;
 			YPivotMesh->bVisible = true;
 			ZPivotMesh->bVisible = true;
@@ -12423,8 +11746,7 @@ void wxGLPanel::UpdateTransformTool() {
 	Vector3 unprojected;
 	gls.UnprojectCamera(unprojected);
 
-	if (lastCenterDistance != 0.0f)
-	{
+	if (lastCenterDistance != 0.0f) {
 		float factor = 1.0f / lastCenterDistance;
 		XMoveMesh->ScaleVertices(xformCenter, factor);
 		YMoveMesh->ScaleVertices(xformCenter, factor);
@@ -12457,8 +11779,7 @@ void wxGLPanel::UpdateTransformTool() {
 }
 
 void wxGLPanel::ShowPivot(bool show) {
-	if (show)
-	{
+	if (show) {
 		XPivotMesh = gls.AddVis3dArrow(pivotPosition, Vector3(1.0f, 0.0f, 0.0f), 0.03f, 0.1f, 1.0f, Vector3(1.0f, 0.0f, 0.0f), "XPivotMesh");
 		YPivotMesh = gls.AddVis3dArrow(pivotPosition, Vector3(0.0f, 1.0f, 0.0f), 0.03f, 0.1f, 1.0f, Vector3(0.0f, 1.0f, 0.0f), "YPivotMesh");
 		ZPivotMesh = gls.AddVis3dArrow(pivotPosition, Vector3(0.0f, 0.0f, 1.0f), 0.03f, 0.1f, 1.0f, Vector3(0.0f, 0.0f, 1.0f), "ZPivotMesh");
@@ -12471,10 +11792,8 @@ void wxGLPanel::ShowPivot(bool show) {
 
 		lastCenterPivotDistance = 0.0f;
 	}
-	else
-	{
-		if (XPivotMesh)
-		{
+	else {
+		if (XPivotMesh) {
 			XPivotMesh->bVisible = false;
 			YPivotMesh->bVisible = false;
 			ZPivotMesh->bVisible = false;
@@ -12496,8 +11815,7 @@ void wxGLPanel::UpdatePivot() {
 	Vector3 unprojected;
 	gls.UnprojectCamera(unprojected);
 
-	if (lastCenterPivotDistance != 0.0f)
-	{
+	if (lastCenterPivotDistance != 0.0f) {
 		float factor = 1.0f / lastCenterPivotDistance;
 		XPivotMesh->ScaleVertices(pivotPosition, factor);
 		YPivotMesh->ScaleVertices(pivotPosition, factor);
@@ -12516,20 +11834,20 @@ void wxGLPanel::UpdatePivot() {
 void wxGLPanel::ShowNodes(bool show) {
 	nodesMode = show;
 
-	for (auto &m : nodesPoints)
+	for (auto& m : nodesPoints)
 		m->bVisible = show;
 
-	for (auto &m : nodesLines)
+	for (auto& m : nodesLines)
 		m->bVisible = show;
 
 	gls.RenderOneFrame();
 }
 
 void wxGLPanel::UpdateNodes() {
-	for (auto &m : nodesPoints)
+	for (auto& m : nodesPoints)
 		gls.DeleteOverlay(m);
 
-	for (auto &m : nodesLines)
+	for (auto& m : nodesLines)
 		gls.DeleteOverlay(m);
 
 	nodesPoints.clear();
@@ -12537,12 +11855,10 @@ void wxGLPanel::UpdateNodes() {
 
 	auto workNif = os->project->GetWorkNif();
 
-	std::function<void(NiNode*, NiNode*, const Vector3&, const Vector3&)> addChildNodes = [&](NiNode* node, NiNode* parent, const Vector3& rootPosition, const Vector3& parentPosition)
-	{
+	std::function<void(NiNode*, NiNode*, const Vector3&, const Vector3&)> addChildNodes = [&](NiNode* node, NiNode* parent, const Vector3& rootPosition, const Vector3& parentPosition) {
 		MatTransform ttg = node->GetTransformToParent();
 		NiNode* parentNode = parent;
-		while (parentNode)
-		{
+		while (parentNode) {
 			ttg = parentNode->GetTransformToParent().ComposeTransforms(ttg);
 			parentNode = workNif->GetParentNode(parentNode);
 		}
@@ -12550,32 +11866,27 @@ void wxGLPanel::UpdateNodes() {
 		Vector3 position = ttg.ApplyTransform(rootPosition);
 
 		std::string nodeName = node->name.get();
-		if (!nodeName.empty())
-		{
+		if (!nodeName.empty()) {
 			Vector3 renderPosition = mesh::VecToMeshCoords(position);
 
 			auto pointMesh = gls.AddVisPoint(renderPosition, "P_" + nodeName);
-			if (pointMesh)
-			{
+			if (pointMesh) {
 				pointMesh->bVisible = nodesMode;
 				nodesPoints.push_back(pointMesh);
 			}
 
-			if (parent)
-			{
+			if (parent) {
 				Vector3 renderParentPosition = mesh::VecToMeshCoords(parentPosition);
 
 				auto lineMesh = gls.AddVisSeg(renderParentPosition, renderPosition, "L_" + nodeName);
-				if (lineMesh)
-				{
+				if (lineMesh) {
 					lineMesh->bVisible = nodesMode;
 					nodesLines.push_back(lineMesh);
 				}
 			}
 		}
 
-		for (auto &child : node->childRefs)
-		{
+		for (auto& child : node->childRefs) {
 			auto childNode = workNif->GetHeader().GetBlock<NiNode>(child);
 			if (childNode)
 				addChildNodes(childNode, node, rootPosition, position);
@@ -12592,20 +11903,20 @@ void wxGLPanel::UpdateNodes() {
 void wxGLPanel::ShowBones(bool show) {
 	bonesMode = show;
 
-	for (auto &m : bonesPoints)
+	for (auto& m : bonesPoints)
 		m->bVisible = show;
 
-	for (auto &m : bonesLines)
+	for (auto& m : bonesLines)
 		m->bVisible = show;
 
 	gls.RenderOneFrame();
 }
 
 void wxGLPanel::UpdateBones() {
-	for (auto &m : bonesPoints)
+	for (auto& m : bonesPoints)
 		gls.DeleteOverlay(m);
 
-	for (auto &m : bonesLines)
+	for (auto& m : bonesLines)
 		gls.DeleteOverlay(m);
 
 	bonesPoints.clear();
@@ -12613,28 +11924,22 @@ void wxGLPanel::UpdateBones() {
 
 	auto workAnim = os->project->GetWorkAnim();
 
-	std::function<bool(AnimBone*, const Vector3&)> addChildBones = [&](AnimBone* parent, const Vector3& rootPosition)
-	{
+	std::function<bool(AnimBone*, const Vector3&)> addChildBones = [&](AnimBone* parent, const Vector3& rootPosition) {
 		bool anyBoneInSelection = false;
 
-		for (auto &cb : parent->children)
-		{
+		for (auto& cb : parent->children) {
 			bool childBonesInSelection = addChildBones(cb, rootPosition);
 
-			if (!cb->boneName.empty())
-			{
+			if (!cb->boneName.empty()) {
 				bool boneInSelection = false;
-				for (auto &si : os->GetSelectedItems())
-				{
-					if (workAnim->GetShapeBoneIndex(si->GetShape()->name.get(), cb->boneName) != -1)
-					{
+				for (auto& si : os->GetSelectedItems()) {
+					if (workAnim->GetShapeBoneIndex(si->GetShape()->name.get(), cb->boneName) != -1) {
 						boneInSelection = true;
 						break;
 					}
 				}
 
-				if (boneInSelection || childBonesInSelection)
-				{
+				if (boneInSelection || childBonesInSelection) {
 					Vector3 position = cb->xformToGlobal.ApplyTransform(rootPosition);
 					Vector3 parentPosition = parent->xformToGlobal.ApplyTransform(rootPosition);
 					bool matchesParent = position.IsNearlyEqualTo(parentPosition);
@@ -12642,19 +11947,16 @@ void wxGLPanel::UpdateBones() {
 					Vector3 renderPosition = mesh::VecToMeshCoords(position);
 
 					auto pointMesh = gls.AddVisPoint(renderPosition, "BP_" + cb->boneName);
-					if (pointMesh)
-					{
+					if (pointMesh) {
 						pointMesh->bVisible = bonesMode;
 						bonesPoints.push_back(pointMesh);
 					}
 
 					Vector3 renderParentPosition = mesh::VecToMeshCoords(parentPosition);
 
-					if (!matchesParent)
-					{
+					if (!matchesParent) {
 						auto lineMesh = gls.AddVisSeg(renderParentPosition, renderPosition, "BL_" + cb->boneName);
-						if (lineMesh)
-						{
+						if (lineMesh) {
 							lineMesh->bVisible = bonesMode;
 							bonesLines.push_back(lineMesh);
 						}
@@ -12678,18 +11980,15 @@ void wxGLPanel::UpdateBones() {
 void wxGLPanel::UpdateNodeColors() {
 	std::string activeBone = os->GetActiveBone();
 
-	for (auto &m : nodesPoints)
-	{
+	for (auto& m : nodesPoints) {
 		auto nodeName = m->shapeName.substr(2, m->shapeName.length() - 2);
-		if (nodeName == activeBone)
-		{
+		if (nodeName == activeBone) {
 			m->color.x = 1.0f;
 			m->color.y = 0.0f;
 			m->color.z = 0.0f;
 			m->overlayLayer = OverlayLayer::NodeSelection;
 		}
-		else
-		{
+		else {
 			m->color.x = 0.0f;
 			m->color.y = 1.0f;
 			m->color.z = 0.0f;
@@ -12697,18 +11996,15 @@ void wxGLPanel::UpdateNodeColors() {
 		}
 	}
 
-	for (auto &m : nodesLines)
-	{
+	for (auto& m : nodesLines) {
 		auto nodeName = m->shapeName.substr(2, m->shapeName.length() - 2);
-		if (nodeName == activeBone)
-		{
+		if (nodeName == activeBone) {
 			m->color.x = 0.7f;
 			m->color.y = 0.0f;
 			m->color.z = 0.0f;
 			m->overlayLayer = OverlayLayer::NodeSelection;
 		}
-		else
-		{
+		else {
 			m->color.x = 0.0f;
 			m->color.y = 0.7f;
 			m->color.z = 0.0f;
@@ -12716,18 +12012,15 @@ void wxGLPanel::UpdateNodeColors() {
 		}
 	}
 
-	for (auto &m : bonesPoints)
-	{
+	for (auto& m : bonesPoints) {
 		auto nodeName = m->shapeName.substr(3, m->shapeName.length() - 3);
-		if (nodeName == activeBone)
-		{
+		if (nodeName == activeBone) {
 			m->color.x = 1.0f;
 			m->color.y = 0.0f;
 			m->color.z = 0.0f;
 			m->overlayLayer = OverlayLayer::NodeSelection;
 		}
-		else
-		{
+		else {
 			m->color.x = 0.0f;
 			m->color.y = 1.0f;
 			m->color.z = 0.0f;
@@ -12735,18 +12028,15 @@ void wxGLPanel::UpdateNodeColors() {
 		}
 	}
 
-	for (auto &m : bonesLines)
-	{
+	for (auto& m : bonesLines) {
 		auto nodeName = m->shapeName.substr(3, m->shapeName.length() - 3);
-		if (nodeName == activeBone)
-		{
+		if (nodeName == activeBone) {
 			m->color.x = 0.7f;
 			m->color.y = 0.0f;
 			m->color.z = 0.0f;
 			m->overlayLayer = OverlayLayer::NodeSelection;
 		}
-		else
-		{
+		else {
 			m->color.x = 0.0f;
 			m->color.y = 0.7f;
 			m->color.z = 0.0f;
@@ -12758,14 +12048,14 @@ void wxGLPanel::UpdateNodeColors() {
 void wxGLPanel::ShowFloor(bool show) {
 	floorMode = show;
 
-	for (auto &m : floorMeshes)
+	for (auto& m : floorMeshes)
 		m->bVisible = show;
 
 	gls.RenderOneFrame();
 }
 
 void wxGLPanel::UpdateFloor() {
-	for (auto &m : floorMeshes)
+	for (auto& m : floorMeshes)
 		gls.DeleteMesh(m);
 
 	floorMeshes.clear();
@@ -12782,8 +12072,7 @@ void wxGLPanel::UpdateFloor() {
 
 	Vector3 floorColor(0.0f, 0.0f, 1.0f);
 	auto floorMesh = gls.AddVisPlane(floorMat, Vector2(floorWidth, floorWidth), 1.0f, 0.0f, "", &floorColor, true);
-	if (floorMesh)
-	{
+	if (floorMesh) {
 		floorMesh->prop.alpha = 0.05f;
 		floorMesh->bVisible = floorMode;
 		floorMeshes.push_back(floorMesh);
@@ -12792,14 +12081,12 @@ void wxGLPanel::UpdateFloor() {
 	float nextLinePos = floorWidth - floorWidthHalf;
 
 	// Floor with width on X and Y axis (big grid)
-	for (int i = 0; i < numLinesBig; i++)
-	{
+	for (int i = 0; i < numLinesBig; i++) {
 		Vector3 startPos(floorWidthHalf, 0.0f, nextLinePos);
 		Vector3 endPos(-floorWidthHalf, 0.0f, nextLinePos);
 
 		auto lineMesh = gls.AddVisSeg(startPos, endPos, "", true);
-		if (lineMesh)
-		{
+		if (lineMesh) {
 			lineMesh->color.x = 0.0f;
 			lineMesh->color.y = 1.0f;
 			lineMesh->color.z = 0.0f;
@@ -12811,8 +12098,7 @@ void wxGLPanel::UpdateFloor() {
 		endPos = Vector3(nextLinePos, 0.0f, -floorWidthHalf);
 
 		lineMesh = gls.AddVisSeg(startPos, endPos, "", true);
-		if (lineMesh)
-		{
+		if (lineMesh) {
 			lineMesh->color.x = 0.0f;
 			lineMesh->color.y = 1.0f;
 			lineMesh->color.z = 0.0f;
@@ -12826,14 +12112,12 @@ void wxGLPanel::UpdateFloor() {
 	nextLinePos = floorWidth - floorWidthHalf;
 
 	// Floor with width on X and Y axis (small grid)
-	for (int i = 0; i < numLinesSmall; i++)
-	{
+	for (int i = 0; i < numLinesSmall; i++) {
 		Vector3 startPos(floorWidthHalf, 0.0f, nextLinePos);
 		Vector3 endPos(-floorWidthHalf, 0.0f, nextLinePos);
 
 		auto lineMesh = gls.AddVisSeg(startPos, endPos, "", true);
-		if (lineMesh)
-		{
+		if (lineMesh) {
 			lineMesh->color.x = 0.0f;
 			lineMesh->color.y = 1.0f;
 			lineMesh->color.z = 0.0f;
@@ -12846,8 +12130,7 @@ void wxGLPanel::UpdateFloor() {
 		endPos = Vector3(nextLinePos, 0.0f, -floorWidthHalf);
 
 		lineMesh = gls.AddVisSeg(startPos, endPos, "", true);
-		if (lineMesh)
-		{
+		if (lineMesh) {
 			lineMesh->color.x = 0.0f;
 			lineMesh->color.y = 1.0f;
 			lineMesh->color.z = 0.0f;
@@ -12861,17 +12144,14 @@ void wxGLPanel::UpdateFloor() {
 }
 
 void wxGLPanel::ShowVertexEdit(bool show) {
-	for (auto &m : gls.GetMeshes())
+	for (auto& m : gls.GetMeshes())
 		if (m)
 			m->bShowPoints = false;
 
-	if (show)
-	{
-		if (os->activeItem)
-		{
+	if (show) {
+		if (os->activeItem) {
 			mesh* m = GetMesh(os->activeItem->GetShape()->name.get());
-			if (m)
-			{
+			if (m) {
 				m->bShowPoints = true;
 				m->QueueUpdate(mesh::UpdateType::VertexColors);
 			}
@@ -12886,7 +12166,7 @@ void wxGLPanel::OnIdle(wxIdleEvent& WXUNUSED(event)) {
 		lbuttonDown || rbuttonDown || mbuttonDown)
 		return;
 
-	for (auto &m : BVHUpdateQueue)
+	for (auto& m : BVHUpdateQueue)
 		m->CreateBVH();
 
 	BVHUpdateQueue.clear();
@@ -12898,8 +12178,7 @@ void wxGLPanel::OnPaint(wxPaintEvent& event) {
 	// We could register for the EVT_SHOW event, but unfortunately it
 	// appears to only be called after the first few EVT_PAINT events.
 	// It also isn't supported on all platforms.
-	if (firstPaint)
-	{
+	if (firstPaint) {
 		firstPaint = false;
 		OnShown();
 	}
@@ -12917,8 +12196,7 @@ void wxGLPanel::OnSize(wxSizeEvent& event) {
 void wxGLPanel::OnMouseWheel(wxMouseEvent& event) {
 	int delt = event.GetWheelRotation();
 
-	if (event.ControlDown())
-	{
+	if (event.ControlDown()) {
 		std::string sliderName = os->lastActiveSlider;
 
 		if (sliderName.empty())
@@ -12932,10 +12210,8 @@ void wxGLPanel::OnMouseWheel(wxMouseEvent& event) {
 
 		size_t sliderCount = os->project->SliderCount();
 		size_t sliderIndex = 0;
-		if (os->project->SliderIndexFromName(sliderName, sliderIndex))
-		{
-			if (delt < 0)
-			{
+		if (os->project->SliderIndexFromName(sliderName, sliderIndex)) {
+			if (delt < 0) {
 				++sliderIndex;
 
 				if (sliderIndex == sliderCount)
@@ -12944,8 +12220,7 @@ void wxGLPanel::OnMouseWheel(wxMouseEvent& event) {
 				os->EnterSliderEdit(os->project->GetSliderName(sliderIndex));
 				os->ScrollToActiveSlider();
 			}
-			else
-			{
+			else {
 				if (sliderIndex == 0)
 					sliderIndex = sliderCount - 1;
 				else
@@ -12956,12 +12231,10 @@ void wxGLPanel::OnMouseWheel(wxMouseEvent& event) {
 			}
 		}
 	}
-	else if (wxGetKeyState(wxKeyCode('S')))
-	{
+	else if (wxGetKeyState(wxKeyCode('S'))) {
 		wxPoint p = event.GetPosition();
 
-		if (brushMode)
-		{
+		if (brushMode) {
 			// Adjust brush size
 			if (delt < 0)
 				DecBrush();
@@ -12974,8 +12247,7 @@ void wxGLPanel::OnMouseWheel(wxMouseEvent& event) {
 			gls.RenderOneFrame();
 		}
 	}
-	else
-	{
+	else {
 		gls.DollyCamera(delt);
 		UpdateTransformTool();
 		UpdatePivot();
@@ -12994,8 +12266,7 @@ void wxGLPanel::OnMouseMove(wxMouseEvent& event) {
 
 	ShowRotationCenter(false);
 
-	if (mbuttonDown)
-	{
+	if (mbuttonDown) {
 		isMDragging = true;
 		if (wxGetKeyState(wxKeyCode::WXK_SHIFT))
 			gls.DollyCamera(y - lastY);
@@ -13007,24 +12278,19 @@ void wxGLPanel::OnMouseMove(wxMouseEvent& event) {
 		gls.RenderOneFrame();
 	}
 
-	if (rbuttonDown)
-	{
+	if (rbuttonDown) {
 		isRDragging = true;
-		if (wxGetKeyState(WXK_SHIFT))
-		{
+		if (wxGetKeyState(WXK_SHIFT)) {
 			gls.PanCamera(x - lastX, y - lastY);
 		}
-		else
-		{
+		else {
 			gls.TurnTableCamera(x - lastX);
 			gls.PitchCamera(y - lastY);
 			ShowRotationCenter();
 		}
 
-		if (wxGetKeyState(WXK_ALT))
-		{
-			if (hoverPoint != -1)
-			{
+		if (wxGetKeyState(WXK_ALT)) {
+			if (hoverPoint != -1) {
 				rotationCenterMode = RotationCenterMode::Picked;
 				gls.camRotOffset = hoverCoord;
 			}
@@ -13035,37 +12301,28 @@ void wxGLPanel::OnMouseMove(wxMouseEvent& event) {
 		gls.RenderOneFrame();
 	}
 
-	if (lbuttonDown)
-	{
+	if (lbuttonDown) {
 		isLDragging = true;
-		if (isTransforming)
-		{
+		if (isTransforming) {
 			UpdateTransform(event.GetPosition());
 		}
-		else if (isMovingPivot)
-		{
+		else if (isMovingPivot) {
 			UpdatePivotPosition(event.GetPosition());
 		}
-		else if (isPainting)
-		{
+		else if (isPainting) {
 			UpdateBrushStroke(event.GetPosition());
 		}
-		else if (isSelecting)
-		{
+		else if (isSelecting) {
 			SelectVertex(event.GetPosition());
 		}
-		else if (isPickingVertex)
-		{
+		else if (isPickingVertex) {
 			UpdatePickVertex(event.GetPosition());
 		}
-		else if (isPickingEdge)
-		{
+		else if (isPickingEdge) {
 			UpdatePickEdge(event.GetPosition());
 		}
-		else
-		{
-			if (Config.MatchValue("Input/LeftMousePan", "true"))
-			{
+		else {
+			if (Config.MatchValue("Input/LeftMousePan", "true")) {
 				gls.PanCamera(x - lastX, y - lastY);
 				UpdateTransformTool();
 				UpdatePivot();
@@ -13075,8 +12332,7 @@ void wxGLPanel::OnMouseMove(wxMouseEvent& event) {
 		gls.RenderOneFrame();
 	}
 
-	if (!rbuttonDown && !lbuttonDown)
-	{
+	if (!rbuttonDown && !lbuttonDown) {
 		hoverMeshName.clear();
 		hoverPoint = -1;
 		hoverCoord.Zero();
@@ -13085,20 +12341,16 @@ void wxGLPanel::OnMouseMove(wxMouseEvent& event) {
 		Vector3 hoverColor;
 		float hoverAlpha = 1.0f;
 
-		if (editMode)
-		{
+		if (editMode) {
 			cursorExists = gls.UpdateCursor(x, y, bGlobalBrushCollision, &hoverMeshName, &hoverPoint, &hoverColor, &hoverAlpha, &hoverEdge, &hoverCoord);
 		}
-		else
-		{
+		else {
 			cursorExists = false;
 			gls.ShowCursor(false);
 		}
 
-		if ((transformMode || pivotMode) && !isTransforming && !isMovingPivot)
-		{
-			if (XMoveMesh)
-			{
+		if ((transformMode || pivotMode) && !isTransforming && !isMovingPivot) {
+			if (XMoveMesh) {
 				XMoveMesh->color = Vector3(1.0f, 0.0f, 0.0f);
 				YMoveMesh->color = Vector3(0.0f, 1.0f, 0.0f);
 				ZMoveMesh->color = Vector3(0.0f, 0.0f, 1.0f);
@@ -13111,8 +12363,7 @@ void wxGLPanel::OnMouseMove(wxMouseEvent& event) {
 				ScaleUniformMesh->color = Vector3(0.0f, 0.0f, 0.0f);
 			}
 
-			if (XPivotMesh)
-			{
+			if (XPivotMesh) {
 				XPivotMesh->color = Vector3(1.0f, 0.0f, 0.0f);
 				YPivotMesh->color = Vector3(0.0f, 1.0f, 0.0f);
 				ZPivotMesh->color = Vector3(0.0f, 0.0f, 1.0f);
@@ -13121,10 +12372,8 @@ void wxGLPanel::OnMouseMove(wxMouseEvent& event) {
 
 			Vector3 outOrigin, outNormal;
 			mesh* hitMesh = nullptr;
-			if (gls.CollideOverlay(x, y, outOrigin, outNormal, &hitMesh))
-			{
-				if (hitMesh && hitMesh != PivotCenterMesh)
-				{
+			if (gls.CollideOverlay(x, y, outOrigin, outNormal, &hitMesh)) {
+				if (hitMesh && hitMesh != PivotCenterMesh) {
 					hitMesh->color = Vector3(1.0f, 1.0f, 0.0f);
 					gls.ShowCursor(false);
 				}
@@ -13133,24 +12382,20 @@ void wxGLPanel::OnMouseMove(wxMouseEvent& event) {
 
 		gls.RenderOneFrame();
 
-		if (os->statusBar)
-		{
-			if (cursorExists)
-			{
+		if (os->statusBar) {
+			if (cursorExists) {
 				if (activeTool == ToolID::MaskBrush)
 					os->statusBar->SetStatusText(wxString::Format("Vertex: %d, Mask: %g", hoverPoint, hoverColor.x), 1);
 				else if (activeTool == ToolID::WeightBrush)
 					os->statusBar->SetStatusText(wxString::Format("Vertex: %d, Weight: %g", hoverPoint, hoverColor.y), 1);
 				else if (activeTool == ToolID::ColorBrush || activeTool == ToolID::AlphaBrush)
 					os->statusBar->SetStatusText(wxString::Format("Vertex: %d, Color: %g, %g, %g, Alpha: %g", hoverPoint, hoverColor.x, hoverColor.y, hoverColor.z, hoverAlpha), 1);
-				else
-				{
+				else {
 					Vector3 hoverCoordNif = mesh::VecToNifCoords(hoverCoord);
 					os->statusBar->SetStatusText(wxString::Format("Vertex: %d, X: %.5f Y: %.5f Z: %.5f", hoverPoint, hoverCoordNif.x, hoverCoordNif.y, hoverCoordNif.z), 1);
 				}
 			}
-			else
-			{
+			else {
 				os->statusBar->SetStatusText("", 1);
 			}
 		}
@@ -13166,46 +12411,38 @@ void wxGLPanel::OnLeftDown(wxMouseEvent& event) {
 
 	lbuttonDown = true;
 
-	if (transformMode)
-	{
+	if (transformMode) {
 		bool meshHit = StartTransform(event.GetPosition());
-		if (meshHit)
-		{
+		if (meshHit) {
 			isTransforming = true;
 			return;
 		}
 	}
 
-	if (pivotMode)
-	{
+	if (pivotMode) {
 		bool meshHit = StartPivotPosition(event.GetPosition());
-		if (meshHit)
-		{
+		if (meshHit) {
 			isMovingPivot = true;
 			return;
 		}
 	}
 
-	if (brushMode)
-	{
+	if (brushMode) {
 		bool meshHit = StartBrushStroke(event.GetPosition());
 		if (meshHit)
 			isPainting = true;
 	}
-	else if (activeTool == ToolID::CollapseVertex)
-	{
+	else if (activeTool == ToolID::CollapseVertex) {
 		bool meshHit = StartPickVertex();
 		if (meshHit)
 			isPickingVertex = true;
 	}
-	else if (activeTool == ToolID::FlipEdge || activeTool == ToolID::SplitEdge)
-	{
+	else if (activeTool == ToolID::FlipEdge || activeTool == ToolID::SplitEdge) {
 		bool meshHit = StartPickEdge();
 		if (meshHit)
 			isPickingEdge = true;
 	}
-	else if (vertexEdit)
-	{
+	else if (vertexEdit) {
 		bool meshHit = SelectVertex(event.GetPosition());
 		if (meshHit)
 			isSelecting = true;
@@ -13231,8 +12468,7 @@ void wxGLPanel::OnLeftUp(wxMouseEvent& event) {
 	if (GetCapture() == this)
 		ReleaseMouse();
 
-	if (!isLDragging && !isPainting && activeTool == ToolID::Select)
-	{
+	if (!isLDragging && !isPainting && activeTool == ToolID::Select) {
 		int x, y;
 		event.GetPosition(&x, &y);
 		wxPoint p = event.GetPosition();
@@ -13242,32 +12478,27 @@ void wxGLPanel::OnLeftUp(wxMouseEvent& event) {
 			os->SelectShape(m->shapeName);
 	}
 
-	if (isPainting)
-	{
+	if (isPainting) {
 		EndBrushStroke();
 		isPainting = false;
 	}
 
-	if (isPickingVertex)
-	{
+	if (isPickingVertex) {
 		EndPickVertex();
 		isPickingVertex = false;
 	}
 
-	if (isPickingEdge)
-	{
+	if (isPickingEdge) {
 		EndPickEdge();
 		isPickingEdge = false;
 	}
 
-	if (isTransforming)
-	{
+	if (isTransforming) {
 		EndTransform();
 		isTransforming = false;
 	}
 
-	if (isMovingPivot)
-	{
+	if (isMovingPivot) {
 		EndPivotPosition();
 		isMovingPivot = false;
 	}
@@ -13282,32 +12513,27 @@ void wxGLPanel::OnLeftUp(wxMouseEvent& event) {
 }
 
 void wxGLPanel::OnCaptureLost(wxMouseCaptureLostEvent& WXUNUSED(event)) {
-	if (isPainting)
-	{
+	if (isPainting) {
 		EndBrushStroke();
 		isPainting = false;
 	}
 
-	if (isPickingVertex)
-	{
+	if (isPickingVertex) {
 		EndPickVertex();
 		isPickingVertex = false;
 	}
 
-	if (isPickingEdge)
-	{
+	if (isPickingEdge) {
 		EndPickEdge();
 		isPickingEdge = false;
 	}
 
-	if (isTransforming)
-	{
+	if (isTransforming) {
 		EndTransform();
 		isTransforming = false;
 	}
 
-	if (isMovingPivot)
-	{
+	if (isMovingPivot) {
 		EndPivotPosition();
 		isMovingPivot = false;
 	}
@@ -13342,19 +12568,16 @@ void wxGLPanel::OnRightUp(wxMouseEvent& WXUNUSED(event)) {
 
 
 bool DnDFile::OnDropFiles(wxCoord, wxCoord, const wxArrayString& fileNames) {
-	if (owner)
-	{
+	if (owner) {
 		NiShape* mergeShape = nullptr;
 		if (owner->activeItem && fileNames.GetCount() == 1)
 			mergeShape = owner->activeItem->GetShape();
 
-		for (auto &inputFile : fileNames)
-		{
+		for (auto& inputFile : fileNames) {
 			wxString dataName = inputFile.AfterLast('/').AfterLast('\\');
 			dataName = dataName.BeforeLast('.');
 
-			if (inputFile.Lower().EndsWith(".nif"))
-			{
+			if (inputFile.Lower().EndsWith(".nif")) {
 				owner->StartProgress(_("Adding NIF file..."));
 				owner->UpdateProgress(1, _("Adding NIF file..."));
 				owner->project->ImportNIF(inputFile.ToUTF8().data(), false);
@@ -13366,8 +12589,7 @@ bool DnDFile::OnDropFiles(wxCoord, wxCoord, const wxArrayString& fileNames) {
 				owner->UpdateProgress(100, _("Finished"));
 				owner->EndProgress();
 			}
-			else if (inputFile.Lower().EndsWith(".obj"))
-			{
+			else if (inputFile.Lower().EndsWith(".obj")) {
 				owner->StartProgress("Adding OBJ file...");
 				owner->UpdateProgress(1, _("Adding OBJ file..."));
 				owner->project->ImportOBJ(inputFile.ToUTF8().data(), dataName.ToUTF8().data(), mergeShape);
@@ -13379,8 +12601,7 @@ bool DnDFile::OnDropFiles(wxCoord, wxCoord, const wxArrayString& fileNames) {
 				owner->UpdateProgress(100, _("Finished"));
 				owner->EndProgress();
 			}
-			else if (inputFile.Lower().EndsWith(".fbx"))
-			{
+			else if (inputFile.Lower().EndsWith(".fbx")) {
 				owner->StartProgress(_("Adding FBX file..."));
 				owner->UpdateProgress(1, _("Adding FBX file..."));
 				owner->project->ImportFBX(inputFile.ToUTF8().data(), dataName.ToUTF8().data(), mergeShape);
@@ -13401,11 +12622,9 @@ bool DnDFile::OnDropFiles(wxCoord, wxCoord, const wxArrayString& fileNames) {
 }
 
 bool DnDSliderFile::OnDropFiles(wxCoord, wxCoord, const wxArrayString& fileNames) {
-	if (owner)
-	{
+	if (owner) {
 		bool isMultiple = (fileNames.GetCount() > 1);
-		for (size_t i = 0; i < fileNames.GetCount(); i++)
-		{
+		for (size_t i = 0; i < fileNames.GetCount(); i++) {
 			wxString inputFile;
 			inputFile = fileNames.Item(i);
 
@@ -13415,16 +12634,13 @@ bool DnDSliderFile::OnDropFiles(wxCoord, wxCoord, const wxArrayString& fileNames
 			bool isBSD = inputFile.MakeLower().EndsWith(".bsd");
 			bool isOBJ = inputFile.MakeLower().EndsWith(".obj");
 			bool isFBX = inputFile.MakeLower().EndsWith(".fbx");
-			if (isBSD || isOBJ)
-			{
-				if (!owner->activeItem)
-				{
+			if (isBSD || isOBJ) {
+				if (!owner->activeItem) {
 					wxMessageBox(_("There is no shape selected!"), _("Error"));
 					return false;
 				}
 
-				if (lastResult == wxDragCopy)
-				{
+				if (lastResult == wxDragCopy) {
 					targetSlider = owner->NewSlider(dataName.ToUTF8().data(), isMultiple);
 				}
 
@@ -13464,12 +12680,9 @@ wxDragResult DnDSliderFile::OnDragOver(wxCoord x, wxCoord y, wxDragResult defRes
 	if (defResult == wxDragCopy)
 		return lastResult;
 
-	if (owner)
-	{
-		for (auto &child : owner->sliderDisplays)
-		{
-			if (child.second->sliderPane->GetRect().Contains(x, y))
-			{
+	if (owner) {
+		for (auto& child : owner->sliderDisplays) {
+			if (child.second->sliderPane->GetRect().Contains(x, y)) {
 				targetSlider = child.first;
 				lastResult = wxDragMove;
 				break;
@@ -13487,10 +12700,8 @@ wxDragResult DnDSliderFile::OnDragOver(wxCoord x, wxCoord y, wxDragResult defRes
 }
 
 
-std::string JoinStrings(const std::vector<std::string>& elements, const char* const separator)
-{
-	switch (elements.size())
-	{
+std::string JoinStrings(const std::vector<std::string>& elements, const char* const separator) {
+	switch (elements.size()) {
 	case 0:
 		return "";
 	case 1:

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -3576,7 +3576,7 @@ bool OutfitStudioFrame::AlertProgressError(int error, const wxString& title, con
 
 	wxLogError(message);
 	wxMessageBox(message, _(title), wxICON_ERROR);
-	EndProgress();
+	EndProgress("", true);
 	RefreshGUIFromProj();
 	return true;
 }
@@ -3652,9 +3652,11 @@ void OutfitStudioFrame::OnConvertBodyReference(wxCommandEvent& WXUNUSED(event)) 
 	auto shapes = project->GetWorkNif()->GetShapes(); // get outfit shapes
 
 	UpdateProgress(5, _("Loading conversion reference..."));
+	StartSubProgress(5, 10);
 	if (AlertProgressError(LoadReferenceTemplate(conversionRefTemplate, keepZapSliders), "Load Error", "Failed to load conversion reference"))
 		return;
-
+	EndProgress();
+	
 	StartSubProgress(10, 20);
 	CreateSetSliders();
 	RefreshGUIFromProj();
@@ -3663,7 +3665,7 @@ void OutfitStudioFrame::OnConvertBodyReference(wxCommandEvent& WXUNUSED(event)) 
 	StartSubProgress(20, 35);
 	if (AlertProgressError(ConformShapes(shapes, true), "Conform Error", "Failed to conform shapes"))
 		return;
-
+	
 	UpdateProgress(35, _("Updating conversion Slider..."));
 	SetSliderValue(project->activeSet.size() - 1, 100);
 	ApplySliders();
@@ -3676,9 +3678,11 @@ void OutfitStudioFrame::OnConvertBodyReference(wxCommandEvent& WXUNUSED(event)) 
 	RefreshGUIFromProj();
 	
 	UpdateProgress(50, _("Loading new reference..."));
+	StartSubProgress(50, 55);
 	if (AlertProgressError(LoadReferenceTemplate(newRefTemplate, keepZapSliders), "Load Error", "Failed to load new reference"))
 		return;
-
+	EndProgress();
+	
 	StartSubProgress(55, 65);
 	CreateSetSliders();
 	RefreshGUIFromProj();

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -48,6 +48,7 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_MENU(XRCID("btnLoadProject"), OutfitStudioFrame::OnLoadProject)
 	EVT_MENU(XRCID("btnAddProject"), OutfitStudioFrame::OnAddProject)
 	EVT_MENU(XRCID("fileLoadRef"), OutfitStudioFrame::OnLoadReference)
+	EVT_MENU(XRCID("fileConvBodyRef"), OutfitStudioFrame::OnConvertBodyReference)
 	EVT_MENU(XRCID("fileLoadOutfit"), OutfitStudioFrame::OnLoadOutfit)
 	EVT_MENU(XRCID("fileSave"), OutfitStudioFrame::OnSaveSliderSet)
 	EVT_MENU(XRCID("fileSaveAs"), OutfitStudioFrame::OnSaveSliderSetAs)
@@ -100,7 +101,7 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_MENU(XRCID("importNIF"), OutfitStudioFrame::OnImportNIF)
 	EVT_MENU(XRCID("exportNIF"), OutfitStudioFrame::OnExportNIF)
 	EVT_MENU(XRCID("exportNIFWithRef"), OutfitStudioFrame::OnExportNIFWithRef)
-	EVT_MENU(XRCID("bakeNifInPlace"), OutfitStudioFrame::OnBakeNifInPlace)
+	EVT_MENU(XRCID("bakeNifInPlace"), OutfitStudioFrame::OnBakeConversionReference)
 	EVT_MENU(XRCID("exportShapeNIF"), OutfitStudioFrame::OnExportShapeNIF)
 
 	EVT_MENU(XRCID("importOBJ"), OutfitStudioFrame::OnImportOBJ)
@@ -3527,1256 +3528,1519 @@ void OutfitStudioFrame::OnLoadReference(wxCommandEvent& WXUNUSED(event)) {
 	EndProgress();
 }
 
-void OutfitStudioFrame::OnLoadOutfit(wxCommandEvent& WXUNUSED(event)) {
+int OutfitStudioFrame::LoadReferenceTemplate(const wxString& refTemplate, bool keepZapSliders)
+{
+	NiShape* baseShape = project->GetBaseShape();
+	if (baseShape)
+		glView->DeleteMesh(baseShape->name.get());
+	
+	int error;
+	wxLogMessage("Loading reference template '%s'...", refTemplate);
+	std::string tmplName{refTemplate.ToUTF8()};
+	auto tmpl = find_if(refTemplates.begin(), refTemplates.end(), [&tmplName](const RefTemplate& rt) { return rt.GetName() == tmplName; });
+	if (tmpl != refTemplates.end())
+	{
+		if (wxFileName(wxString::FromUTF8(tmpl->GetSource())).IsRelative())
+			error = project->LoadReferenceTemplate(GetProjectPath() + PathSepStr + tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), tmpl->GetLoadAll(), false, keepZapSliders, true);
+		else
+			error = project->LoadReferenceTemplate(tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), tmpl->GetLoadAll(), false, keepZapSliders, true);
+	}
+	else
+		error = 1;
+
+	if(!error) {
+		// since some reference files have multiple shapes, just update all textures
+		for(auto &s : project->GetWorkNif()->GetShapes())
+			project->SetTextures(s);
+
+		RefreshGUIFromProj();
+		CreateSetSliders();
+	}
+
+	return error;
+}
+
+void OutfitStudioFrame::LoadDialogChoice(wxDialog& dlg, const char* dlgProperty) const
+{
+	wxChoice* choice = XRCCTRL(dlg, dlgProperty, wxChoice);
+	for (auto &tmpl : refTemplates)
+		choice->Append(tmpl.GetName());
+
+	std::string lastValue = OutfitStudioConfig[dlgProperty];
+	if (!choice->SetStringSelection(wxString::FromUTF8(lastValue)))
+		choice->Select(0);
+}
+
+void OutfitStudioFrame::LoadDialogText(wxDialog& dlg, const char* dlgProperty) const
+{
+	wxTextCtrl* tmplChoice = XRCCTRL(dlg, dlgProperty, wxTextCtrl);
+	std::string lastValue = OutfitStudioConfig[dlgProperty];
+	tmplChoice->SetValue(lastValue);
+}
+
+bool OutfitStudioFrame::AlertProgressError(int error, const wxString& title, const wxString& message)
+{
+	if (error == 0)
+		return false;
+	
+	wxLogError(message);
+	wxMessageBox(message, _(title), wxICON_ERROR);
+	EndProgress();
+	RefreshGUIFromProj();
+	return true;
+}
+
+void OutfitStudioFrame::OnConvertBodyReference(wxCommandEvent& WXUNUSED(event)) {
+	if (bEditSlider) {
+		wxMessageBox(_("You're currently editing slider data, please exit the slider's edit mode (pencil button) and try again."));
+		return;
+	}
+
+	UpdateReferenceTemplates();
+
 	wxDialog dlg;
 	int result = wxID_CANCEL;
+	if (wxXmlResource::Get()->LoadObject((wxObject*)&dlg, this, "dlgConvertBodyRef", "wxDialog")) {
 
-	if (wxXmlResource::Get()->LoadObject((wxObject*)&dlg, this, "dlgLoadOutfit", "wxDialog")) {
-		XRCCTRL(dlg, "npWorkFilename", wxFilePickerCtrl)->Bind(wxEVT_FILEPICKER_CHANGED, &OutfitStudioFrame::OnLoadOutfitFP_File, this);
-		XRCCTRL(dlg, "npTexFilename", wxFilePickerCtrl)->Bind(wxEVT_FILEPICKER_CHANGED, &OutfitStudioFrame::OnLoadOutfitFP_Texture, this);
-		if (project->GetWorkNif()->IsValid())
-			XRCCTRL(dlg, "npWorkAdd", wxCheckBox)->Enable();
+		LoadDialogChoice(dlg, "npConvRefChoice");
+		LoadDialogChoice(dlg, "npNewRefChoice");
+		LoadDialogText(dlg, "npRemoveText");
+		LoadDialogText(dlg, "npAppendText");
 
 		result = dlg.ShowModal();
 	}
 	if (result == wxID_CANCEL)
 		return;
 
-	std::string outfitName = XRCCTRL(dlg, "npOutfitName", wxTextCtrl)->GetValue();
+	StartProgress(_("Start Conversion.."));
 
-	menuBar->Enable(XRCID("fileSave"), false);
+	bool keepZapSliders = (XRCCTRL(dlg, "chkKeepZapSliders", wxCheckBox)->IsChecked());
+	wxString conversionRefTemplate = XRCCTRL(dlg, "npConvRefChoice", wxChoice)->GetStringSelection();
+	wxString newRefTemplate = XRCCTRL(dlg, "npNewRefChoice", wxChoice)->GetStringSelection();
+	wxString removeFromProjectText = XRCCTRL(dlg, "npRemoveText", wxTextCtrl)->GetValue();
+	wxString appendToProjectText = XRCCTRL(dlg, "npAppendText", wxTextCtrl)->GetValue();
+	OutfitStudioConfig.SetValue("npConvRefChoice", conversionRefTemplate.ToStdString());
+	OutfitStudioConfig.SetValue("npNewRefChoice", newRefTemplate.ToStdString());
+	OutfitStudioConfig.SetValue("npRemoveText", removeFromProjectText.ToStdString());
+	OutfitStudioConfig.SetValue("npAppendText", appendToProjectText.ToStdString());
+	Config.SaveConfig(Config["AppDir"] + "/Config.xml");
 
-	wxLogMessage("Loading outfit...");
-	StartProgress(_("Loading outfit..."));
-
-	for (auto &s : project->GetWorkNif()->GetShapes()) {
-		if (!project->IsBaseShape(s)) {
-			glView->DeleteMesh(s->name.get());
+	UpdateProgress(1, _("Updating Project Output Settings"));
+	
+	wxStringTokenizer tkz(removeFromProjectText, wxT(","));
+	bool modifiedName = false;
+	while ( tkz.HasMoreTokens() )
+	{
+	    wxString token = tkz.GetNextToken();
+		if(!modifiedName && !appendToProjectText.IsEmpty() && project->mFileName.Contains(token)) {
+			project->mFileName.Replace(token, appendToProjectText);
+			modifiedName = true;
 		}
-	}
-
-	bool keepShapes = XRCCTRL(dlg, "npWorkAdd", wxCheckBox)->IsChecked();
-	UpdateProgress(1, _("Loading outfit..."));
-
-	int ret = 0;
-	if (XRCCTRL(dlg, "npWorkFile", wxRadioButton)->GetValue() == true) {
-		wxString fileName = XRCCTRL(dlg, "npWorkFilename", wxFilePickerCtrl)->GetPath();
-		if (fileName.Lower().EndsWith(".nif")) {
-			if (!keepShapes)
-				ret = project->ImportNIF(fileName.ToUTF8().data(), true, outfitName);
-			else
-				ret = project->ImportNIF(fileName.ToUTF8().data(), false);
+		else {
+			project->mFileName.Replace(token, "");
 		}
-		else if (fileName.Lower().EndsWith(".obj"))
-			ret = project->ImportOBJ(fileName.ToUTF8().data(), outfitName);
-		else if (fileName.Lower().EndsWith(".fbx"))
-			ret = project->ImportFBX(fileName.ToUTF8().data(), outfitName);
+		project->mOutfitName.Replace(token, "");
+		project->mDataDir.Replace(token, "");
+		project->mBaseFile.Replace(token, "");
 	}
-	else
-		project->ClearOutfit();
+	if(!appendToProjectText.IsEmpty())
+	{
+		if(project->mOutfitName[0] != ' ')
+			project->mOutfitName.Prepend(' ');
+		if(project->mDataDir[0] != ' ')
+			project->mDataDir.Prepend(' ');
+		if(project->mBaseFile[0] != ' ')
+			project->mBaseFile.Prepend(' ');
+		project->mOutfitName.Prepend(appendToProjectText);
+		project->mDataDir.Prepend(appendToProjectText);
+		project->mBaseFile.Prepend(appendToProjectText);
+		
+		project->outfitName = project->mOutfitName.ToStdString();
+		UpdateTitle();
+	}
+	
+	project->DeleteShape(project->GetBaseShape());
+	auto shapes = project->GetWorkNif()->GetShapes(); // get outfit shapes
 
-	if (ret) {
-		EndProgress();
-		RefreshGUIFromProj();
+	UpdateProgress(5, _("Loading conversion reference..."));
+	if (AlertProgressError(LoadReferenceTemplate(conversionRefTemplate, keepZapSliders), "Load Error", "Failed to load conversion reference"))
 		return;
-	}
+	
+	UpdateProgress(10, _("Conforming outfit parts..."));
+	if (AlertProgressError(ConformShapes(shapes, true), "Conform Error", "Failed to conform shapes"))
+		return;
+	
+	UpdateProgress(25, _("Updating conversion Slider..."));
+	SetSliderValue(project->activeSet.size() - 1, 100);
+	ApplySliders();
 
-	if (XRCCTRL(dlg, "npTexAuto", wxRadioButton)->GetValue() == true)
-		project->SetTextures();
-	else {
-		std::vector<std::string> texVec = { XRCCTRL(dlg, "npTexFilename", wxFilePickerCtrl)->GetPath().ToUTF8().data() };
-		project->SetTextures(texVec);
-	}
+	UpdateProgress(30, _("Baking conversion reference..."));
+	if (AlertProgressError(BakeConversionReference(), "Bake Error", "Failed to bake conversion reference"))
+		return;
 
-	wxLogMessage("Creating outfit...");
-	UpdateProgress(50, _("Creating outfit..."));
+	UpdateProgress(40, _("Loading new reference..."));
+	if (AlertProgressError(LoadReferenceTemplate(newRefTemplate, keepZapSliders), "Load Error", "Failed to load new reference"))
+		return;
+
+	UpdateProgress(55, _("Copying bones..."));
+	if (AlertProgressError(CopyBoneWeightForShapes(shapes, 0, false, true), "Copy Bone Weights Error", "Failed to copy bone weights"))
+		return;
+
+	UpdateProgress(80, _("Conforming outfit parts..."));
+	if (AlertProgressError(ConformShapes(shapes, true), "Conform Error", "Failed to conform shapes"))
+		return;
+	
 	RefreshGUIFromProj();
-
-	UpdateTitle();
-
-	wxLogMessage("Outfit loaded.");
+	ApplySliders();
+	
+	wxLogMessage("Finished conversion.");
 	UpdateProgress(100, _("Finished"));
 	EndProgress();
-}
-
-void OutfitStudioFrame::OnUnloadProject(wxCommandEvent& WXUNUSED(event)) {
-	wxMessageDialog dlg(this, _("Unload the project? All unsaved changes will be lost"), _("Unload Project"), wxOK | wxCANCEL | wxICON_WARNING | wxCANCEL_DEFAULT);
-	dlg.SetOKCancelLabels(_("Unload"), _("Cancel"));
-	if (dlg.ShowModal() != wxID_OK)
-		return;
-
-	wxLogMessage("Unloading project...");
-	menuBar->Enable(XRCID("fileSave"), false);
-
-	ClearProject();
-	project->ClearReference();
-	project->ClearOutfit();
-
-	glView->Cleanup();
-	glView->GetUndoHistory()->ClearHistory();
-
-	activeSlider.clear();
-	lastActiveSlider.clear();
-	bEditSlider = false;
-	MenuExitSliderEdit();
-
-	delete project;
-	project = new OutfitProject(this);
-
-	CreateSetSliders();
-	RefreshGUIFromProj(false);
-	glView->Render();
-}
-
-void OutfitStudioFrame::UpdateReferenceTemplates() {
-	refTemplates.clear();
-
-	std::string fileName = GetProjectPath() + "/RefTemplates.xml";
-	if (wxFileName::IsFileReadable(fileName)) {
-		RefTemplateFile refTemplateFile(fileName);
-		refTemplateFile.GetAll(refTemplates);
 	}
 
-	RefTemplateCollection refTemplateCol;
-	refTemplateCol.Load(GetProjectPath() + "/RefTemplates");
-	refTemplateCol.GetAll(refTemplates);
-}
+	void OutfitStudioFrame::OnLoadOutfit(wxCommandEvent& WXUNUSED(event)) {
+		wxDialog dlg;
+		int result = wxID_CANCEL;
 
-void OutfitStudioFrame::ClearProject() {
-	if (editUV)
-		editUV->Close();
+		if (wxXmlResource::Get()->LoadObject((wxObject*)&dlg, this, "dlgLoadOutfit", "wxDialog"))
+		{
+			XRCCTRL(dlg, "npWorkFilename", wxFilePickerCtrl)->Bind(wxEVT_FILEPICKER_CHANGED, &OutfitStudioFrame::OnLoadOutfitFP_File, this);
+			XRCCTRL(dlg, "npTexFilename", wxFilePickerCtrl)->Bind(wxEVT_FILEPICKER_CHANGED, &OutfitStudioFrame::OnLoadOutfitFP_Texture, this);
+			if (project->GetWorkNif()->IsValid())
+				XRCCTRL(dlg, "npWorkAdd", wxCheckBox)->Enable();
 
-	for (auto &s : project->GetWorkNif()->GetShapeNames())
-		glView->DeleteMesh(s);
+			result = dlg.ShowModal();
+		}
+		if (result == wxID_CANCEL)
+			return;
 
-	project->mFileName.clear();
-	project->mOutfitName.clear();
-	project->mDataDir.clear();
-	project->mBaseFile.clear();
-	project->mGamePath.clear();
-	project->mGameFile.clear();
+		std::string outfitName = XRCCTRL(dlg, "npOutfitName", wxTextCtrl)->GetValue();
 
-	if (wxGetApp().targetGame == SKYRIM || wxGetApp().targetGame == SKYRIMSE || wxGetApp().targetGame == SKYRIMVR)
-		project->mGenWeights = true;
-	else
-		project->mGenWeights = false;
+		menuBar->Enable(XRCID("fileSave"), false);
 
-	project->mCopyRef = true;
+		wxLogMessage("Loading outfit...");
+		StartProgress(_("Loading outfit..."));
 
-	glView->ClearOverlays();
-	activePartition.Unset();
-	activeSegment.Unset();
-
-	lastSelectedBones.clear();
-	lastNormalizeBones.clear();
-
-	if (currentTabButton)
-		currentTabButton->SetPendingChanges(false);
-
-	auto cMaskName = (wxChoice*)FindWindowByName("cMaskName");
-	cMaskName->Clear();
-
-	auto cPoseName = (wxChoice*)FindWindowByName("cPoseName");
-	cPoseName->Clear();
-
-	project->outfitName.clear();
-	pendingChanges = false;
-	UpdateTitle();
-}
-
-void OutfitStudioFrame::RenameProject(const std::string& projectName) {
-	project->outfitName = projectName;
-	if (outfitRoot.IsOk())
-		outfitShapes->SetItemText(outfitRoot, wxString::FromUTF8(projectName));
-
-	UpdateTitle();
-}
-
-void OutfitStudioFrame::LockShapeSelect() {
-	selectionLocked = true;
-	outfitShapes->Disable();
-}
-
-void OutfitStudioFrame::UnlockShapeSelect() {
-	selectionLocked = false;
-	outfitShapes->Enable();
-}
-
-void OutfitStudioFrame::RefreshGUIFromProj(bool render) {
-	LockShapeSelect();
-
-	selectedItems.clear();
-	std::vector<ShapeItemState> prevStates;
-
-	if (outfitRoot.IsOk()) {
-		wxTreeItemIdValue cookie;
-		wxTreeItemId child = outfitShapes->GetFirstChild(outfitRoot, cookie);
-		while (child.IsOk()) {
-			auto itemData = (ShapeItemData*)outfitShapes->GetItemData(child);
-			if (itemData) {
-				ShapeItemState prevState;
-				prevState.shape = itemData->GetShape();
-				prevState.state = outfitShapes->GetItemState(child);
-
-				if (outfitShapes->IsSelected(child))
-					prevState.selected = true;
-
-				prevStates.push_back(prevState);
+		for (auto &s : project->GetWorkNif()->GetShapes())
+		{
+			if (!project->IsBaseShape(s))
+			{
+				glView->DeleteMesh(s->name.get());
 			}
-
-			child = outfitShapes->GetNextChild(outfitRoot, cookie);
 		}
 
-		outfitShapes->UnselectAll();
-		outfitShapes->DeleteChildren(outfitRoot);
-		outfitShapes->Delete(outfitRoot);
-		outfitRoot.Unset();
-	}
+		bool keepShapes = XRCCTRL(dlg, "npWorkAdd", wxCheckBox)->IsChecked();
+		UpdateProgress(1, _("Loading outfit..."));
 
-	auto shapes = project->GetWorkNif()->GetShapes();
-	if (shapes.size() > 0) {
-		if (shapes.size() == 1 && project->IsBaseShape(shapes.front()))
-			outfitRoot = outfitShapes->AppendItem(shapesRoot, "Reference Only");
+		int ret = 0;
+		if (XRCCTRL(dlg, "npWorkFile", wxRadioButton)->GetValue() == true)
+		{
+			wxString fileName = XRCCTRL(dlg, "npWorkFilename", wxFilePickerCtrl)->GetPath();
+			if (fileName.Lower().EndsWith(".nif"))
+			{
+				if (!keepShapes)
+					ret = project->ImportNIF(fileName.ToUTF8().data(), true, outfitName);
+				else
+					ret = project->ImportNIF(fileName.ToUTF8().data(), false);
+			}
+			else if (fileName.Lower().EndsWith(".obj"))
+				ret = project->ImportOBJ(fileName.ToUTF8().data(), outfitName);
+			else if (fileName.Lower().EndsWith(".fbx"))
+				ret = project->ImportFBX(fileName.ToUTF8().data(), outfitName);
+		}
 		else
-			outfitRoot = outfitShapes->AppendItem(shapesRoot, wxString::FromUTF8(project->OutfitName()));
-	}
+			project->ClearOutfit();
 
-	wxTreeItemId item;
-	wxTreeItemId firstItem;
-	wxTreeItemId prevFirstSelItem;
-	for (auto &shape : shapes) {
-		auto itemData = new ShapeItemData(shape);
-		item = outfitShapes->AppendItem(outfitRoot, wxString::FromUTF8(shape->name.get()));
-		outfitShapes->SetItemState(item, 0);
-		outfitShapes->SetItemData(item, itemData);
-
-		if (project->IsBaseShape(shape)) {
-			outfitShapes->SetItemBold(item);
-			outfitShapes->SetItemTextColour(item, wxColour(0, 255, 0));
+		if (ret)
+		{
+			EndProgress();
+			RefreshGUIFromProj();
+			return;
 		}
 
-		auto it = std::find_if(prevStates.begin(), prevStates.end(), [&shape](const ShapeItemState& state) {
-			return state.shape == shape;
-		});
-
-		if (it != prevStates.end()) {
-			outfitShapes->SetItemState(item, it->state);
-
-			if (it->selected) {
-				outfitShapes->SelectItem(item);
-				selectedItems.push_back(itemData);
-
-				if (!prevFirstSelItem.IsOk())
-					prevFirstSelItem = item;
-			}
+		if (XRCCTRL(dlg, "npTexAuto", wxRadioButton)->GetValue() == true)
+			project->SetTextures();
+		else
+		{
+			std::vector<std::string> texVec = { XRCCTRL(dlg, "npTexFilename", wxFilePickerCtrl)->GetPath().ToUTF8().data() };
+			project->SetTextures(texVec);
 		}
 
-		if (!firstItem.IsOk())
-			firstItem = item;
+		wxLogMessage("Creating outfit...");
+		UpdateProgress(50, _("Creating outfit..."));
+		RefreshGUIFromProj();
+
+		UpdateTitle();
+
+		wxLogMessage("Outfit loaded.");
+		UpdateProgress(100, _("Finished"));
+		EndProgress();
 	}
 
-	UnlockShapeSelect();
+	void OutfitStudioFrame::OnUnloadProject(wxCommandEvent& WXUNUSED(event)) {
+		wxMessageDialog dlg(this, _("Unload the project? All unsaved changes will be lost"), _("Unload Project"), wxOK | wxCANCEL | wxICON_WARNING | wxCANCEL_DEFAULT);
+		dlg.SetOKCancelLabels(_("Unload"), _("Cancel"));
+		if (dlg.ShowModal() != wxID_OK)
+			return;
 
-	if (prevFirstSelItem.IsOk())
-		activeItem = (ShapeItemData*)outfitShapes->GetItemData(prevFirstSelItem);
-	else if (firstItem.IsOk())
-		outfitShapes->SelectItem(firstItem);
-	else
-		activeItem = nullptr;
+		wxLogMessage("Unloading project...");
+		menuBar->Enable(XRCID("fileSave"), false);
 
-	outfitShapes->ExpandAll();
-	MeshesFromProj();
+		ClearProject();
+		project->ClearReference();
+		project->ClearOutfit();
 
-	UpdateAnimationGUI();
+		glView->Cleanup();
+		glView->GetUndoHistory()->ClearHistory();
 
-	if (outfitRoot.IsOk()) {
-		wxTreeItemIdValue cookie;
-		wxTreeItemId child = outfitShapes->GetFirstChild(outfitRoot, cookie);
-		while (child.IsOk()) {
-			bool vis = true;
-			bool ghost = false;
-
-			int state = outfitShapes->GetItemState(child);
-			switch (state) {
-			case 1:
-				vis = false;
-				ghost = false;
-				break;
-			case 2:
-				vis = true;
-				ghost = true;
-				break;
-			default:
-				vis = true;
-				ghost = false;
-				break;
-			}
-
-			std::string shapeName{outfitShapes->GetItemText(child).ToUTF8()};
-			glView->SetShapeGhostMode(shapeName, ghost);
-			glView->ShowShape(shapeName, vis);
-			child = outfitShapes->GetNextChild(outfitRoot, cookie);
-		}
-	}
-
-	UpdateUndoTools();
-	glView->UpdateFloor();
-
-	if (render)
-		glView->Render();
-}
-
-void OutfitStudioFrame::UpdateAnimationGUI() {
-	// Preserve x-mirror and pose bones
-	int xMChoice = cXMirrorBone->GetSelection();
-	std::string manualXMirrorBone;
-	if (xMChoice >= 2)
-		manualXMirrorBone = cXMirrorBone->GetString(xMChoice);
-
-	std::string poseBone;
-	int poseBoneSel = cPoseBone->GetSelection();
-	if (poseBoneSel != wxNOT_FOUND)
-		poseBone = cPoseBone->GetString(poseBoneSel).ToStdString();
-
-	if (lastSelectedBones.count(activeBone) == 0)
-		activeBone.clear();
-
-	UpdateBoneTree();
-
-	cXMirrorBone->Clear();
-	cXMirrorBone->AppendString("None");
-	cXMirrorBone->AppendString("Auto");
-	cXMirrorBone->SetSelection(xMChoice == 1 ? 1 : 0);
-	cPoseBone->Clear();
-
-	std::vector<std::string> activeBones;
-	project->GetActiveBones(activeBones);
-
-	// Re-fill mirror and pose bone lists
-	for (auto &bone : activeBones) {
-		cXMirrorBone->AppendString(bone);
-
-		if (xMChoice >= 2 && bone == manualXMirrorBone)
-			cXMirrorBone->SetSelection(cXMirrorBone->GetCount() - 1);
-
-		cPoseBone->AppendString(bone);
-
-		if (poseBone == bone)
-			cPoseBone->SetSelection(cPoseBone->GetCount() - 1);
-	}
-
-	CalcAutoXMirrorBone();
-
-	if (cPoseBone->GetSelection() == wxNOT_FOUND && cPoseBone->GetCount() > 0)
-		cPoseBone->SetSelection(0);
-
-	auto cPoseName = (wxChoice*)FindWindowByName("cPoseName");
-	cPoseName->Clear();
-
-	std::string poseDataPath = GetProjectPath() + "/PoseData";
-	poseDataCollection.LoadData(poseDataPath);
-
-	for (auto &poseData : poseDataCollection.poseData) {
-		wxString poseName = wxString::FromUTF8(poseData.name);
-		cPoseName->Append(poseName, &poseData);
-	}
-
-	RefreshGUIWeightColors();
-	PoseToGUI();
-
-	glView->UpdateNodes();
-	glView->UpdateBones();
-}
-
-void OutfitStudioFrame::UpdateBoneTree() {
-	bool saveRUI = recursingUI;
-	recursingUI = true;
-
-	// Clear bone tree
-	if (outfitBones->GetChildrenCount(bonesRoot) > 0)
-		outfitBones->DeleteChildren(bonesRoot);
-
-	wxString filterStr = bonesFilter->GetValue();
-	filterStr.MakeLower();
-
-	// Refill bone tree, re-setting normalize state and re-selecting bones
-	std::vector<std::string> activeBones;
-	project->GetActiveBones(activeBones);
-
-	for (auto &bone : activeBones) {
-		// Filter out bone by name
-		wxString boneStr = wxString::FromUTF8(bone);
-		if (!boneStr.Lower().Contains(filterStr))
-			continue;
-
-		wxTreeItemId item = outfitBones->AppendItem(bonesRoot, boneStr);
-		outfitBones->SetItemState(item, lastNormalizeBones.count(bone) != 0 ? 1 : 0);
-
-		if (lastSelectedBones.count(bone) != 0) {
-			outfitBones->SelectItem(item);
-			if (activeBone.empty())
-				activeBone = bone;
-		}
-	}
-
-	recursingUI = saveRUI;
-
-	HighlightBoneNamesWithWeights();
-	UpdateBoneCounts();
-}
-
-void OutfitStudioFrame::MeshesFromProj(const bool reloadTextures) {
-	for (auto &shape : project->GetWorkNif()->GetShapes())
-		MeshFromProj(shape, reloadTextures);
-
-	if (glView->GetVertexEdit())
-		glView->ShowVertexEdit();
-}
-
-void OutfitStudioFrame::MeshFromProj(NiShape* shape, const bool reloadTextures) {
-	if (editUV)
-		editUV->Close();
-
-	if (extInitialized) {
-		glView->DeleteMesh(shape->name.get());
-		glView->AddMeshFromNif(project->GetWorkNif(), shape->name.get());
-
-		MaterialFile matFile;
-		bool hasMatFile = project->GetShapeMaterialFile(shape, matFile);
-		glView->SetMeshTextures(shape->name.get(), project->GetShapeTextures(shape), hasMatFile, matFile, reloadTextures);
-
-		UpdateMeshFromSet(shape);
-	}
-
-	std::vector<std::string> selShapes;
-	for (auto &i : selectedItems)
-		selShapes.push_back(i->GetShape()->name.get());
-
-	glView->SetActiveShapes(selShapes);
-
-	if (activeItem)
-		glView->SetSelectedShape(activeItem->GetShape()->name.get());
-	else
-		glView->SetSelectedShape("");
-}
-
-void OutfitStudioFrame::UpdateMeshFromSet(NiShape* shape) {
-	std::string shapeName = shape->name.get();
-	mesh* m = glView->GetMesh(shapeName);
-	if (m) {
-		m->smoothSeamNormals = project->activeSet.GetSmoothSeamNormals(shapeName);
-		m->lockNormals = project->activeSet.GetLockNormals(shapeName);
-	}
-}
-
-void OutfitStudioFrame::FillVertexColors() {
-	std::vector<std::string> shapeNames = project->GetWorkNif()->GetShapeNames();
-
-	for (auto &s : shapeNames) {
-		mesh* m = glView->GetMesh(s);
-		if (!m)
-			continue;
-
-		m->ColorFill(Vector3(1.0f, 1.0f, 1.0f));
-		m->AlphaFill(1.0f);
-
-		const std::vector<Color4>* vcolors = project->GetWorkNif()->GetColorsForShape(s);
-		if (vcolors) {
-			for (size_t v = 0; v < vcolors->size(); v++) {
-				m->vcolors[v].x = vcolors->at(v).r;
-				m->vcolors[v].y = vcolors->at(v).g;
-				m->vcolors[v].z = vcolors->at(v).b;
-				m->valpha[v] = vcolors->at(v).a;
-			}
-		}
-	}
-}
-
-void OutfitStudioFrame::OnSSSNameCopy(wxCommandEvent& event) {
-	wxWindow* win = ((wxButton*)event.GetEventObject())->GetParent();
-	std::string copyStr{XRCCTRL(*win, "sssName", wxTextCtrl)->GetValue().ToUTF8()};
-
-	project->ReplaceForbidden(copyStr);
-
-	wxString defStr = wxString::FromUTF8(copyStr);
-	wxString defSliderSetFile = defStr + ".osp";
-	wxString defShapeDataDir = defStr;
-	wxString defOutputFile = defStr + ".nif";
-
-	wxFilePickerCtrl* fp = (wxFilePickerCtrl*)win->FindWindowByName("sssSliderSetFile");
-	fp->SetPath(defSliderSetFile);
-
-	wxDirPickerCtrl* dp = (wxDirPickerCtrl*)win->FindWindowByName("sssShapeDataFolder");
-	dp->SetPath(defShapeDataDir);
-
-	fp = (wxFilePickerCtrl*)win->FindWindowByName("sssShapeDataFile");
-	fp->SetPath(defOutputFile);
-}
-
-void OutfitStudioFrame::OnSSSGenWeightsTrue(wxCommandEvent& event) {
-	wxWindow* win = ((wxRadioButton*)event.GetEventObject())->GetParent();
-	XRCCTRL(*win, "m_lowHighInfo", wxStaticText)->SetLabel("_0/_1.nif");
-}
-
-void OutfitStudioFrame::OnSSSGenWeightsFalse(wxCommandEvent& event) {
-	wxWindow* win = ((wxRadioButton*)event.GetEventObject())->GetParent();
-	XRCCTRL(*win, "m_lowHighInfo", wxStaticText)->SetLabel(".nif");
-}
-
-void OutfitStudioFrame::OnSaveSliderSet(wxCommandEvent& WXUNUSED(event)) {
-	SaveProject();
-}
-
-void OutfitStudioFrame::OnSaveSliderSetAs(wxCommandEvent& WXUNUSED(event)) {
-	SaveProjectAs();
-}
-
-void OutfitStudioFrame::OnSetBaseShape(wxCommandEvent& WXUNUSED(event)) {
-	wxLogMessage("Setting new base shape.");
-	project->ClearBoneScale();
-
-	for (auto &s : project->GetWorkNif()->GetShapes())
-		UpdateShapeSource(s);
-
-	ZeroSliders();
-	if (!activeSlider.empty()) {
-		bEditSlider = false;
-		SliderDisplay* d = sliderDisplays[activeSlider];
-		d->slider->SetFocus();
-		HighlightSlider("");
 		activeSlider.clear();
+		lastActiveSlider.clear();
+		bEditSlider = false;
+		MenuExitSliderEdit();
+
+		delete project;
+		project = new OutfitProject(this);
+
+		CreateSetSliders();
+		RefreshGUIFromProj(false);
+		glView->Render();
 	}
-}
 
-void OutfitStudioFrame::OnImportNIF(wxCommandEvent& WXUNUSED(event)) {
-	wxFileDialog importDialog(this, _("Import NIF file"), wxEmptyString, wxEmptyString, "NIF Files (*.nif)|*.nif", wxFD_FILE_MUST_EXIST | wxFD_MULTIPLE);
-	if (importDialog.ShowModal() == wxID_CANCEL)
-		return;
+	void OutfitStudioFrame::UpdateReferenceTemplates() {
+		refTemplates.clear();
 
-	wxArrayString fileNames;
-	importDialog.GetPaths(fileNames);
+		std::string fileName = GetProjectPath() + "/RefTemplates.xml";
+		if (wxFileName::IsFileReadable(fileName))
+		{
+			RefTemplateFile refTemplateFile(fileName);
+			refTemplateFile.GetAll(refTemplates);
+		}
 
-	StartProgress(_("Importing NIF file..."));
-	UpdateProgress(1, _("Importing NIF file..."));
+		RefTemplateCollection refTemplateCol;
+		refTemplateCol.Load(GetProjectPath() + "/RefTemplates");
+		refTemplateCol.GetAll(refTemplates);
+	}
 
-	for (auto &fileName : fileNames)
-		project->ImportNIF(fileName.ToUTF8().data(), false);
+	void OutfitStudioFrame::ClearProject() {
+		if (editUV)
+			editUV->Close();
 
-	UpdateProgress(60, _("Refreshing GUI..."));
-	project->SetTextures();
+		for (auto &s : project->GetWorkNif()->GetShapeNames())
+			glView->DeleteMesh(s);
 
-	SetPendingChanges();
-	RefreshGUIFromProj();
+		project->mFileName.clear();
+		project->mOutfitName.clear();
+		project->mDataDir.clear();
+		project->mBaseFile.clear();
+		project->mGamePath.clear();
+		project->mGameFile.clear();
 
-	UpdateProgress(100, _("Finished."));
-	EndProgress();
-}
+		if (wxGetApp().targetGame == SKYRIM || wxGetApp().targetGame == SKYRIMSE || wxGetApp().targetGame == SKYRIMVR)
+			project->mGenWeights = true;
+		else
+			project->mGenWeights = false;
 
-void OutfitStudioFrame::OnExportNIF(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetWorkNif()->IsValid())
-		return;
+		project->mCopyRef = true;
 
-	if (HasUnweightedCheck())
-		return;
+		glView->ClearOverlays();
+		activePartition.Unset();
+		activeSegment.Unset();
 
-	wxString fileName = wxFileSelector(_("Export outfit NIF"), wxEmptyString, wxEmptyString, ".nif", "*.nif", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
-	if (fileName.IsEmpty())
-		return;
+		lastSelectedBones.clear();
+		lastNormalizeBones.clear();
 
-	wxLogMessage("Exporting project to NIF file '%s'...", fileName);
-	project->ClearBoneScale();
+		if (currentTabButton)
+			currentTabButton->SetPendingChanges(false);
 
-	std::vector<mesh*> shapeMeshes;
-	for (auto &s : project->GetWorkNif()->GetShapes()) {
-		if (!project->IsBaseShape(s)) {
-			mesh* m = glView->GetMesh(s->name.get());
+		auto cMaskName = (wxChoice*)FindWindowByName("cMaskName");
+		cMaskName->Clear();
+
+		auto cPoseName = (wxChoice*)FindWindowByName("cPoseName");
+		cPoseName->Clear();
+
+		project->outfitName.clear();
+		pendingChanges = false;
+		UpdateTitle();
+	}
+
+	void OutfitStudioFrame::RenameProject(const std::string& projectName) {
+		project->outfitName = projectName;
+		if (outfitRoot.IsOk())
+			outfitShapes->SetItemText(outfitRoot, wxString::FromUTF8(projectName));
+
+		UpdateTitle();
+	}
+
+	void OutfitStudioFrame::LockShapeSelect() {
+		selectionLocked = true;
+		outfitShapes->Disable();
+	}
+
+	void OutfitStudioFrame::UnlockShapeSelect() {
+		selectionLocked = false;
+		outfitShapes->Enable();
+	}
+
+	void OutfitStudioFrame::RefreshGUIFromProj(bool render) {
+		LockShapeSelect();
+
+		selectedItems.clear();
+		std::vector<ShapeItemState> prevStates;
+
+		if (outfitRoot.IsOk())
+		{
+			wxTreeItemIdValue cookie;
+			wxTreeItemId child = outfitShapes->GetFirstChild(outfitRoot, cookie);
+			while (child.IsOk())
+			{
+				auto itemData = (ShapeItemData*)outfitShapes->GetItemData(child);
+				if (itemData)
+				{
+					ShapeItemState prevState;
+					prevState.shape = itemData->GetShape();
+					prevState.state = outfitShapes->GetItemState(child);
+
+					if (outfitShapes->IsSelected(child))
+						prevState.selected = true;
+
+					prevStates.push_back(prevState);
+				}
+
+				child = outfitShapes->GetNextChild(outfitRoot, cookie);
+			}
+
+			outfitShapes->UnselectAll();
+			outfitShapes->DeleteChildren(outfitRoot);
+			outfitShapes->Delete(outfitRoot);
+			outfitRoot.Unset();
+		}
+
+		auto shapes = project->GetWorkNif()->GetShapes();
+		if (shapes.size() > 0)
+		{
+			if (shapes.size() == 1 && project->IsBaseShape(shapes.front()))
+				outfitRoot = outfitShapes->AppendItem(shapesRoot, "Reference Only");
+			else
+				outfitRoot = outfitShapes->AppendItem(shapesRoot, wxString::FromUTF8(project->OutfitName()));
+		}
+
+		wxTreeItemId item;
+		wxTreeItemId firstItem;
+		wxTreeItemId prevFirstSelItem;
+		for (auto &shape : shapes)
+		{
+			auto itemData = new ShapeItemData(shape);
+			item = outfitShapes->AppendItem(outfitRoot, wxString::FromUTF8(shape->name.get()));
+			outfitShapes->SetItemState(item, 0);
+			outfitShapes->SetItemData(item, itemData);
+
+			if (project->IsBaseShape(shape))
+			{
+				outfitShapes->SetItemBold(item);
+				outfitShapes->SetItemTextColour(item, wxColour(0, 255, 0));
+			}
+
+			auto it = std::find_if(prevStates.begin(), prevStates.end(), [&shape](const ShapeItemState& state)
+			{
+				return state.shape == shape;
+			});
+
+			if (it != prevStates.end())
+			{
+				outfitShapes->SetItemState(item, it->state);
+
+				if (it->selected)
+				{
+					outfitShapes->SelectItem(item);
+					selectedItems.push_back(itemData);
+
+					if (!prevFirstSelItem.IsOk())
+						prevFirstSelItem = item;
+				}
+			}
+
+			if (!firstItem.IsOk())
+				firstItem = item;
+		}
+
+		UnlockShapeSelect();
+
+		if (prevFirstSelItem.IsOk())
+			activeItem = (ShapeItemData*)outfitShapes->GetItemData(prevFirstSelItem);
+		else if (firstItem.IsOk())
+			outfitShapes->SelectItem(firstItem);
+		else
+			activeItem = nullptr;
+
+		outfitShapes->ExpandAll();
+		MeshesFromProj();
+
+		UpdateAnimationGUI();
+
+		if (outfitRoot.IsOk())
+		{
+			wxTreeItemIdValue cookie;
+			wxTreeItemId child = outfitShapes->GetFirstChild(outfitRoot, cookie);
+			while (child.IsOk())
+			{
+				bool vis = true;
+				bool ghost = false;
+
+				int state = outfitShapes->GetItemState(child);
+				switch (state)
+				{
+				case 1:
+					vis = false;
+					ghost = false;
+					break;
+				case 2:
+					vis = true;
+					ghost = true;
+					break;
+				default:
+					vis = true;
+					ghost = false;
+					break;
+				}
+
+				std::string shapeName{outfitShapes->GetItemText(child).ToUTF8()};
+				glView->SetShapeGhostMode(shapeName, ghost);
+				glView->ShowShape(shapeName, vis);
+				child = outfitShapes->GetNextChild(outfitRoot, cookie);
+			}
+		}
+
+		UpdateUndoTools();
+		glView->UpdateFloor();
+
+		if (render)
+			glView->Render();
+	}
+
+	void OutfitStudioFrame::UpdateAnimationGUI() {
+		// Preserve x-mirror and pose bones
+		int xMChoice = cXMirrorBone->GetSelection();
+		std::string manualXMirrorBone;
+		if (xMChoice >= 2)
+			manualXMirrorBone = cXMirrorBone->GetString(xMChoice);
+
+		std::string poseBone;
+		int poseBoneSel = cPoseBone->GetSelection();
+		if (poseBoneSel != wxNOT_FOUND)
+			poseBone = cPoseBone->GetString(poseBoneSel).ToStdString();
+
+		if (lastSelectedBones.count(activeBone) == 0)
+			activeBone.clear();
+
+		UpdateBoneTree();
+
+		cXMirrorBone->Clear();
+		cXMirrorBone->AppendString("None");
+		cXMirrorBone->AppendString("Auto");
+		cXMirrorBone->SetSelection(xMChoice == 1 ? 1 : 0);
+		cPoseBone->Clear();
+
+		std::vector<std::string> activeBones;
+		project->GetActiveBones(activeBones);
+
+		// Re-fill mirror and pose bone lists
+		for (auto &bone : activeBones)
+		{
+			cXMirrorBone->AppendString(bone);
+
+			if (xMChoice >= 2 && bone == manualXMirrorBone)
+				cXMirrorBone->SetSelection(cXMirrorBone->GetCount() - 1);
+
+			cPoseBone->AppendString(bone);
+
+			if (poseBone == bone)
+				cPoseBone->SetSelection(cPoseBone->GetCount() - 1);
+		}
+
+		CalcAutoXMirrorBone();
+
+		if (cPoseBone->GetSelection() == wxNOT_FOUND && cPoseBone->GetCount() > 0)
+			cPoseBone->SetSelection(0);
+
+		auto cPoseName = (wxChoice*)FindWindowByName("cPoseName");
+		cPoseName->Clear();
+
+		std::string poseDataPath = GetProjectPath() + "/PoseData";
+		poseDataCollection.LoadData(poseDataPath);
+
+		for (auto &poseData : poseDataCollection.poseData)
+		{
+			wxString poseName = wxString::FromUTF8(poseData.name);
+			cPoseName->Append(poseName, &poseData);
+		}
+
+		RefreshGUIWeightColors();
+		PoseToGUI();
+
+		glView->UpdateNodes();
+		glView->UpdateBones();
+	}
+
+	void OutfitStudioFrame::UpdateBoneTree() {
+		bool saveRUI = recursingUI;
+		recursingUI = true;
+
+		// Clear bone tree
+		if (outfitBones->GetChildrenCount(bonesRoot) > 0)
+			outfitBones->DeleteChildren(bonesRoot);
+
+		wxString filterStr = bonesFilter->GetValue();
+		filterStr.MakeLower();
+
+		// Refill bone tree, re-setting normalize state and re-selecting bones
+		std::vector<std::string> activeBones;
+		project->GetActiveBones(activeBones);
+
+		for (auto &bone : activeBones)
+		{
+			// Filter out bone by name
+			wxString boneStr = wxString::FromUTF8(bone);
+			if (!boneStr.Lower().Contains(filterStr))
+				continue;
+
+			wxTreeItemId item = outfitBones->AppendItem(bonesRoot, boneStr);
+			outfitBones->SetItemState(item, lastNormalizeBones.count(bone) != 0 ? 1 : 0);
+
+			if (lastSelectedBones.count(bone) != 0)
+			{
+				outfitBones->SelectItem(item);
+				if (activeBone.empty())
+					activeBone = bone;
+			}
+		}
+
+		recursingUI = saveRUI;
+
+		HighlightBoneNamesWithWeights();
+		UpdateBoneCounts();
+	}
+
+	void OutfitStudioFrame::MeshesFromProj(const bool reloadTextures) {
+		for (auto &shape : project->GetWorkNif()->GetShapes())
+			MeshFromProj(shape, reloadTextures);
+
+		if (glView->GetVertexEdit())
+			glView->ShowVertexEdit();
+	}
+
+	void OutfitStudioFrame::MeshFromProj(NiShape* shape, const bool reloadTextures) {
+		if (editUV)
+			editUV->Close();
+
+		if (extInitialized)
+		{
+			glView->DeleteMesh(shape->name.get());
+			glView->AddMeshFromNif(project->GetWorkNif(), shape->name.get());
+
+			MaterialFile matFile;
+			bool hasMatFile = project->GetShapeMaterialFile(shape, matFile);
+			glView->SetMeshTextures(shape->name.get(), project->GetShapeTextures(shape), hasMatFile, matFile, reloadTextures);
+
+			UpdateMeshFromSet(shape);
+		}
+
+		std::vector<std::string> selShapes;
+		for (auto &i : selectedItems)
+			selShapes.push_back(i->GetShape()->name.get());
+
+		glView->SetActiveShapes(selShapes);
+
+		if (activeItem)
+			glView->SetSelectedShape(activeItem->GetShape()->name.get());
+		else
+			glView->SetSelectedShape("");
+	}
+
+	void OutfitStudioFrame::UpdateMeshFromSet(NiShape* shape) {
+		std::string shapeName = shape->name.get();
+		mesh* m = glView->GetMesh(shapeName);
+		if (m)
+		{
+			m->smoothSeamNormals = project->activeSet.GetSmoothSeamNormals(shapeName);
+			m->lockNormals = project->activeSet.GetLockNormals(shapeName);
+		}
+	}
+
+	void OutfitStudioFrame::FillVertexColors() {
+		std::vector<std::string> shapeNames = project->GetWorkNif()->GetShapeNames();
+
+		for (auto &s : shapeNames)
+		{
+			mesh* m = glView->GetMesh(s);
+			if (!m)
+				continue;
+
+			m->ColorFill(Vector3(1.0f, 1.0f, 1.0f));
+			m->AlphaFill(1.0f);
+
+			const std::vector<Color4>* vcolors = project->GetWorkNif()->GetColorsForShape(s);
+			if (vcolors)
+			{
+				for (size_t v = 0; v < vcolors->size(); v++)
+				{
+					m->vcolors[v].x = vcolors->at(v).r;
+					m->vcolors[v].y = vcolors->at(v).g;
+					m->vcolors[v].z = vcolors->at(v).b;
+					m->valpha[v] = vcolors->at(v).a;
+				}
+			}
+		}
+	}
+
+	void OutfitStudioFrame::OnSSSNameCopy(wxCommandEvent& event) {
+		wxWindow* win = ((wxButton*)event.GetEventObject())->GetParent();
+		std::string copyStr{XRCCTRL(*win, "sssName", wxTextCtrl)->GetValue().ToUTF8()};
+
+		project->ReplaceForbidden(copyStr);
+
+		wxString defStr = wxString::FromUTF8(copyStr);
+		wxString defSliderSetFile = defStr + ".osp";
+		wxString defShapeDataDir = defStr;
+		wxString defOutputFile = defStr + ".nif";
+
+		wxFilePickerCtrl* fp = (wxFilePickerCtrl*)win->FindWindowByName("sssSliderSetFile");
+		fp->SetPath(defSliderSetFile);
+
+		wxDirPickerCtrl* dp = (wxDirPickerCtrl*)win->FindWindowByName("sssShapeDataFolder");
+		dp->SetPath(defShapeDataDir);
+
+		fp = (wxFilePickerCtrl*)win->FindWindowByName("sssShapeDataFile");
+		fp->SetPath(defOutputFile);
+	}
+
+	void OutfitStudioFrame::OnSSSGenWeightsTrue(wxCommandEvent& event) {
+		wxWindow* win = ((wxRadioButton*)event.GetEventObject())->GetParent();
+		XRCCTRL(*win, "m_lowHighInfo", wxStaticText)->SetLabel("_0/_1.nif");
+	}
+
+	void OutfitStudioFrame::OnSSSGenWeightsFalse(wxCommandEvent& event) {
+		wxWindow* win = ((wxRadioButton*)event.GetEventObject())->GetParent();
+		XRCCTRL(*win, "m_lowHighInfo", wxStaticText)->SetLabel(".nif");
+	}
+
+	void OutfitStudioFrame::OnSaveSliderSet(wxCommandEvent& WXUNUSED(event))
+	{
+		SaveProject();
+	}
+
+	void OutfitStudioFrame::OnSaveSliderSetAs(wxCommandEvent& WXUNUSED(event))
+	{
+		SaveProjectAs();
+	}
+
+	void OutfitStudioFrame::OnSetBaseShape(wxCommandEvent& WXUNUSED(event)) {
+		wxLogMessage("Setting new base shape.");
+		project->ClearBoneScale();
+
+		for (auto &s : project->GetWorkNif()->GetShapes())
+			UpdateShapeSource(s);
+
+		ZeroSliders();
+		if (!activeSlider.empty())
+		{
+			bEditSlider = false;
+			SliderDisplay* d = sliderDisplays[activeSlider];
+			d->slider->SetFocus();
+			HighlightSlider("");
+			activeSlider.clear();
+		}
+	}
+
+	void OutfitStudioFrame::OnImportNIF(wxCommandEvent& WXUNUSED(event)) {
+		wxFileDialog importDialog(this, _("Import NIF file"), wxEmptyString, wxEmptyString, "NIF Files (*.nif)|*.nif", wxFD_FILE_MUST_EXIST | wxFD_MULTIPLE);
+		if (importDialog.ShowModal() == wxID_CANCEL)
+			return;
+
+		wxArrayString fileNames;
+		importDialog.GetPaths(fileNames);
+
+		StartProgress(_("Importing NIF file..."));
+		UpdateProgress(1, _("Importing NIF file..."));
+
+		for (auto &fileName : fileNames)
+			project->ImportNIF(fileName.ToUTF8().data(), false);
+
+		UpdateProgress(60, _("Refreshing GUI..."));
+		project->SetTextures();
+
+		SetPendingChanges();
+		RefreshGUIFromProj();
+
+		UpdateProgress(100, _("Finished."));
+		EndProgress();
+	}
+
+	void OutfitStudioFrame::OnExportNIF(wxCommandEvent& WXUNUSED(event)) {
+		if (!project->GetWorkNif()->IsValid())
+			return;
+
+		if (HasUnweightedCheck())
+			return;
+
+		wxString fileName = wxFileSelector(_("Export outfit NIF"), wxEmptyString, wxEmptyString, ".nif", "*.nif", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
+		if (fileName.IsEmpty())
+			return;
+
+		wxLogMessage("Exporting project to NIF file '%s'...", fileName);
+		project->ClearBoneScale();
+
+		std::vector<mesh*> shapeMeshes;
+		for (auto &s : project->GetWorkNif()->GetShapes())
+		{
+			if (!project->IsBaseShape(s))
+			{
+				mesh* m = glView->GetMesh(s->name.get());
+				if (m)
+					shapeMeshes.push_back(m);
+			}
+		}
+
+		int error = project->ExportNIF(fileName.ToUTF8().data(), shapeMeshes);
+		if (error)
+		{
+			wxLogError("Failed to save NIF file '%s'!", fileName);
+			wxMessageBox(wxString::Format(_("Failed to save NIF file '%s'!"), fileName), _("Export Error"), wxICON_ERROR);
+		}
+	}
+
+	void OutfitStudioFrame::OnExportNIFWithRef(wxCommandEvent& event) {
+		if (!project->GetWorkNif()->IsValid())
+			return;
+
+		if (!project->GetBaseShape())
+		{
+			OnExportNIF(event);
+			return;
+		}
+
+		if (HasUnweightedCheck())
+			return;
+
+		wxString fileName = wxFileSelector(_("Export project NIF"), wxEmptyString, wxEmptyString, ".nif", "*.nif", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
+		if (fileName.IsEmpty())
+			return;
+
+		wxLogMessage("Exporting project with reference to NIF file '%s'...", fileName);
+		project->ClearBoneScale();
+
+		std::vector<mesh*> shapeMeshes;
+		for (auto &s : project->GetWorkNif()->GetShapeNames())
+		{
+			mesh* m = glView->GetMesh(s);
 			if (m)
 				shapeMeshes.push_back(m);
 		}
+
+		int error = project->ExportNIF(fileName.ToUTF8().data(), shapeMeshes, true);
+		if (error)
+		{
+			wxLogError("Failed to save NIF file '%s' with reference!", fileName);
+			wxMessageBox(wxString::Format(_("Failed to save NIF file '%s' with reference!"), fileName), _("Export Error"), wxICON_ERROR);
+		}
 	}
 
-	int error = project->ExportNIF(fileName.ToUTF8().data(), shapeMeshes);
-	if (error) {
-		wxLogError("Failed to save NIF file '%s'!", fileName);
-		wxMessageBox(wxString::Format(_("Failed to save NIF file '%s'!"), fileName), _("Export Error"), wxICON_ERROR);
-	}
-}
+	int OutfitStudioFrame::BakeConversionReference() const
+	{
+		if (!project->GetWorkNif()->IsValid())
+			return 1;
 
-void OutfitStudioFrame::OnExportNIFWithRef(wxCommandEvent& event) {
-	if (!project->GetWorkNif()->IsValid())
-		return;
+		wxLogMessage("Baking nif with reference");
+		project->ClearBoneScale();
 
-	if (!project->GetBaseShape()) {
-		OnExportNIF(event);
-		return;
-	}
+		std::vector<mesh*> shapeMeshes;
+		for (auto &s : project->GetWorkNif()->GetShapeNames())
+		{
+			mesh* m = glView->GetMesh(s);
+			if (m)
+				shapeMeshes.push_back(m);
+		}
 
-	if (HasUnweightedCheck())
-		return;
-
-	wxString fileName = wxFileSelector(_("Export project NIF"), wxEmptyString, wxEmptyString, ".nif", "*.nif", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
-	if (fileName.IsEmpty())
-		return;
-
-	wxLogMessage("Exporting project with reference to NIF file '%s'...", fileName);
-	project->ClearBoneScale();
-
-	std::vector<mesh*> shapeMeshes;
-	for (auto &s : project->GetWorkNif()->GetShapeNames()) {
-		mesh* m = glView->GetMesh(s);
-		if (m)
-			shapeMeshes.push_back(m);
+		return project->BakeConversionReference(shapeMeshes, project->GetBaseShape() != nullptr);
 	}
 
-	int error = project->ExportNIF(fileName.ToUTF8().data(), shapeMeshes, true);
-	if (error) {
-		wxLogError("Failed to save NIF file '%s' with reference!", fileName);
-		wxMessageBox(wxString::Format(_("Failed to save NIF file '%s' with reference!"), fileName), _("Export Error"), wxICON_ERROR);
-	}
-}
-
-void OutfitStudioFrame::OnBakeNifInPlace(wxCommandEvent& event) {
-	if (!project->GetWorkNif()->IsValid())
-		return;
-
-	wxLogMessage("Baking nif with reference");
-	project->ClearBoneScale();
-
-	std::vector<mesh*> shapeMeshes;
-	for (auto &s : project->GetWorkNif()->GetShapeNames()) {
-		mesh* m = glView->GetMesh(s);
-		if (m)
-			shapeMeshes.push_back(m);
+	void OutfitStudioFrame::OnBakeConversionReference(wxCommandEvent& event)
+	{
+		int error = BakeConversionReference();
+		if (error)
+		{
+			wxLogError("Failed to bake conversion reference");
+			wxMessageBox("Failed to bake conversion reference", _("Bake Error"), wxICON_ERROR);
+		}
 	}
 
-	int error = project->BakeNifInPlace(shapeMeshes, project->GetBaseShape() != nullptr);
-	if (error) {
-		wxLogError("Failed to bake NIF");
-		wxMessageBox("Failed to bake NIF", _("Export Error"), wxICON_ERROR);
-	}
-}
-
-void OutfitStudioFrame::OnExportShapeNIF(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-
-	if (HasUnweightedCheck())
-		return;
-
-	wxString fileName = wxFileSelector(_("Export selected shapes to NIF"), wxEmptyString, wxEmptyString, ".nif", "*.nif", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
-	if (fileName.IsEmpty())
-		return;
-
-	std::vector<std::string> shapes;
-	for (auto &i : selectedItems)
-		shapes.push_back(i->GetShape()->name.get());
-
-	wxLogMessage("Exporting selected shapes to NIF file '%s'.", fileName);
-	project->ClearBoneScale();
-
-	if (project->ExportShapeNIF(fileName.ToUTF8().data(), shapes)) {
-		wxLogError("Failed to export selected shapes to NIF file '%s'!", fileName);
-		wxMessageBox(_("Failed to export selected shapes to NIF file!"), _("Error"), wxICON_ERROR);
-	}
-}
-
-void OutfitStudioFrame::OnImportOBJ(wxCommandEvent& WXUNUSED(event)) {
-	wxFileDialog importDialog(this, _("Import .obj file for new shape"), wxEmptyString, wxEmptyString, "OBJ Files (*.obj)|*.obj", wxFD_FILE_MUST_EXIST | wxFD_MULTIPLE);
-	if (importDialog.ShowModal() == wxID_CANCEL)
-		return;
-
-	wxArrayString fileNames;
-	importDialog.GetPaths(fileNames);
-
-	for (auto &fileName : fileNames) {
-		wxLogMessage("Importing shape(s) from OBJ file '%s'...", fileName);
-
-		int ret;
-		if (activeItem)
-			ret = project->ImportOBJ(fileName.ToUTF8().data(), project->OutfitName(), activeItem->GetShape());
-		else
-			ret = project->ImportOBJ(fileName.ToUTF8().data(), project->OutfitName());
-
-		if (ret == 101)
-			wxLogMessage("Updated shape '%s' from OBJ file '%s'.", activeItem->GetShape()->name.get(), fileName);
-	}
-
-	RefreshGUIFromProj(false);
-	SetPendingChanges();
-
-	wxLogMessage("Imported shape(s) from OBJ.");
-	glView->Render();
-}
-
-void OutfitStudioFrame::OnExportOBJ(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetWorkNif()->IsValid())
-		return;
-
-	bool hasSkinTrans = false;
-	for (NiShape *shape : project->GetWorkNif()->GetShapes()) {
-		if (!project->GetWorkAnim()->shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(MatTransform()))
-			hasSkinTrans = true;
-	}
-	bool transToGlobal = false;
-	if (hasSkinTrans) {
-		int res = wxMessageBox(_("Some of the shapes have skin coordinate systems that are not the same as the global coordinate system.  Should the geometry be transformed to global coordinates in the OBJ?  (This is not recommended.)"), _("Transform to global"), wxYES_NO | wxCANCEL);
-		if (res == wxCANCEL)
+	void OutfitStudioFrame::OnExportShapeNIF(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
 			return;
-		transToGlobal = (res == wxYES);
-	}
+		}
 
-	wxString fileName = wxFileSelector(_("Export project as an .obj file"), wxEmptyString, wxEmptyString, ".obj", "*.obj", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
-	if (fileName.IsEmpty())
-		return;
-
-	wxLogMessage("Exporting project to OBJ file '%s'...", fileName);
-	project->ClearBoneScale();
-
-	if (project->ExportOBJ(fileName.ToUTF8().data(), project->GetWorkNif()->GetShapes(), transToGlobal, Vector3(0.1f, 0.1f, 0.1f))) {
-		wxLogError("Failed to export OBJ file '%s'!", fileName);
-		wxMessageBox(_("Failed to export OBJ file!"), _("Export Error"), wxICON_ERROR);
-	}
-}
-
-void OutfitStudioFrame::OnExportShapeOBJ(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-
-	bool hasSkinTrans = false;
-	for (auto &i : selectedItems) {
-		NiShape *shape = i->GetShape();
-		if (!project->GetWorkAnim()->shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(MatTransform()))
-			hasSkinTrans = true;
-	}
-	bool transToGlobal = false;
-	if (hasSkinTrans) {
-		int res = wxMessageBox(_("Some of the shapes have skin coordinate systems that are not the same as the global coordinate system.  Should the geometry be transformed to global coordinates in the OBJ?"), _("Transform to global"), wxYES_NO | wxCANCEL);
-		if (res == wxCANCEL)
+		if (HasUnweightedCheck())
 			return;
-		transToGlobal = (res == wxYES);
-	}
 
-	if (selectedItems.size() > 1) {
-		wxString fileName = wxFileSelector(_("Export selected shapes as an .obj file"), wxEmptyString, wxEmptyString, ".obj", "OBJ Files (*.obj)|*.obj", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
+		wxString fileName = wxFileSelector(_("Export selected shapes to NIF"), wxEmptyString, wxEmptyString, ".nif", "*.nif", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
 		if (fileName.IsEmpty())
 			return;
 
-		wxLogMessage("Exporting selected shapes as OBJ file to '%s'.", fileName);
-		project->ClearBoneScale();
-
-		std::vector<NiShape*> shapes;
-		shapes.reserve(selectedItems.size());
+		std::vector<std::string> shapes;
 		for (auto &i : selectedItems)
-			shapes.push_back(i->GetShape());
+			shapes.push_back(i->GetShape()->name.get());
 
-		if (project->ExportOBJ(fileName.ToUTF8().data(), shapes, transToGlobal, Vector3(0.1f, 0.1f, 0.1f))) {
-			wxLogError("Failed to export OBJ file '%s'!", fileName);
-			wxMessageBox(_("Failed to export OBJ file!"), _("Error"), wxICON_ERROR);
-		}
-	}
-	else {
-		wxString fileName = wxFileSelector(_("Export shape as an .obj file"), wxEmptyString, wxString(activeItem->GetShape()->name.get() + ".obj"), ".obj", "OBJ Files (*.obj)|*.obj", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
-		if (fileName.IsEmpty())
-			return;
-
-		wxLogMessage("Exporting shape '%s' as OBJ file to '%s'.", activeItem->GetShape()->name.get(), fileName);
+		wxLogMessage("Exporting selected shapes to NIF file '%s'.", fileName);
 		project->ClearBoneScale();
 
-		std::vector<NiShape*> shapes = { activeItem->GetShape() };
-		if (project->ExportOBJ(fileName.ToUTF8().data(), shapes, transToGlobal, Vector3(0.1f, 0.1f, 0.1f))) {
-			wxLogError("Failed to export OBJ file '%s'!", fileName);
-			wxMessageBox(_("Failed to export OBJ file!"), _("Error"), wxICON_ERROR);
+		if (project->ExportShapeNIF(fileName.ToUTF8().data(), shapes))
+		{
+			wxLogError("Failed to export selected shapes to NIF file '%s'!", fileName);
+			wxMessageBox(_("Failed to export selected shapes to NIF file!"), _("Error"), wxICON_ERROR);
 		}
 	}
-}
 
-void OutfitStudioFrame::OnImportFBX(wxCommandEvent& WXUNUSED(event)) {
-	wxFileDialog importDialog(this, _("Import .fbx file for new shape"), wxEmptyString, wxEmptyString, "FBX Files (*.fbx)|*.fbx", wxFD_FILE_MUST_EXIST | wxFD_MULTIPLE);
-	if (importDialog.ShowModal() == wxID_CANCEL)
-		return;
-
-	wxArrayString fileNames;
-	importDialog.GetPaths(fileNames);
-
-	for (auto &fileName : fileNames) {
-		wxLogMessage("Importing shape(s) from FBX file '%s'...", fileName);
-
-		int ret;
-		if (activeItem)
-			ret = project->ImportFBX(fileName.ToUTF8().data(), project->OutfitName(), activeItem->GetShape());
-		else
-			ret = project->ImportFBX(fileName.ToUTF8().data(), project->OutfitName());
-
-		if (ret == 101)
-			wxLogMessage("Updated shape '%s' from FBX file '%s'.", activeItem->GetShape()->name.get(), fileName);
-	}
-
-	RefreshGUIFromProj(false);
-	SetPendingChanges();
-
-	wxLogMessage("Imported shape(s) from FBX.");
-	glView->Render();
-}
-
-void OutfitStudioFrame::OnExportFBX(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetWorkNif()->IsValid())
-		return;
-
-	if (HasUnweightedCheck())
-		return;
-
-	bool hasSkinTrans = false;
-	for (NiShape *shape : project->GetWorkNif()->GetShapes()) {
-		if (!project->GetWorkAnim()->shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(MatTransform()))
-			hasSkinTrans = true;
-	}
-	bool transToGlobal = false;
-	if (hasSkinTrans) {
-		int res = wxMessageBox(_("Some of the shapes have skin coordinate systems that are not the same as the global coordinate system.  Should the geometry be transformed to global coordinates in the FBX?  (This is not recommended.)"), _("Transform to global"), wxYES_NO | wxCANCEL);
-		if (res == wxCANCEL)
-			return;
-		transToGlobal = (res == wxYES);
-	}
-
-	wxString fileName = wxFileSelector(_("Export project as an .fbx file"), wxEmptyString, wxEmptyString, ".fbx", "FBX Files (*.fbx)|*.fbx", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
-	if (fileName.IsEmpty())
-		return;
-
-	wxLogMessage("Exporting project to OBJ file '%s'...", fileName);
-	project->ClearBoneScale();
-
-	if (!project->ExportFBX(fileName.ToUTF8().data(), project->GetWorkNif()->GetShapes(), transToGlobal)) {
-		wxLogError("Failed to export FBX file '%s'!", fileName);
-		wxMessageBox(_("Failed to export FBX file!"), _("Export Error"), wxICON_ERROR);
-	}
-}
-
-void OutfitStudioFrame::OnExportShapeFBX(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-
-	bool hasSkinTrans = false;
-	for (auto &i : selectedItems) {
-		NiShape *shape = i->GetShape();
-		if (!project->GetWorkAnim()->shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(MatTransform()))
-			hasSkinTrans = true;
-	}
-	bool transToGlobal = false;
-	if (hasSkinTrans) {
-		int res = wxMessageBox(_("Some of the shapes have skin coordinate systems that are not the same as the global coordinate system.  Should the geometry be transformed to global coordinates in the FBX?"), _("Transform to global"), wxYES_NO | wxCANCEL);
-		if (res == wxCANCEL)
-			return;
-		transToGlobal = (res == wxYES);
-	}
-
-	if (selectedItems.size() > 1) {
-		wxString fileName = wxFileSelector(_("Export selected shapes as an .fbx file"), wxEmptyString, wxEmptyString, ".fbx", "FBX Files (*.fbx)|*.fbx", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
-		if (fileName.IsEmpty())
+	void OutfitStudioFrame::OnImportOBJ(wxCommandEvent& WXUNUSED(event)) {
+		wxFileDialog importDialog(this, _("Import .obj file for new shape"), wxEmptyString, wxEmptyString, "OBJ Files (*.obj)|*.obj", wxFD_FILE_MUST_EXIST | wxFD_MULTIPLE);
+		if (importDialog.ShowModal() == wxID_CANCEL)
 			return;
 
-		wxLogMessage("Exporting selected shapes as FBX file to '%s'.", fileName);
-		project->ClearBoneScale();
+		wxArrayString fileNames;
+		importDialog.GetPaths(fileNames);
 
-		std::vector<NiShape*> shapes;
-		shapes.reserve(selectedItems.size());
-		for (auto &i : selectedItems)
-			shapes.push_back(i->GetShape());
+		for (auto &fileName : fileNames)
+		{
+			wxLogMessage("Importing shape(s) from OBJ file '%s'...", fileName);
 
-		if (!project->ExportFBX(fileName.ToUTF8().data(), shapes, transToGlobal)) {
-			wxLogError("Failed to export FBX file '%s'!", fileName);
-			wxMessageBox(_("Failed to export FBX file!"), _("Error"), wxICON_ERROR);
+			int ret;
+			if (activeItem)
+				ret = project->ImportOBJ(fileName.ToUTF8().data(), project->OutfitName(), activeItem->GetShape());
+			else
+				ret = project->ImportOBJ(fileName.ToUTF8().data(), project->OutfitName());
+
+			if (ret == 101)
+				wxLogMessage("Updated shape '%s' from OBJ file '%s'.", activeItem->GetShape()->name.get(), fileName);
 		}
-	}
-	else {
-		wxString fileName = wxFileSelector(_("Export shape as an .fbx file"), wxEmptyString, wxString(activeItem->GetShape()->name.get() + ".fbx"), ".fbx", "FBX Files (*.fbx)|*.fbx", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
-		if (fileName.IsEmpty())
-			return;
-
-		wxLogMessage("Exporting shape '%s' as FBX file to '%s'.", activeItem->GetShape()->name.get(), fileName);
-		project->ClearBoneScale();
-
-		std::vector<NiShape*> shapes = { activeItem->GetShape() };
-		if (!project->ExportFBX(fileName.ToUTF8().data(), shapes, transToGlobal)) {
-			wxLogError("Failed to export FBX file '%s'!", fileName);
-			wxMessageBox(_("Failed to export FBX file!"), _("Error"), wxICON_ERROR);
-		}
-	}
-}
-
-void OutfitStudioFrame::OnImportTRIHead(wxCommandEvent& WXUNUSED(event)) {
-	wxFileDialog importDialog(this, _("Import .tri morphs"), wxEmptyString, wxEmptyString, "TRI (Head) Files (*.tri)|*.tri", wxFD_FILE_MUST_EXIST | wxFD_MULTIPLE);
-	if (importDialog.ShowModal() == wxID_CANCEL)
-		return;
-
-	wxArrayString fileNames;
-	importDialog.GetPaths(fileNames);
-
-	sliderScroll->Freeze();
-	MenuExitSliderEdit();
-	sliderScroll->FitInside();
-	activeSlider.clear();
-
-	for (auto &fn : fileNames) {
-		wxFileName fileName(fn);
-		wxLogMessage("Importing morphs from TRI (head) file '%s'...", fn);
-
-		TriHeadFile tri;
-		if (!tri.Read(fn.ToUTF8().data())) {
-			wxLogError("Failed to load TRI file '%s'!", fn);
-			wxMessageBox(_("Failed to load TRI file!"), _("Error"), wxICON_ERROR);
-			return;
-		}
-
-		std::string shapeName{fileName.GetName().ToUTF8()};
-		while (project->IsValidShape(shapeName)) {
-			std::string result{wxGetTextFromUser(_("Please enter a new unique name for the shape."), _("Rename Shape"), shapeName, this).ToUTF8()};
-			if (result.empty())
-				continue;
-
-			shapeName = std::move(result);
-		}
-
-		auto verts = tri.GetVertices();
-		auto tris = tri.GetTriangles();
-		auto uvs = tri.GetUV();
-		auto shape = project->CreateNifShapeFromData(shapeName, &verts, &tris, &uvs);
-		if (!shape)
-			return;
 
 		RefreshGUIFromProj(false);
+		SetPendingChanges();
 
-		auto morphs = tri.GetMorphs();
-		for (auto &morph : morphs) {
-			if (!project->ValidSlider(morph.morphName)) {
-				createSliderGUI(morph.morphName, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
-				project->AddEmptySlider(morph.morphName);
-				ShowSliderEffect(morph.morphName);
-			}
+		wxLogMessage("Imported shape(s) from OBJ.");
+		glView->Render();
+	}
 
-			std::unordered_map<uint16_t, Vector3> diff;
-			diff.reserve(morph.vertices.size());
+	void OutfitStudioFrame::OnExportOBJ(wxCommandEvent& WXUNUSED(event)) {
+		if (!project->GetWorkNif()->IsValid())
+			return;
 
-			for (size_t i = 0; i < morph.vertices.size(); i++)
-				diff[i] = morph.vertices[i];
+		bool hasSkinTrans = false;
+		for (NiShape *shape : project->GetWorkNif()->GetShapes())
+		{
+			if (!project->GetWorkAnim()->shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(MatTransform()))
+				hasSkinTrans = true;
+		}
+		bool transToGlobal = false;
+		if (hasSkinTrans)
+		{
+			int res = wxMessageBox(_("Some of the shapes have skin coordinate systems that are not the same as the global coordinate system.  Should the geometry be transformed to global coordinates in the OBJ?  (This is not recommended.)"), _("Transform to global"), wxYES_NO | wxCANCEL);
+			if (res == wxCANCEL)
+				return;
+			transToGlobal = (res == wxYES);
+		}
 
-			project->SetSliderFromDiff(morph.morphName, shape, diff);
+		wxString fileName = wxFileSelector(_("Export project as an .obj file"), wxEmptyString, wxEmptyString, ".obj", "*.obj", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
+		if (fileName.IsEmpty())
+			return;
+
+		wxLogMessage("Exporting project to OBJ file '%s'...", fileName);
+		project->ClearBoneScale();
+
+		if (project->ExportOBJ(fileName.ToUTF8().data(), project->GetWorkNif()->GetShapes(), transToGlobal, Vector3(0.1f, 0.1f, 0.1f)))
+		{
+			wxLogError("Failed to export OBJ file '%s'!", fileName);
+			wxMessageBox(_("Failed to export OBJ file!"), _("Export Error"), wxICON_ERROR);
 		}
 	}
 
-	sliderScroll->FitInside();
-	sliderScroll->Thaw();
+	void OutfitStudioFrame::OnExportShapeOBJ(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
 
-	SetPendingChanges();
+		bool hasSkinTrans = false;
+		for (auto &i : selectedItems)
+		{
+			NiShape *shape = i->GetShape();
+			if (!project->GetWorkAnim()->shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(MatTransform()))
+				hasSkinTrans = true;
+		}
+		bool transToGlobal = false;
+		if (hasSkinTrans)
+		{
+			int res = wxMessageBox(_("Some of the shapes have skin coordinate systems that are not the same as the global coordinate system.  Should the geometry be transformed to global coordinates in the OBJ?"), _("Transform to global"), wxYES_NO | wxCANCEL);
+			if (res == wxCANCEL)
+				return;
+			transToGlobal = (res == wxYES);
+		}
 
-	ApplySliders();
-	DoFilterSliders();
-}
+		if (selectedItems.size() > 1)
+		{
+			wxString fileName = wxFileSelector(_("Export selected shapes as an .obj file"), wxEmptyString, wxEmptyString, ".obj", "OBJ Files (*.obj)|*.obj", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
+			if (fileName.IsEmpty())
+				return;
 
-void OutfitStudioFrame::OnExportTRIHead(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetWorkNif()->IsValid()) {
-		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
-		return;
+			wxLogMessage("Exporting selected shapes as OBJ file to '%s'.", fileName);
+			project->ClearBoneScale();
+
+			std::vector<NiShape*> shapes;
+			shapes.reserve(selectedItems.size());
+			for (auto &i : selectedItems)
+				shapes.push_back(i->GetShape());
+
+			if (project->ExportOBJ(fileName.ToUTF8().data(), shapes, transToGlobal, Vector3(0.1f, 0.1f, 0.1f)))
+			{
+				wxLogError("Failed to export OBJ file '%s'!", fileName);
+				wxMessageBox(_("Failed to export OBJ file!"), _("Error"), wxICON_ERROR);
+			}
+		}
+		else
+		{
+			wxString fileName = wxFileSelector(_("Export shape as an .obj file"), wxEmptyString, wxString(activeItem->GetShape()->name.get() + ".obj"), ".obj", "OBJ Files (*.obj)|*.obj", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
+			if (fileName.IsEmpty())
+				return;
+
+			wxLogMessage("Exporting shape '%s' as OBJ file to '%s'.", activeItem->GetShape()->name.get(), fileName);
+			project->ClearBoneScale();
+
+			std::vector<NiShape*> shapes = { activeItem->GetShape() };
+			if (project->ExportOBJ(fileName.ToUTF8().data(), shapes, transToGlobal, Vector3(0.1f, 0.1f, 0.1f)))
+			{
+				wxLogError("Failed to export OBJ file '%s'!", fileName);
+				wxMessageBox(_("Failed to export OBJ file!"), _("Error"), wxICON_ERROR);
+			}
+		}
 	}
 
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
+	void OutfitStudioFrame::OnImportFBX(wxCommandEvent& WXUNUSED(event)) {
+		wxFileDialog importDialog(this, _("Import .fbx file for new shape"), wxEmptyString, wxEmptyString, "FBX Files (*.fbx)|*.fbx", wxFD_FILE_MUST_EXIST | wxFD_MULTIPLE);
+		if (importDialog.ShowModal() == wxID_CANCEL)
+			return;
+
+		wxArrayString fileNames;
+		importDialog.GetPaths(fileNames);
+
+		for (auto &fileName : fileNames)
+		{
+			wxLogMessage("Importing shape(s) from FBX file '%s'...", fileName);
+
+			int ret;
+			if (activeItem)
+				ret = project->ImportFBX(fileName.ToUTF8().data(), project->OutfitName(), activeItem->GetShape());
+			else
+				ret = project->ImportFBX(fileName.ToUTF8().data(), project->OutfitName());
+
+			if (ret == 101)
+				wxLogMessage("Updated shape '%s' from FBX file '%s'.", activeItem->GetShape()->name.get(), fileName);
+		}
+
+		RefreshGUIFromProj(false);
+		SetPendingChanges();
+
+		wxLogMessage("Imported shape(s) from FBX.");
+		glView->Render();
 	}
 
-	wxString dir = wxDirSelector(_("Export .tri morphs"), wxEmptyString, wxDD_DEFAULT_STYLE, wxDefaultPosition, this);
-	if (dir.IsEmpty())
-		return;
+	void OutfitStudioFrame::OnExportFBX(wxCommandEvent& WXUNUSED(event)) {
+		if (!project->GetWorkNif()->IsValid())
+			return;
 
-	for (auto &shape : project->GetWorkNif()->GetShapes()) {
-		std::string fn = dir + PathSepStr + shape->name.get() + ".tri";
+		if (HasUnweightedCheck())
+			return;
 
-		wxLogMessage("Exporting TRI (head) morphs of '%s' to '%s'...", shape->name.get(), fn);
-		if (!project->WriteHeadTRI(shape, fn)) {
+		bool hasSkinTrans = false;
+		for (NiShape *shape : project->GetWorkNif()->GetShapes())
+		{
+			if (!project->GetWorkAnim()->shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(MatTransform()))
+				hasSkinTrans = true;
+		}
+		bool transToGlobal = false;
+		if (hasSkinTrans)
+		{
+			int res = wxMessageBox(_("Some of the shapes have skin coordinate systems that are not the same as the global coordinate system.  Should the geometry be transformed to global coordinates in the FBX?  (This is not recommended.)"), _("Transform to global"), wxYES_NO | wxCANCEL);
+			if (res == wxCANCEL)
+				return;
+			transToGlobal = (res == wxYES);
+		}
+
+		wxString fileName = wxFileSelector(_("Export project as an .fbx file"), wxEmptyString, wxEmptyString, ".fbx", "FBX Files (*.fbx)|*.fbx", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
+		if (fileName.IsEmpty())
+			return;
+
+		wxLogMessage("Exporting project to OBJ file '%s'...", fileName);
+		project->ClearBoneScale();
+
+		if (!project->ExportFBX(fileName.ToUTF8().data(), project->GetWorkNif()->GetShapes(), transToGlobal))
+		{
+			wxLogError("Failed to export FBX file '%s'!", fileName);
+			wxMessageBox(_("Failed to export FBX file!"), _("Export Error"), wxICON_ERROR);
+		}
+	}
+
+	void OutfitStudioFrame::OnExportShapeFBX(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+
+		bool hasSkinTrans = false;
+		for (auto &i : selectedItems)
+		{
+			NiShape *shape = i->GetShape();
+			if (!project->GetWorkAnim()->shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(MatTransform()))
+				hasSkinTrans = true;
+		}
+		bool transToGlobal = false;
+		if (hasSkinTrans)
+		{
+			int res = wxMessageBox(_("Some of the shapes have skin coordinate systems that are not the same as the global coordinate system.  Should the geometry be transformed to global coordinates in the FBX?"), _("Transform to global"), wxYES_NO | wxCANCEL);
+			if (res == wxCANCEL)
+				return;
+			transToGlobal = (res == wxYES);
+		}
+
+		if (selectedItems.size() > 1)
+		{
+			wxString fileName = wxFileSelector(_("Export selected shapes as an .fbx file"), wxEmptyString, wxEmptyString, ".fbx", "FBX Files (*.fbx)|*.fbx", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
+			if (fileName.IsEmpty())
+				return;
+
+			wxLogMessage("Exporting selected shapes as FBX file to '%s'.", fileName);
+			project->ClearBoneScale();
+
+			std::vector<NiShape*> shapes;
+			shapes.reserve(selectedItems.size());
+			for (auto &i : selectedItems)
+				shapes.push_back(i->GetShape());
+
+			if (!project->ExportFBX(fileName.ToUTF8().data(), shapes, transToGlobal))
+			{
+				wxLogError("Failed to export FBX file '%s'!", fileName);
+				wxMessageBox(_("Failed to export FBX file!"), _("Error"), wxICON_ERROR);
+			}
+		}
+		else
+		{
+			wxString fileName = wxFileSelector(_("Export shape as an .fbx file"), wxEmptyString, wxString(activeItem->GetShape()->name.get() + ".fbx"), ".fbx", "FBX Files (*.fbx)|*.fbx", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
+			if (fileName.IsEmpty())
+				return;
+
+			wxLogMessage("Exporting shape '%s' as FBX file to '%s'.", activeItem->GetShape()->name.get(), fileName);
+			project->ClearBoneScale();
+
+			std::vector<NiShape*> shapes = { activeItem->GetShape() };
+			if (!project->ExportFBX(fileName.ToUTF8().data(), shapes, transToGlobal))
+			{
+				wxLogError("Failed to export FBX file '%s'!", fileName);
+				wxMessageBox(_("Failed to export FBX file!"), _("Error"), wxICON_ERROR);
+			}
+		}
+	}
+
+	void OutfitStudioFrame::OnImportTRIHead(wxCommandEvent& WXUNUSED(event)) {
+		wxFileDialog importDialog(this, _("Import .tri morphs"), wxEmptyString, wxEmptyString, "TRI (Head) Files (*.tri)|*.tri", wxFD_FILE_MUST_EXIST | wxFD_MULTIPLE);
+		if (importDialog.ShowModal() == wxID_CANCEL)
+			return;
+
+		wxArrayString fileNames;
+		importDialog.GetPaths(fileNames);
+
+		sliderScroll->Freeze();
+		MenuExitSliderEdit();
+		sliderScroll->FitInside();
+		activeSlider.clear();
+
+		for (auto &fn : fileNames)
+		{
+			wxFileName fileName(fn);
+			wxLogMessage("Importing morphs from TRI (head) file '%s'...", fn);
+
+			TriHeadFile tri;
+			if (!tri.Read(fn.ToUTF8().data()))
+			{
+				wxLogError("Failed to load TRI file '%s'!", fn);
+				wxMessageBox(_("Failed to load TRI file!"), _("Error"), wxICON_ERROR);
+				return;
+			}
+
+			std::string shapeName{fileName.GetName().ToUTF8()};
+			while (project->IsValidShape(shapeName))
+			{
+				std::string result{wxGetTextFromUser(_("Please enter a new unique name for the shape."), _("Rename Shape"), shapeName, this).ToUTF8()};
+				if (result.empty())
+					continue;
+
+				shapeName = std::move(result);
+			}
+
+			auto verts = tri.GetVertices();
+			auto tris = tri.GetTriangles();
+			auto uvs = tri.GetUV();
+			auto shape = project->CreateNifShapeFromData(shapeName, &verts, &tris, &uvs);
+			if (!shape)
+				return;
+
+			RefreshGUIFromProj(false);
+
+			auto morphs = tri.GetMorphs();
+			for (auto &morph : morphs)
+			{
+				if (!project->ValidSlider(morph.morphName))
+				{
+					createSliderGUI(morph.morphName, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
+					project->AddEmptySlider(morph.morphName);
+					ShowSliderEffect(morph.morphName);
+				}
+
+				std::unordered_map<uint16_t, Vector3> diff;
+				diff.reserve(morph.vertices.size());
+
+				for (size_t i = 0; i < morph.vertices.size(); i++)
+					diff[i] = morph.vertices[i];
+
+				project->SetSliderFromDiff(morph.morphName, shape, diff);
+			}
+		}
+
+		sliderScroll->FitInside();
+		sliderScroll->Thaw();
+
+		SetPendingChanges();
+
+		ApplySliders();
+		DoFilterSliders();
+	}
+
+	void OutfitStudioFrame::OnExportTRIHead(wxCommandEvent& WXUNUSED(event)) {
+		if (!project->GetWorkNif()->IsValid())
+		{
+			wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
+			return;
+		}
+
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+
+		wxString dir = wxDirSelector(_("Export .tri morphs"), wxEmptyString, wxDD_DEFAULT_STYLE, wxDefaultPosition, this);
+		if (dir.IsEmpty())
+			return;
+
+		for (auto &shape : project->GetWorkNif()->GetShapes())
+		{
+			std::string fn = dir + PathSepStr + shape->name.get() + ".tri";
+
+			wxLogMessage("Exporting TRI (head) morphs of '%s' to '%s'...", shape->name.get(), fn);
+			if (!project->WriteHeadTRI(shape, fn))
+			{
+				wxLogError("Failed to export TRI file to '%s'!", fn);
+				wxMessageBox(_("Failed to export TRI file!"), _("Error"), wxICON_ERROR);
+			}
+		}
+	}
+
+	void OutfitStudioFrame::OnExportShapeTRIHead(wxCommandEvent& WXUNUSED(event)) {
+		if (!project->GetWorkNif()->IsValid())
+		{
+			wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
+			return;
+		}
+
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+
+		wxString fn = wxFileSelector(_("Export .tri morphs"), wxEmptyString, wxEmptyString, ".tri", "*.tri", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
+		if (fn.IsEmpty())
+			return;
+
+		wxLogMessage("Exporting TRI (head) morphs to '%s'...", fn);
+		if (!project->WriteHeadTRI(activeItem->GetShape(), fn.ToUTF8().data()))
+		{
 			wxLogError("Failed to export TRI file to '%s'!", fn);
 			wxMessageBox(_("Failed to export TRI file!"), _("Error"), wxICON_ERROR);
 		}
 	}
-}
 
-void OutfitStudioFrame::OnExportShapeTRIHead(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetWorkNif()->IsValid()) {
-		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
-		return;
-	}
-
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-
-	wxString fn = wxFileSelector(_("Export .tri morphs"), wxEmptyString, wxEmptyString, ".tri", "*.tri", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
-	if (fn.IsEmpty())
-		return;
-
-	wxLogMessage("Exporting TRI (head) morphs to '%s'...", fn);
-	if (!project->WriteHeadTRI(activeItem->GetShape(), fn.ToUTF8().data())) {
-		wxLogError("Failed to export TRI file to '%s'!", fn);
-		wxMessageBox(_("Failed to export TRI file!"), _("Error"), wxICON_ERROR);
-	}
-}
-
-void OutfitStudioFrame::OnImportPhysicsData(wxCommandEvent& WXUNUSED(event)) {
-	wxString fileName = wxFileSelector(_("Import physics data to project"), wxEmptyString, wxEmptyString, ".hkx", "*.hkx", wxFD_FILE_MUST_EXIST, this);
-	if (fileName.IsEmpty())
-		return;
-
-	auto physicsBlock = std::make_unique<BSClothExtraData>();
-	if (!physicsBlock->FromHKX(fileName.ToUTF8().data())) {
-		wxLogError("Failed to import physics data file '%s'!", fileName);
-		wxMessageBox(wxString::Format(_("Failed to import physics data file '%s'!"), fileName), _("Import Error"), wxICON_ERROR);
-	}
-
-	auto& physicsData = project->GetClothData();
-	physicsData[fileName.ToUTF8().data()] = std::move(physicsBlock);
-
-	SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnExportPhysicsData(wxCommandEvent& WXUNUSED(event)) {
-	auto& physicsData = project->GetClothData();
-	if (physicsData.empty()) {
-		wxMessageBox(_("There is no physics data loaded!"), _("Info"), wxICON_INFORMATION);
-		return;
-	}
-
-	wxArrayString fileNames;
-	for (auto &data : physicsData)
-		fileNames.Add(wxString::FromUTF8(data.first));
-
-	wxSingleChoiceDialog physicsDataChoice(this, _("Please choose the physics data source you want to export."), _("Choose physics data"), fileNames);
-	if (physicsDataChoice.ShowModal() == wxID_CANCEL)
-		return;
-
-	int sel = physicsDataChoice.GetSelection();
-	std::string selString{fileNames[sel].ToUTF8()};
-
-	if (!selString.empty()) {
-		wxString fileName = wxFileSelector(_("Export physics data"), wxEmptyString, wxEmptyString, ".hkx", "*.hkx", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
+	void OutfitStudioFrame::OnImportPhysicsData(wxCommandEvent& WXUNUSED(event)) {
+		wxString fileName = wxFileSelector(_("Import physics data to project"), wxEmptyString, wxEmptyString, ".hkx", "*.hkx", wxFD_FILE_MUST_EXIST, this);
 		if (fileName.IsEmpty())
 			return;
 
-		if (!physicsData[selString]->ToHKX(fileName.ToUTF8().data())) {
-			wxLogError("Failed to save physics data file '%s'!", fileName);
-			wxMessageBox(wxString::Format(_("Failed to save physics data file '%s'!"), fileName), _("Export Error"), wxICON_ERROR);
-		}
-	}
-}
-
-void OutfitStudioFrame::OnMakeConvRef(wxCommandEvent& WXUNUSED(event)) {
-	if (project->AllSlidersZero()) {
-		wxMessageBox(_("This function requires at least one slider position to be non-zero."));
-		return;
-	}
-
-	std::string namebase = "ConvertToBase";
-	char thename[256];
-	snprintf(thename, 256, "%s", namebase.c_str());
-	int count = 1;
-	while (sliderDisplays.find(thename) != sliderDisplays.end())
-		snprintf(thename, 256, "%s%d", namebase.c_str(), count++);
-
-	std::string finalName{wxGetTextFromUser(_("Create a conversion slider for the current slider settings with the following name: "), _("Create New Conversion Slider"), thename, this).ToUTF8()};
-	if (finalName.empty())
-		return;
-
-	wxLogMessage("Creating new conversion slider '%s'...", finalName);
-
-	project->ClearBoneScale();
-	project->AddCombinedSlider(finalName);
-
-	auto baseShape = project->GetBaseShape();
-	if (baseShape) {
-		mesh* m = glView->GetMesh(baseShape->name.get());
-		if (m)
-			project->UpdateShapeFromMesh(baseShape, m);
-
-		project->NegateSlider(finalName, baseShape);
-	}
-
-	std::vector<std::string> sliderList;
-	project->GetSliderList(sliderList);
-	for (auto &s : sliderList) {
-		if (!s.compare(finalName))
-			continue;
-		project->DeleteSlider(s);
-	}
-
-	glView->GetUndoHistory()->ClearHistory();
-
-	activeSlider.clear();
-	lastActiveSlider.clear();
-	bEditSlider = false;
-	MenuExitSliderEdit();
-
-	CreateSetSliders();
-}
-
-void OutfitStudioFrame::OnSelectSliders(wxCommandEvent& event) {
-	bool checked = event.IsChecked();
-	for (auto &sd : sliderDisplays)
-		ShowSliderEffect(sd.first, checked);
-
-	ApplySliders();
-}
-
-void OutfitStudioFrame::OnSliderFilterChanged(wxCommandEvent& WXUNUSED(event)) {
-	DoFilterSliders();
-}
-
-void OutfitStudioFrame::DoFilterSliders() {
-	wxString filterStr = sliderFilter->GetValue();
-	filterStr.MakeLower();
-
-	for (auto &sd : sliderDisplays) {
-		if (!sd.second)
-			continue;
-
-		sd.second->sliderPane->Hide();
-
-		// Filter slider by name
-		wxString sliderStr = wxString::FromUTF8(sd.first);
-		if (sliderStr.Lower().Contains(filterStr))
-			sd.second->sliderPane->Show();
-	}
-
-	sliderScroll->FitInside();
-}
-
-void OutfitStudioFrame::OnBonesFilterChanged(wxCommandEvent& WXUNUSED(event)) {
-	UpdateBoneTree();
-}
-
-void OutfitStudioFrame::OnFixedWeight(wxCommandEvent& event) {
-	bool checked = event.IsChecked();
-	TB_Weight* weightBrush = dynamic_cast<TB_Weight*>(glView->GetActiveBrush());
-	if (weightBrush)
-		weightBrush->bFixedWeight = checked;
-}
-
-void OutfitStudioFrame::OnCBNormalizeWeights(wxCommandEvent& event) {
-	bool checked = event.IsChecked();
-	TB_Weight* weightBrush = dynamic_cast<TB_Weight*>(glView->GetActiveBrush());
-	if (weightBrush)
-		weightBrush->bNormalizeWeights = checked;
-}
-
-void OutfitStudioFrame::ToggleVisibility(wxTreeItemId firstItem) {
-	bool vis = true;
-	bool ghost = false;
-	int state = 0;
-
-	if (!firstItem.IsOk()) {
-		if (!selectedItems.empty()) {
-			firstItem = selectedItems.front()->GetId();
-		}
-	}
-
-	if (firstItem.IsOk()) {
-		state = outfitShapes->GetItemState(firstItem);
-		switch (state) {
-		case 0:
-			vis = false;
-			ghost = false;
-			state = 1;
-			break;
-		case 1:
-			vis = true;
-			ghost = true;
-			state = 2;
-			break;
-		default:
-			vis = true;
-			ghost = false;
-			state = 0;
-			break;
+		auto physicsBlock = std::make_unique<BSClothExtraData>();
+		if (!physicsBlock->FromHKX(fileName.ToUTF8().data()))
+		{
+			wxLogError("Failed to import physics data file '%s'!", fileName);
+			wxMessageBox(wxString::Format(_("Failed to import physics data file '%s'!"), fileName), _("Import Error"), wxICON_ERROR);
 		}
 
-		std::string shapeName{outfitShapes->GetItemText(firstItem).ToUTF8()};
-		glView->SetShapeGhostMode(shapeName, ghost);
-		glView->ShowShape(shapeName, vis);
-		outfitShapes->SetItemState(firstItem, state);
+		auto& physicsData = project->GetClothData();
+		physicsData[fileName.ToUTF8().data()] = std::move(physicsBlock);
+
+		SetPendingChanges();
 	}
 
-	if (selectedItems.size() > 1) {
-		for (auto &i : selectedItems) {
-			if (i->GetId().GetID() != firstItem.GetID()) {
-				std::string shapeName{outfitShapes->GetItemText(i->GetId()).ToUTF8()};
-				glView->SetShapeGhostMode(shapeName, ghost);
-				glView->ShowShape(shapeName, vis);
-				outfitShapes->SetItemState(i->GetId(), state);
+	void OutfitStudioFrame::OnExportPhysicsData(wxCommandEvent& WXUNUSED(event)) {
+		auto& physicsData = project->GetClothData();
+		if (physicsData.empty())
+		{
+			wxMessageBox(_("There is no physics data loaded!"), _("Info"), wxICON_INFORMATION);
+			return;
+		}
+
+		wxArrayString fileNames;
+		for (auto &data : physicsData)
+			fileNames.Add(wxString::FromUTF8(data.first));
+
+		wxSingleChoiceDialog physicsDataChoice(this, _("Please choose the physics data source you want to export."), _("Choose physics data"), fileNames);
+		if (physicsDataChoice.ShowModal() == wxID_CANCEL)
+			return;
+
+		int sel = physicsDataChoice.GetSelection();
+		std::string selString{fileNames[sel].ToUTF8()};
+
+		if (!selString.empty())
+		{
+			wxString fileName = wxFileSelector(_("Export physics data"), wxEmptyString, wxEmptyString, ".hkx", "*.hkx", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
+			if (fileName.IsEmpty())
+				return;
+
+			if (!physicsData[selString]->ToHKX(fileName.ToUTF8().data()))
+			{
+				wxLogError("Failed to save physics data file '%s'!", fileName);
+				wxMessageBox(wxString::Format(_("Failed to save physics data file '%s'!"), fileName), _("Export Error"), wxICON_ERROR);
 			}
 		}
 	}
 
-	glView->Render();
-}
+	void OutfitStudioFrame::OnMakeConvRef(wxCommandEvent& WXUNUSED(event)) {
+		if (project->AllSlidersZero())
+		{
+			wxMessageBox(_("This function requires at least one slider position to be non-zero."));
+			return;
+		}
 
-void OutfitStudioFrame::OnShapeVisToggle(wxTreeEvent& event) {
-	ToggleVisibility(event.GetItem());
-	event.Skip();
-}
+		std::string namebase = "ConvertToBase";
+		char thename[256];
+		snprintf(thename, 256, "%s", namebase.c_str());
+		int count = 1;
+		while (sliderDisplays.find(thename) != sliderDisplays.end())
+			snprintf(thename, 256, "%s%d", namebase.c_str(), count++);
 
-void OutfitStudioFrame::OnShapeSelect(wxTreeEvent& event) {
-	wxTreeItemId item = event.GetItem();
-	if (!item.IsOk()) {
-		event.Veto();
-		return;
+		std::string finalName{wxGetTextFromUser(_("Create a conversion slider for the current slider settings with the following name: "), _("Create New Conversion Slider"), thename, this).ToUTF8()};
+		if (finalName.empty())
+			return;
+
+		wxLogMessage("Creating new conversion slider '%s'...", finalName);
+
+		project->ClearBoneScale();
+		project->AddCombinedSlider(finalName);
+
+		auto baseShape = project->GetBaseShape();
+		if (baseShape)
+		{
+			mesh* m = glView->GetMesh(baseShape->name.get());
+			if (m)
+				project->UpdateShapeFromMesh(baseShape, m);
+
+			project->NegateSlider(finalName, baseShape);
+		}
+
+		std::vector<std::string> sliderList;
+		project->GetSliderList(sliderList);
+		for (auto &s : sliderList)
+		{
+			if (!s.compare(finalName))
+				continue;
+			project->DeleteSlider(s);
+		}
+
+		glView->GetUndoHistory()->ClearHistory();
+
+		activeSlider.clear();
+		lastActiveSlider.clear();
+		bEditSlider = false;
+		MenuExitSliderEdit();
+
+		CreateSetSliders();
 	}
 
-	if (selectionLocked) {
-		event.Veto();
-		return;
+	void OutfitStudioFrame::OnSelectSliders(wxCommandEvent& event) {
+		bool checked = event.IsChecked();
+		for (auto &sd : sliderDisplays)
+			ShowSliderEffect(sd.first, checked);
+
+		ApplySliders();
 	}
 
-	if (outfitShapes->GetItemParent(item).IsOk()) {
-		if (outfitShapes->IsSelected(item))
-			activeItem = (ShapeItemData*)outfitShapes->GetItemData(item);
-		else
-			activeItem = nullptr;
-	}
-	else {
-		wxTreeItemIdValue cookie;
-		wxTreeItemId subitem = outfitShapes->GetFirstChild(item, cookie);
-		if (subitem.IsOk() && outfitShapes->IsSelected(subitem))
-			activeItem = (ShapeItemData*)outfitShapes->GetItemData(subitem);
-		else
-			activeItem = nullptr;
+	void OutfitStudioFrame::OnSliderFilterChanged(wxCommandEvent& WXUNUSED(event))
+	{
+		DoFilterSliders();
 	}
 
-	selectedItems.clear();
+	void OutfitStudioFrame::DoFilterSliders() {
+		wxString filterStr = sliderFilter->GetValue();
+		filterStr.MakeLower();
 
-	std::vector<std::string> shapeNames;
-	wxArrayTreeItemIds selected;
-	outfitShapes->GetSelections(selected);
+		for (auto &sd : sliderDisplays)
+		{
+			if (!sd.second)
+				continue;
 
-	for (auto &i : selected) {
-		if (outfitShapes->GetItemParent(i).IsOk()) {
-			auto data = (ShapeItemData*)outfitShapes->GetItemData(i);
-			if (data) {
-				shapeNames.push_back(data->GetShape()->name.get());
-				selectedItems.push_back(data);
+			sd.second->sliderPane->Hide();
 
-				if (!activeItem)
-					activeItem = data;
+			// Filter slider by name
+			wxString sliderStr = wxString::FromUTF8(sd.first);
+			if (sliderStr.Lower().Contains(filterStr))
+				sd.second->sliderPane->Show();
+		}
+
+		sliderScroll->FitInside();
+	}
+
+	void OutfitStudioFrame::OnBonesFilterChanged(wxCommandEvent& WXUNUSED(event))
+	{
+		UpdateBoneTree();
+	}
+
+	void OutfitStudioFrame::OnFixedWeight(wxCommandEvent& event) {
+		bool checked = event.IsChecked();
+		TB_Weight* weightBrush = dynamic_cast<TB_Weight*>(glView->GetActiveBrush());
+		if (weightBrush)
+			weightBrush->bFixedWeight = checked;
+	}
+
+	void OutfitStudioFrame::OnCBNormalizeWeights(wxCommandEvent& event) {
+		bool checked = event.IsChecked();
+		TB_Weight* weightBrush = dynamic_cast<TB_Weight*>(glView->GetActiveBrush());
+		if (weightBrush)
+			weightBrush->bNormalizeWeights = checked;
+	}
+
+	void OutfitStudioFrame::ToggleVisibility(wxTreeItemId firstItem) {
+		bool vis = true;
+		bool ghost = false;
+		int state = 0;
+
+		if (!firstItem.IsOk())
+		{
+			if (!selectedItems.empty())
+			{
+				firstItem = selectedItems.front()->GetId();
 			}
 		}
-		else {
+
+		if (firstItem.IsOk())
+		{
+			state = outfitShapes->GetItemState(firstItem);
+			switch (state)
+			{
+			case 0:
+				vis = false;
+				ghost = false;
+				state = 1;
+				break;
+			case 1:
+				vis = true;
+				ghost = true;
+				state = 2;
+				break;
+			default:
+				vis = true;
+				ghost = false;
+				state = 0;
+				break;
+			}
+
+			std::string shapeName{outfitShapes->GetItemText(firstItem).ToUTF8()};
+			glView->SetShapeGhostMode(shapeName, ghost);
+			glView->ShowShape(shapeName, vis);
+			outfitShapes->SetItemState(firstItem, state);
+		}
+
+		if (selectedItems.size() > 1)
+		{
+			for (auto &i : selectedItems)
+			{
+				if (i->GetId().GetID() != firstItem.GetID())
+				{
+					std::string shapeName{outfitShapes->GetItemText(i->GetId()).ToUTF8()};
+					glView->SetShapeGhostMode(shapeName, ghost);
+					glView->ShowShape(shapeName, vis);
+					outfitShapes->SetItemState(i->GetId(), state);
+				}
+			}
+		}
+
+		glView->Render();
+	}
+
+	void OutfitStudioFrame::OnShapeVisToggle(wxTreeEvent& event) {
+		ToggleVisibility(event.GetItem());
+		event.Skip();
+	}
+
+	void OutfitStudioFrame::OnShapeSelect(wxTreeEvent& event) {
+		wxTreeItemId item = event.GetItem();
+		if (!item.IsOk())
+		{
+			event.Veto();
+			return;
+		}
+
+		if (selectionLocked)
+		{
+			event.Veto();
+			return;
+		}
+
+		if (outfitShapes->GetItemParent(item).IsOk())
+		{
+			if (outfitShapes->IsSelected(item))
+				activeItem = (ShapeItemData*)outfitShapes->GetItemData(item);
+			else
+				activeItem = nullptr;
+		}
+		else
+		{
 			wxTreeItemIdValue cookie;
-			wxTreeItemId subitem = outfitShapes->GetFirstChild(i, cookie);
-			if (subitem.IsOk()) {
-				auto data = (ShapeItemData*)outfitShapes->GetItemData(subitem);
-				if (data) {
+			wxTreeItemId subitem = outfitShapes->GetFirstChild(item, cookie);
+			if (subitem.IsOk() && outfitShapes->IsSelected(subitem))
+				activeItem = (ShapeItemData*)outfitShapes->GetItemData(subitem);
+			else
+				activeItem = nullptr;
+		}
+
+		selectedItems.clear();
+
+		std::vector<std::string> shapeNames;
+		wxArrayTreeItemIds selected;
+		outfitShapes->GetSelections(selected);
+
+		for (auto &i : selected)
+		{
+			if (outfitShapes->GetItemParent(i).IsOk())
+			{
+				auto data = (ShapeItemData*)outfitShapes->GetItemData(i);
+				if (data)
+				{
 					shapeNames.push_back(data->GetShape()->name.get());
 					selectedItems.push_back(data);
 
@@ -4784,73 +5048,115 @@ void OutfitStudioFrame::OnShapeSelect(wxTreeEvent& event) {
 						activeItem = data;
 				}
 			}
+			else
+			{
+				wxTreeItemIdValue cookie;
+				wxTreeItemId subitem = outfitShapes->GetFirstChild(i, cookie);
+				if (subitem.IsOk())
+				{
+					auto data = (ShapeItemData*)outfitShapes->GetItemData(subitem);
+					if (data)
+					{
+						shapeNames.push_back(data->GetShape()->name.get());
+						selectedItems.push_back(data);
+
+						if (!activeItem)
+							activeItem = data;
+					}
+				}
+			}
+		}
+
+		glView->SetActiveShapes(shapeNames);
+
+		if (activeItem)
+			glView->SetSelectedShape(activeItem->GetShape()->name.get());
+		else
+			glView->SetSelectedShape("");
+
+		UpdateActiveShape();
+		glView->GetUndoHistory()->ClearHistory();
+	}
+
+	void OutfitStudioFrame::OnShapeActivated(wxTreeEvent& event) {
+		int hitFlags;
+		outfitShapes->HitTest(event.GetPoint(), hitFlags);
+
+		if (hitFlags & wxTREE_HITTEST_ONITEMSTATEICON)
+			return;
+
+		wxCommandEvent evt;
+		OnShapeProperties(evt);
+	}
+
+	void OutfitStudioFrame::ToggleBoneState(wxTreeItemId item) {
+		if (!item.IsOk())
+			return;
+
+		std::string text = outfitBones->GetItemText(item).ToStdString();
+		int state = outfitBones->GetItemState(item);
+
+		switch (state)
+		{
+		case 0:
+			outfitBones->SetItemState(item, 1);
+			lastNormalizeBones.insert(text);
+			break;
+		default:
+			outfitBones->SetItemState(item, 0);
+			lastNormalizeBones.erase(text);
+			break;
 		}
 	}
 
-	glView->SetActiveShapes(shapeNames);
-
-	if (activeItem)
-		glView->SetSelectedShape(activeItem->GetShape()->name.get());
-	else
-		glView->SetSelectedShape("");
-
-	UpdateActiveShape();
-	glView->GetUndoHistory()->ClearHistory();
-}
-
-void OutfitStudioFrame::OnShapeActivated(wxTreeEvent& event) {
-	int hitFlags;
-	outfitShapes->HitTest(event.GetPoint(), hitFlags);
-
-	if (hitFlags & wxTREE_HITTEST_ONITEMSTATEICON)
-		return;
-
-	wxCommandEvent evt;
-	OnShapeProperties(evt);
-}
-
-void OutfitStudioFrame::ToggleBoneState(wxTreeItemId item) {
-	if (!item.IsOk())
-		return;
-
-	std::string text = outfitBones->GetItemText(item).ToStdString();
-	int state = outfitBones->GetItemState(item);
-
-	switch (state) {
-	case 0:
-		outfitBones->SetItemState(item, 1);
-		lastNormalizeBones.insert(text);
-		break;
-	default:
-		outfitBones->SetItemState(item, 0);
-		lastNormalizeBones.erase(text);
-		break;
-	}
-}
-
-void OutfitStudioFrame::OnBoneStateToggle(wxTreeEvent& event) {
-	ToggleBoneState(event.GetItem());
-	event.Skip();
-}
-
-void OutfitStudioFrame::RefreshGUIWeightColors() {
-	// Clear vcolors of all shapes
-	for (auto &s : project->GetWorkNif()->GetShapeNames()) {
-		mesh* m = glView->GetMesh(s);
-		if (m)
-			m->ColorChannelFill(1, 0.0f);
+	void OutfitStudioFrame::OnBoneStateToggle(wxTreeEvent& event) {
+		ToggleBoneState(event.GetItem());
+		event.Skip();
 	}
 
-	if (!activeBone.empty()) {
-		// Show weights of selected shapes without reference
-		for (auto &s : selectedItems) {
-			if (!project->IsBaseShape(s->GetShape())) {
-				auto weights = project->GetWorkAnim()->GetWeightsPtr(s->GetShape()->name.get(), activeBone);
+	void OutfitStudioFrame::RefreshGUIWeightColors() {
+		// Clear vcolors of all shapes
+		for (auto &s : project->GetWorkNif()->GetShapeNames())
+		{
+			mesh* m = glView->GetMesh(s);
+			if (m)
+				m->ColorChannelFill(1, 0.0f);
+		}
 
-				mesh* m = glView->GetMesh(s->GetShape()->name.get());
-				if (m) {
+		if (!activeBone.empty())
+		{
+			// Show weights of selected shapes without reference
+			for (auto &s : selectedItems)
+			{
+				if (!project->IsBaseShape(s->GetShape()))
+				{
+					auto weights = project->GetWorkAnim()->GetWeightsPtr(s->GetShape()->name.get(), activeBone);
+
+					mesh* m = glView->GetMesh(s->GetShape()->name.get());
+					if (m)
+					{
+						m->ColorChannelFill(1, 0.0f);
+						if (weights)
+						{
+							for (auto &bw : *weights)
+								m->vcolors[bw.first].y = bw.second;
+						}
+					}
+				}
+			}
+
+			// Always show weights of reference shape
+			NiShape* baseShape = project->GetBaseShape();
+			if (baseShape)
+			{
+				auto weights = project->GetWorkAnim()->GetWeightsPtr(baseShape->name.get(), activeBone);
+
+				mesh* m = glView->GetMesh(baseShape->name.get());
+				if (m)
+				{
 					m->ColorChannelFill(1, 0.0f);
-					if (weights) {
+					if (weights)
+					{
 						for (auto &bw : *weights)
 							m->vcolors[bw.first].y = bw.second;
 					}
@@ -4858,4414 +5164,4915 @@ void OutfitStudioFrame::RefreshGUIWeightColors() {
 			}
 		}
 
-		// Always show weights of reference shape
-		NiShape* baseShape = project->GetBaseShape();
-		if (baseShape) {
-			auto weights = project->GetWorkAnim()->GetWeightsPtr(baseShape->name.get(), activeBone);
+		glView->Refresh();
+	}
 
-			mesh* m = glView->GetMesh(baseShape->name.get());
-			if (m) {
-				m->ColorChannelFill(1, 0.0f);
-				if (weights) {
-					for (auto &bw : *weights)
-						m->vcolors[bw.first].y = bw.second;
-				}
+	void OutfitStudioFrame::OnBoneSelect(wxTreeEvent& event) {
+		if (recursingUI)
+			return;
+
+		project->ClearBoneScale();
+		boneScale->SetValue(0);
+
+		wxTreeItemId item = event.GetItem();
+		if (!activeItem || !item.IsOk())
+			return;
+
+		wxArrayTreeItemIds selected;
+		outfitBones->GetSelections(selected);
+
+		activeBone.clear();
+		std::string selBone = outfitBones->GetItemText(item);
+
+		if (!outfitBones->IsSelected(item))
+		{
+			if (!selected.IsEmpty())
+			{
+				std::string frontBone = outfitBones->GetItemText(selected.front());
+				activeBone = frontBone;
 			}
 		}
-	}
-
-	glView->Refresh();
-}
-
-void OutfitStudioFrame::OnBoneSelect(wxTreeEvent& event) {
-	if (recursingUI)
-		return;
-
-	project->ClearBoneScale();
-	boneScale->SetValue(0);
-
-	wxTreeItemId item = event.GetItem();
-	if (!activeItem || !item.IsOk())
-		return;
-
-	wxArrayTreeItemIds selected;
-	outfitBones->GetSelections(selected);
-
-	activeBone.clear();
-	std::string selBone = outfitBones->GetItemText(item);
-
-	if (!outfitBones->IsSelected(item)) {
-		if (!selected.IsEmpty()) {
-			std::string frontBone = outfitBones->GetItemText(selected.front());
-			activeBone = frontBone;
-		}
-	}
-	else {
-		activeBone = selBone;
-		if (selected.GetCount() == 1)
-			lastSelectedBones.clear();
-	}
-
-	wxTreeItemIdValue cookie;
-	wxTreeItemId itemTree = outfitBones->GetFirstChild(bonesRoot, cookie);
-	while (itemTree.IsOk()) {
-		std::string boneName = outfitBones->GetItemText(itemTree).ToStdString();
-		if (outfitBones->IsSelected(itemTree))
-			lastSelectedBones.insert(boneName);
 		else
-			lastSelectedBones.erase(boneName);
-
-		itemTree = outfitBones->GetNextChild(bonesRoot, cookie);
-	}
-
-	glView->UpdateNodeColors();
-	RefreshGUIWeightColors();
-	CalcAutoXMirrorBone();
-}
-
-void OutfitStudioFrame::OnCheckTreeSel(wxTreeEvent& event) {
-	int outflags;
-	wxPoint p;
-	wxGetMousePosition(&p.x, &p.y);
-	p = outfitShapes->ScreenToClient(p);
-
-	int mask = wxTREE_HITTEST_ONITEMINDENT | wxTREE_HITTEST_ONITEMSTATEICON;
-	outfitShapes->HitTest(p, outflags);
-	if ((outflags & mask) != 0)
-		event.Veto();
-}
-
-void OutfitStudioFrame::OnShapeContext(wxTreeEvent& event) {
-	wxTreeItemId item = event.GetItem();
-	if (outfitShapes->GetItemParent(item).IsOk()) {
-		outfitShapes->SelectItem(item);
-
-		wxMenu* menu = wxXmlResource::Get()->LoadMenu("menuMeshContext");
-		if (menu) {
-			PopupMenu(menu);
-			delete menu;
+		{
+			activeBone = selBone;
+			if (selected.GetCount() == 1)
+				lastSelectedBones.clear();
 		}
-	}
-}
 
-void OutfitStudioFrame::OnShapeDrag(wxTreeEvent& event) {
-	if (activeItem) {
+		wxTreeItemIdValue cookie;
+		wxTreeItemId itemTree = outfitBones->GetFirstChild(bonesRoot, cookie);
+		while (itemTree.IsOk())
+		{
+			std::string boneName = outfitBones->GetItemText(itemTree).ToStdString();
+			if (outfitBones->IsSelected(itemTree))
+				lastSelectedBones.insert(boneName);
+			else
+				lastSelectedBones.erase(boneName);
+
+			itemTree = outfitBones->GetNextChild(bonesRoot, cookie);
+		}
+
+		glView->UpdateNodeColors();
+		RefreshGUIWeightColors();
+		CalcAutoXMirrorBone();
+	}
+
+	void OutfitStudioFrame::OnCheckTreeSel(wxTreeEvent& event) {
+		int outflags;
 		wxPoint p;
 		wxGetMousePosition(&p.x, &p.y);
 		p = outfitShapes->ScreenToClient(p);
 
-		int outflags;
-		outfitShapes->HitTest(p, outflags);
-
 		int mask = wxTREE_HITTEST_ONITEMINDENT | wxTREE_HITTEST_ONITEMSTATEICON;
-		if ((outflags & mask) == 0) {
-			outfitShapes->SetCursor(wxCURSOR_HAND);
-			event.Allow();
-		}
-		else
+		outfitShapes->HitTest(p, outflags);
+		if ((outflags & mask) != 0)
 			event.Veto();
 	}
-}
 
-void OutfitStudioFrame::OnShapeDrop(wxTreeEvent& event) {
-	outfitShapes->SetCursor(wxNullCursor);
-	wxTreeItemId dropItem = event.GetItem();
+	void OutfitStudioFrame::OnShapeContext(wxTreeEvent& event) {
+		wxTreeItemId item = event.GetItem();
+		if (outfitShapes->GetItemParent(item).IsOk())
+		{
+			outfitShapes->SelectItem(item);
 
-	if (!dropItem.IsOk() || !activeItem)
-		return;
-
-	// Make first child
-	if (dropItem == outfitRoot)
-		dropItem = 0;
-	
-	// Duplicate item
-	wxTreeItemId movedItem = outfitShapes->InsertItem(outfitRoot, dropItem, activeItem->GetShape()->name.get());
-	if (!movedItem.IsOk())
-		return;
-
-	// Set data
-	auto dropData = new ShapeItemData(activeItem->GetShape());
-	outfitShapes->SetItemState(movedItem, 0);
-	outfitShapes->SetItemData(movedItem, dropData);
-	if (project->IsBaseShape(dropData->GetShape())) {
-		outfitShapes->SetItemBold(movedItem);
-		outfitShapes->SetItemTextColour(movedItem, wxColour(0, 255, 0));
-	}
-	
-	// Delete old item
-	outfitShapes->Delete(activeItem->GetId());
-
-	// Select new item
-	outfitShapes->UnselectAll();
-	outfitShapes->SelectItem(movedItem);
-}
-
-void OutfitStudioFrame::OnBoneContext(wxTreeEvent& event) {
-	contextBone.clear();
-	wxTreeItemId itemId = event.GetItem();
-	if (itemId.IsOk())
-		contextBone = outfitBones->GetItemText(itemId);
-	wxMenu* menu = wxXmlResource::Get()->LoadMenu("menuBoneContext");
-	if (menu) {
-		PopupMenu(menu);
-		delete menu;
-	}
-}
-
-void OutfitStudioFrame::OnBoneTreeContext(wxCommandEvent& WXUNUSED(event)) {
-	contextBone.clear();
-	wxMenu* menu = wxXmlResource::Get()->LoadMenu("menuBoneTreeContext");
-	if (menu) {
-		PopupMenu(menu);
-		delete menu;
-	}
-}
-
-void OutfitStudioFrame::OnSegmentSelect(wxTreeEvent& event) {
-	ShowSegment(event.GetItem());
-}
-
-void OutfitStudioFrame::OnSegmentContext(wxTreeEvent& event) {
-	if (!event.GetItem().IsOk())
-		return;
-
-	segmentTree->SelectItem(event.GetItem());
-
-	wxMenu* menu = nullptr;
-	SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(event.GetItem()));
-	if (subSegmentData)
-		menu = wxXmlResource::Get()->LoadMenu("menuSubSegmentContext");
-	else
-		menu = wxXmlResource::Get()->LoadMenu("menuSegmentContext");
-
-	if (menu) {
-		PopupMenu(menu);
-		delete menu;
-	}
-}
-
-void OutfitStudioFrame::OnSegmentTreeContext(wxCommandEvent& WXUNUSED(event)) {
-	wxMenu* menu = wxXmlResource::Get()->LoadMenu("menuSegmentTreeContext");
-	if (menu) {
-		PopupMenu(menu);
-		delete menu;
-	}
-}
-
-int OutfitStudioFrame::CalcMaxSegPartID() {
-	int maxid = -1;
-	wxTreeItemIdValue cookie;
-	wxTreeItemId child = segmentTree->GetFirstChild(segmentRoot, cookie);
-	while (child.IsOk()) {
-		SegmentItemData* segmentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(child));
-		if (segmentData)
-			maxid = std::max(maxid, segmentData->partID);
-		wxTreeItemIdValue subCookie;
-		wxTreeItemId subChild = segmentTree->GetFirstChild(child, subCookie);
-		while (subChild.IsOk()) {
-			SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(subChild));
-			if (subSegmentData)
-				maxid = std::max(maxid, subSegmentData->partID);
-			subChild = segmentTree->GetNextChild(child, subCookie);
+			wxMenu* menu = wxXmlResource::Get()->LoadMenu("menuMeshContext");
+			if (menu)
+			{
+				PopupMenu(menu);
+				delete menu;
+			}
 		}
-		child = segmentTree->GetNextChild(segmentRoot, cookie);
-	}
-	return maxid;
-}
-
-void OutfitStudioFrame::OnAddSegment(wxCommandEvent& WXUNUSED(event)) {
-	int newPartID = CalcMaxSegPartID() + 1;
-	wxTreeItemId newItem;
-	if (!activeSegment.IsOk() || segmentTree->GetChildrenCount(segmentRoot) <= 0) {
-		// The new segment is the only partition: assign all triangles.
-		for (size_t i = 0; i < triSParts.size(); ++i)
-			triSParts[i] = newPartID;
-
-		newItem = segmentTree->AppendItem(segmentRoot, "Segment", -1, -1, new SegmentItemData(newPartID));
-	}
-	else
-		newItem = segmentTree->InsertItem(segmentRoot, activeSegment, "Segment", -1, -1, new SegmentItemData(newPartID));
-
-	if (newItem.IsOk()) {
-		segmentTree->UnselectAll();
-		segmentTree->SelectItem(newItem);
 	}
 
-	UpdateSegmentNames();
-	segmentTabButton->SetPendingChanges();
-}
+	void OutfitStudioFrame::OnShapeDrag(wxTreeEvent& event)
+	{
+		if (activeItem)
+		{
+			wxPoint p;
+			wxGetMousePosition(&p.x, &p.y);
+			p = outfitShapes->ScreenToClient(p);
 
-void OutfitStudioFrame::OnAddSubSegment(wxCommandEvent& WXUNUSED(event)) {
-	int newPartID = CalcMaxSegPartID() + 1;
-	wxTreeItemId newItem;
-	wxTreeItemId parent = segmentTree->GetItemParent(activeSegment);
-	if (parent == segmentRoot) {
-		if (segmentTree->GetChildrenCount(activeSegment) <= 0) {
-			// The new subsegment will be the only child: assign all of
-			// the segment's triangles to it.
-			SegmentItemData* segmentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(activeSegment));
-			if (segmentData)
-				for (size_t i = 0; i < triSParts.size(); ++i)
-					if (triSParts[i] == segmentData->partID)
-						triSParts[i] = newPartID;
+			int outflags;
+			outfitShapes->HitTest(p, outflags);
+
+			int mask = wxTREE_HITTEST_ONITEMINDENT | wxTREE_HITTEST_ONITEMSTATEICON;
+			if ((outflags & mask) == 0)
+			{
+				outfitShapes->SetCursor(wxCURSOR_HAND);
+				event.Allow();
+			}
+			else
+				event.Veto();
 		}
-
-		newItem = segmentTree->PrependItem(activeSegment, "Sub Segment", -1, -1, new SubSegmentItemData(newPartID, 0, 0xFFFFFFFF));
-	}
-	else
-		newItem = segmentTree->InsertItem(parent, activeSegment, "Sub Segment", -1, -1, new SubSegmentItemData(newPartID, 0, 0xFFFFFFFF));
-
-	if (newItem.IsOk()) {
-		segmentTree->UnselectAll();
-		segmentTree->SelectItem(newItem);
 	}
 
-	UpdateSegmentNames();
-	segmentTabButton->SetPendingChanges();
-}
+	void OutfitStudioFrame::OnShapeDrop(wxTreeEvent& event) {
+		outfitShapes->SetCursor(wxNullCursor);
+		wxTreeItemId dropItem = event.GetItem();
 
-void OutfitStudioFrame::OnDeleteSegment(wxCommandEvent& WXUNUSED(event)) {
-	SegmentItemData* segmentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(activeSegment));
-	if (segmentData) {
-		// Collect list of partition IDs that will be disappearing.
-		std::vector<bool> oldPartIDs(CalcMaxSegPartID() + 1, false);
-		oldPartIDs[segmentData->partID] = true;
+		if (!dropItem.IsOk() || !activeItem)
+			return;
+
+		// Make first child
+		if (dropItem == outfitRoot)
+			dropItem = 0;
+	
+		// Duplicate item
+		wxTreeItemId movedItem = outfitShapes->InsertItem(outfitRoot, dropItem, activeItem->GetShape()->name.get());
+		if (!movedItem.IsOk())
+			return;
+
+		// Set data
+		auto dropData = new ShapeItemData(activeItem->GetShape());
+		outfitShapes->SetItemState(movedItem, 0);
+		outfitShapes->SetItemData(movedItem, dropData);
+		if (project->IsBaseShape(dropData->GetShape()))
+		{
+			outfitShapes->SetItemBold(movedItem);
+			outfitShapes->SetItemTextColour(movedItem, wxColour(0, 255, 0));
+		}
+	
+		// Delete old item
+		outfitShapes->Delete(activeItem->GetId());
+
+		// Select new item
+		outfitShapes->UnselectAll();
+		outfitShapes->SelectItem(movedItem);
+	}
+
+	void OutfitStudioFrame::OnBoneContext(wxTreeEvent& event) {
+		contextBone.clear();
+		wxTreeItemId itemId = event.GetItem();
+		if (itemId.IsOk())
+			contextBone = outfitBones->GetItemText(itemId);
+		wxMenu* menu = wxXmlResource::Get()->LoadMenu("menuBoneContext");
+		if (menu)
+		{
+			PopupMenu(menu);
+			delete menu;
+		}
+	}
+
+	void OutfitStudioFrame::OnBoneTreeContext(wxCommandEvent& WXUNUSED(event)) {
+		contextBone.clear();
+		wxMenu* menu = wxXmlResource::Get()->LoadMenu("menuBoneTreeContext");
+		if (menu)
+		{
+			PopupMenu(menu);
+			delete menu;
+		}
+	}
+
+	void OutfitStudioFrame::OnSegmentSelect(wxTreeEvent& event)
+	{
+		ShowSegment(event.GetItem());
+	}
+
+	void OutfitStudioFrame::OnSegmentContext(wxTreeEvent& event) {
+		if (!event.GetItem().IsOk())
+			return;
+
+		segmentTree->SelectItem(event.GetItem());
+
+		wxMenu* menu = nullptr;
+		SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(event.GetItem()));
+		if (subSegmentData)
+			menu = wxXmlResource::Get()->LoadMenu("menuSubSegmentContext");
+		else
+			menu = wxXmlResource::Get()->LoadMenu("menuSegmentContext");
+
+		if (menu)
+		{
+			PopupMenu(menu);
+			delete menu;
+		}
+	}
+
+	void OutfitStudioFrame::OnSegmentTreeContext(wxCommandEvent& WXUNUSED(event)) {
+		wxMenu* menu = wxXmlResource::Get()->LoadMenu("menuSegmentTreeContext");
+		if (menu)
+		{
+			PopupMenu(menu);
+			delete menu;
+		}
+	}
+
+	int OutfitStudioFrame::CalcMaxSegPartID() {
+		int maxid = -1;
 		wxTreeItemIdValue cookie;
-		wxTreeItemId child = segmentTree->GetFirstChild(activeSegment, cookie);
-		while (child.IsOk()) {
-			SubSegmentItemData* childData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(child));
-			if (childData)
-				oldPartIDs[childData->partID] = true;
-			child = segmentTree->GetNextChild(activeSegment, cookie);
+		wxTreeItemId child = segmentTree->GetFirstChild(segmentRoot, cookie);
+		while (child.IsOk())
+		{
+			SegmentItemData* segmentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(child));
+			if (segmentData)
+				maxid = std::max(maxid, segmentData->partID);
+			wxTreeItemIdValue subCookie;
+			wxTreeItemId subChild = segmentTree->GetFirstChild(child, subCookie);
+			while (subChild.IsOk())
+			{
+				SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(subChild));
+				if (subSegmentData)
+					maxid = std::max(maxid, subSegmentData->partID);
+				subChild = segmentTree->GetNextChild(child, subCookie);
+			}
+			child = segmentTree->GetNextChild(segmentRoot, cookie);
+		}
+		return maxid;
+	}
+
+	void OutfitStudioFrame::OnAddSegment(wxCommandEvent& WXUNUSED(event)) {
+		int newPartID = CalcMaxSegPartID() + 1;
+		wxTreeItemId newItem;
+		if (!activeSegment.IsOk() || segmentTree->GetChildrenCount(segmentRoot) <= 0)
+		{
+			// The new segment is the only partition: assign all triangles.
+			for (size_t i = 0; i < triSParts.size(); ++i)
+				triSParts[i] = newPartID;
+
+			newItem = segmentTree->AppendItem(segmentRoot, "Segment", -1, -1, new SegmentItemData(newPartID));
+		}
+		else
+			newItem = segmentTree->InsertItem(segmentRoot, activeSegment, "Segment", -1, -1, new SegmentItemData(newPartID));
+
+		if (newItem.IsOk())
+		{
+			segmentTree->UnselectAll();
+			segmentTree->SelectItem(newItem);
 		}
 
-		// Find a new partition to put triangles into.
-		int newPartID = -1;
-		wxTreeItemId sibling = segmentTree->GetPrevSibling(activeSegment);
-		if (!sibling.IsOk())
-			sibling = segmentTree->GetNextSibling(activeSegment);
-		if (sibling.IsOk()) {
-			SegmentItemData* siblingData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(sibling));
-			if (siblingData)
-				newPartID = siblingData->partID;
+		UpdateSegmentNames();
+		segmentTabButton->SetPendingChanges();
+	}
 
-			child = segmentTree->GetFirstChild(sibling, cookie);
-			if (child.IsOk()) {
+	void OutfitStudioFrame::OnAddSubSegment(wxCommandEvent& WXUNUSED(event)) {
+		int newPartID = CalcMaxSegPartID() + 1;
+		wxTreeItemId newItem;
+		wxTreeItemId parent = segmentTree->GetItemParent(activeSegment);
+		if (parent == segmentRoot)
+		{
+			if (segmentTree->GetChildrenCount(activeSegment) <= 0)
+			{
+				// The new subsegment will be the only child: assign all of
+				// the segment's triangles to it.
+				SegmentItemData* segmentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(activeSegment));
+				if (segmentData)
+					for (size_t i = 0; i < triSParts.size(); ++i)
+						if (triSParts[i] == segmentData->partID)
+							triSParts[i] = newPartID;
+			}
+
+			newItem = segmentTree->PrependItem(activeSegment, "Sub Segment", -1, -1, new SubSegmentItemData(newPartID, 0, 0xFFFFFFFF));
+		}
+		else
+			newItem = segmentTree->InsertItem(parent, activeSegment, "Sub Segment", -1, -1, new SubSegmentItemData(newPartID, 0, 0xFFFFFFFF));
+
+		if (newItem.IsOk())
+		{
+			segmentTree->UnselectAll();
+			segmentTree->SelectItem(newItem);
+		}
+
+		UpdateSegmentNames();
+		segmentTabButton->SetPendingChanges();
+	}
+
+	void OutfitStudioFrame::OnDeleteSegment(wxCommandEvent& WXUNUSED(event)) {
+		SegmentItemData* segmentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(activeSegment));
+		if (segmentData)
+		{
+			// Collect list of partition IDs that will be disappearing.
+			std::vector<bool> oldPartIDs(CalcMaxSegPartID() + 1, false);
+			oldPartIDs[segmentData->partID] = true;
+			wxTreeItemIdValue cookie;
+			wxTreeItemId child = segmentTree->GetFirstChild(activeSegment, cookie);
+			while (child.IsOk())
+			{
 				SubSegmentItemData* childData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(child));
 				if (childData)
-					newPartID = childData->partID;
+					oldPartIDs[childData->partID] = true;
+				child = segmentTree->GetNextChild(activeSegment, cookie);
 			}
-		}
 
-		// Assign triangles from old partitions to new partition.
-		for (size_t i = 0; i < triSParts.size(); ++i)
-			if (triSParts[i] >= 0 && triSParts[i] < static_cast<int>(oldPartIDs.size()) && oldPartIDs[triSParts[i]])
-				triSParts[i] = newPartID;
+			// Find a new partition to put triangles into.
+			int newPartID = -1;
+			wxTreeItemId sibling = segmentTree->GetPrevSibling(activeSegment);
+			if (!sibling.IsOk())
+				sibling = segmentTree->GetNextSibling(activeSegment);
+			if (sibling.IsOk())
+			{
+				SegmentItemData* siblingData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(sibling));
+				if (siblingData)
+					newPartID = siblingData->partID;
 
-		segmentTree->UnselectAll();
-		segmentTree->Delete(activeSegment);
-		if (sibling.IsOk())
-			segmentTree->SelectItem(sibling);
-		else
-			activeSegment.Unset();
-	}
-
-	UpdateSegmentNames();
-	segmentTabButton->SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnDeleteSubSegment(wxCommandEvent& WXUNUSED(event)) {
-	SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(activeSegment));
-	wxTreeItemId newSelItem;
-	if (subSegmentData) {
-		int oldPartID = subSegmentData->partID, newPartID = -1;
-
-		// Find a partition to assign triangles to.
-		wxTreeItemId sibling = segmentTree->GetPrevSibling(activeSegment);
-		if (!sibling.IsOk())
-			sibling = segmentTree->GetNextSibling(activeSegment);
-
-		if (sibling.IsOk()) {
-			SubSegmentItemData* siblingData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(sibling));
-			if (siblingData)
-				newPartID = siblingData->partID;
-			newSelItem = sibling;
-		}
-		else {
-			wxTreeItemId parent = segmentTree->GetItemParent(activeSegment);
-			if (parent.IsOk()) {
-				SegmentItemData* parentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(parent));
-				if (parentData)
-					newPartID = parentData->partID;
-			}
-			newSelItem = parent;
-		}
-
-		// Assign triangles to new partition.
-		for (size_t i = 0; i < triSParts.size(); ++i)
-			if (triSParts[i] == oldPartID)
-				triSParts[i] = newPartID;
-
-		segmentTree->UnselectAll();
-		segmentTree->Delete(activeSegment);
-		segmentTree->SelectItem(newSelItem);
-	}
-
-	UpdateSegmentNames();
-	segmentTabButton->SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnSegmentSlotChanged(wxCommandEvent& event) {
-	wxChoice* segmentSlot = (wxChoice*)event.GetEventObject();
-
-	if (activeSegment.IsOk() && segmentTree->GetItemParent(activeSegment).IsOk()) {
-		SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(activeSegment));
-		if (subSegmentData) {
-			subSegmentData->userSlotID = 0;
-
-			if (segmentSlot->GetSelection() > 0) {
-				wxString slotSel = segmentSlot->GetStringSelection();
-				if (slotSel.length() >= 2) {
-					unsigned long slot = 0;
-					slotSel.Mid(0, 2).ToULong(&slot);
-
-					if (slot > 0)
-						subSegmentData->userSlotID = slot;
+				child = segmentTree->GetFirstChild(sibling, cookie);
+				if (child.IsOk())
+				{
+					SubSegmentItemData* childData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(child));
+					if (childData)
+						newPartID = childData->partID;
 				}
 			}
 
-			UpdateSegmentNames();
-			segmentTabButton->SetPendingChanges();
+			// Assign triangles from old partitions to new partition.
+			for (size_t i = 0; i < triSParts.size(); ++i)
+				if (triSParts[i] >= 0 && triSParts[i] < static_cast<int>(oldPartIDs.size()) && oldPartIDs[triSParts[i]])
+					triSParts[i] = newPartID;
+
+			segmentTree->UnselectAll();
+			segmentTree->Delete(activeSegment);
+			if (sibling.IsOk())
+				segmentTree->SelectItem(sibling);
+			else
+				activeSegment.Unset();
 		}
+
+		UpdateSegmentNames();
+		segmentTabButton->SetPendingChanges();
 	}
-}
 
-void OutfitStudioFrame::OnSegmentTypeChanged(wxCommandEvent& event) {
-	wxChoice* segmentType = (wxChoice*)event.GetEventObject();
-
-	if (activeSegment.IsOk() && segmentTree->GetItemParent(activeSegment).IsOk()) {
+	void OutfitStudioFrame::OnDeleteSubSegment(wxCommandEvent& WXUNUSED(event)) {
 		SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(activeSegment));
-		if (subSegmentData) {
-			unsigned long type = 0xFFFFFFFF;
+		wxTreeItemId newSelItem;
+		if (subSegmentData)
+		{
+			int oldPartID = subSegmentData->partID, newPartID = -1;
 
-			wxString hashSel = segmentType->GetStringSelection();
-			int hashPos = hashSel.First("0x");
-			if (hashPos != wxNOT_FOUND)
-				hashSel.Mid(hashPos).ToULong(&type, 16);
+			// Find a partition to assign triangles to.
+			wxTreeItemId sibling = segmentTree->GetPrevSibling(activeSegment);
+			if (!sibling.IsOk())
+				sibling = segmentTree->GetNextSibling(activeSegment);
 
-			subSegmentData->material = type;
-			UpdateSegmentNames();
-			segmentTabButton->SetPendingChanges();
+			if (sibling.IsOk())
+			{
+				SubSegmentItemData* siblingData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(sibling));
+				if (siblingData)
+					newPartID = siblingData->partID;
+				newSelItem = sibling;
+			}
+			else
+			{
+				wxTreeItemId parent = segmentTree->GetItemParent(activeSegment);
+				if (parent.IsOk())
+				{
+					SegmentItemData* parentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(parent));
+					if (parentData)
+						newPartID = parentData->partID;
+				}
+				newSelItem = parent;
+			}
+
+			// Assign triangles to new partition.
+			for (size_t i = 0; i < triSParts.size(); ++i)
+				if (triSParts[i] == oldPartID)
+					triSParts[i] = newPartID;
+
+			segmentTree->UnselectAll();
+			segmentTree->Delete(activeSegment);
+			segmentTree->SelectItem(newSelItem);
 		}
+
+		UpdateSegmentNames();
+		segmentTabButton->SetPendingChanges();
 	}
-}
 
-void OutfitStudioFrame::OnSegmentApply(wxCommandEvent& WXUNUSED(event)) {
-	ApplySegments();
-}
+	void OutfitStudioFrame::OnSegmentSlotChanged(wxCommandEvent& event) {
+		wxChoice* segmentSlot = (wxChoice*)event.GetEventObject();
 
-void OutfitStudioFrame::ApplySegments() {
-	NifSegmentationInfo inf;
+		if (activeSegment.IsOk() && segmentTree->GetItemParent(activeSegment).IsOk())
+		{
+			SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(activeSegment));
+			if (subSegmentData)
+			{
+				subSegmentData->userSlotID = 0;
 
-	wxTreeItemIdValue cookie;
-	wxTreeItemId child = segmentTree->GetFirstChild(segmentRoot, cookie);
+				if (segmentSlot->GetSelection() > 0)
+				{
+					wxString slotSel = segmentSlot->GetStringSelection();
+					if (slotSel.length() >= 2)
+					{
+						unsigned long slot = 0;
+						slotSel.Mid(0, 2).ToULong(&slot);
 
-	while (child.IsOk()) {
-		SegmentItemData* segmentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(child));
-		if (segmentData) {
-			inf.segs.emplace_back();
-			NifSegmentInfo &seg = inf.segs.back();
-			seg.partID = segmentData->partID;
-			size_t childCount = segmentTree->GetChildrenCount(child);
-
-			if (childCount > 0) {
-				seg.subs.resize(childCount);
-				int childInd = 0;
-
-				wxTreeItemIdValue subCookie;
-				wxTreeItemId subChild = segmentTree->GetFirstChild(child, subCookie);
-				while (subChild.IsOk()) {
-					SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(subChild));
-					if (subSegmentData) {
-						NifSubSegmentInfo &sub = seg.subs[childInd++];
-						sub.partID = subSegmentData->partID;
-						sub.userSlotID = subSegmentData->userSlotID;
-						sub.material = subSegmentData->material;
-						sub.extraData = subSegmentData->extraData;
+						if (slot > 0)
+							subSegmentData->userSlotID = slot;
 					}
-
-					subChild = segmentTree->GetNextChild(child, subCookie);
 				}
+
+				UpdateSegmentNames();
+				segmentTabButton->SetPendingChanges();
 			}
 		}
-
-		child = segmentTree->GetNextChild(segmentRoot, cookie);
 	}
 
-	wxTextCtrl* segmentSSF = (wxTextCtrl*)FindWindowByName("segmentSSF");
-	inf.ssfFile = segmentSSF->GetValue().ToStdString();
+	void OutfitStudioFrame::OnSegmentTypeChanged(wxCommandEvent& event) {
+		wxChoice* segmentType = (wxChoice*)event.GetEventObject();
 
-	project->GetWorkNif()->SetShapeSegments(activeItem->GetShape(), inf, triSParts);
-	MeshFromProj(activeItem->GetShape());
+		if (activeSegment.IsOk() && segmentTree->GetItemParent(activeSegment).IsOk())
+		{
+			SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(activeSegment));
+			if (subSegmentData)
+			{
+				unsigned long type = 0xFFFFFFFF;
 
-	CreateSegmentTree(activeItem->GetShape());
-	SetPendingChanges();
-}
+				wxString hashSel = segmentType->GetStringSelection();
+				int hashPos = hashSel.First("0x");
+				if (hashPos != wxNOT_FOUND)
+					hashSel.Mid(hashPos).ToULong(&type, 16);
 
-void OutfitStudioFrame::OnSegmentReset(wxCommandEvent& WXUNUSED(event)) {
-	ResetSegments();
-}
+				subSegmentData->material = type;
+				UpdateSegmentNames();
+				segmentTabButton->SetPendingChanges();
+			}
+		}
+	}
 
-void OutfitStudioFrame::ResetSegments() {
-	if (activeItem)
+	void OutfitStudioFrame::OnSegmentApply(wxCommandEvent& WXUNUSED(event))
+	{
+		ApplySegments();
+	}
+
+	void OutfitStudioFrame::ApplySegments() {
+		NifSegmentationInfo inf;
+
+		wxTreeItemIdValue cookie;
+		wxTreeItemId child = segmentTree->GetFirstChild(segmentRoot, cookie);
+
+		while (child.IsOk())
+		{
+			SegmentItemData* segmentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(child));
+			if (segmentData)
+			{
+				inf.segs.emplace_back();
+				NifSegmentInfo &seg = inf.segs.back();
+				seg.partID = segmentData->partID;
+				size_t childCount = segmentTree->GetChildrenCount(child);
+
+				if (childCount > 0)
+				{
+					seg.subs.resize(childCount);
+					int childInd = 0;
+
+					wxTreeItemIdValue subCookie;
+					wxTreeItemId subChild = segmentTree->GetFirstChild(child, subCookie);
+					while (subChild.IsOk())
+					{
+						SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(subChild));
+						if (subSegmentData)
+						{
+							NifSubSegmentInfo &sub = seg.subs[childInd++];
+							sub.partID = subSegmentData->partID;
+							sub.userSlotID = subSegmentData->userSlotID;
+							sub.material = subSegmentData->material;
+							sub.extraData = subSegmentData->extraData;
+						}
+
+						subChild = segmentTree->GetNextChild(child, subCookie);
+					}
+				}
+			}
+
+			child = segmentTree->GetNextChild(segmentRoot, cookie);
+		}
+
+		wxTextCtrl* segmentSSF = (wxTextCtrl*)FindWindowByName("segmentSSF");
+		inf.ssfFile = segmentSSF->GetValue().ToStdString();
+
+		project->GetWorkNif()->SetShapeSegments(activeItem->GetShape(), inf, triSParts);
+		MeshFromProj(activeItem->GetShape());
+
 		CreateSegmentTree(activeItem->GetShape());
-	else
-		CreateSegmentTree(nullptr);
-}
-
-void OutfitStudioFrame::OnSegmentEditSSF(wxCommandEvent& WXUNUSED(event)) {
-	auto segmentSSF = (wxTextCtrl*)FindWindowByName("segmentSSF");
-
-	wxString result = wxGetTextFromUser(_("Please enter an SSF file path."), _("SSF File"), segmentSSF->GetValue());
-	if (result.empty())
-		return;
-
-	segmentSSF->ChangeValue(result);
-	segmentTabButton->SetPendingChanges();
-}
-
-void OutfitStudioFrame::CreateSegmentTree(NiShape* shape) {
-	if (segmentTree->GetChildrenCount(segmentRoot) > 0) {
-		triSParts.clear(); // DeleteChildren calls OnSegmentSelect
-		segmentTree->DeleteChildren(segmentRoot);
+		SetPendingChanges();
 	}
 
-	segmentTabButton->SetPendingChanges(false);
+	void OutfitStudioFrame::OnSegmentReset(wxCommandEvent& WXUNUSED(event))
+	{
+		ResetSegments();
+	}
 
-	NifSegmentationInfo inf;
-	if (project->GetWorkNif()->GetShapeSegments(shape, inf, triSParts)) {
-		for (size_t i = 0; i < inf.segs.size(); i++) {
-			wxTreeItemId segID = segmentTree->AppendItem(segmentRoot, "Segment", -1, -1, new SegmentItemData(inf.segs[i].partID));
-			if (segID.IsOk()) {
-				for (size_t j = 0; j < inf.segs[i].subs.size(); j++) {
-					NifSubSegmentInfo &sub = inf.segs[i].subs[j];
-					segmentTree->AppendItem(segID, "Sub Segment", -1, -1,
-						new SubSegmentItemData(sub.partID, sub.userSlotID, sub.material, sub.extraData));
-				}
-			}
+	void OutfitStudioFrame::ResetSegments()
+	{
+		if (activeItem)
+			CreateSegmentTree(activeItem->GetShape());
+		else
+			CreateSegmentTree(nullptr);
+	}
+
+	void OutfitStudioFrame::OnSegmentEditSSF(wxCommandEvent& WXUNUSED(event)) {
+		auto segmentSSF = (wxTextCtrl*)FindWindowByName("segmentSSF");
+
+		wxString result = wxGetTextFromUser(_("Please enter an SSF file path."), _("SSF File"), segmentSSF->GetValue());
+		if (result.empty())
+			return;
+
+		segmentSSF->ChangeValue(result);
+		segmentTabButton->SetPendingChanges();
+	}
+
+	void OutfitStudioFrame::CreateSegmentTree(NiShape* shape) {
+		if (segmentTree->GetChildrenCount(segmentRoot) > 0)
+		{
+			triSParts.clear(); // DeleteChildren calls OnSegmentSelect
+			segmentTree->DeleteChildren(segmentRoot);
 		}
-	}
 
-	wxTextCtrl* segmentSSF = (wxTextCtrl*)FindWindowByName("segmentSSF");
-	segmentSSF->ChangeValue(inf.ssfFile);
+		segmentTabButton->SetPendingChanges(false);
 
-	UpdateSegmentNames();
-	segmentTree->ExpandAll();
-
-	wxTreeItemIdValue cookie;
-	wxTreeItemId child = segmentTree->GetFirstChild(segmentRoot, cookie);
-	if (child.IsOk())
-		segmentTree->SelectItem(child);
-}
-
-void OutfitStudioFrame::ShowSegment(const wxTreeItemId& item, bool updateFromMask) {
-	if (!activeItem || !glView->GetSegmentMode())
-		return;
-
-	std::unordered_map<uint16_t, float> mask;
-	wxChoice* segmentType = nullptr;
-	wxChoice* segmentSlot = nullptr;
-	if (!updateFromMask) {
-		segmentType = (wxChoice*)FindWindowByName("segmentType");
-		segmentType->Disable();
-		segmentType->SetSelection(0);
-
-		segmentSlot = (wxChoice*)FindWindowByName("segmentSlot");
-		segmentSlot->Disable();
-		segmentSlot->SetSelection(0);
-	}
-	else
-		glView->GetActiveMask(mask);
-
-	if (item.IsOk())
-		activeSegment = item;
-
-	if (!activeSegment.IsOk() || !segmentTree->GetItemParent(activeSegment).IsOk())
-		return;
-
-	// Get all triangles of the active shape
-	std::vector<Triangle> tris;
-	if (activeItem->GetShape())
-		activeItem->GetShape()->GetTriangles(tris);
-	if (triSParts.size() != tris.size())
-		return;
-
-	// selPartIDs will be true for selected item and its children.
-	std::vector<bool> selPartIDs(CalcMaxSegPartID() + 1, false);
-
-	SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(activeSegment));
-	if (subSegmentData) {
-		// Active segment is a subsegment
-		selPartIDs[subSegmentData->partID] = true;
-
-		if (updateFromMask) {
-			// Add triangles from mask
-			for (size_t t = 0; t < tris.size(); t++) {
-				if (mask.find(tris[t].p1) != mask.end() && mask.find(tris[t].p2) != mask.end() && mask.find(tris[t].p3) != mask.end())
-					triSParts[t] = subSegmentData->partID;
-			}
-		}
-		else {
-			if (subSegmentData->material != 0xFFFFFFFF) {
-				bool typeFound = false;
-				auto typeHash = wxString::Format("0x%08x", subSegmentData->material);
-				for (uint32_t i = 0; i < segmentType->GetCount(); i++) {
-					auto typeString = segmentType->GetString(i);
-					if (typeString.Contains(typeHash)) {
-						segmentType->SetSelection((int)i);
-						typeFound = true;
-						break;
+		NifSegmentationInfo inf;
+		if (project->GetWorkNif()->GetShapeSegments(shape, inf, triSParts))
+		{
+			for (size_t i = 0; i < inf.segs.size(); i++)
+			{
+				wxTreeItemId segID = segmentTree->AppendItem(segmentRoot, "Segment", -1, -1, new SegmentItemData(inf.segs[i].partID));
+				if (segID.IsOk())
+				{
+					for (size_t j = 0; j < inf.segs[i].subs.size(); j++)
+					{
+						NifSubSegmentInfo &sub = inf.segs[i].subs[j];
+						segmentTree->AppendItem(segID, "Sub Segment", -1, -1,
+						                        new SubSegmentItemData(sub.partID, sub.userSlotID, sub.material, sub.extraData));
 					}
 				}
-
-				if (!typeFound)
-					segmentType->SetSelection(segmentType->Append(typeHash));
 			}
-
-			segmentType->Enable();
-
-			for (uint32_t i = 0; i < segmentSlot->GetCount(); i++) {
-				wxString slotPrefix = wxString::Format("%d - ", subSegmentData->userSlotID);
-				auto slotString = segmentSlot->GetString(i);
-				if (slotString.StartsWith(slotPrefix)) {
-					segmentSlot->SetSelection((int)i);
-					break;
-				}
-			}
-
-			segmentSlot->Enable();
 		}
-	}
-	else {
-		SegmentItemData* segmentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(activeSegment));
-		if (segmentData) {
-			// Active segment is a normal segment
-			// Collect list of partition IDs for segment and children.
-			// Also find partition ID of last child, or segment if none.
-			selPartIDs[segmentData->partID] = true;
-			int destPartID = segmentData->partID;
-			wxTreeItemIdValue subCookie;
-			wxTreeItemId child = segmentTree->GetFirstChild(activeSegment, subCookie);
-			while (child.IsOk()) {
-				SubSegmentItemData* childData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(child));
-				if (childData) {
-					selPartIDs[childData->partID] = true;
-					destPartID = childData->partID;
-				}
-				child = segmentTree->GetNextChild(activeSegment, subCookie);
-			}
 
-			if (updateFromMask) {
+		wxTextCtrl* segmentSSF = (wxTextCtrl*)FindWindowByName("segmentSSF");
+		segmentSSF->ChangeValue(inf.ssfFile);
+
+		UpdateSegmentNames();
+		segmentTree->ExpandAll();
+
+		wxTreeItemIdValue cookie;
+		wxTreeItemId child = segmentTree->GetFirstChild(segmentRoot, cookie);
+		if (child.IsOk())
+			segmentTree->SelectItem(child);
+	}
+
+	void OutfitStudioFrame::ShowSegment(const wxTreeItemId& item, bool updateFromMask) {
+		if (!activeItem || !glView->GetSegmentMode())
+			return;
+
+		std::unordered_map<uint16_t, float> mask;
+		wxChoice* segmentType = nullptr;
+		wxChoice* segmentSlot = nullptr;
+		if (!updateFromMask)
+		{
+			segmentType = (wxChoice*)FindWindowByName("segmentType");
+			segmentType->Disable();
+			segmentType->SetSelection(0);
+
+			segmentSlot = (wxChoice*)FindWindowByName("segmentSlot");
+			segmentSlot->Disable();
+			segmentSlot->SetSelection(0);
+		}
+		else
+			glView->GetActiveMask(mask);
+
+		if (item.IsOk())
+			activeSegment = item;
+
+		if (!activeSegment.IsOk() || !segmentTree->GetItemParent(activeSegment).IsOk())
+			return;
+
+		// Get all triangles of the active shape
+		std::vector<Triangle> tris;
+		if (activeItem->GetShape())
+			activeItem->GetShape()->GetTriangles(tris);
+		if (triSParts.size() != tris.size())
+			return;
+
+		// selPartIDs will be true for selected item and its children.
+		std::vector<bool> selPartIDs(CalcMaxSegPartID() + 1, false);
+
+		SubSegmentItemData* subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(activeSegment));
+		if (subSegmentData)
+		{
+			// Active segment is a subsegment
+			selPartIDs[subSegmentData->partID] = true;
+
+			if (updateFromMask)
+			{
 				// Add triangles from mask
-				for (size_t t = 0; t < tris.size(); t++) {
-					if (mask.find(tris[t].p1) != mask.end() && mask.find(tris[t].p2) != mask.end() && mask.find(tris[t].p3) != mask.end() && (triSParts[t] < 0 || !selPartIDs[triSParts[t]]))
-						triSParts[t] = destPartID;
+				for (size_t t = 0; t < tris.size(); t++)
+				{
+					if (mask.find(tris[t].p1) != mask.end() && mask.find(tris[t].p2) != mask.end() && mask.find(tris[t].p3) != mask.end())
+						triSParts[t] = subSegmentData->partID;
 				}
 			}
-		}
-	}
-
-	// Display segmentation colors depending on what is selected
-	mesh* m = glView->GetMesh(activeItem->GetShape()->name.get());
-	if (m) {
-		SetSubMeshesForPartitions(m, triSParts);
-
-		// Set colors for segments
-		int nsm = m->subMeshes.size();
-		m->subMeshesColor.resize(nsm);
-		for (int pi = 0; pi < nsm; ++pi) {
-			if (selPartIDs[pi]) {
-				m->subMeshesColor[pi].x = 1.0f;
-				m->subMeshesColor[pi].y = 0.0f;
-				m->subMeshesColor[pi].z = 0.0f;
-			}
-			else {
-				float colorValue = (pi + 1.0f) / (nsm + 1);
-				m->subMeshesColor[pi] = glView->CreateColorRamp(colorValue);
-			}
-		}
-
-		// Set mask
-		m->ColorFill(Vector3(0.0f, 0.0f, 0.0f));
-
-		for (size_t i = 0; i < triSParts.size(); ++i) {
-			if (triSParts[i] < 0 || !selPartIDs[triSParts[i]])
-				continue;
-
-			m->vcolors[tris[i].p1].x = 1.0f;
-			m->vcolors[tris[i].p2].x = 1.0f;
-			m->vcolors[tris[i].p3].x = 1.0f;
-		}
-	}
-
-	glView->Render();
-}
-
-void OutfitStudioFrame::UpdateSegmentNames() {
-	auto segmentSlot = (wxChoice*)FindWindowByName("segmentSlot");
-	auto segmentType = (wxChoice*)FindWindowByName("segmentType");
-
-	int segmentIndex = 0;
-	wxTreeItemIdValue cookie;
-	wxTreeItemId child = segmentTree->GetFirstChild(segmentRoot, cookie);
-
-	while (child.IsOk()) {
-		segmentTree->SetItemText(child, wxString::Format("Segment #%d", segmentIndex));
-
-		int subSegmentIndex = 0;
-		wxTreeItemIdValue subCookie;
-		wxTreeItemId subChild = segmentTree->GetFirstChild(child, subCookie);
-
-		while (subChild.IsOk()) {
-			std::string subSegmentName = "Default";
-			std::string subSegmentSlot = "";
-
-			auto subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(subChild));
-			if (subSegmentData) {
-				if (subSegmentData->material != 0xFFFFFFFF) {
+			else
+			{
+				if (subSegmentData->material != 0xFFFFFFFF)
+				{
 					bool typeFound = false;
 					auto typeHash = wxString::Format("0x%08x", subSegmentData->material);
-					for (uint32_t i = 0; i < segmentType->GetCount(); i++) {
+					for (uint32_t i = 0; i < segmentType->GetCount(); i++)
+					{
 						auto typeString = segmentType->GetString(i);
-						if (typeString.Contains(typeHash)) {
-							subSegmentName = typeString.BeforeLast('|');
+						if (typeString.Contains(typeHash))
+						{
+							segmentType->SetSelection((int)i);
 							typeFound = true;
 							break;
 						}
 					}
 
 					if (!typeFound)
-						subSegmentName = typeHash;
+						segmentType->SetSelection(segmentType->Append(typeHash));
 				}
 
-				if (subSegmentData->userSlotID >= 30) {
-					wxString slotPrefix = wxString::Format("%d - ", subSegmentData->userSlotID);
+				segmentType->Enable();
 
-					for (uint32_t i = 0; i < segmentSlot->GetCount(); i++) {
-						auto slotString = segmentSlot->GetString(i);
-						if (slotString.StartsWith(slotPrefix)) {
-							subSegmentSlot = wxString::Format("(Slot %s)", slotString);
-							break;
-						}
+				for (uint32_t i = 0; i < segmentSlot->GetCount(); i++)
+				{
+					wxString slotPrefix = wxString::Format("%d - ", subSegmentData->userSlotID);
+					auto slotString = segmentSlot->GetString(i);
+					if (slotString.StartsWith(slotPrefix))
+					{
+						segmentSlot->SetSelection((int)i);
+						break;
+					}
+				}
+
+				segmentSlot->Enable();
+			}
+		}
+		else
+		{
+			SegmentItemData* segmentData = dynamic_cast<SegmentItemData*>(segmentTree->GetItemData(activeSegment));
+			if (segmentData)
+			{
+				// Active segment is a normal segment
+				// Collect list of partition IDs for segment and children.
+				// Also find partition ID of last child, or segment if none.
+				selPartIDs[segmentData->partID] = true;
+				int destPartID = segmentData->partID;
+				wxTreeItemIdValue subCookie;
+				wxTreeItemId child = segmentTree->GetFirstChild(activeSegment, subCookie);
+				while (child.IsOk())
+				{
+					SubSegmentItemData* childData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(child));
+					if (childData)
+					{
+						selPartIDs[childData->partID] = true;
+						destPartID = childData->partID;
+					}
+					child = segmentTree->GetNextChild(activeSegment, subCookie);
+				}
+
+				if (updateFromMask)
+				{
+					// Add triangles from mask
+					for (size_t t = 0; t < tris.size(); t++)
+					{
+						if (mask.find(tris[t].p1) != mask.end() && mask.find(tris[t].p2) != mask.end() && mask.find(tris[t].p3) != mask.end() && (triSParts[t] < 0 || !selPartIDs[triSParts[t]]))
+							triSParts[t] = destPartID;
 					}
 				}
 			}
-
-			segmentTree->SetItemText(subChild, wxString::Format("#%d: %s%s", subSegmentIndex, subSegmentName, subSegmentSlot));
-
-			subChild = segmentTree->GetNextChild(child, subCookie);
-			subSegmentIndex++;
 		}
 
-		child = segmentTree->GetNextChild(segmentRoot, cookie);
-		segmentIndex++;
-	}
-}
+		// Display segmentation colors depending on what is selected
+		mesh* m = glView->GetMesh(activeItem->GetShape()->name.get());
+		if (m)
+		{
+			SetSubMeshesForPartitions(m, triSParts);
 
-void OutfitStudioFrame::OnPartitionSelect(wxTreeEvent& event) {
-	ShowPartition(event.GetItem());
-}
-
-void OutfitStudioFrame::OnPartitionContext(wxTreeEvent& event) {
-	if (!event.GetItem().IsOk())
-		return;
-
-	partitionTree->SelectItem(event.GetItem());
-
-	wxMenu* menu = nullptr;
-	PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(event.GetItem()));
-	if (partitionData)
-		menu = wxXmlResource::Get()->LoadMenu("menuPartitionContext");
-
-	if (menu) {
-		PopupMenu(menu);
-		delete menu;
-	}
-}
-
-void OutfitStudioFrame::OnPartitionTreeContext(wxCommandEvent& WXUNUSED(event)) {
-	wxMenu* menu = wxXmlResource::Get()->LoadMenu("menuPartitionTreeContext");
-	if (menu) {
-		PopupMenu(menu);
-		delete menu;
-	}
-}
-
-void OutfitStudioFrame::OnAddPartition(wxCommandEvent& WXUNUSED(event)) {
-	bool isSkyrim = wxGetApp().targetGame == SKYRIM || wxGetApp().targetGame == SKYRIMSE || wxGetApp().targetGame == SKYRIMVR;
-
-	// Find an unused partition index
-	std::set<int> partInds;
-	wxTreeItemIdValue cookie;
-	wxTreeItemId child = partitionTree->GetFirstChild(partitionRoot, cookie);
-	while (child.IsOk()) {
-		PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(child));
-		if (partitionData)
-			partInds.insert(partitionData->index);
-		child = partitionTree->GetNextChild(partitionRoot, cookie);
-	}
-
-	int partInd = 0;
-	while (partInds.count(partInd) != 0) ++partInd;
-
-	// Create partition item
-	wxTreeItemId newItem;
-	if (!activePartition.IsOk() || partitionTree->GetChildrenCount(partitionRoot) <= 0) {
-		auto shape = activeItem->GetShape();
-		if (shape && shape->GetNumVertices() > 0) {
-			newItem = partitionTree->AppendItem(partitionRoot, "Partition", -1, -1,
-				new PartitionItemData(partInd, isSkyrim ? 32 : 0));
-		}
-
-		for (int &pi : triParts)
-			pi = partInd;
-	}
-	else
-		newItem = partitionTree->InsertItem(partitionRoot, activePartition, "Partition", -1, -1,
-			new PartitionItemData(partInd, isSkyrim ? 32 : 0));
-
-	if (newItem.IsOk()) {
-		partitionTree->UnselectAll();
-		partitionTree->SelectItem(newItem);
-	}
-
-	UpdatePartitionNames();
-	partitionTabButton->SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnDeletePartition(wxCommandEvent& WXUNUSED(event)) {
-	PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(activePartition));
-	if (partitionData) {
-		wxTreeItemId sibling = partitionTree->GetPrevSibling(activePartition);
-		if (!sibling.IsOk())
-			sibling = partitionTree->GetNextSibling(activePartition);
-
-		int newIndex = -1;
-		if (sibling.IsOk()) {
-			PartitionItemData *siblingData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(sibling));
-			if (siblingData)
-				newIndex = siblingData->index;
-		}
-		for (size_t i = 0; i < triParts.size(); ++i)
-			if (triParts[i] == partitionData->index)
-				triParts[i] = newIndex;
-
-		if (sibling.IsOk()) {
-			partitionTree->UnselectAll();
-			partitionTree->Delete(activePartition);
-			partitionTree->SelectItem(sibling);
-
-			ShowPartition(sibling);
-		}
-		else {
-			partitionTree->Delete(activePartition);
-			activePartition.Unset();
-		}
-	}
-
-	UpdatePartitionNames();
-	partitionTabButton->SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnPartitionTypeChanged(wxCommandEvent& event) {
-	wxChoice* partitionType = (wxChoice*)event.GetEventObject();
-
-	if (activePartition.IsOk() && partitionTree->GetItemParent(activePartition).IsOk()) {
-		PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(activePartition));
-		if (partitionData) {
-			unsigned long type = 0;
-			partitionType->GetStringSelection().ToULong(&type);
-			partitionData->type = type;
-		}
-	}
-
-	UpdatePartitionNames();
-	partitionTabButton->SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnPartitionApply(wxCommandEvent& WXUNUSED(event)) {
-	ApplyPartitions();
-}
-
-void OutfitStudioFrame::ApplyPartitions() {
-	auto shape = activeItem->GetShape();
-	if (!shape)
-		return;
-
-	NiVector<BSDismemberSkinInstance::PartitionInfo> partitionInfo;
-	std::vector<bool> delPartFlags;
-
-	wxTreeItemIdValue cookie;
-	wxTreeItemId child = partitionTree->GetFirstChild(partitionRoot, cookie);
-
-	while (child.IsOk()) {
-		PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(child));
-		if (partitionData) {
-			const int index = partitionData->index;
-			if (index >= partitionInfo.size()) {
-				partitionInfo.resize(index + 1);
-				delPartFlags.resize(index + 1, true);
-			}
-			partitionInfo[index].flags = PF_EDITOR_VISIBLE;
-			partitionInfo[index].partID = partitionData->type;
-			delPartFlags[index] = false;
-		}
-
-		child = partitionTree->GetNextChild(partitionRoot, cookie);
-	}
-
-	std::vector<uint32_t> delPartInds;
-	for (uint32_t pi = 0; pi < delPartFlags.size(); ++pi)
-		if (delPartFlags[pi])
-			delPartInds.push_back(pi);
-
-	project->GetWorkNif()->SetShapePartitions(shape, partitionInfo, triParts);
-	if (!delPartInds.empty())
-		project->GetWorkNif()->DeletePartitions(shape, delPartInds);
-
-	CreatePartitionTree(shape);
-	SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnPartitionReset(wxCommandEvent& WXUNUSED(event)) {
-	ResetPartitions();
-}
-
-void OutfitStudioFrame::ResetPartitions() {
-	if (activeItem)
-		CreatePartitionTree(activeItem->GetShape());
-	else
-		CreatePartitionTree(nullptr);
-}
-
-void OutfitStudioFrame::CreatePartitionTree(NiShape* shape) {
-	if (partitionTree->GetChildrenCount(partitionRoot) > 0) {
-		triParts.clear(); // DeleteChildren calls OnPartitionSelect
-		partitionTree->DeleteChildren(partitionRoot);
-	}
-
-	partitionTabButton->SetPendingChanges(false);
-
-	NiVector<BSDismemberSkinInstance::PartitionInfo> partitionInfo;
-	if (project->GetWorkNif()->GetShapePartitions(shape, partitionInfo, triParts)) {
-		for (int i = 0; i < partitionInfo.size(); i++) {
-			partitionTree->AppendItem(partitionRoot, "Partition", -1, -1, new PartitionItemData(i, partitionInfo[i].partID));
-		}
-	}
-
-	UpdatePartitionNames();
-	partitionTree->ExpandAll();
-
-	wxTreeItemIdValue cookie;
-	wxTreeItemId child = partitionTree->GetFirstChild(partitionRoot, cookie);
-	if (child.IsOk())
-		partitionTree->SelectItem(child);
-}
-
-void OutfitStudioFrame::ShowPartition(const wxTreeItemId& item, bool updateFromMask) {
-	if (!activeItem || !glView->GetSegmentMode())
-		return;
-	auto shape = activeItem->GetShape();
-	if (!shape)
-		return;
-
-	std::unordered_map<uint16_t, float> mask;
-	wxChoice* partitionType = nullptr;
-	wxArrayString partitionStrings;
-	if (!updateFromMask) {
-		partitionType = (wxChoice*)FindWindowByName("partitionType");
-		partitionType->Disable();
-		partitionType->SetSelection(0);
-		partitionStrings = partitionType->GetStrings();
-	}
-	else
-		glView->GetActiveMask(mask);
-
-	if (item.IsOk())
-		activePartition = item;
-
-	if (!activePartition.IsOk() || !partitionTree->GetItemParent(activePartition).IsOk())
-		return;
-
-	// Get all triangles of the active shape
-	std::vector<Triangle> allTris;
-	shape->GetTriangles(allTris);
-	if (allTris.size() != triParts.size())
-		return;
-
-	PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(activePartition));
-	if (partitionData) {
-		if (!updateFromMask) {
-			for (auto &s : partitionStrings) {
-				if (s.StartsWith(wxString::Format("%d", partitionData->type))) {
-					// Show correct data in UI
-					partitionType->Enable();
-					partitionType->SetStringSelection(s);
+			// Set colors for segments
+			int nsm = m->subMeshes.size();
+			m->subMeshesColor.resize(nsm);
+			for (int pi = 0; pi < nsm; ++pi)
+			{
+				if (selPartIDs[pi])
+				{
+					m->subMeshesColor[pi].x = 1.0f;
+					m->subMeshesColor[pi].y = 0.0f;
+					m->subMeshesColor[pi].z = 0.0f;
+				}
+				else
+				{
+					float colorValue = (pi + 1.0f) / (nsm + 1);
+					m->subMeshesColor[pi] = glView->CreateColorRamp(colorValue);
 				}
 			}
-		}
-		else {
-			// Add triangles from mask
-			for (size_t triInd = 0; triInd < allTris.size(); ++triInd) {
-				const Triangle &tri = allTris[triInd];
-				if (mask.find(tri.p1) != mask.end() && mask.find(tri.p2) != mask.end() && mask.find(tri.p3) != mask.end())
-					triParts[triInd] = partitionData->index;
-			}
-		}
-	}
 
-	// Display partition colors depending on what is selected
-	mesh* m = glView->GetMesh(activeItem->GetShape()->name.get());
-	if (m) {
-		SetSubMeshesForPartitions(m, triParts);
+			// Set mask
+			m->ColorFill(Vector3(0.0f, 0.0f, 0.0f));
 
-		// Set colors for non-selected partitions
-		int nsm = m->subMeshes.size();
-		m->subMeshesColor.resize(nsm);
-
-		for (int pi = 0; pi < nsm; ++pi) {
-			float colorValue = (pi + 1.0f) / (nsm + 1);
-			m->subMeshesColor[pi] = glView->CreateColorRamp(colorValue);
-		}
-
-		// Set color for selected partition
-		if (partitionData) {
-			if (nsm > partitionData->index) {
-				m->subMeshesColor[partitionData->index].x = 1.0f;
-				m->subMeshesColor[partitionData->index].y = 0.0f;
-				m->subMeshesColor[partitionData->index].z = 0.0f;
-			}
-		}
-
-		// Set mask
-		m->ColorFill(Vector3(0.0f, 0.0f, 0.0f));
-
-		if (partitionData) {
-			for (size_t i = 0; i < allTris.size(); ++i) {
-				if (triParts[i] != partitionData->index)
+			for (size_t i = 0; i < triSParts.size(); ++i)
+			{
+				if (triSParts[i] < 0 || !selPartIDs[triSParts[i]])
 					continue;
 
-				const Triangle &t = allTris[i];
-				m->vcolors[t.p1].x = 1.0f;
-				m->vcolors[t.p2].x = 1.0f;
-				m->vcolors[t.p3].x = 1.0f;
+				m->vcolors[tris[i].p1].x = 1.0f;
+				m->vcolors[tris[i].p2].x = 1.0f;
+				m->vcolors[tris[i].p3].x = 1.0f;
 			}
+		}
+
+		glView->Render();
+	}
+
+	void OutfitStudioFrame::UpdateSegmentNames() {
+		auto segmentSlot = (wxChoice*)FindWindowByName("segmentSlot");
+		auto segmentType = (wxChoice*)FindWindowByName("segmentType");
+
+		int segmentIndex = 0;
+		wxTreeItemIdValue cookie;
+		wxTreeItemId child = segmentTree->GetFirstChild(segmentRoot, cookie);
+
+		while (child.IsOk())
+		{
+			segmentTree->SetItemText(child, wxString::Format("Segment #%d", segmentIndex));
+
+			int subSegmentIndex = 0;
+			wxTreeItemIdValue subCookie;
+			wxTreeItemId subChild = segmentTree->GetFirstChild(child, subCookie);
+
+			while (subChild.IsOk())
+			{
+				std::string subSegmentName = "Default";
+				std::string subSegmentSlot = "";
+
+				auto subSegmentData = dynamic_cast<SubSegmentItemData*>(segmentTree->GetItemData(subChild));
+				if (subSegmentData)
+				{
+					if (subSegmentData->material != 0xFFFFFFFF)
+					{
+						bool typeFound = false;
+						auto typeHash = wxString::Format("0x%08x", subSegmentData->material);
+						for (uint32_t i = 0; i < segmentType->GetCount(); i++)
+						{
+							auto typeString = segmentType->GetString(i);
+							if (typeString.Contains(typeHash))
+							{
+								subSegmentName = typeString.BeforeLast('|');
+								typeFound = true;
+								break;
+							}
+						}
+
+						if (!typeFound)
+							subSegmentName = typeHash;
+					}
+
+					if (subSegmentData->userSlotID >= 30)
+					{
+						wxString slotPrefix = wxString::Format("%d - ", subSegmentData->userSlotID);
+
+						for (uint32_t i = 0; i < segmentSlot->GetCount(); i++)
+						{
+							auto slotString = segmentSlot->GetString(i);
+							if (slotString.StartsWith(slotPrefix))
+							{
+								subSegmentSlot = wxString::Format("(Slot %s)", slotString);
+								break;
+							}
+						}
+					}
+				}
+
+				segmentTree->SetItemText(subChild, wxString::Format("#%d: %s%s", subSegmentIndex, subSegmentName, subSegmentSlot));
+
+				subChild = segmentTree->GetNextChild(child, subCookie);
+				subSegmentIndex++;
+			}
+
+			child = segmentTree->GetNextChild(segmentRoot, cookie);
+			segmentIndex++;
 		}
 	}
 
-	glView->Render();
-}
+	void OutfitStudioFrame::OnPartitionSelect(wxTreeEvent& event)
+	{
+		ShowPartition(event.GetItem());
+	}
 
-void OutfitStudioFrame::UpdatePartitionNames() {
-	wxChoice* partitionType = (wxChoice*)FindWindowByName("partitionType");
-	wxArrayString partitionStrings = partitionType->GetStrings();
+	void OutfitStudioFrame::OnPartitionContext(wxTreeEvent& event) {
+		if (!event.GetItem().IsOk())
+			return;
 
-	wxTreeItemIdValue cookie;
-	wxTreeItemId child = partitionTree->GetFirstChild(partitionRoot, cookie);
+		partitionTree->SelectItem(event.GetItem());
 
-	while (child.IsOk()) {
-		PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(child));
-		if (partitionData) {
-			bool found = false;
-			for (auto &s : partitionStrings) {
-				if (s.StartsWith(wxString::Format("%d", partitionData->type))) {
-					partitionTree->SetItemText(child, s);
-					found = true;
-					break;
+		wxMenu* menu = nullptr;
+		PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(event.GetItem()));
+		if (partitionData)
+			menu = wxXmlResource::Get()->LoadMenu("menuPartitionContext");
+
+		if (menu)
+		{
+			PopupMenu(menu);
+			delete menu;
+		}
+	}
+
+	void OutfitStudioFrame::OnPartitionTreeContext(wxCommandEvent& WXUNUSED(event)) {
+		wxMenu* menu = wxXmlResource::Get()->LoadMenu("menuPartitionTreeContext");
+		if (menu)
+		{
+			PopupMenu(menu);
+			delete menu;
+		}
+	}
+
+	void OutfitStudioFrame::OnAddPartition(wxCommandEvent& WXUNUSED(event)) {
+		bool isSkyrim = wxGetApp().targetGame == SKYRIM || wxGetApp().targetGame == SKYRIMSE || wxGetApp().targetGame == SKYRIMVR;
+
+		// Find an unused partition index
+		std::set<int> partInds;
+		wxTreeItemIdValue cookie;
+		wxTreeItemId child = partitionTree->GetFirstChild(partitionRoot, cookie);
+		while (child.IsOk())
+		{
+			PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(child));
+			if (partitionData)
+				partInds.insert(partitionData->index);
+			child = partitionTree->GetNextChild(partitionRoot, cookie);
+		}
+
+		int partInd = 0;
+		while (partInds.count(partInd) != 0) ++partInd;
+
+		// Create partition item
+		wxTreeItemId newItem;
+		if (!activePartition.IsOk() || partitionTree->GetChildrenCount(partitionRoot) <= 0)
+		{
+			auto shape = activeItem->GetShape();
+			if (shape && shape->GetNumVertices() > 0)
+			{
+				newItem = partitionTree->AppendItem(partitionRoot, "Partition", -1, -1,
+				                                    new PartitionItemData(partInd, isSkyrim ? 32 : 0));
+			}
+
+			for (int &pi : triParts)
+				pi = partInd;
+		}
+		else
+			newItem = partitionTree->InsertItem(partitionRoot, activePartition, "Partition", -1, -1,
+			                                    new PartitionItemData(partInd, isSkyrim ? 32 : 0));
+
+		if (newItem.IsOk())
+		{
+			partitionTree->UnselectAll();
+			partitionTree->SelectItem(newItem);
+		}
+
+		UpdatePartitionNames();
+		partitionTabButton->SetPendingChanges();
+	}
+
+	void OutfitStudioFrame::OnDeletePartition(wxCommandEvent& WXUNUSED(event)) {
+		PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(activePartition));
+		if (partitionData)
+		{
+			wxTreeItemId sibling = partitionTree->GetPrevSibling(activePartition);
+			if (!sibling.IsOk())
+				sibling = partitionTree->GetNextSibling(activePartition);
+
+			int newIndex = -1;
+			if (sibling.IsOk())
+			{
+				PartitionItemData *siblingData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(sibling));
+				if (siblingData)
+					newIndex = siblingData->index;
+			}
+			for (size_t i = 0; i < triParts.size(); ++i)
+				if (triParts[i] == partitionData->index)
+					triParts[i] = newIndex;
+
+			if (sibling.IsOk())
+			{
+				partitionTree->UnselectAll();
+				partitionTree->Delete(activePartition);
+				partitionTree->SelectItem(sibling);
+
+				ShowPartition(sibling);
+			}
+			else
+			{
+				partitionTree->Delete(activePartition);
+				activePartition.Unset();
+			}
+		}
+
+		UpdatePartitionNames();
+		partitionTabButton->SetPendingChanges();
+	}
+
+	void OutfitStudioFrame::OnPartitionTypeChanged(wxCommandEvent& event) {
+		wxChoice* partitionType = (wxChoice*)event.GetEventObject();
+
+		if (activePartition.IsOk() && partitionTree->GetItemParent(activePartition).IsOk())
+		{
+			PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(activePartition));
+			if (partitionData)
+			{
+				unsigned long type = 0;
+				partitionType->GetStringSelection().ToULong(&type);
+				partitionData->type = type;
+			}
+		}
+
+		UpdatePartitionNames();
+		partitionTabButton->SetPendingChanges();
+	}
+
+	void OutfitStudioFrame::OnPartitionApply(wxCommandEvent& WXUNUSED(event))
+	{
+		ApplyPartitions();
+	}
+
+	void OutfitStudioFrame::ApplyPartitions() {
+		auto shape = activeItem->GetShape();
+		if (!shape)
+			return;
+
+		NiVector<BSDismemberSkinInstance::PartitionInfo> partitionInfo;
+		std::vector<bool> delPartFlags;
+
+		wxTreeItemIdValue cookie;
+		wxTreeItemId child = partitionTree->GetFirstChild(partitionRoot, cookie);
+
+		while (child.IsOk())
+		{
+			PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(child));
+			if (partitionData)
+			{
+				const int index = partitionData->index;
+				if (index >= partitionInfo.size())
+				{
+					partitionInfo.resize(index + 1);
+					delPartFlags.resize(index + 1, true);
+				}
+				partitionInfo[index].flags = PF_EDITOR_VISIBLE;
+				partitionInfo[index].partID = partitionData->type;
+				delPartFlags[index] = false;
+			}
+
+			child = partitionTree->GetNextChild(partitionRoot, cookie);
+		}
+
+		std::vector<uint32_t> delPartInds;
+		for (uint32_t pi = 0; pi < delPartFlags.size(); ++pi)
+			if (delPartFlags[pi])
+				delPartInds.push_back(pi);
+
+		project->GetWorkNif()->SetShapePartitions(shape, partitionInfo, triParts);
+		if (!delPartInds.empty())
+			project->GetWorkNif()->DeletePartitions(shape, delPartInds);
+
+		CreatePartitionTree(shape);
+		SetPendingChanges();
+	}
+
+	void OutfitStudioFrame::OnPartitionReset(wxCommandEvent& WXUNUSED(event))
+	{
+		ResetPartitions();
+	}
+
+	void OutfitStudioFrame::ResetPartitions()
+	{
+		if (activeItem)
+			CreatePartitionTree(activeItem->GetShape());
+		else
+			CreatePartitionTree(nullptr);
+	}
+
+	void OutfitStudioFrame::CreatePartitionTree(NiShape* shape) {
+		if (partitionTree->GetChildrenCount(partitionRoot) > 0)
+		{
+			triParts.clear(); // DeleteChildren calls OnPartitionSelect
+			partitionTree->DeleteChildren(partitionRoot);
+		}
+
+		partitionTabButton->SetPendingChanges(false);
+
+		NiVector<BSDismemberSkinInstance::PartitionInfo> partitionInfo;
+		if (project->GetWorkNif()->GetShapePartitions(shape, partitionInfo, triParts))
+		{
+			for (int i = 0; i < partitionInfo.size(); i++)
+			{
+				partitionTree->AppendItem(partitionRoot, "Partition", -1, -1, new PartitionItemData(i, partitionInfo[i].partID));
+			}
+		}
+
+		UpdatePartitionNames();
+		partitionTree->ExpandAll();
+
+		wxTreeItemIdValue cookie;
+		wxTreeItemId child = partitionTree->GetFirstChild(partitionRoot, cookie);
+		if (child.IsOk())
+			partitionTree->SelectItem(child);
+	}
+
+	void OutfitStudioFrame::ShowPartition(const wxTreeItemId& item, bool updateFromMask) {
+		if (!activeItem || !glView->GetSegmentMode())
+			return;
+		auto shape = activeItem->GetShape();
+		if (!shape)
+			return;
+
+		std::unordered_map<uint16_t, float> mask;
+		wxChoice* partitionType = nullptr;
+		wxArrayString partitionStrings;
+		if (!updateFromMask)
+		{
+			partitionType = (wxChoice*)FindWindowByName("partitionType");
+			partitionType->Disable();
+			partitionType->SetSelection(0);
+			partitionStrings = partitionType->GetStrings();
+		}
+		else
+			glView->GetActiveMask(mask);
+
+		if (item.IsOk())
+			activePartition = item;
+
+		if (!activePartition.IsOk() || !partitionTree->GetItemParent(activePartition).IsOk())
+			return;
+
+		// Get all triangles of the active shape
+		std::vector<Triangle> allTris;
+		shape->GetTriangles(allTris);
+		if (allTris.size() != triParts.size())
+			return;
+
+		PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(activePartition));
+		if (partitionData)
+		{
+			if (!updateFromMask)
+			{
+				for (auto &s : partitionStrings)
+				{
+					if (s.StartsWith(wxString::Format("%d", partitionData->type)))
+					{
+						// Show correct data in UI
+						partitionType->Enable();
+						partitionType->SetStringSelection(s);
+					}
+				}
+			}
+			else
+			{
+				// Add triangles from mask
+				for (size_t triInd = 0; triInd < allTris.size(); ++triInd)
+				{
+					const Triangle &tri = allTris[triInd];
+					if (mask.find(tri.p1) != mask.end() && mask.find(tri.p2) != mask.end() && mask.find(tri.p3) != mask.end())
+						triParts[triInd] = partitionData->index;
+				}
+			}
+		}
+
+		// Display partition colors depending on what is selected
+		mesh* m = glView->GetMesh(activeItem->GetShape()->name.get());
+		if (m)
+		{
+			SetSubMeshesForPartitions(m, triParts);
+
+			// Set colors for non-selected partitions
+			int nsm = m->subMeshes.size();
+			m->subMeshesColor.resize(nsm);
+
+			for (int pi = 0; pi < nsm; ++pi)
+			{
+				float colorValue = (pi + 1.0f) / (nsm + 1);
+				m->subMeshesColor[pi] = glView->CreateColorRamp(colorValue);
+			}
+
+			// Set color for selected partition
+			if (partitionData)
+			{
+				if (nsm > partitionData->index)
+				{
+					m->subMeshesColor[partitionData->index].x = 1.0f;
+					m->subMeshesColor[partitionData->index].y = 0.0f;
+					m->subMeshesColor[partitionData->index].z = 0.0f;
 				}
 			}
 
-			if (!found)
-				partitionTree->SetItemText(child, wxString::Format("%d Unknown", partitionData->type));
+			// Set mask
+			m->ColorFill(Vector3(0.0f, 0.0f, 0.0f));
+
+			if (partitionData)
+			{
+				for (size_t i = 0; i < allTris.size(); ++i)
+				{
+					if (triParts[i] != partitionData->index)
+						continue;
+
+					const Triangle &t = allTris[i];
+					m->vcolors[t.p1].x = 1.0f;
+					m->vcolors[t.p2].x = 1.0f;
+					m->vcolors[t.p3].x = 1.0f;
+				}
+			}
 		}
 
-		child = partitionTree->GetNextChild(partitionRoot, cookie);
+		glView->Render();
 	}
-}
 
-void OutfitStudioFrame::SetSubMeshesForPartitions(mesh *m, const std::vector<int> &tp) {
-	uint32_t nTris = static_cast<uint32_t>(tp.size());
+	void OutfitStudioFrame::UpdatePartitionNames() {
+		wxChoice* partitionType = (wxChoice*)FindWindowByName("partitionType");
+		wxArrayString partitionStrings = partitionType->GetStrings();
 
-	// Sort triangles (via triInds) by partition number, negative partition
-	// numbers at the end.
-	std::vector<uint32_t> triInds(nTris);
-	for (uint32_t ti = 0; ti < nTris; ++ti)
-		triInds[ti] = ti;
+		wxTreeItemIdValue cookie;
+		wxTreeItemId child = partitionTree->GetFirstChild(partitionRoot, cookie);
 
-	std::stable_sort(triInds.begin(), triInds.end(), [&tp](int i, int j) {
-		return tp[j] < 0 || tp[i] < tp[j];
-	});
+		while (child.IsOk())
+		{
+			PartitionItemData* partitionData = dynamic_cast<PartitionItemData*>(partitionTree->GetItemData(child));
+			if (partitionData)
+			{
+				bool found = false;
+				for (auto &s : partitionStrings)
+				{
+					if (s.StartsWith(wxString::Format("%d", partitionData->type)))
+					{
+						partitionTree->SetItemText(child, s);
+						found = true;
+						break;
+					}
+				}
 
-	// Re-order triangles
-	for (uint32_t ti = 0; ti < nTris; ++ti)
-		m->renderTris[ti] = m->tris[triInds[ti]];
+				if (!found)
+					partitionTree->SetItemText(child, wxString::Format("%d Unknown", partitionData->type));
+			}
 
-	// Find first triangle of each sub-mesh.
-	m->subMeshes.clear();
-	m->subMeshesColor.clear();
-
-	for (uint32_t ti = 0; ti < nTris; ++ti) {
-		while (tp[triInds[ti]] >= static_cast<int>(m->subMeshes.size()))
-			m->subMeshes.emplace_back(ti, 0);
-
-		if (tp[triInds[ti]] < 0) {
-			m->subMeshes.emplace_back(ti, 0);
-			break;
+			child = partitionTree->GetNextChild(partitionRoot, cookie);
 		}
 	}
 
-	// Calculate size of each sub-mesh.
-	m->subMeshes.emplace_back(nTris, 0);
-	for (size_t si = 0; si + 1 < m->subMeshes.size(); ++si)
-		m->subMeshes[si].second = m->subMeshes[si + 1].first - m->subMeshes[si].first;
+	void OutfitStudioFrame::SetSubMeshesForPartitions(mesh *m, const std::vector<int> &tp) {
+		uint32_t nTris = static_cast<uint32_t>(tp.size());
 
-	m->subMeshes.pop_back();
-	m->QueueUpdate(mesh::UpdateType::Indices);
-}
+		// Sort triangles (via triInds) by partition number, negative partition
+		// numbers at the end.
+		std::vector<uint32_t> triInds(nTris);
+		for (uint32_t ti = 0; ti < nTris; ++ti)
+			triInds[ti] = ti;
 
-void OutfitStudioFrame::SetNoSubMeshes(mesh *m) {
-	if (!m)
-		return;
+		std::stable_sort(triInds.begin(), triInds.end(), [&tp](int i, int j)
+		{
+			return tp[j] < 0 || tp[i] < tp[j];
+		});
 
-	m->subMeshes.clear();
-	m->subMeshesColor.clear();
+		// Re-order triangles
+		for (uint32_t ti = 0; ti < nTris; ++ti)
+			m->renderTris[ti] = m->tris[triInds[ti]];
 
-	for (int ti = 0; ti < m->nTris; ++ti)
-		m->renderTris[ti] = m->tris[ti];
+		// Find first triangle of each sub-mesh.
+		m->subMeshes.clear();
+		m->subMeshesColor.clear();
 
-	m->QueueUpdate(mesh::UpdateType::Indices);
-}
+		for (uint32_t ti = 0; ti < nTris; ++ti)
+		{
+			while (tp[triInds[ti]] >= static_cast<int>(m->subMeshes.size()))
+				m->subMeshes.emplace_back(ti, 0);
 
-void OutfitStudioFrame::SetNoSubMeshes() {
-	if (!activeItem)
-		return;
+			if (tp[triInds[ti]] < 0)
+			{
+				m->subMeshes.emplace_back(ti, 0);
+				break;
+			}
+		}
 
-	SetNoSubMeshes(glView->GetMesh(activeItem->GetShape()->name.get()));
-}
+		// Calculate size of each sub-mesh.
+		m->subMeshes.emplace_back(nTris, 0);
+		for (size_t si = 0; si + 1 < m->subMeshes.size(); ++si)
+			m->subMeshes[si].second = m->subMeshes[si + 1].first - m->subMeshes[si].first;
 
-void OutfitStudioFrame::OnCheckBox(wxCommandEvent& event) {
-	wxCheckBox* box = (wxCheckBox*)event.GetEventObject();
-	if (!box)
-		return;
+		m->subMeshes.pop_back();
+		m->QueueUpdate(mesh::UpdateType::Indices);
+	}
 
-	std::string name = box->GetName().BeforeLast('|');
-	ShowSliderEffect(name, event.IsChecked());
-	ApplySliders();
-}
+	void OutfitStudioFrame::SetNoSubMeshes(mesh *m) {
+		if (!m)
+			return;
 
-void OutfitStudioFrame::OnSelectTool(wxCommandEvent& event) {
-	int id = event.GetId();
+		m->subMeshes.clear();
+		m->subMeshesColor.clear();
 
-	if (id == XRCID("btnSelect"))
-		SelectTool(ToolID::Select);
-	else if (id == XRCID("btnTransform"))
-		SelectTool(ToolID::Transform);
-	else if (id == XRCID("btnPivot"))
-		SelectTool(ToolID::Pivot);
-	else if (id == XRCID("btnVertexEdit"))
-		SelectTool(ToolID::VertexEdit);
-	else if (id == XRCID("btnMaskBrush"))
-		SelectTool(ToolID::MaskBrush);
-	else if (id == XRCID("btnInflateBrush"))
-		SelectTool(ToolID::InflateBrush);
-	else if (id == XRCID("btnDeflateBrush"))
-		SelectTool(ToolID::DeflateBrush);
-	else if (id == XRCID("btnMoveBrush"))
-		SelectTool(ToolID::MoveBrush);
-	else if (id == XRCID("btnSmoothBrush"))
-		SelectTool(ToolID::SmoothBrush);
-	else if (id == XRCID("btnUndiffBrush"))
-		SelectTool(ToolID::UndiffBrush);
-	else if (id == XRCID("btnWeightBrush"))
-		SelectTool(ToolID::WeightBrush);
-	else if (id == XRCID("btnColorBrush"))
-		SelectTool(ToolID::ColorBrush);
-	else if (id == XRCID("btnAlphaBrush"))
-		SelectTool(ToolID::AlphaBrush);
-	else if (id == XRCID("btnCollapseVertex"))
-		SelectTool(ToolID::CollapseVertex);
-	else if (id == XRCID("btnFlipEdgeTool"))
-		SelectTool(ToolID::FlipEdge);
-	else if (id == XRCID("btnSplitEdgeTool"))
-		SelectTool(ToolID::SplitEdge);
-	else
-		SelectTool(ToolID::Any);
+		for (int ti = 0; ti < m->nTris; ++ti)
+			m->renderTris[ti] = m->tris[ti];
 
-	// Remember last standard tool used in regular tabs
-	if (meshTabButton->GetCheck() || lightsTabButton->GetCheck()) {
-		auto activeBrush = glView->GetActiveBrush();
-		if (activeBrush) {
-			int brushType = activeBrush->Type();
-			if (brushType == TBT_STANDARD || brushType == TBT_MASK || brushType == TBT_MOVE) {
-				glView->SetLastTool(glView->GetActiveTool());
+		m->QueueUpdate(mesh::UpdateType::Indices);
+	}
+
+	void OutfitStudioFrame::SetNoSubMeshes() {
+		if (!activeItem)
+			return;
+
+		SetNoSubMeshes(glView->GetMesh(activeItem->GetShape()->name.get()));
+	}
+
+	void OutfitStudioFrame::OnCheckBox(wxCommandEvent& event) {
+		wxCheckBox* box = (wxCheckBox*)event.GetEventObject();
+		if (!box)
+			return;
+
+		std::string name = box->GetName().BeforeLast('|');
+		ShowSliderEffect(name, event.IsChecked());
+		ApplySliders();
+	}
+
+	void OutfitStudioFrame::OnSelectTool(wxCommandEvent& event) {
+		int id = event.GetId();
+
+		if (id == XRCID("btnSelect"))
+			SelectTool(ToolID::Select);
+		else if (id == XRCID("btnTransform"))
+			SelectTool(ToolID::Transform);
+		else if (id == XRCID("btnPivot"))
+			SelectTool(ToolID::Pivot);
+		else if (id == XRCID("btnVertexEdit"))
+			SelectTool(ToolID::VertexEdit);
+		else if (id == XRCID("btnMaskBrush"))
+			SelectTool(ToolID::MaskBrush);
+		else if (id == XRCID("btnInflateBrush"))
+			SelectTool(ToolID::InflateBrush);
+		else if (id == XRCID("btnDeflateBrush"))
+			SelectTool(ToolID::DeflateBrush);
+		else if (id == XRCID("btnMoveBrush"))
+			SelectTool(ToolID::MoveBrush);
+		else if (id == XRCID("btnSmoothBrush"))
+			SelectTool(ToolID::SmoothBrush);
+		else if (id == XRCID("btnUndiffBrush"))
+			SelectTool(ToolID::UndiffBrush);
+		else if (id == XRCID("btnWeightBrush"))
+			SelectTool(ToolID::WeightBrush);
+		else if (id == XRCID("btnColorBrush"))
+			SelectTool(ToolID::ColorBrush);
+		else if (id == XRCID("btnAlphaBrush"))
+			SelectTool(ToolID::AlphaBrush);
+		else if (id == XRCID("btnCollapseVertex"))
+			SelectTool(ToolID::CollapseVertex);
+		else if (id == XRCID("btnFlipEdgeTool"))
+			SelectTool(ToolID::FlipEdge);
+		else if (id == XRCID("btnSplitEdgeTool"))
+			SelectTool(ToolID::SplitEdge);
+		else
+			SelectTool(ToolID::Any);
+
+		// Remember last standard tool used in regular tabs
+		if (meshTabButton->GetCheck() || lightsTabButton->GetCheck())
+		{
+			auto activeBrush = glView->GetActiveBrush();
+			if (activeBrush)
+			{
+				int brushType = activeBrush->Type();
+				if (brushType == TBT_STANDARD || brushType == TBT_MASK || brushType == TBT_MOVE)
+				{
+					glView->SetLastTool(glView->GetActiveTool());
+				}
 			}
 		}
 	}
-}
 
-void OutfitStudioFrame::OnSetView(wxCommandEvent& event) {
-	int id = event.GetId();
+	void OutfitStudioFrame::OnSetView(wxCommandEvent& event) {
+		int id = event.GetId();
 
-	if (id == XRCID("btnViewFront"))
-		glView->SetView('F');
-	else if (id == XRCID("btnViewBack"))
-		glView->SetView('B');
-	else if (id == XRCID("btnViewLeft"))
-		glView->SetView('L');
-	else if (id == XRCID("btnViewRight"))
-		glView->SetView('R');
-}
-
-void OutfitStudioFrame::OnTogglePerspective(wxCommandEvent& event) {
-	bool enabled = event.IsChecked();
-	menuBar->Check(event.GetId(), enabled);
-	toolBarV->ToggleTool(event.GetId(), enabled);
-	glView->SetPerspective(enabled);
-}
-
-void OutfitStudioFrame::OnToggleRotationCenter(wxCommandEvent& WXUNUSED(event)) {
-	if (glView->rotationCenterMode != RotationCenterMode::Zero) {
-		glView->rotationCenterMode = RotationCenterMode::Zero;
-		glView->gls.camRotOffset.Zero();
-	}
-	else {
-		glView->rotationCenterMode = RotationCenterMode::MeshCenter;
-		glView->gls.camRotOffset = glView->gls.GetActiveCenter();
+		if (id == XRCID("btnViewFront"))
+			glView->SetView('F');
+		else if (id == XRCID("btnViewBack"))
+			glView->SetView('B');
+		else if (id == XRCID("btnViewLeft"))
+			glView->SetView('L');
+		else if (id == XRCID("btnViewRight"))
+			glView->SetView('R');
 	}
 
-	glView->Render();
-}
-
-void OutfitStudioFrame::OnShowNodes(wxCommandEvent& event) {
-	bool enabled = event.IsChecked();
-	menuBar->Check(event.GetId(), enabled);
-	toolBarV->ToggleTool(event.GetId(), enabled);
-	glView->ShowNodes(enabled);
-}
-
-void OutfitStudioFrame::OnShowBones(wxCommandEvent& event) {
-	bool enabled = event.IsChecked();
-	menuBar->Check(event.GetId(), enabled);
-	toolBarV->ToggleTool(event.GetId(), enabled);
-	glView->ShowBones(enabled);
-}
-
-void OutfitStudioFrame::OnShowFloor(wxCommandEvent& event) {
-	bool enabled = event.IsChecked();
-	menuBar->Check(event.GetId(), enabled);
-	toolBarV->ToggleTool(event.GetId(), enabled);
-	glView->ShowFloor(enabled);
-}
-
-void OutfitStudioFrame::OnBrushSettings(wxCommandEvent& WXUNUSED(event)) {
-	if (brushSettingsPopup)
-		CloseBrushSettings();
-	else
-		PopupBrushSettings(false);
-}
-
-void OutfitStudioFrame::OnFieldOfViewSlider(wxCommandEvent& event) {
-	auto fovSlider = reinterpret_cast<wxSlider*>(event.GetEventObject());
-	int fieldOfView = fovSlider->GetValue();
-
-	wxStaticText* fovLabel = (wxStaticText*)toolBarH->FindWindowByName("fovLabel");
-	fovLabel->SetLabel(wxString::Format(_("Field of View: %d"), fieldOfView));
-
-	glView->SetFieldOfView(fieldOfView);
-}
-
-void OutfitStudioFrame::OnUpdateLights(wxCommandEvent& WXUNUSED(event)) {
-	wxSlider* ambientSlider = (wxSlider*)lightSettings->FindWindowByName("lightAmbientSlider");
-	wxSlider* frontalSlider = (wxSlider*)lightSettings->FindWindowByName("lightFrontalSlider");
-	wxSlider* directional0Slider = (wxSlider*)lightSettings->FindWindowByName("lightDirectional0Slider");
-	wxSlider* directional1Slider = (wxSlider*)lightSettings->FindWindowByName("lightDirectional1Slider");
-	wxSlider* directional2Slider = (wxSlider*)lightSettings->FindWindowByName("lightDirectional2Slider");
-
-	int ambient = ambientSlider->GetValue();
-	int frontal = frontalSlider->GetValue();
-	int directional0 = directional0Slider->GetValue();
-	int directional1 = directional1Slider->GetValue();
-	int directional2 = directional2Slider->GetValue();
-	glView->UpdateLights(ambient, frontal, directional0, directional1, directional2);
-
-	Config.SetValue("Lights/Ambient", ambient);
-	Config.SetValue("Lights/Frontal", frontal);
-	Config.SetValue("Lights/Directional0", directional0);
-	Config.SetValue("Lights/Directional1", directional1);
-	Config.SetValue("Lights/Directional2", directional2);
-}
-
-void OutfitStudioFrame::OnResetLights(wxCommandEvent& WXUNUSED(event)) {
-	int ambient = 20;
-	int frontal = 20;
-	int directional0 = 60;
-	int directional1 = 60;
-	int directional2 = 85;
-
-	glView->UpdateLights(ambient, frontal, directional0, directional1, directional2);
-
-	wxSlider* lightAmbientSlider = (wxSlider*)lightSettings->FindWindowByName("lightAmbientSlider");
-	lightAmbientSlider->SetValue(ambient);
-
-	wxSlider* lightFrontalSlider = (wxSlider*)lightSettings->FindWindowByName("lightFrontalSlider");
-	lightFrontalSlider->SetValue(frontal);
-
-	wxSlider* lightDirectional0Slider = (wxSlider*)lightSettings->FindWindowByName("lightDirectional0Slider");
-	lightDirectional0Slider->SetValue(directional0);
-
-	wxSlider* lightDirectional1Slider = (wxSlider*)lightSettings->FindWindowByName("lightDirectional1Slider");
-	lightDirectional1Slider->SetValue(directional1);
-
-	wxSlider* lightDirectional2Slider = (wxSlider*)lightSettings->FindWindowByName("lightDirectional2Slider");
-	lightDirectional2Slider->SetValue(directional2);
-
-	Config.SetValue("Lights/Ambient", ambient);
-	Config.SetValue("Lights/Frontal", frontal);
-	Config.SetValue("Lights/Directional0", directional0);
-	Config.SetValue("Lights/Directional1", directional1);
-	Config.SetValue("Lights/Directional2", directional2);
-}
-
-void OutfitStudioFrame::OnClickSliderButton(wxCommandEvent& event) {
-	wxWindow* btn = (wxWindow*)event.GetEventObject();
-	if (!btn)
-		return;
-
-	wxString buttonName = btn->GetName();
-	std::string clickedName{buttonName.BeforeLast('|').ToUTF8()};
-	if (clickedName.empty()) {
-		event.Skip();
-		return;
+	void OutfitStudioFrame::OnTogglePerspective(wxCommandEvent& event) {
+		bool enabled = event.IsChecked();
+		menuBar->Check(event.GetId(), enabled);
+		toolBarV->ToggleTool(event.GetId(), enabled);
+		glView->SetPerspective(enabled);
 	}
 
-	wxString buttonNameId = buttonName.AfterLast('|');
-
-	float scale = 0.0f;
-	if (buttonNameId == "btnMinus")
-		scale = 0.99f;
-	else if (buttonNameId == "btnPlus")
-		scale = 1.01f;
-
-	if (scale != 0.0f) {
-		for (auto &i : selectedItems) {
-			auto shape = i->GetShape();
-			std::vector<Vector3> verts;
-			project->ScaleMorphResult(shape, activeSlider, scale);
-			project->GetLiveVerts(shape, verts);
-			glView->UpdateMeshVertices(shape->name.get(), &verts);
+	void OutfitStudioFrame::OnToggleRotationCenter(wxCommandEvent& WXUNUSED(event)) {
+		if (glView->rotationCenterMode != RotationCenterMode::Zero)
+		{
+			glView->rotationCenterMode = RotationCenterMode::Zero;
+			glView->gls.camRotOffset.Zero();
 		}
-		return;
+		else
+		{
+			glView->rotationCenterMode = RotationCenterMode::MeshCenter;
+			glView->gls.camRotOffset = glView->gls.GetActiveCenter();
+		}
+
+		glView->Render();
 	}
 
-	if (buttonNameId == "btnSliderProp") {
-		ShowSliderProperties(clickedName);
-		return;
+	void OutfitStudioFrame::OnShowNodes(wxCommandEvent& event) {
+		bool enabled = event.IsChecked();
+		menuBar->Check(event.GetId(), enabled);
+		toolBarV->ToggleTool(event.GetId(), enabled);
+		glView->ShowNodes(enabled);
 	}
 
-	if (activeSlider != clickedName)
-		EnterSliderEdit(clickedName);
-	else
-		ExitSliderEdit();
-}
+	void OutfitStudioFrame::OnShowBones(wxCommandEvent& event) {
+		bool enabled = event.IsChecked();
+		menuBar->Check(event.GetId(), enabled);
+		toolBarV->ToggleTool(event.GetId(), enabled);
+		glView->ShowBones(enabled);
+	}
 
-void OutfitStudioFrame::OnReadoutChange(wxCommandEvent& event) {
-	wxTextCtrl* w = (wxTextCtrl*)event.GetEventObject();
-	event.Skip();
-	if (!w)
-		return;
+	void OutfitStudioFrame::OnShowFloor(wxCommandEvent& event) {
+		bool enabled = event.IsChecked();
+		menuBar->Check(event.GetId(), enabled);
+		toolBarV->ToggleTool(event.GetId(), enabled);
+		glView->ShowFloor(enabled);
+	}
 
-	wxString sn = w->GetName();
-	if (!sn.EndsWith("|readout", &sn))
-		return;
+	void OutfitStudioFrame::OnBrushSettings(wxCommandEvent& WXUNUSED(event))
+	{
+		if (brushSettingsPopup)
+			CloseBrushSettings();
+		else
+			PopupBrushSettings(false);
+	}
 
-	std::string sliderName{sn.ToUTF8()};
+	void OutfitStudioFrame::OnFieldOfViewSlider(wxCommandEvent& event) {
+		auto fovSlider = reinterpret_cast<wxSlider*>(event.GetEventObject());
+		int fieldOfView = fovSlider->GetValue();
 
-	double v;
-	wxString val = w->GetValue();
-	val.Replace("%", "");
-	if (!val.ToDouble(&v))
-		return;
+		wxStaticText* fovLabel = (wxStaticText*)toolBarH->FindWindowByName("fovLabel");
+		fovLabel->SetLabel(wxString::Format(_("Field of View: %d"), fieldOfView));
 
-	SliderDisplay* d = sliderDisplays[sliderName];
-	d->slider->SetValue(v);
+		glView->SetFieldOfView(fieldOfView);
+	}
 
-	project->SliderValue(sliderName) = v / 100.0f;
+	void OutfitStudioFrame::OnUpdateLights(wxCommandEvent& WXUNUSED(event)) {
+		wxSlider* ambientSlider = (wxSlider*)lightSettings->FindWindowByName("lightAmbientSlider");
+		wxSlider* frontalSlider = (wxSlider*)lightSettings->FindWindowByName("lightFrontalSlider");
+		wxSlider* directional0Slider = (wxSlider*)lightSettings->FindWindowByName("lightDirectional0Slider");
+		wxSlider* directional1Slider = (wxSlider*)lightSettings->FindWindowByName("lightDirectional1Slider");
+		wxSlider* directional2Slider = (wxSlider*)lightSettings->FindWindowByName("lightDirectional2Slider");
 
-	ApplySliders();
-}
+		int ambient = ambientSlider->GetValue();
+		int frontal = frontalSlider->GetValue();
+		int directional0 = directional0Slider->GetValue();
+		int directional1 = directional1Slider->GetValue();
+		int directional2 = directional2Slider->GetValue();
+		glView->UpdateLights(ambient, frontal, directional0, directional1, directional2);
 
-void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
-	int id = event.GetId();
+		Config.SetValue("Lights/Ambient", ambient);
+		Config.SetValue("Lights/Frontal", frontal);
+		Config.SetValue("Lights/Directional0", directional0);
+		Config.SetValue("Lights/Directional1", directional1);
+		Config.SetValue("Lights/Directional2", directional2);
+	}
 
-	if (currentTabButton && currentTabButton->HasPendingChanges()) {
-		wxMessageDialog dlg(this, _("Your changes were not applied yet. Do you want to apply or reset them?"), _("Pending Changes"), wxYES_NO | wxCANCEL | wxICON_WARNING | wxCANCEL_DEFAULT);
-		dlg.SetYesNoCancelLabels(_("Apply"), _("Reset"), _("Cancel"));
+	void OutfitStudioFrame::OnResetLights(wxCommandEvent& WXUNUSED(event)) {
+		int ambient = 20;
+		int frontal = 20;
+		int directional0 = 60;
+		int directional1 = 60;
+		int directional2 = 85;
 
-		int res = dlg.ShowModal();
-		if (res == wxID_YES) {
-			if (currentTabButton == partitionTabButton)
-				ApplyPartitions();
-			else if (currentTabButton == segmentTabButton)
-				ApplySegments();
-		}
-		else if (res == wxID_NO) {
-			if (currentTabButton == partitionTabButton)
-				ResetPartitions();
-			else if (currentTabButton == segmentTabButton)
-				ResetSegments();
-		}
-		else {
+		glView->UpdateLights(ambient, frontal, directional0, directional1, directional2);
+
+		wxSlider* lightAmbientSlider = (wxSlider*)lightSettings->FindWindowByName("lightAmbientSlider");
+		lightAmbientSlider->SetValue(ambient);
+
+		wxSlider* lightFrontalSlider = (wxSlider*)lightSettings->FindWindowByName("lightFrontalSlider");
+		lightFrontalSlider->SetValue(frontal);
+
+		wxSlider* lightDirectional0Slider = (wxSlider*)lightSettings->FindWindowByName("lightDirectional0Slider");
+		lightDirectional0Slider->SetValue(directional0);
+
+		wxSlider* lightDirectional1Slider = (wxSlider*)lightSettings->FindWindowByName("lightDirectional1Slider");
+		lightDirectional1Slider->SetValue(directional1);
+
+		wxSlider* lightDirectional2Slider = (wxSlider*)lightSettings->FindWindowByName("lightDirectional2Slider");
+		lightDirectional2Slider->SetValue(directional2);
+
+		Config.SetValue("Lights/Ambient", ambient);
+		Config.SetValue("Lights/Frontal", frontal);
+		Config.SetValue("Lights/Directional0", directional0);
+		Config.SetValue("Lights/Directional1", directional1);
+		Config.SetValue("Lights/Directional2", directional2);
+	}
+
+	void OutfitStudioFrame::OnClickSliderButton(wxCommandEvent& event) {
+		wxWindow* btn = (wxWindow*)event.GetEventObject();
+		if (!btn)
+			return;
+
+		wxString buttonName = btn->GetName();
+		std::string clickedName{buttonName.BeforeLast('|').ToUTF8()};
+		if (clickedName.empty())
+		{
 			event.Skip();
 			return;
 		}
-	}
 
-	if (id != meshTabButton->GetId())
-		masksPane->Hide();
+		wxString buttonNameId = buttonName.AfterLast('|');
 
-	if (id != segmentTabButton->GetId()) {
-		wxStaticText* segmentTypeLabel = (wxStaticText*)FindWindowByName("segmentTypeLabel");
-		wxChoice* segmentType = (wxChoice*)FindWindowByName("segmentType");
-		wxStaticText* segmentSlotLabel = (wxStaticText*)FindWindowByName("segmentSlotLabel");
-		wxChoice* segmentSlot = (wxChoice*)FindWindowByName("segmentSlot");
-		wxStaticText* segmentSSFLabel = (wxStaticText*)FindWindowByName("segmentSSFLabel");
-		wxButton* segmentSSFEdit = (wxButton*)FindWindowByName("segmentSSFEdit");
-		wxTextCtrl* segmentSSF = (wxTextCtrl*)FindWindowByName("segmentSSF");
-		wxButton* segmentApply = (wxButton*)FindWindowByName("segmentApply");
-		wxButton* segmentReset = (wxButton*)FindWindowByName("segmentReset");
+		float scale = 0.0f;
+		if (buttonNameId == "btnMinus")
+			scale = 0.99f;
+		else if (buttonNameId == "btnPlus")
+			scale = 1.01f;
 
-		segmentTypeLabel->Show(false);
-		segmentType->Show(false);
-		segmentSlotLabel->Show(false);
-		segmentSlot->Show(false);
-		segmentSSFLabel->Show(false);
-		segmentSSFEdit->Show(false);
-		segmentSSF->Show(false);
-		segmentApply->Show(false);
-		segmentReset->Show(false);
-
-		if (glView->GetSegmentMode())
-			glView->ClearActiveColors();
-
-		glView->SetSegmentMode(false);
-		glView->SetMaskVisible();
-		glView->SetGlobalBrushCollision();
-
-		menuBar->Check(XRCID("btnBrushCollision"), true);
-		menuBar->Enable(XRCID("btnBrushCollision"), true);
-		menuBar->Enable(XRCID("btnSelect"), true);
-		menuBar->Enable(XRCID("btnClearMask"), true);
-		menuBar->Enable(XRCID("btnInvertMask"), true);
-		menuBar->Enable(XRCID("deleteVerts"), true);
-
-		toolBarV->ToggleTool(XRCID("btnBrushCollision"), true);
-		toolBarV->EnableTool(XRCID("btnBrushCollision"), true);
-		toolBarH->EnableTool(XRCID("btnSelect"), true);
-	}
-
-	if (id != partitionTabButton->GetId()) {
-		wxStaticText* partitionTypeLabel = (wxStaticText*)FindWindowByName("partitionTypeLabel");
-		wxChoice* partitionType = (wxChoice*)FindWindowByName("partitionType");
-		wxButton* partitionApply = (wxButton*)FindWindowByName("partitionApply");
-		wxButton* partitionReset = (wxButton*)FindWindowByName("partitionReset");
-
-		partitionTypeLabel->Show(false);
-		partitionType->Show(false);
-		partitionApply->Show(false);
-		partitionReset->Show(false);
-
-		if (glView->GetSegmentMode())
-			glView->ClearActiveColors();
-
-		glView->SetSegmentMode(false);
-		glView->SetMaskVisible();
-		glView->SetGlobalBrushCollision();
-
-		menuBar->Check(XRCID("btnBrushCollision"), true);
-		menuBar->Enable(XRCID("btnBrushCollision"), true);
-		menuBar->Enable(XRCID("btnSelect"), true);
-		menuBar->Enable(XRCID("btnClearMask"), true);
-		menuBar->Enable(XRCID("btnInvertMask"), true);
-		menuBar->Enable(XRCID("deleteVerts"), true);
-
-		toolBarV->ToggleTool(XRCID("btnBrushCollision"), true);
-		toolBarV->EnableTool(XRCID("btnBrushCollision"), true);
-		toolBarH->EnableTool(XRCID("btnSelect"), true);
-	}
-
-	if (id != boneTabButton->GetId()) {
-		boneScale->Show(false);
-		cXMirrorBone->Show(false);
-
-		wxStaticText* totalBoneCountLabel = (wxStaticText*)FindWindowByName("totalBoneCountLabel");
-		wxStaticText* selectedBoneCountLabel = (wxStaticText*)FindWindowByName("selectedBoneCountLabel");
-		wxStaticText* boneScaleLabel = (wxStaticText*)FindWindowByName("boneScaleLabel");
-		wxCheckBox* cbFixedWeight = (wxCheckBox*)FindWindowByName("cbFixedWeight");
-		wxCheckBox* cbNormalizeWeights = (wxCheckBox*)FindWindowByName("cbNormalizeWeights");
-		wxStaticText* xMirrorBoneLabel = (wxStaticText*)FindWindowByName("xMirrorBoneLabel");
-
-		totalBoneCountLabel->Show(false);
-		selectedBoneCountLabel->Show(false);
-		boneScaleLabel->Show(false);
-		cbFixedWeight->Show(false);
-		cbNormalizeWeights->Show(false);
-		xMirrorBoneLabel->Show(false);
-		posePane->Show(false);
-		bonesFilter->GetParent()->Show(false);
-
-		project->ClearBoneScale();
-
-		if (project->bPose) {
-			project->bPose = false;
-			ApplyPose();
+		if (scale != 0.0f)
+		{
+			for (auto &i : selectedItems)
+			{
+				auto shape = i->GetShape();
+				std::vector<Vector3> verts;
+				project->ScaleMorphResult(shape, activeSlider, scale);
+				project->GetLiveVerts(shape, verts);
+				glView->UpdateMeshVertices(shape->name.get(), &verts);
+			}
+			return;
 		}
 
-		glView->SetWeightVisible(false);
-	}
-
-	if (id != colorsTabButton->GetId()) {
-		glView->SetColorsVisible(false);
-
-		if (colorSettings->IsShown())
-			glView->ClearColors();
-	}
-
-	if (id != boneTabButton->GetId() || id != colorsTabButton->GetId()) {
-		glView->SetTransformMode(false);
-
-		menuBar->Check(XRCID("btnInflateBrush"), true);
-		menuBar->Enable(XRCID("btnTransform"), true);
-		menuBar->Enable(XRCID("btnPivot"), true);
-		menuBar->Enable(XRCID("btnVertexEdit"), true);
-		menuBar->Enable(XRCID("btnWeightBrush"), false);
-		menuBar->Enable(XRCID("btnColorBrush"), false);
-		menuBar->Enable(XRCID("btnAlphaBrush"), false);
-		menuBar->Enable(XRCID("btnInflateBrush"), true);
-		menuBar->Enable(XRCID("btnDeflateBrush"), true);
-		menuBar->Enable(XRCID("btnMoveBrush"), true);
-		menuBar->Enable(XRCID("btnSmoothBrush"), true);
-		menuBar->Enable(XRCID("btnUndiffBrush"), true);
-		menuBar->Enable(XRCID("btnCollapseVertex"), true);
-		menuBar->Enable(XRCID("btnFlipEdgeTool"), true);
-		menuBar->Enable(XRCID("btnSplitEdgeTool"), true);
-		menuBar->Enable(XRCID("deleteVerts"), true);
-
-		toolBarH->ToggleTool(XRCID("btnInflateBrush"), true);
-		toolBarH->EnableTool(XRCID("btnWeightBrush"), false);
-		toolBarH->EnableTool(XRCID("btnColorBrush"), false);
-		toolBarH->EnableTool(XRCID("btnAlphaBrush"), false);
-		toolBarV->EnableTool(XRCID("btnTransform"), true);
-		toolBarV->EnableTool(XRCID("btnPivot"), true);
-		toolBarV->EnableTool(XRCID("btnVertexEdit"), true);
-		toolBarH->EnableTool(XRCID("btnInflateBrush"), true);
-		toolBarH->EnableTool(XRCID("btnDeflateBrush"), true);
-		toolBarH->EnableTool(XRCID("btnMoveBrush"), true);
-		toolBarH->EnableTool(XRCID("btnSmoothBrush"), true);
-		toolBarH->EnableTool(XRCID("btnUndiffBrush"), true);
-		toolBarH->EnableTool(XRCID("btnCollapseVertex"), true);
-		toolBarH->EnableTool(XRCID("btnFlipEdgeTool"), true);
-		toolBarH->EnableTool(XRCID("btnSplitEdgeTool"), true);
-	}
-
-	if (id == meshTabButton->GetId()) {
-		currentTabButton = meshTabButton;
-
-		outfitBones->Hide();
-		colorSettings->Hide();
-		segmentTree->Hide();
-		partitionTree->Hide();
-		lightSettings->Hide();
-		outfitShapes->Show();
-
-		boneTabButton->SetCheck(false);
-		colorsTabButton->SetCheck(false);
-		segmentTabButton->SetCheck(false);
-		partitionTabButton->SetCheck(false);
-		lightsTabButton->SetCheck(false);
-
-		masksPane->Show();
-
-		SetNoSubMeshes();
-		SelectTool(glView->GetLastTool());
-	}
-	else if (id == boneTabButton->GetId()) {
-		currentTabButton = boneTabButton;
-
-		outfitShapes->Hide();
-		colorSettings->Hide();
-		segmentTree->Hide();
-		partitionTree->Hide();
-		lightSettings->Hide();
-		outfitBones->Show();
-
-		meshTabButton->SetCheck(false);
-		colorsTabButton->SetCheck(false);
-		segmentTabButton->SetCheck(false);
-		partitionTabButton->SetCheck(false);
-		lightsTabButton->SetCheck(false);
-
-		boneScale->SetValue(0);
-		boneScale->Show();
-		cXMirrorBone->Show();
-
-		wxStaticText* totalBoneCountLabel = (wxStaticText*)FindWindowByName("totalBoneCountLabel");
-		wxStaticText* selectedBoneCountLabel = (wxStaticText*)FindWindowByName("selectedBoneCountLabel");
-		wxStaticText* boneScaleLabel = (wxStaticText*)FindWindowByName("boneScaleLabel");
-		wxCheckBox* cbFixedWeight = (wxCheckBox*)FindWindowByName("cbFixedWeight");
-		wxCheckBox* cbNormalizeWeights = (wxCheckBox*)FindWindowByName("cbNormalizeWeights");
-		wxStaticText* xMirrorBoneLabel = (wxStaticText*)FindWindowByName("xMirrorBoneLabel");
-
-		totalBoneCountLabel->Show();
-		selectedBoneCountLabel->Show();
-		boneScaleLabel->Show();
-		cbFixedWeight->Show();
-		cbNormalizeWeights->Show();
-		xMirrorBoneLabel->Show();
-		posePane->Show();
-		bonesFilter->GetParent()->Show();
-		
-		glView->SetTransformMode(false);
-		SelectTool(ToolID::WeightBrush);
-		glView->SetWeightVisible();
-
-		project->bPose = cbPose->GetValue();
-
-		if (project->bPose)
-			ApplyPose();
-
-		menuBar->Check(XRCID("btnWeightBrush"), true);
-		menuBar->Enable(XRCID("btnWeightBrush"), true);
-		menuBar->Enable(XRCID("btnColorBrush"), false);
-		menuBar->Enable(XRCID("btnAlphaBrush"), false);
-		menuBar->Enable(XRCID("btnTransform"), false);
-		menuBar->Enable(XRCID("btnPivot"), false);
-		menuBar->Enable(XRCID("btnVertexEdit"), false);
-		menuBar->Enable(XRCID("btnInflateBrush"), false);
-		menuBar->Enable(XRCID("btnDeflateBrush"), false);
-		menuBar->Enable(XRCID("btnMoveBrush"), false);
-		menuBar->Enable(XRCID("btnSmoothBrush"), false);
-		menuBar->Enable(XRCID("btnUndiffBrush"), false);
-		menuBar->Enable(XRCID("btnCollapseVertex"), false);
-		menuBar->Enable(XRCID("btnFlipEdgeTool"), false);
-		menuBar->Enable(XRCID("btnSplitEdgeTool"), false);
-		menuBar->Enable(XRCID("deleteVerts"), false);
-
-		toolBarH->ToggleTool(XRCID("btnWeightBrush"), true);
-		toolBarH->EnableTool(XRCID("btnWeightBrush"), true);
-		toolBarH->EnableTool(XRCID("btnColorBrush"), false);
-		toolBarH->EnableTool(XRCID("btnAlphaBrush"), false);
-		toolBarV->EnableTool(XRCID("btnTransform"), false);
-		toolBarV->EnableTool(XRCID("btnPivot"), false);
-		toolBarV->EnableTool(XRCID("btnVertexEdit"), false);
-		toolBarH->EnableTool(XRCID("btnInflateBrush"), false);
-		toolBarH->EnableTool(XRCID("btnDeflateBrush"), false);
-		toolBarH->EnableTool(XRCID("btnMoveBrush"), false);
-		toolBarH->EnableTool(XRCID("btnSmoothBrush"), false);
-		toolBarH->EnableTool(XRCID("btnUndiffBrush"), false);
-		toolBarH->EnableTool(XRCID("btnCollapseVertex"), false);
-		toolBarH->EnableTool(XRCID("btnFlipEdgeTool"), false);
-		toolBarH->EnableTool(XRCID("btnSplitEdgeTool"), false);
-
-		SetNoSubMeshes();
-
-		ReselectBone();
-		glView->GetUndoHistory()->ClearHistory();
-	}
-	else if (id == colorsTabButton->GetId()) {
-		currentTabButton = colorsTabButton;
-
-		outfitShapes->Hide();
-		outfitBones->Hide();
-		segmentTree->Hide();
-		partitionTree->Hide();
-		lightSettings->Hide();
-		colorSettings->Show();
-
-		meshTabButton->SetCheck(false);
-		boneTabButton->SetCheck(false);
-		segmentTabButton->SetCheck(false);
-		partitionTabButton->SetCheck(false);
-		lightsTabButton->SetCheck(false);
-
-		glView->SetTransformMode(false);
-		SelectTool(ToolID::ColorBrush);
-		glView->SetColorsVisible();
-
-		wxButton* btnSwapBrush = (wxButton*)FindWindowById(XRCID("btnSwapBrush"), colorSettings);
-		btnSwapBrush->SetLabel(_("Edit Alpha"));
-
-		FillVertexColors();
-
-		menuBar->Check(XRCID("btnColorBrush"), true);
-		menuBar->Enable(XRCID("btnColorBrush"), true);
-		menuBar->Enable(XRCID("btnAlphaBrush"), true);
-		menuBar->Enable(XRCID("btnWeightBrush"), false);
-		menuBar->Enable(XRCID("btnTransform"), false);
-		menuBar->Enable(XRCID("btnPivot"), false);
-		menuBar->Enable(XRCID("btnVertexEdit"), false);
-		menuBar->Enable(XRCID("btnInflateBrush"), false);
-		menuBar->Enable(XRCID("btnDeflateBrush"), false);
-		menuBar->Enable(XRCID("btnMoveBrush"), false);
-		menuBar->Enable(XRCID("btnSmoothBrush"), false);
-		menuBar->Enable(XRCID("btnUndiffBrush"), false);
-		menuBar->Enable(XRCID("btnCollapseVertex"), false);
-		menuBar->Enable(XRCID("btnFlipEdgeTool"), false);
-		menuBar->Enable(XRCID("btnSplitEdgeTool"), false);
-		menuBar->Enable(XRCID("deleteVerts"), false);
-
-		toolBarH->ToggleTool(XRCID("btnColorBrush"), true);
-		toolBarH->EnableTool(XRCID("btnColorBrush"), true);
-		toolBarH->EnableTool(XRCID("btnAlphaBrush"), true);
-		toolBarH->EnableTool(XRCID("btnWeightBrush"), false);
-		toolBarV->EnableTool(XRCID("btnTransform"), false);
-		toolBarV->EnableTool(XRCID("btnPivot"), false);
-		toolBarV->EnableTool(XRCID("btnVertexEdit"), false);
-		toolBarH->EnableTool(XRCID("btnInflateBrush"), false);
-		toolBarH->EnableTool(XRCID("btnDeflateBrush"), false);
-		toolBarH->EnableTool(XRCID("btnMoveBrush"), false);
-		toolBarH->EnableTool(XRCID("btnSmoothBrush"), false);
-		toolBarH->EnableTool(XRCID("btnUndiffBrush"), false);
-		toolBarH->EnableTool(XRCID("btnCollapseVertex"), false);
-		toolBarH->EnableTool(XRCID("btnFlipEdgeTool"), false);
-		toolBarH->EnableTool(XRCID("btnSplitEdgeTool"), false);
-
-		SetNoSubMeshes();
-	}
-	else if (id == segmentTabButton->GetId()) {
-		currentTabButton = segmentTabButton;
-
-		outfitShapes->Hide();
-		outfitBones->Hide();
-		colorSettings->Hide();
-		partitionTree->Hide();
-		lightSettings->Hide();
-		segmentTree->Show();
-
-		meshTabButton->SetCheck(false);
-		boneTabButton->SetCheck(false);
-		colorsTabButton->SetCheck(false);
-		partitionTabButton->SetCheck(false);
-		lightsTabButton->SetCheck(false);
-
-		wxStaticText* segmentTypeLabel = (wxStaticText*)FindWindowByName("segmentTypeLabel");
-		wxChoice* segmentType = (wxChoice*)FindWindowByName("segmentType");
-		wxStaticText* segmentSlotLabel = (wxStaticText*)FindWindowByName("segmentSlotLabel");
-		wxChoice* segmentSlot = (wxChoice*)FindWindowByName("segmentSlot");
-		wxStaticText* segmentSSFLabel = (wxStaticText*)FindWindowByName("segmentSSFLabel");
-		wxButton* segmentSSFEdit = (wxButton*)FindWindowByName("segmentSSFEdit");
-		wxTextCtrl* segmentSSF = (wxTextCtrl*)FindWindowByName("segmentSSF");
-		wxButton* segmentApply = (wxButton*)FindWindowByName("segmentApply");
-		wxButton* segmentReset = (wxButton*)FindWindowByName("segmentReset");
-
-		segmentTypeLabel->Show();
-		segmentType->Show();
-		segmentSlotLabel->Show();
-		segmentSlot->Show();
-		segmentSSFLabel->Show();
-		segmentSSFEdit->Show();
-		segmentSSF->Show();
-		segmentApply->Show();
-		segmentReset->Show();
-
-		SelectTool(ToolID::MaskBrush);
-		glView->SetSegmentMode();
-		glView->SetMaskVisible(false);
-		glView->SetGlobalBrushCollision(false);
-		glView->ClearColors();
-
-		menuBar->Check(XRCID("btnMaskBrush"), true);
-		menuBar->Check(XRCID("btnBrushCollision"), false);
-		menuBar->Enable(XRCID("btnSelect"), false);
-		menuBar->Enable(XRCID("btnTransform"), false);
-		menuBar->Enable(XRCID("btnPivot"), false);
-		menuBar->Enable(XRCID("btnVertexEdit"), false);
-		menuBar->Enable(XRCID("btnInflateBrush"), false);
-		menuBar->Enable(XRCID("btnDeflateBrush"), false);
-		menuBar->Enable(XRCID("btnMoveBrush"), false);
-		menuBar->Enable(XRCID("btnSmoothBrush"), false);
-		menuBar->Enable(XRCID("btnUndiffBrush"), false);
-		menuBar->Enable(XRCID("btnBrushCollision"), false);
-		menuBar->Enable(XRCID("btnClearMask"), false);
-		menuBar->Enable(XRCID("btnInvertMask"), false);
-		menuBar->Enable(XRCID("btnCollapseVertex"), false);
-		menuBar->Enable(XRCID("btnFlipEdgeTool"), false);
-		menuBar->Enable(XRCID("btnSplitEdgeTool"), false);
-		menuBar->Enable(XRCID("deleteVerts"), false);
-
-		toolBarH->ToggleTool(XRCID("btnMaskBrush"), true);
-		toolBarV->ToggleTool(XRCID("btnBrushCollision"), false);
-		toolBarH->EnableTool(XRCID("btnSelect"), false);
-		toolBarV->EnableTool(XRCID("btnTransform"), false);
-		toolBarV->EnableTool(XRCID("btnPivot"), false);
-		toolBarV->EnableTool(XRCID("btnVertexEdit"), false);
-		toolBarH->EnableTool(XRCID("btnInflateBrush"), false);
-		toolBarH->EnableTool(XRCID("btnDeflateBrush"), false);
-		toolBarH->EnableTool(XRCID("btnMoveBrush"), false);
-		toolBarH->EnableTool(XRCID("btnSmoothBrush"), false);
-		toolBarH->EnableTool(XRCID("btnUndiffBrush"), false);
-		toolBarH->EnableTool(XRCID("btnCollapseVertex"), false);
-		toolBarH->EnableTool(XRCID("btnFlipEdgeTool"), false);
-		toolBarH->EnableTool(XRCID("btnSplitEdgeTool"), false);
-		toolBarV->EnableTool(XRCID("btnBrushCollision"), false);
-
-		ShowSegment(segmentTree->GetSelection());
-	}
-	else if (id == partitionTabButton->GetId()) {
-		currentTabButton = partitionTabButton;
-
-		outfitShapes->Hide();
-		outfitBones->Hide();
-		colorSettings->Hide();
-		segmentTree->Hide();
-		lightSettings->Hide();
-		partitionTree->Show();
-
-		meshTabButton->SetCheck(false);
-		boneTabButton->SetCheck(false);
-		colorsTabButton->SetCheck(false);
-		segmentTabButton->SetCheck(false);
-		lightsTabButton->SetCheck(false);
-
-		wxStaticText* partitionTypeLabel = (wxStaticText*)FindWindowByName("partitionTypeLabel");
-		wxChoice* partitionType = (wxChoice*)FindWindowByName("partitionType");
-		wxButton* partitionApply = (wxButton*)FindWindowByName("partitionApply");
-		wxButton* partitionReset = (wxButton*)FindWindowByName("partitionReset");
-
-		partitionTypeLabel->Show();
-		partitionType->Show();
-		partitionApply->Show();
-		partitionReset->Show();
-
-		SelectTool(ToolID::MaskBrush);
-		glView->SetSegmentMode();
-		glView->SetMaskVisible(false);
-		glView->SetGlobalBrushCollision(false);
-		glView->ClearColors();
-
-		menuBar->Check(XRCID("btnMaskBrush"), true);
-		menuBar->Check(XRCID("btnBrushCollision"), false);
-		menuBar->Enable(XRCID("btnSelect"), false);
-		menuBar->Enable(XRCID("btnTransform"), false);
-		menuBar->Enable(XRCID("btnPivot"), false);
-		menuBar->Enable(XRCID("btnVertexEdit"), false);
-		menuBar->Enable(XRCID("btnInflateBrush"), false);
-		menuBar->Enable(XRCID("btnDeflateBrush"), false);
-		menuBar->Enable(XRCID("btnMoveBrush"), false);
-		menuBar->Enable(XRCID("btnSmoothBrush"), false);
-		menuBar->Enable(XRCID("btnUndiffBrush"), false);
-		menuBar->Enable(XRCID("btnBrushCollision"), false);
-		menuBar->Enable(XRCID("btnClearMask"), false);
-		menuBar->Enable(XRCID("btnInvertMask"), false);
-		menuBar->Enable(XRCID("btnCollapseVertex"), false);
-		menuBar->Enable(XRCID("btnFlipEdgeTool"), false);
-		menuBar->Enable(XRCID("btnSplitEdgeTool"), false);
-		menuBar->Enable(XRCID("deleteVerts"), false);
-
-		toolBarH->ToggleTool(XRCID("btnMaskBrush"), true);
-		toolBarV->ToggleTool(XRCID("btnBrushCollision"), false);
-		toolBarH->EnableTool(XRCID("btnSelect"), false);
-		toolBarV->EnableTool(XRCID("btnTransform"), false);
-		toolBarV->EnableTool(XRCID("btnPivot"), false);
-		toolBarV->EnableTool(XRCID("btnVertexEdit"), false);
-		toolBarH->EnableTool(XRCID("btnInflateBrush"), false);
-		toolBarH->EnableTool(XRCID("btnDeflateBrush"), false);
-		toolBarH->EnableTool(XRCID("btnMoveBrush"), false);
-		toolBarH->EnableTool(XRCID("btnSmoothBrush"), false);
-		toolBarH->EnableTool(XRCID("btnUndiffBrush"), false);
-		toolBarH->EnableTool(XRCID("btnCollapseVertex"), false);
-		toolBarH->EnableTool(XRCID("btnFlipEdgeTool"), false);
-		toolBarH->EnableTool(XRCID("btnSplitEdgeTool"), false);
-		toolBarV->EnableTool(XRCID("btnBrushCollision"), false);
-
-		ShowPartition(partitionTree->GetSelection());
-	}
-	else if (id == lightsTabButton->GetId()) {
-		currentTabButton = lightsTabButton;
-
-		outfitShapes->Hide();
-		outfitBones->Hide();
-		colorSettings->Hide();
-		segmentTree->Hide();
-		partitionTree->Hide();
-		lightSettings->Show();
-
-		meshTabButton->SetCheck(false);
-		boneTabButton->SetCheck(false);
-		colorsTabButton->SetCheck(false);
-		segmentTabButton->SetCheck(false);
-		partitionTabButton->SetCheck(false);
-
-		SetNoSubMeshes();
-		SelectTool(glView->GetLastTool());
-	}
-
-	CheckBrushBounds();
-	UpdateBrushSettings();
-
-	wxPanel* topSplitPanel = (wxPanel*)FindWindowByName("topSplitPanel");
-	wxPanel* bottomSplitPanel = (wxPanel*)FindWindowByName("bottomSplitPanel");
-
-	topSplitPanel->Layout();
-	bottomSplitPanel->Layout();
-
-	Refresh();
-}
-
-void OutfitStudioFrame::OnBrushColorChanged(wxColourPickerEvent& event) {
-	wxColour color = event.GetColour();
-	Vector3 brushColor;
-	brushColor.x = color.Red() / 255.0f;
-	brushColor.y = color.Green() / 255.0f;
-	brushColor.z = color.Blue() / 255.0f;
-	glView->SetColorBrush(brushColor);
-}
-
-void OutfitStudioFrame::OnSwapBrush(wxCommandEvent& WXUNUSED(event)) {
-	ToolID activeTool = glView->GetActiveTool();
-	if (activeTool == ToolID::ColorBrush)
-		SelectTool(ToolID::AlphaBrush);
-	else if (activeTool == ToolID::AlphaBrush)
-		SelectTool(ToolID::ColorBrush);
-}
-
-void OutfitStudioFrame::ScrollWindowIntoView(wxScrolledWindow* scrolled, wxWindow* window) {
-	// "window" must be an immediate child of "scrolled"
-	int scrollRateY = 0;
-	scrolled->GetScrollPixelsPerUnit(nullptr, &scrollRateY);
-
-	wxPoint window_pos = scrolled->CalcUnscrolledPosition(window->GetPosition());
-	scrolled->Scroll(0, window_pos.y / scrollRateY);
-}
-
-void OutfitStudioFrame::HighlightSlider(const std::string& name) {
-	for (auto &d : sliderDisplays) {
-		if (d.first == name) {
-			d.second->hilite = true;
-			d.second->sliderPane->SetBackgroundColour(wxColour(125, 77, 138));
+		if (buttonNameId == "btnSliderProp")
+		{
+			ShowSliderProperties(clickedName);
+			return;
 		}
-		else {
-			d.second->hilite = false;
-			d.second->sliderPane->SetBackgroundColour(wxColour(64, 64, 64));
-			d.second->slider->Disable();
-			d.second->slider->Enable();
-		}
+
+		if (activeSlider != clickedName)
+			EnterSliderEdit(clickedName);
+		else
+			ExitSliderEdit();
 	}
-	sliderScroll->Refresh();
-}
 
-void OutfitStudioFrame::ZeroSliders() {
-	if (!project->AllSlidersZero()) {
-		for (size_t s = 0; s < project->SliderCount(); s++) {
-			if (project->SliderClamp(s))
-				continue;
+	void OutfitStudioFrame::OnReadoutChange(wxCommandEvent& event) {
+		wxTextCtrl* w = (wxTextCtrl*)event.GetEventObject();
+		event.Skip();
+		if (!w)
+			return;
 
-			SetSliderValue(s, 0);
-			sliderDisplays[project->GetSliderName(s)]->slider->SetValue(0);
-		}
+		wxString sn = w->GetName();
+		if (!sn.EndsWith("|readout", &sn))
+			return;
+
+		std::string sliderName{sn.ToUTF8()};
+
+		double v;
+		wxString val = w->GetValue();
+		val.Replace("%", "");
+		if (!val.ToDouble(&v))
+			return;
+
+		SliderDisplay* d = sliderDisplays[sliderName];
+		d->slider->SetValue(v);
+
+		project->SliderValue(sliderName) = v / 100.0f;
+
 		ApplySliders();
 	}
-}
 
-void OutfitStudioFrame::OnSlider(wxScrollEvent& event) {
-	wxSlider* s = ((wxSlider*)event.GetEventObject());
-	if (!s)
-		return;
+	void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
+		int id = event.GetId();
 
-	wxString sliderName = s->GetName();
-	// Note that this function should never be called for any of the
-	// sliders checked in the next 'if' statement.
-	if (sliderName == "brushSize" ||
-		sliderName == "brushStrength" ||
-		sliderName == "brushFocus" ||
-		sliderName == "brushSpacing" ||
-		sliderName == "rxPoseSlider" ||
-		sliderName == "ryPoseSlider" ||
-		sliderName == "rzPoseSlider" ||
-		sliderName == "txPoseSlider" ||
-		sliderName == "tyPoseSlider" ||
-		sliderName == "tzPoseSlider")
-		return;
+		if (currentTabButton && currentTabButton->HasPendingChanges())
+		{
+			wxMessageDialog dlg(this, _("Your changes were not applied yet. Do you want to apply or reset them?"), _("Pending Changes"), wxYES_NO | wxCANCEL | wxICON_WARNING | wxCANCEL_DEFAULT);
+			dlg.SetYesNoCancelLabels(_("Apply"), _("Reset"), _("Cancel"));
 
-	if (sliderName != "boneScale") {
-		project->ClearBoneScale(false);
-		boneScale->SetValue(0);
+			int res = dlg.ShowModal();
+			if (res == wxID_YES)
+			{
+				if (currentTabButton == partitionTabButton)
+					ApplyPartitions();
+				else if (currentTabButton == segmentTabButton)
+					ApplySegments();
+			}
+			else if (res == wxID_NO)
+			{
+				if (currentTabButton == partitionTabButton)
+					ResetPartitions();
+				else if (currentTabButton == segmentTabButton)
+					ResetSegments();
+			}
+			else
+			{
+				event.Skip();
+				return;
+			}
+		}
+
+		if (id != meshTabButton->GetId())
+			masksPane->Hide();
+
+		if (id != segmentTabButton->GetId())
+		{
+			wxStaticText* segmentTypeLabel = (wxStaticText*)FindWindowByName("segmentTypeLabel");
+			wxChoice* segmentType = (wxChoice*)FindWindowByName("segmentType");
+			wxStaticText* segmentSlotLabel = (wxStaticText*)FindWindowByName("segmentSlotLabel");
+			wxChoice* segmentSlot = (wxChoice*)FindWindowByName("segmentSlot");
+			wxStaticText* segmentSSFLabel = (wxStaticText*)FindWindowByName("segmentSSFLabel");
+			wxButton* segmentSSFEdit = (wxButton*)FindWindowByName("segmentSSFEdit");
+			wxTextCtrl* segmentSSF = (wxTextCtrl*)FindWindowByName("segmentSSF");
+			wxButton* segmentApply = (wxButton*)FindWindowByName("segmentApply");
+			wxButton* segmentReset = (wxButton*)FindWindowByName("segmentReset");
+
+			segmentTypeLabel->Show(false);
+			segmentType->Show(false);
+			segmentSlotLabel->Show(false);
+			segmentSlot->Show(false);
+			segmentSSFLabel->Show(false);
+			segmentSSFEdit->Show(false);
+			segmentSSF->Show(false);
+			segmentApply->Show(false);
+			segmentReset->Show(false);
+
+			if (glView->GetSegmentMode())
+				glView->ClearActiveColors();
+
+			glView->SetSegmentMode(false);
+			glView->SetMaskVisible();
+			glView->SetGlobalBrushCollision();
+
+			menuBar->Check(XRCID("btnBrushCollision"), true);
+			menuBar->Enable(XRCID("btnBrushCollision"), true);
+			menuBar->Enable(XRCID("btnSelect"), true);
+			menuBar->Enable(XRCID("btnClearMask"), true);
+			menuBar->Enable(XRCID("btnInvertMask"), true);
+			menuBar->Enable(XRCID("deleteVerts"), true);
+
+			toolBarV->ToggleTool(XRCID("btnBrushCollision"), true);
+			toolBarV->EnableTool(XRCID("btnBrushCollision"), true);
+			toolBarH->EnableTool(XRCID("btnSelect"), true);
+		}
+
+		if (id != partitionTabButton->GetId())
+		{
+			wxStaticText* partitionTypeLabel = (wxStaticText*)FindWindowByName("partitionTypeLabel");
+			wxChoice* partitionType = (wxChoice*)FindWindowByName("partitionType");
+			wxButton* partitionApply = (wxButton*)FindWindowByName("partitionApply");
+			wxButton* partitionReset = (wxButton*)FindWindowByName("partitionReset");
+
+			partitionTypeLabel->Show(false);
+			partitionType->Show(false);
+			partitionApply->Show(false);
+			partitionReset->Show(false);
+
+			if (glView->GetSegmentMode())
+				glView->ClearActiveColors();
+
+			glView->SetSegmentMode(false);
+			glView->SetMaskVisible();
+			glView->SetGlobalBrushCollision();
+
+			menuBar->Check(XRCID("btnBrushCollision"), true);
+			menuBar->Enable(XRCID("btnBrushCollision"), true);
+			menuBar->Enable(XRCID("btnSelect"), true);
+			menuBar->Enable(XRCID("btnClearMask"), true);
+			menuBar->Enable(XRCID("btnInvertMask"), true);
+			menuBar->Enable(XRCID("deleteVerts"), true);
+
+			toolBarV->ToggleTool(XRCID("btnBrushCollision"), true);
+			toolBarV->EnableTool(XRCID("btnBrushCollision"), true);
+			toolBarH->EnableTool(XRCID("btnSelect"), true);
+		}
+
+		if (id != boneTabButton->GetId())
+		{
+			boneScale->Show(false);
+			cXMirrorBone->Show(false);
+
+			wxStaticText* totalBoneCountLabel = (wxStaticText*)FindWindowByName("totalBoneCountLabel");
+			wxStaticText* selectedBoneCountLabel = (wxStaticText*)FindWindowByName("selectedBoneCountLabel");
+			wxStaticText* boneScaleLabel = (wxStaticText*)FindWindowByName("boneScaleLabel");
+			wxCheckBox* cbFixedWeight = (wxCheckBox*)FindWindowByName("cbFixedWeight");
+			wxCheckBox* cbNormalizeWeights = (wxCheckBox*)FindWindowByName("cbNormalizeWeights");
+			wxStaticText* xMirrorBoneLabel = (wxStaticText*)FindWindowByName("xMirrorBoneLabel");
+
+			totalBoneCountLabel->Show(false);
+			selectedBoneCountLabel->Show(false);
+			boneScaleLabel->Show(false);
+			cbFixedWeight->Show(false);
+			cbNormalizeWeights->Show(false);
+			xMirrorBoneLabel->Show(false);
+			posePane->Show(false);
+			bonesFilter->GetParent()->Show(false);
+
+			project->ClearBoneScale();
+
+			if (project->bPose)
+			{
+				project->bPose = false;
+				ApplyPose();
+			}
+
+			glView->SetWeightVisible(false);
+		}
+
+		if (id != colorsTabButton->GetId())
+		{
+			glView->SetColorsVisible(false);
+
+			if (colorSettings->IsShown())
+				glView->ClearColors();
+		}
+
+		if (id != boneTabButton->GetId() || id != colorsTabButton->GetId())
+		{
+			glView->SetTransformMode(false);
+
+			menuBar->Check(XRCID("btnInflateBrush"), true);
+			menuBar->Enable(XRCID("btnTransform"), true);
+			menuBar->Enable(XRCID("btnPivot"), true);
+			menuBar->Enable(XRCID("btnVertexEdit"), true);
+			menuBar->Enable(XRCID("btnWeightBrush"), false);
+			menuBar->Enable(XRCID("btnColorBrush"), false);
+			menuBar->Enable(XRCID("btnAlphaBrush"), false);
+			menuBar->Enable(XRCID("btnInflateBrush"), true);
+			menuBar->Enable(XRCID("btnDeflateBrush"), true);
+			menuBar->Enable(XRCID("btnMoveBrush"), true);
+			menuBar->Enable(XRCID("btnSmoothBrush"), true);
+			menuBar->Enable(XRCID("btnUndiffBrush"), true);
+			menuBar->Enable(XRCID("btnCollapseVertex"), true);
+			menuBar->Enable(XRCID("btnFlipEdgeTool"), true);
+			menuBar->Enable(XRCID("btnSplitEdgeTool"), true);
+			menuBar->Enable(XRCID("deleteVerts"), true);
+
+			toolBarH->ToggleTool(XRCID("btnInflateBrush"), true);
+			toolBarH->EnableTool(XRCID("btnWeightBrush"), false);
+			toolBarH->EnableTool(XRCID("btnColorBrush"), false);
+			toolBarH->EnableTool(XRCID("btnAlphaBrush"), false);
+			toolBarV->EnableTool(XRCID("btnTransform"), true);
+			toolBarV->EnableTool(XRCID("btnPivot"), true);
+			toolBarV->EnableTool(XRCID("btnVertexEdit"), true);
+			toolBarH->EnableTool(XRCID("btnInflateBrush"), true);
+			toolBarH->EnableTool(XRCID("btnDeflateBrush"), true);
+			toolBarH->EnableTool(XRCID("btnMoveBrush"), true);
+			toolBarH->EnableTool(XRCID("btnSmoothBrush"), true);
+			toolBarH->EnableTool(XRCID("btnUndiffBrush"), true);
+			toolBarH->EnableTool(XRCID("btnCollapseVertex"), true);
+			toolBarH->EnableTool(XRCID("btnFlipEdgeTool"), true);
+			toolBarH->EnableTool(XRCID("btnSplitEdgeTool"), true);
+		}
+
+		if (id == meshTabButton->GetId())
+		{
+			currentTabButton = meshTabButton;
+
+			outfitBones->Hide();
+			colorSettings->Hide();
+			segmentTree->Hide();
+			partitionTree->Hide();
+			lightSettings->Hide();
+			outfitShapes->Show();
+
+			boneTabButton->SetCheck(false);
+			colorsTabButton->SetCheck(false);
+			segmentTabButton->SetCheck(false);
+			partitionTabButton->SetCheck(false);
+			lightsTabButton->SetCheck(false);
+
+			masksPane->Show();
+
+			SetNoSubMeshes();
+			SelectTool(glView->GetLastTool());
+		}
+		else if (id == boneTabButton->GetId())
+		{
+			currentTabButton = boneTabButton;
+
+			outfitShapes->Hide();
+			colorSettings->Hide();
+			segmentTree->Hide();
+			partitionTree->Hide();
+			lightSettings->Hide();
+			outfitBones->Show();
+
+			meshTabButton->SetCheck(false);
+			colorsTabButton->SetCheck(false);
+			segmentTabButton->SetCheck(false);
+			partitionTabButton->SetCheck(false);
+			lightsTabButton->SetCheck(false);
+
+			boneScale->SetValue(0);
+			boneScale->Show();
+			cXMirrorBone->Show();
+
+			wxStaticText* totalBoneCountLabel = (wxStaticText*)FindWindowByName("totalBoneCountLabel");
+			wxStaticText* selectedBoneCountLabel = (wxStaticText*)FindWindowByName("selectedBoneCountLabel");
+			wxStaticText* boneScaleLabel = (wxStaticText*)FindWindowByName("boneScaleLabel");
+			wxCheckBox* cbFixedWeight = (wxCheckBox*)FindWindowByName("cbFixedWeight");
+			wxCheckBox* cbNormalizeWeights = (wxCheckBox*)FindWindowByName("cbNormalizeWeights");
+			wxStaticText* xMirrorBoneLabel = (wxStaticText*)FindWindowByName("xMirrorBoneLabel");
+
+			totalBoneCountLabel->Show();
+			selectedBoneCountLabel->Show();
+			boneScaleLabel->Show();
+			cbFixedWeight->Show();
+			cbNormalizeWeights->Show();
+			xMirrorBoneLabel->Show();
+			posePane->Show();
+			bonesFilter->GetParent()->Show();
+		
+			glView->SetTransformMode(false);
+			SelectTool(ToolID::WeightBrush);
+			glView->SetWeightVisible();
+
+			project->bPose = cbPose->GetValue();
+
+			if (project->bPose)
+				ApplyPose();
+
+			menuBar->Check(XRCID("btnWeightBrush"), true);
+			menuBar->Enable(XRCID("btnWeightBrush"), true);
+			menuBar->Enable(XRCID("btnColorBrush"), false);
+			menuBar->Enable(XRCID("btnAlphaBrush"), false);
+			menuBar->Enable(XRCID("btnTransform"), false);
+			menuBar->Enable(XRCID("btnPivot"), false);
+			menuBar->Enable(XRCID("btnVertexEdit"), false);
+			menuBar->Enable(XRCID("btnInflateBrush"), false);
+			menuBar->Enable(XRCID("btnDeflateBrush"), false);
+			menuBar->Enable(XRCID("btnMoveBrush"), false);
+			menuBar->Enable(XRCID("btnSmoothBrush"), false);
+			menuBar->Enable(XRCID("btnUndiffBrush"), false);
+			menuBar->Enable(XRCID("btnCollapseVertex"), false);
+			menuBar->Enable(XRCID("btnFlipEdgeTool"), false);
+			menuBar->Enable(XRCID("btnSplitEdgeTool"), false);
+			menuBar->Enable(XRCID("deleteVerts"), false);
+
+			toolBarH->ToggleTool(XRCID("btnWeightBrush"), true);
+			toolBarH->EnableTool(XRCID("btnWeightBrush"), true);
+			toolBarH->EnableTool(XRCID("btnColorBrush"), false);
+			toolBarH->EnableTool(XRCID("btnAlphaBrush"), false);
+			toolBarV->EnableTool(XRCID("btnTransform"), false);
+			toolBarV->EnableTool(XRCID("btnPivot"), false);
+			toolBarV->EnableTool(XRCID("btnVertexEdit"), false);
+			toolBarH->EnableTool(XRCID("btnInflateBrush"), false);
+			toolBarH->EnableTool(XRCID("btnDeflateBrush"), false);
+			toolBarH->EnableTool(XRCID("btnMoveBrush"), false);
+			toolBarH->EnableTool(XRCID("btnSmoothBrush"), false);
+			toolBarH->EnableTool(XRCID("btnUndiffBrush"), false);
+			toolBarH->EnableTool(XRCID("btnCollapseVertex"), false);
+			toolBarH->EnableTool(XRCID("btnFlipEdgeTool"), false);
+			toolBarH->EnableTool(XRCID("btnSplitEdgeTool"), false);
+
+			SetNoSubMeshes();
+
+			ReselectBone();
+			glView->GetUndoHistory()->ClearHistory();
+		}
+		else if (id == colorsTabButton->GetId())
+		{
+			currentTabButton = colorsTabButton;
+
+			outfitShapes->Hide();
+			outfitBones->Hide();
+			segmentTree->Hide();
+			partitionTree->Hide();
+			lightSettings->Hide();
+			colorSettings->Show();
+
+			meshTabButton->SetCheck(false);
+			boneTabButton->SetCheck(false);
+			segmentTabButton->SetCheck(false);
+			partitionTabButton->SetCheck(false);
+			lightsTabButton->SetCheck(false);
+
+			glView->SetTransformMode(false);
+			SelectTool(ToolID::ColorBrush);
+			glView->SetColorsVisible();
+
+			wxButton* btnSwapBrush = (wxButton*)FindWindowById(XRCID("btnSwapBrush"), colorSettings);
+			btnSwapBrush->SetLabel(_("Edit Alpha"));
+
+			FillVertexColors();
+
+			menuBar->Check(XRCID("btnColorBrush"), true);
+			menuBar->Enable(XRCID("btnColorBrush"), true);
+			menuBar->Enable(XRCID("btnAlphaBrush"), true);
+			menuBar->Enable(XRCID("btnWeightBrush"), false);
+			menuBar->Enable(XRCID("btnTransform"), false);
+			menuBar->Enable(XRCID("btnPivot"), false);
+			menuBar->Enable(XRCID("btnVertexEdit"), false);
+			menuBar->Enable(XRCID("btnInflateBrush"), false);
+			menuBar->Enable(XRCID("btnDeflateBrush"), false);
+			menuBar->Enable(XRCID("btnMoveBrush"), false);
+			menuBar->Enable(XRCID("btnSmoothBrush"), false);
+			menuBar->Enable(XRCID("btnUndiffBrush"), false);
+			menuBar->Enable(XRCID("btnCollapseVertex"), false);
+			menuBar->Enable(XRCID("btnFlipEdgeTool"), false);
+			menuBar->Enable(XRCID("btnSplitEdgeTool"), false);
+			menuBar->Enable(XRCID("deleteVerts"), false);
+
+			toolBarH->ToggleTool(XRCID("btnColorBrush"), true);
+			toolBarH->EnableTool(XRCID("btnColorBrush"), true);
+			toolBarH->EnableTool(XRCID("btnAlphaBrush"), true);
+			toolBarH->EnableTool(XRCID("btnWeightBrush"), false);
+			toolBarV->EnableTool(XRCID("btnTransform"), false);
+			toolBarV->EnableTool(XRCID("btnPivot"), false);
+			toolBarV->EnableTool(XRCID("btnVertexEdit"), false);
+			toolBarH->EnableTool(XRCID("btnInflateBrush"), false);
+			toolBarH->EnableTool(XRCID("btnDeflateBrush"), false);
+			toolBarH->EnableTool(XRCID("btnMoveBrush"), false);
+			toolBarH->EnableTool(XRCID("btnSmoothBrush"), false);
+			toolBarH->EnableTool(XRCID("btnUndiffBrush"), false);
+			toolBarH->EnableTool(XRCID("btnCollapseVertex"), false);
+			toolBarH->EnableTool(XRCID("btnFlipEdgeTool"), false);
+			toolBarH->EnableTool(XRCID("btnSplitEdgeTool"), false);
+
+			SetNoSubMeshes();
+		}
+		else if (id == segmentTabButton->GetId())
+		{
+			currentTabButton = segmentTabButton;
+
+			outfitShapes->Hide();
+			outfitBones->Hide();
+			colorSettings->Hide();
+			partitionTree->Hide();
+			lightSettings->Hide();
+			segmentTree->Show();
+
+			meshTabButton->SetCheck(false);
+			boneTabButton->SetCheck(false);
+			colorsTabButton->SetCheck(false);
+			partitionTabButton->SetCheck(false);
+			lightsTabButton->SetCheck(false);
+
+			wxStaticText* segmentTypeLabel = (wxStaticText*)FindWindowByName("segmentTypeLabel");
+			wxChoice* segmentType = (wxChoice*)FindWindowByName("segmentType");
+			wxStaticText* segmentSlotLabel = (wxStaticText*)FindWindowByName("segmentSlotLabel");
+			wxChoice* segmentSlot = (wxChoice*)FindWindowByName("segmentSlot");
+			wxStaticText* segmentSSFLabel = (wxStaticText*)FindWindowByName("segmentSSFLabel");
+			wxButton* segmentSSFEdit = (wxButton*)FindWindowByName("segmentSSFEdit");
+			wxTextCtrl* segmentSSF = (wxTextCtrl*)FindWindowByName("segmentSSF");
+			wxButton* segmentApply = (wxButton*)FindWindowByName("segmentApply");
+			wxButton* segmentReset = (wxButton*)FindWindowByName("segmentReset");
+
+			segmentTypeLabel->Show();
+			segmentType->Show();
+			segmentSlotLabel->Show();
+			segmentSlot->Show();
+			segmentSSFLabel->Show();
+			segmentSSFEdit->Show();
+			segmentSSF->Show();
+			segmentApply->Show();
+			segmentReset->Show();
+
+			SelectTool(ToolID::MaskBrush);
+			glView->SetSegmentMode();
+			glView->SetMaskVisible(false);
+			glView->SetGlobalBrushCollision(false);
+			glView->ClearColors();
+
+			menuBar->Check(XRCID("btnMaskBrush"), true);
+			menuBar->Check(XRCID("btnBrushCollision"), false);
+			menuBar->Enable(XRCID("btnSelect"), false);
+			menuBar->Enable(XRCID("btnTransform"), false);
+			menuBar->Enable(XRCID("btnPivot"), false);
+			menuBar->Enable(XRCID("btnVertexEdit"), false);
+			menuBar->Enable(XRCID("btnInflateBrush"), false);
+			menuBar->Enable(XRCID("btnDeflateBrush"), false);
+			menuBar->Enable(XRCID("btnMoveBrush"), false);
+			menuBar->Enable(XRCID("btnSmoothBrush"), false);
+			menuBar->Enable(XRCID("btnUndiffBrush"), false);
+			menuBar->Enable(XRCID("btnBrushCollision"), false);
+			menuBar->Enable(XRCID("btnClearMask"), false);
+			menuBar->Enable(XRCID("btnInvertMask"), false);
+			menuBar->Enable(XRCID("btnCollapseVertex"), false);
+			menuBar->Enable(XRCID("btnFlipEdgeTool"), false);
+			menuBar->Enable(XRCID("btnSplitEdgeTool"), false);
+			menuBar->Enable(XRCID("deleteVerts"), false);
+
+			toolBarH->ToggleTool(XRCID("btnMaskBrush"), true);
+			toolBarV->ToggleTool(XRCID("btnBrushCollision"), false);
+			toolBarH->EnableTool(XRCID("btnSelect"), false);
+			toolBarV->EnableTool(XRCID("btnTransform"), false);
+			toolBarV->EnableTool(XRCID("btnPivot"), false);
+			toolBarV->EnableTool(XRCID("btnVertexEdit"), false);
+			toolBarH->EnableTool(XRCID("btnInflateBrush"), false);
+			toolBarH->EnableTool(XRCID("btnDeflateBrush"), false);
+			toolBarH->EnableTool(XRCID("btnMoveBrush"), false);
+			toolBarH->EnableTool(XRCID("btnSmoothBrush"), false);
+			toolBarH->EnableTool(XRCID("btnUndiffBrush"), false);
+			toolBarH->EnableTool(XRCID("btnCollapseVertex"), false);
+			toolBarH->EnableTool(XRCID("btnFlipEdgeTool"), false);
+			toolBarH->EnableTool(XRCID("btnSplitEdgeTool"), false);
+			toolBarV->EnableTool(XRCID("btnBrushCollision"), false);
+
+			ShowSegment(segmentTree->GetSelection());
+		}
+		else if (id == partitionTabButton->GetId())
+		{
+			currentTabButton = partitionTabButton;
+
+			outfitShapes->Hide();
+			outfitBones->Hide();
+			colorSettings->Hide();
+			segmentTree->Hide();
+			lightSettings->Hide();
+			partitionTree->Show();
+
+			meshTabButton->SetCheck(false);
+			boneTabButton->SetCheck(false);
+			colorsTabButton->SetCheck(false);
+			segmentTabButton->SetCheck(false);
+			lightsTabButton->SetCheck(false);
+
+			wxStaticText* partitionTypeLabel = (wxStaticText*)FindWindowByName("partitionTypeLabel");
+			wxChoice* partitionType = (wxChoice*)FindWindowByName("partitionType");
+			wxButton* partitionApply = (wxButton*)FindWindowByName("partitionApply");
+			wxButton* partitionReset = (wxButton*)FindWindowByName("partitionReset");
+
+			partitionTypeLabel->Show();
+			partitionType->Show();
+			partitionApply->Show();
+			partitionReset->Show();
+
+			SelectTool(ToolID::MaskBrush);
+			glView->SetSegmentMode();
+			glView->SetMaskVisible(false);
+			glView->SetGlobalBrushCollision(false);
+			glView->ClearColors();
+
+			menuBar->Check(XRCID("btnMaskBrush"), true);
+			menuBar->Check(XRCID("btnBrushCollision"), false);
+			menuBar->Enable(XRCID("btnSelect"), false);
+			menuBar->Enable(XRCID("btnTransform"), false);
+			menuBar->Enable(XRCID("btnPivot"), false);
+			menuBar->Enable(XRCID("btnVertexEdit"), false);
+			menuBar->Enable(XRCID("btnInflateBrush"), false);
+			menuBar->Enable(XRCID("btnDeflateBrush"), false);
+			menuBar->Enable(XRCID("btnMoveBrush"), false);
+			menuBar->Enable(XRCID("btnSmoothBrush"), false);
+			menuBar->Enable(XRCID("btnUndiffBrush"), false);
+			menuBar->Enable(XRCID("btnBrushCollision"), false);
+			menuBar->Enable(XRCID("btnClearMask"), false);
+			menuBar->Enable(XRCID("btnInvertMask"), false);
+			menuBar->Enable(XRCID("btnCollapseVertex"), false);
+			menuBar->Enable(XRCID("btnFlipEdgeTool"), false);
+			menuBar->Enable(XRCID("btnSplitEdgeTool"), false);
+			menuBar->Enable(XRCID("deleteVerts"), false);
+
+			toolBarH->ToggleTool(XRCID("btnMaskBrush"), true);
+			toolBarV->ToggleTool(XRCID("btnBrushCollision"), false);
+			toolBarH->EnableTool(XRCID("btnSelect"), false);
+			toolBarV->EnableTool(XRCID("btnTransform"), false);
+			toolBarV->EnableTool(XRCID("btnPivot"), false);
+			toolBarV->EnableTool(XRCID("btnVertexEdit"), false);
+			toolBarH->EnableTool(XRCID("btnInflateBrush"), false);
+			toolBarH->EnableTool(XRCID("btnDeflateBrush"), false);
+			toolBarH->EnableTool(XRCID("btnMoveBrush"), false);
+			toolBarH->EnableTool(XRCID("btnSmoothBrush"), false);
+			toolBarH->EnableTool(XRCID("btnUndiffBrush"), false);
+			toolBarH->EnableTool(XRCID("btnCollapseVertex"), false);
+			toolBarH->EnableTool(XRCID("btnFlipEdgeTool"), false);
+			toolBarH->EnableTool(XRCID("btnSplitEdgeTool"), false);
+			toolBarV->EnableTool(XRCID("btnBrushCollision"), false);
+
+			ShowPartition(partitionTree->GetSelection());
+		}
+		else if (id == lightsTabButton->GetId())
+		{
+			currentTabButton = lightsTabButton;
+
+			outfitShapes->Hide();
+			outfitBones->Hide();
+			colorSettings->Hide();
+			segmentTree->Hide();
+			partitionTree->Hide();
+			lightSettings->Show();
+
+			meshTabButton->SetCheck(false);
+			boneTabButton->SetCheck(false);
+			colorsTabButton->SetCheck(false);
+			segmentTabButton->SetCheck(false);
+			partitionTabButton->SetCheck(false);
+
+			SetNoSubMeshes();
+			SelectTool(glView->GetLastTool());
+		}
+
+		CheckBrushBounds();
+		UpdateBrushSettings();
+
+		wxPanel* topSplitPanel = (wxPanel*)FindWindowByName("topSplitPanel");
+		wxPanel* bottomSplitPanel = (wxPanel*)FindWindowByName("bottomSplitPanel");
+
+		topSplitPanel->Layout();
+		bottomSplitPanel->Layout();
+
+		Refresh();
 	}
 
-	if (sliderName == "boneScale") {
-		if (!activeBone.empty())
-			project->ApplyBoneScale(activeBone, event.GetPosition(), true);
-
-		glView->Render();
-		return;
+	void OutfitStudioFrame::OnBrushColorChanged(wxColourPickerEvent& event) {
+		wxColour color = event.GetColour();
+		Vector3 brushColor;
+		brushColor.x = color.Red() / 255.0f;
+		brushColor.y = color.Green() / 255.0f;
+		brushColor.z = color.Blue() / 255.0f;
+		glView->SetColorBrush(brushColor);
 	}
 
-	std::string sn{sliderName.BeforeLast('|').ToUTF8()};
-	if (sn.empty())
-		return;
+	void OutfitStudioFrame::OnSwapBrush(wxCommandEvent& WXUNUSED(event)) {
+		ToolID activeTool = glView->GetActiveTool();
+		if (activeTool == ToolID::ColorBrush)
+			SelectTool(ToolID::AlphaBrush);
+		else if (activeTool == ToolID::AlphaBrush)
+			SelectTool(ToolID::ColorBrush);
+	}
 
-	SetSliderValue(sn, event.GetPosition());
+	void OutfitStudioFrame::ScrollWindowIntoView(wxScrolledWindow* scrolled, wxWindow* window) {
+		// "window" must be an immediate child of "scrolled"
+		int scrollRateY = 0;
+		scrolled->GetScrollPixelsPerUnit(nullptr, &scrollRateY);
 
-	if (!bEditSlider && event.GetEventType() == wxEVT_SCROLL_CHANGED)
-		ApplySliders(true);
-	else
-		ApplySliders(false);
-}
+		wxPoint window_pos = scrolled->CalcUnscrolledPosition(window->GetPosition());
+		scrolled->Scroll(0, window_pos.y / scrollRateY);
+	}
 
-void OutfitStudioFrame::OnLoadPreset(wxCommandEvent& WXUNUSED(event)) {
-	wxDialog dlg;
-	PresetCollection presets;
-	std::vector<std::string> names;
-	wxChoice* presetChoice;
+	void OutfitStudioFrame::HighlightSlider(const std::string& name) {
+		for (auto &d : sliderDisplays)
+		{
+			if (d.first == name)
+			{
+				d.second->hilite = true;
+				d.second->sliderPane->SetBackgroundColour(wxColour(125, 77, 138));
+			}
+			else
+			{
+				d.second->hilite = false;
+				d.second->sliderPane->SetBackgroundColour(wxColour(64, 64, 64));
+				d.second->slider->Disable();
+				d.second->slider->Enable();
+			}
+		}
+		sliderScroll->Refresh();
+	}
 
-	std::string choice;
-	bool hi = true;
+	void OutfitStudioFrame::ZeroSliders()
+	{
+		if (!project->AllSlidersZero())
+		{
+			for (size_t s = 0; s < project->SliderCount(); s++)
+			{
+				if (project->SliderClamp(s))
+					continue;
 
-	presets.LoadPresets(GetProjectPath() + "/SliderPresets", choice, names, true);
-	presets.GetPresetNames(names);
+				SetSliderValue(s, 0);
+				sliderDisplays[project->GetSliderName(s)]->slider->SetValue(0);
+			}
+			ApplySliders();
+		}
+	}
 
-	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgChoosePreset")) {
-		presetChoice = XRCCTRL(dlg, "choicePreset", wxChoice);
-		presetChoice->AppendString("Zero All");
-		for (auto &n : names)
-			presetChoice->AppendString(n);
+	void OutfitStudioFrame::OnSlider(wxScrollEvent& event) {
+		wxSlider* s = ((wxSlider*)event.GetEventObject());
+		if (!s)
+			return;
 
-		presetChoice->SetSelection(0);
+		wxString sliderName = s->GetName();
+		// Note that this function should never be called for any of the
+		// sliders checked in the next 'if' statement.
+		if (sliderName == "brushSize" ||
+			sliderName == "brushStrength" ||
+			sliderName == "brushFocus" ||
+			sliderName == "brushSpacing" ||
+			sliderName == "rxPoseSlider" ||
+			sliderName == "ryPoseSlider" ||
+			sliderName == "rzPoseSlider" ||
+			sliderName == "txPoseSlider" ||
+			sliderName == "tyPoseSlider" ||
+			sliderName == "tzPoseSlider")
+			return;
 
-		dlg.SetSize(wxSize(325, 175));
-		dlg.SetSizeHints(wxSize(325, 175), wxSize(-1, -1));
-		dlg.CenterOnParent();
+		if (sliderName != "boneScale")
+		{
+			project->ClearBoneScale(false);
+			boneScale->SetValue(0);
+		}
 
+		if (sliderName == "boneScale")
+		{
+			if (!activeBone.empty())
+				project->ApplyBoneScale(activeBone, event.GetPosition(), true);
+
+			glView->Render();
+			return;
+		}
+
+		std::string sn{sliderName.BeforeLast('|').ToUTF8()};
+		if (sn.empty())
+			return;
+
+		SetSliderValue(sn, event.GetPosition());
+
+		if (!bEditSlider && event.GetEventType() == wxEVT_SCROLL_CHANGED)
+			ApplySliders(true);
+		else
+			ApplySliders(false);
+	}
+
+	void OutfitStudioFrame::OnLoadPreset(wxCommandEvent& WXUNUSED(event)) {
+		wxDialog dlg;
+		PresetCollection presets;
+		std::vector<std::string> names;
+		wxChoice* presetChoice;
+
+		std::string choice;
+		bool hi = true;
+
+		presets.LoadPresets(GetProjectPath() + "/SliderPresets", choice, names, true);
+		presets.GetPresetNames(names);
+
+		if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgChoosePreset"))
+		{
+			presetChoice = XRCCTRL(dlg, "choicePreset", wxChoice);
+			presetChoice->AppendString("Zero All");
+			for (auto &n : names)
+				presetChoice->AppendString(n);
+
+			presetChoice->SetSelection(0);
+
+			dlg.SetSize(wxSize(325, 175));
+			dlg.SetSizeHints(wxSize(325, 175), wxSize(-1, -1));
+			dlg.CenterOnParent();
+
+			if (dlg.ShowModal() != wxID_OK)
+				return;
+
+			choice = presetChoice->GetStringSelection();
+			if (XRCCTRL(dlg, "weightLo", wxRadioButton)->GetValue())
+				hi = false;
+
+			ZeroSliders();
+
+			if (choice == "Zero All")
+			{
+				wxLogMessage("Sliders were reset to zero.");
+				return;
+			}
+
+			wxLogMessage("Applying preset '%s' with option '%s'.", choice, hi ? "High" : "Low");
+
+			float v;
+			bool r;
+			for (size_t i = 0; i < project->SliderCount(); i++)
+			{
+				if (!presets.GetSliderExists(choice, project->GetSliderName(i)))
+					continue;
+
+				if (project->SliderClamp(i))
+					continue;
+
+				if (hi)
+					r = presets.GetBigPreset(choice, project->GetSliderName(i), v);
+				else
+					r = presets.GetSmallPreset(choice, project->GetSliderName(i), v);
+
+				if (!r)
+					v = project->SliderDefault(i, hi) / 100.0f;
+				if (project->SliderInvert(i))
+					v = 1.0f - v;
+
+				v *= 100.0f;
+				SetSliderValue(i, v);
+			}
+
+			ApplySliders();
+		}
+	}
+
+	void OutfitStudioFrame::OnSavePreset(wxCommandEvent& WXUNUSED(event)) {
+		std::vector<std::string> sliders;
+		project->GetSliderList(sliders);
+		if (sliders.empty())
+		{
+			wxMessageBox(_("There are no sliders loaded!"), _("Error"), wxICON_ERROR, this);
+			return;
+		}
+
+		SliderSetGroupCollection groupCollection;
+		groupCollection.LoadGroups(GetProjectPath() + "/SliderGroups");
+
+		std::set<std::string> allGroups;
+		groupCollection.GetAllGroups(allGroups);
+
+		PresetSaveDialog psd(this);
+		psd.allGroupNames.assign(allGroups.begin(), allGroups.end());
+		psd.FilterGroups();
+
+		psd.ShowModal();
+		if (psd.outFileName.empty())
+			return;
+
+		std::string fileName = psd.outFileName;
+		std::string presetName = psd.outPresetName;
+
+		std::vector<std::string> groups;
+		groups.assign(psd.outGroups.begin(), psd.outGroups.end());
+
+		bool addedSlider = false;
+		PresetCollection presets;
+		for (auto &s : sliders)
+		{
+			size_t index = 0;
+			if (!project->SliderIndexFromName(s, index))
+				continue;
+
+			if (project->SliderZap(index) || project->SliderHidden(index))
+				continue;
+
+			float value = project->SliderValue(index);
+			if (project->SliderInvert(index))
+				value = 1.0f - value;
+
+			if (project->SliderDefault(index, true) == value)
+				continue;
+
+			presets.SetSliderPreset(presetName, s, value, -10000.0f);
+
+			if (!addedSlider)
+				addedSlider = true;
+		}
+
+		if (!addedSlider)
+		{
+			wxLogMessage("No changes were made to the sliders, so no preset was saved!");
+			wxMessageBox(_("No changes were made to the sliders, so no preset was saved!"), _("Info"), wxICON_INFORMATION, this);
+			return;
+		}
+
+		int error = presets.SavePreset(fileName, presetName, "OutfitStudioFrame", groups);
+		if (error)
+		{
+			wxLogError("Failed to save preset (%d)!", error);
+			wxMessageBox(wxString::Format(_("Failed to save preset (%d)!"), error), _("Error"), wxICON_ERROR, this);
+		}
+	}
+
+	void OutfitStudioFrame::OnSliderImportNIF(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+		if (!bEditSlider)
+		{
+			wxMessageBox(_("There is no slider in edit mode to import data to!"), _("Error"));
+			return;
+		}
+
+		wxString fn = wxFileSelector(_("Import .nif file for slider calculation"), wxEmptyString, wxEmptyString, ".nif", "*.nif", wxFD_FILE_MUST_EXIST, this);
+		if (fn.IsEmpty())
+			return;
+
+		wxLogMessage("Importing slider to '%s' for shape '%s' from NIF file '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
+		if (!project->SetSliderFromNIF(activeSlider, activeItem->GetShape(), fn.ToUTF8().data()))
+		{
+			wxLogError("No mesh found in the .nif file that matches currently selected shape!");
+			wxMessageBox(_("No mesh found in the .nif file that matches currently selected shape!"), _("Error"), wxICON_ERROR);
+			return;
+		}
+
+		SetPendingChanges();
+		ApplySliders();
+	}
+
+	void OutfitStudioFrame::OnSliderImportBSD(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+		if (!bEditSlider)
+		{
+			wxMessageBox(_("There is no slider in edit mode to import data to!"), _("Error"));
+			return;
+		}
+
+		wxString fn = wxFileSelector(_("Import .bsd slider data"), wxEmptyString, wxEmptyString, ".bsd", "*.bsd", wxFD_FILE_MUST_EXIST, this);
+		if (fn.IsEmpty())
+			return;
+
+		wxLogMessage("Importing slider to '%s' for shape '%s' from BSD file '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
+		project->SetSliderFromBSD(activeSlider, activeItem->GetShape(), fn.ToUTF8().data());
+
+		SetPendingChanges();
+		ApplySliders();
+	}
+
+	void OutfitStudioFrame::OnSliderImportOBJ(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+		if (!bEditSlider)
+		{
+			wxMessageBox(_("There is no slider in edit mode to import data to!"), _("Error"));
+			return;
+		}
+
+		wxString fn = wxFileSelector(_("Import .obj file for slider calculation"), wxEmptyString, wxEmptyString, ".obj", "*.obj", wxFD_FILE_MUST_EXIST, this);
+		if (fn.IsEmpty())
+			return;
+
+		wxLogMessage("Importing slider to '%s' for shape '%s' from OBJ file '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
+		if (!project->SetSliderFromOBJ(activeSlider, activeItem->GetShape(), fn.ToUTF8().data()))
+		{
+			wxLogError("Vertex count of .obj file mesh does not match currently selected shape!");
+			wxMessageBox(_("Vertex count of .obj file mesh does not match currently selected shape!"), _("Error"), wxICON_ERROR);
+			return;
+		}
+
+		SetPendingChanges();
+		ApplySliders();
+	}
+
+	void OutfitStudioFrame::OnSliderImportOSD(wxCommandEvent& WXUNUSED(event)) {
+		if (!project->GetWorkNif()->IsValid())
+		{
+			wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
+			return;
+		}
+
+		wxString fn = wxFileSelector(_("Import .osd file"), wxEmptyString, wxEmptyString, ".osd", "*.osd", wxFD_FILE_MUST_EXIST, this);
+		if (fn.IsEmpty())
+			return;
+
+		wxMessageDialog dlg(this, _("This will delete all loaded sliders. Are you sure?"), _("OSD Import"), wxOK | wxCANCEL | wxICON_WARNING | wxCANCEL_DEFAULT);
+		dlg.SetOKCancelLabels(_("Import"), _("Cancel"));
 		if (dlg.ShowModal() != wxID_OK)
 			return;
 
-		choice = presetChoice->GetStringSelection();
-		if (XRCCTRL(dlg, "weightLo", wxRadioButton)->GetValue())
-			hi = false;
+		wxLogMessage("Importing morphs from OSD file '%s'...", fn);
 
-		ZeroSliders();
-
-		if (choice == "Zero All") {
-			wxLogMessage("Sliders were reset to zero.");
+		OSDataFile osd;
+		if (!osd.Read(fn.ToUTF8().data()))
+		{
+			wxLogError("Failed to import OSD file '%s'!", fn);
+			wxMessageBox(_("Failed to import OSD file!"), _("Error"), wxICON_ERROR);
 			return;
 		}
 
-		wxLogMessage("Applying preset '%s' with option '%s'.", choice, hi ? "High" : "Low");
+		// Deleting sliders
+		sliderScroll->Freeze();
+		std::vector<std::string> erase;
+		for (auto &sd : sliderDisplays)
+		{
+			sd.second->slider->SetValue(0);
+			SetSliderValue(sd.first, 0);
+			ShowSliderEffect(sd.first, true);
+			sd.second->slider->SetFocus();
 
-		float v;
-		bool r;
-		for (size_t i = 0; i < project->SliderCount(); i++) {
-			if (!presets.GetSliderExists(choice, project->GetSliderName(i)))
+			sd.second->btnSliderEdit->Destroy();
+			sd.second->btnSliderProp->Destroy();
+			sd.second->slider->Destroy();
+			sd.second->sliderName->Destroy();
+			sd.second->sliderNameCheck->Destroy();
+			sd.second->sliderReadout->Destroy();
+			sd.second->sliderPane->Destroy();
+			delete sd.second;
+
+			erase.push_back(sd.first);
+			project->DeleteSlider(sd.first);
+		}
+
+		for (auto &e : erase)
+			sliderDisplays.erase(e);
+
+		MenuExitSliderEdit();
+		sliderScroll->FitInside();
+		activeSlider.clear();
+		lastActiveSlider.clear();
+
+		wxString addedDiffs;
+		auto diffs = osd.GetDataDiffs();
+
+		for (auto &shape : project->GetWorkNif()->GetShapes())
+		{
+			std::string s = shape->name.get();
+			bool added = false;
+			for (auto &diff : diffs)
+			{
+				// Diff name is supposed to begin with matching shape name
+				if (diff.first.substr(0, s.size()) != s)
+					continue;
+
+				std::string diffName = diff.first.substr(s.length(), diff.first.length() - s.length() + 1);
+				if (!project->ValidSlider(diffName))
+				{
+					createSliderGUI(diffName, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
+					project->AddEmptySlider(diffName);
+					ShowSliderEffect(diffName);
+				}
+
+				project->SetSliderFromDiff(diffName, shape, diff.second);
+				added = true;
+			}
+
+			if (added)
+				addedDiffs += s + "\n";
+		}
+
+		sliderScroll->FitInside();
+		sliderScroll->Thaw();
+
+		SetPendingChanges();
+		ApplySliders();
+		DoFilterSliders();
+
+		wxLogMessage("Added morphs for the following shapes:\n%s", addedDiffs);
+		wxMessageBox(wxString::Format(_("Added morphs for the following shapes:\n\n%s"), addedDiffs), _("OSD Import"));
+	}
+
+	void OutfitStudioFrame::OnSliderImportTRI(wxCommandEvent& WXUNUSED(event)) {
+		if (!project->GetWorkNif()->IsValid())
+		{
+			wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
+			return;
+		}
+
+		wxString fn = wxFileSelector(_("Import .tri morphs"), wxEmptyString, wxEmptyString, ".tri", "*.tri", wxFD_FILE_MUST_EXIST, this);
+		if (fn.IsEmpty())
+			return;
+
+		wxMessageDialog dlg(this, _("This will delete all loaded sliders. Are you sure?"), _("TRI Import"), wxOK | wxCANCEL | wxICON_WARNING | wxCANCEL_DEFAULT);
+		dlg.SetOKCancelLabels(_("Import"), _("Cancel"));
+		if (dlg.ShowModal() != wxID_OK)
+			return;
+
+		wxLogMessage("Importing morphs from TRI file '%s'...", fn);
+
+		TriFile tri;
+		if (!tri.Read(fn.ToUTF8().data()))
+		{
+			wxLogError("Failed to load TRI file '%s'!", fn);
+			wxMessageBox(_("Failed to load TRI file!"), _("Error"), wxICON_ERROR);
+			return;
+		}
+
+		// Deleting sliders
+		sliderScroll->Freeze();
+		std::vector<std::string> erase;
+		for (auto &sd : sliderDisplays)
+		{
+			sd.second->slider->SetValue(0);
+			SetSliderValue(sd.first, 0);
+			ShowSliderEffect(sd.first, true);
+			sd.second->slider->SetFocus();
+
+			sd.second->btnSliderEdit->Destroy();
+			sd.second->btnSliderProp->Destroy();
+			sd.second->slider->Destroy();
+			sd.second->sliderName->Destroy();
+			sd.second->sliderNameCheck->Destroy();
+			sd.second->sliderReadout->Destroy();
+			sd.second->sliderPane->Destroy();
+			delete sd.second;
+
+			erase.push_back(sd.first);
+			project->DeleteSlider(sd.first);
+		}
+
+		for (auto &e : erase)
+			sliderDisplays.erase(e);
+
+		MenuExitSliderEdit();
+		sliderScroll->FitInside();
+		activeSlider.clear();
+		lastActiveSlider.clear();
+
+		wxString addedMorphs;
+		auto morphs = tri.GetMorphs();
+		for (auto &morph : morphs)
+		{
+			auto shape = project->GetWorkNif()->FindBlockByName<NiShape>(morph.first);
+			if (!shape)
 				continue;
 
-			if (project->SliderClamp(i))
-				continue;
+			addedMorphs += morph.first + "\n";
+			for (auto &morphData : morph.second)
+			{
+				if (!project->ValidSlider(morphData->name))
+				{
+					createSliderGUI(morphData->name, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
+					project->AddEmptySlider(morphData->name);
+					ShowSliderEffect(morphData->name);
+				}
 
-			if (hi)
-				r = presets.GetBigPreset(choice, project->GetSliderName(i), v);
-			else
-				r = presets.GetSmallPreset(choice, project->GetSliderName(i), v);
+				std::unordered_map<uint16_t, Vector3> diff(morphData->offsets.begin(), morphData->offsets.end());
+				project->SetSliderFromDiff(morphData->name, shape, diff);
 
-			if (!r)
-				v = project->SliderDefault(i, hi) / 100.0f;
-			if (project->SliderInvert(i))
-				v = 1.0f - v;
+				if (morphData->type == MORPHTYPE_UV)
+				{
+					size_t sliderIndex = 0;
+					if (!project->SliderIndexFromName(morphData->name, sliderIndex))
+						continue;
 
-			v *= 100.0f;
-			SetSliderValue(i, v);
+					project->SetSliderUV(sliderIndex, true);
+				}
+			}
+		}
+
+		sliderScroll->FitInside();
+		sliderScroll->Thaw();
+
+		SetPendingChanges();
+		ApplySliders();
+		DoFilterSliders();
+
+		wxLogMessage("Added morphs for the following shapes:\n%s", addedMorphs);
+		wxMessageBox(wxString::Format(_("Added morphs for the following shapes:\n\n%s"), addedMorphs), _("TRI Import"));
+	}
+
+	void OutfitStudioFrame::OnSliderImportFBX(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+		if (!bEditSlider)
+		{
+			wxMessageBox(_("There is no slider in edit mode to import data to!"), _("Error"));
+			return;
+		}
+
+		wxString fn = wxFileSelector(_("Import .fbx file for slider calculation"), wxEmptyString, wxEmptyString, ".fbx", "*.fbx", wxFD_FILE_MUST_EXIST, this);
+		if (fn.IsEmpty())
+			return;
+
+		wxLogMessage("Importing slider to '%s' for shape '%s' from FBX file '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
+		if (!project->SetSliderFromFBX(activeSlider, activeItem->GetShape(), fn.ToUTF8().data()))
+		{
+			wxLogError("Vertex count of .obj file mesh does not match currently selected shape!");
+			wxMessageBox(_("Vertex count of .obj file mesh does not match currently selected shape!"), _("Error"), wxICON_ERROR);
+			return;
+		}
+
+		SetPendingChanges();
+		ApplySliders();
+	}
+
+	void OutfitStudioFrame::OnSliderExportNIF(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+		if (!bEditSlider)
+		{
+			wxMessageBox(_("There is no slider in edit mode to export data from!"), _("Error"));
+			return;
+		}
+
+		if (selectedItems.size() > 1)
+		{
+			wxString dir = wxDirSelector(_("Export .nif slider data to directory"), wxEmptyString, wxDD_DEFAULT_STYLE, wxDefaultPosition, this);
+			if (dir.IsEmpty())
+				return;
+
+			for (auto &i : selectedItems)
+			{
+				std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + i->GetShape()->name.get() + "_" + activeSlider + ".nif";
+				wxLogMessage("Exporting NIF slider data of '%s' for shape '%s' to '%s'...", activeSlider, i->GetShape()->name.get(), targetFile);
+				project->SaveSliderNIF(activeSlider, i->GetShape(), targetFile);
+			}
+		}
+		else
+		{
+			wxString fn = wxFileSelector(_("Export .nif slider data"), wxEmptyString, wxEmptyString, ".nif", "*.nif", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
+			if (fn.IsEmpty())
+				return;
+
+			wxLogMessage("Exporting NIF slider data of '%s' for shape '%s' to '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
+			if (project->SaveSliderNIF(activeSlider, activeItem->GetShape(), fn.ToUTF8().data()))
+			{
+				wxLogError("Failed to export NIF file '%s'!", fn);
+				wxMessageBox(_("Failed to export NIF file!"), _("Error"), wxICON_ERROR);
+			}
 		}
 
 		ApplySliders();
 	}
-}
 
-void OutfitStudioFrame::OnSavePreset(wxCommandEvent& WXUNUSED(event)) {
-	std::vector<std::string> sliders;
-	project->GetSliderList(sliders);
-	if (sliders.empty()) {
-		wxMessageBox(_("There are no sliders loaded!"), _("Error"), wxICON_ERROR, this);
-		return;
-	}
-
-	SliderSetGroupCollection groupCollection;
-	groupCollection.LoadGroups(GetProjectPath() + "/SliderGroups");
-
-	std::set<std::string> allGroups;
-	groupCollection.GetAllGroups(allGroups);
-
-	PresetSaveDialog psd(this);
-	psd.allGroupNames.assign(allGroups.begin(), allGroups.end());
-	psd.FilterGroups();
-
-	psd.ShowModal();
-	if (psd.outFileName.empty())
-		return;
-
-	std::string fileName = psd.outFileName;
-	std::string presetName = psd.outPresetName;
-
-	std::vector<std::string> groups;
-	groups.assign(psd.outGroups.begin(), psd.outGroups.end());
-
-	bool addedSlider = false;
-	PresetCollection presets;
-	for (auto &s : sliders) {
-		size_t index = 0;
-		if (!project->SliderIndexFromName(s, index))
-			continue;
-
-		if (project->SliderZap(index) || project->SliderHidden(index))
-			continue;
-
-		float value = project->SliderValue(index);
-		if (project->SliderInvert(index))
-			value = 1.0f - value;
-
-		if (project->SliderDefault(index, true) == value)
-			continue;
-
-		presets.SetSliderPreset(presetName, s, value, -10000.0f);
-
-		if (!addedSlider)
-			addedSlider = true;
-	}
-
-	if (!addedSlider) {
-		wxLogMessage("No changes were made to the sliders, so no preset was saved!");
-		wxMessageBox(_("No changes were made to the sliders, so no preset was saved!"), _("Info"), wxICON_INFORMATION, this);
-		return;
-	}
-
-	int error = presets.SavePreset(fileName, presetName, "OutfitStudioFrame", groups);
-	if (error) {
-		wxLogError("Failed to save preset (%d)!", error);
-		wxMessageBox(wxString::Format(_("Failed to save preset (%d)!"), error), _("Error"), wxICON_ERROR, this);
-	}
-}
-
-void OutfitStudioFrame::OnSliderImportNIF(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-	if (!bEditSlider) {
-		wxMessageBox(_("There is no slider in edit mode to import data to!"), _("Error"));
-		return;
-	}
-
-	wxString fn = wxFileSelector(_("Import .nif file for slider calculation"), wxEmptyString, wxEmptyString, ".nif", "*.nif", wxFD_FILE_MUST_EXIST, this);
-	if (fn.IsEmpty())
-		return;
-
-	wxLogMessage("Importing slider to '%s' for shape '%s' from NIF file '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
-	if (!project->SetSliderFromNIF(activeSlider, activeItem->GetShape(), fn.ToUTF8().data())) {
-		wxLogError("No mesh found in the .nif file that matches currently selected shape!");
-		wxMessageBox(_("No mesh found in the .nif file that matches currently selected shape!"), _("Error"), wxICON_ERROR);
-		return;
-	}
-
-	SetPendingChanges();
-	ApplySliders();
-}
-
-void OutfitStudioFrame::OnSliderImportBSD(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-	if (!bEditSlider) {
-		wxMessageBox(_("There is no slider in edit mode to import data to!"), _("Error"));
-		return;
-	}
-
-	wxString fn = wxFileSelector(_("Import .bsd slider data"), wxEmptyString, wxEmptyString, ".bsd", "*.bsd", wxFD_FILE_MUST_EXIST, this);
-	if (fn.IsEmpty())
-		return;
-
-	wxLogMessage("Importing slider to '%s' for shape '%s' from BSD file '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
-	project->SetSliderFromBSD(activeSlider, activeItem->GetShape(), fn.ToUTF8().data());
-
-	SetPendingChanges();
-	ApplySliders();
-}
-
-void OutfitStudioFrame::OnSliderImportOBJ(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-	if (!bEditSlider) {
-		wxMessageBox(_("There is no slider in edit mode to import data to!"), _("Error"));
-		return;
-	}
-
-	wxString fn = wxFileSelector(_("Import .obj file for slider calculation"), wxEmptyString, wxEmptyString, ".obj", "*.obj", wxFD_FILE_MUST_EXIST, this);
-	if (fn.IsEmpty())
-		return;
-
-	wxLogMessage("Importing slider to '%s' for shape '%s' from OBJ file '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
-	if (!project->SetSliderFromOBJ(activeSlider, activeItem->GetShape(), fn.ToUTF8().data())) {
-		wxLogError("Vertex count of .obj file mesh does not match currently selected shape!");
-		wxMessageBox(_("Vertex count of .obj file mesh does not match currently selected shape!"), _("Error"), wxICON_ERROR);
-		return;
-	}
-
-	SetPendingChanges();
-	ApplySliders();
-}
-
-void OutfitStudioFrame::OnSliderImportOSD(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetWorkNif()->IsValid()) {
-		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
-		return;
-	}
-
-	wxString fn = wxFileSelector(_("Import .osd file"), wxEmptyString, wxEmptyString, ".osd", "*.osd", wxFD_FILE_MUST_EXIST, this);
-	if (fn.IsEmpty())
-		return;
-
-	wxMessageDialog dlg(this, _("This will delete all loaded sliders. Are you sure?"), _("OSD Import"), wxOK | wxCANCEL | wxICON_WARNING | wxCANCEL_DEFAULT);
-	dlg.SetOKCancelLabels(_("Import"), _("Cancel"));
-	if (dlg.ShowModal() != wxID_OK)
-		return;
-
-	wxLogMessage("Importing morphs from OSD file '%s'...", fn);
-
-	OSDataFile osd;
-	if (!osd.Read(fn.ToUTF8().data())) {
-		wxLogError("Failed to import OSD file '%s'!", fn);
-		wxMessageBox(_("Failed to import OSD file!"), _("Error"), wxICON_ERROR);
-		return;
-	}
-
-	// Deleting sliders
-	sliderScroll->Freeze();
-	std::vector<std::string> erase;
-	for (auto &sd : sliderDisplays) {
-		sd.second->slider->SetValue(0);
-		SetSliderValue(sd.first, 0);
-		ShowSliderEffect(sd.first, true);
-		sd.second->slider->SetFocus();
-
-		sd.second->btnSliderEdit->Destroy();
-		sd.second->btnSliderProp->Destroy();
-		sd.second->slider->Destroy();
-		sd.second->sliderName->Destroy();
-		sd.second->sliderNameCheck->Destroy();
-		sd.second->sliderReadout->Destroy();
-		sd.second->sliderPane->Destroy();
-		delete sd.second;
-
-		erase.push_back(sd.first);
-		project->DeleteSlider(sd.first);
-	}
-
-	for (auto &e : erase)
-		sliderDisplays.erase(e);
-
-	MenuExitSliderEdit();
-	sliderScroll->FitInside();
-	activeSlider.clear();
-	lastActiveSlider.clear();
-
-	wxString addedDiffs;
-	auto diffs = osd.GetDataDiffs();
-
-	for (auto &shape : project->GetWorkNif()->GetShapes()) {
-		std::string s = shape->name.get();
-		bool added = false;
-		for (auto &diff : diffs) {
-			// Diff name is supposed to begin with matching shape name
-			if (diff.first.substr(0, s.size()) != s)
-				continue;
-
-			std::string diffName = diff.first.substr(s.length(), diff.first.length() - s.length() + 1);
-			if (!project->ValidSlider(diffName)) {
-				createSliderGUI(diffName, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
-				project->AddEmptySlider(diffName);
-				ShowSliderEffect(diffName);
-			}
-
-			project->SetSliderFromDiff(diffName, shape, diff.second);
-			added = true;
-		}
-
-		if (added)
-			addedDiffs += s + "\n";
-	}
-
-	sliderScroll->FitInside();
-	sliderScroll->Thaw();
-
-	SetPendingChanges();
-	ApplySliders();
-	DoFilterSliders();
-
-	wxLogMessage("Added morphs for the following shapes:\n%s", addedDiffs);
-	wxMessageBox(wxString::Format(_("Added morphs for the following shapes:\n\n%s"), addedDiffs), _("OSD Import"));
-}
-
-void OutfitStudioFrame::OnSliderImportTRI(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetWorkNif()->IsValid()) {
-		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
-		return;
-	}
-
-	wxString fn = wxFileSelector(_("Import .tri morphs"), wxEmptyString, wxEmptyString, ".tri", "*.tri", wxFD_FILE_MUST_EXIST, this);
-	if (fn.IsEmpty())
-		return;
-
-	wxMessageDialog dlg(this, _("This will delete all loaded sliders. Are you sure?"), _("TRI Import"), wxOK | wxCANCEL | wxICON_WARNING | wxCANCEL_DEFAULT);
-	dlg.SetOKCancelLabels(_("Import"), _("Cancel"));
-	if (dlg.ShowModal() != wxID_OK)
-		return;
-
-	wxLogMessage("Importing morphs from TRI file '%s'...", fn);
-
-	TriFile tri;
-	if (!tri.Read(fn.ToUTF8().data())) {
-		wxLogError("Failed to load TRI file '%s'!", fn);
-		wxMessageBox(_("Failed to load TRI file!"), _("Error"), wxICON_ERROR);
-		return;
-	}
-
-	// Deleting sliders
-	sliderScroll->Freeze();
-	std::vector<std::string> erase;
-	for (auto &sd : sliderDisplays) {
-		sd.second->slider->SetValue(0);
-		SetSliderValue(sd.first, 0);
-		ShowSliderEffect(sd.first, true);
-		sd.second->slider->SetFocus();
-
-		sd.second->btnSliderEdit->Destroy();
-		sd.second->btnSliderProp->Destroy();
-		sd.second->slider->Destroy();
-		sd.second->sliderName->Destroy();
-		sd.second->sliderNameCheck->Destroy();
-		sd.second->sliderReadout->Destroy();
-		sd.second->sliderPane->Destroy();
-		delete sd.second;
-
-		erase.push_back(sd.first);
-		project->DeleteSlider(sd.first);
-	}
-
-	for (auto &e : erase)
-		sliderDisplays.erase(e);
-
-	MenuExitSliderEdit();
-	sliderScroll->FitInside();
-	activeSlider.clear();
-	lastActiveSlider.clear();
-
-	wxString addedMorphs;
-	auto morphs = tri.GetMorphs();
-	for (auto &morph : morphs) {
-		auto shape = project->GetWorkNif()->FindBlockByName<NiShape>(morph.first);
-		if (!shape)
-			continue;
-
-		addedMorphs += morph.first + "\n";
-		for (auto &morphData : morph.second) {
-			if (!project->ValidSlider(morphData->name)) {
-				createSliderGUI(morphData->name, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
-				project->AddEmptySlider(morphData->name);
-				ShowSliderEffect(morphData->name);
-			}
-
-			std::unordered_map<uint16_t, Vector3> diff(morphData->offsets.begin(), morphData->offsets.end());
-			project->SetSliderFromDiff(morphData->name, shape, diff);
-
-			if (morphData->type == MORPHTYPE_UV) {
-				size_t sliderIndex = 0;
-				if (!project->SliderIndexFromName(morphData->name, sliderIndex))
-					continue;
-
-				project->SetSliderUV(sliderIndex, true);
-			}
-		}
-	}
-
-	sliderScroll->FitInside();
-	sliderScroll->Thaw();
-
-	SetPendingChanges();
-	ApplySliders();
-	DoFilterSliders();
-
-	wxLogMessage("Added morphs for the following shapes:\n%s", addedMorphs);
-	wxMessageBox(wxString::Format(_("Added morphs for the following shapes:\n\n%s"), addedMorphs), _("TRI Import"));
-}
-
-void OutfitStudioFrame::OnSliderImportFBX(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-	if (!bEditSlider) {
-		wxMessageBox(_("There is no slider in edit mode to import data to!"), _("Error"));
-		return;
-	}
-
-	wxString fn = wxFileSelector(_("Import .fbx file for slider calculation"), wxEmptyString, wxEmptyString, ".fbx", "*.fbx", wxFD_FILE_MUST_EXIST, this);
-	if (fn.IsEmpty())
-		return;
-
-	wxLogMessage("Importing slider to '%s' for shape '%s' from FBX file '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
-	if (!project->SetSliderFromFBX(activeSlider, activeItem->GetShape(), fn.ToUTF8().data())) {
-		wxLogError("Vertex count of .obj file mesh does not match currently selected shape!");
-		wxMessageBox(_("Vertex count of .obj file mesh does not match currently selected shape!"), _("Error"), wxICON_ERROR);
-		return;
-	}
-
-	SetPendingChanges();
-	ApplySliders();
-}
-
-void OutfitStudioFrame::OnSliderExportNIF(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-	if (!bEditSlider) {
-		wxMessageBox(_("There is no slider in edit mode to export data from!"), _("Error"));
-		return;
-	}
-
-	if (selectedItems.size() > 1) {
-		wxString dir = wxDirSelector(_("Export .nif slider data to directory"), wxEmptyString, wxDD_DEFAULT_STYLE, wxDefaultPosition, this);
-		if (dir.IsEmpty())
+	void OutfitStudioFrame::OnSliderExportBSD(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
 			return;
-
-		for (auto &i : selectedItems) {
-			std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + i->GetShape()->name.get() + "_" + activeSlider + ".nif";
-			wxLogMessage("Exporting NIF slider data of '%s' for shape '%s' to '%s'...", activeSlider, i->GetShape()->name.get(), targetFile);
-			project->SaveSliderNIF(activeSlider, i->GetShape(), targetFile);
 		}
+		if (!bEditSlider)
+		{
+			wxMessageBox(_("There is no slider in edit mode to export data from!"), _("Error"));
+			return;
+		}
+
+		if (selectedItems.size() > 1)
+		{
+			wxString dir = wxDirSelector(_("Export .bsd slider data to directory"), wxEmptyString, wxDD_DEFAULT_STYLE, wxDefaultPosition, this);
+			if (dir.IsEmpty())
+				return;
+
+			for (auto &i : selectedItems)
+			{
+				std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + i->GetShape()->name.get() + "_" + activeSlider + ".bsd";
+				wxLogMessage("Exporting BSD slider data of '%s' for shape '%s' to '%s'...", activeSlider, i->GetShape()->name.get(), targetFile);
+				project->SaveSliderBSD(activeSlider, i->GetShape(), targetFile);
+			}
+		}
+		else
+		{
+			wxString fn = wxFileSelector(_("Export .bsd slider data"), wxEmptyString, wxEmptyString, ".bsd", "*.bsd", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
+			if (fn.IsEmpty())
+				return;
+
+			wxLogMessage("Exporting BSD slider data of '%s' for shape '%s' to '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
+			project->SaveSliderBSD(activeSlider, activeItem->GetShape(), fn.ToUTF8().data());
+		}
+
+		ApplySliders();
 	}
-	else {
-		wxString fn = wxFileSelector(_("Export .nif slider data"), wxEmptyString, wxEmptyString, ".nif", "*.nif", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
+
+	void OutfitStudioFrame::OnSliderExportOBJ(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+		if (!bEditSlider)
+		{
+			wxMessageBox(_("There is no slider in edit mode to export data from!"), _("Error"));
+			return;
+		}
+
+		if (selectedItems.size() > 1)
+		{
+			wxString dir = wxDirSelector(_("Export .obj slider data to directory"), wxEmptyString, wxDD_DEFAULT_STYLE, wxDefaultPosition, this);
+			if (dir.IsEmpty())
+				return;
+
+			for (auto &i : selectedItems)
+			{
+				std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + i->GetShape()->name.get() + "_" + activeSlider + ".obj";
+				wxLogMessage("Exporting OBJ slider data of '%s' for shape '%s' to '%s'...", activeSlider, i->GetShape()->name.get(), targetFile);
+				project->SaveSliderOBJ(activeSlider, i->GetShape(), targetFile);
+			}
+		}
+		else
+		{
+			wxString fn = wxFileSelector(_("Export .obj slider data"), wxEmptyString, wxEmptyString, ".obj", "*.obj", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
+			if (fn.IsEmpty())
+				return;
+
+			wxLogMessage("Exporting OBJ slider data of '%s' for shape '%s' to '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
+			if (project->SaveSliderOBJ(activeSlider, activeItem->GetShape(), fn.ToUTF8().data()))
+			{
+				wxLogError("Failed to export OBJ file '%s'!", fn);
+				wxMessageBox(_("Failed to export OBJ file!"), _("Error"), wxICON_ERROR);
+			}
+		}
+
+		ApplySliders();
+	}
+
+	void OutfitStudioFrame::OnSliderExportOSD(wxCommandEvent& WXUNUSED(event)) {
+		if (!project->GetWorkNif()->IsValid())
+		{
+			wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
+			return;
+		}
+
+		wxString fn = wxFileSelector(_("Export .osd file"), wxEmptyString, wxEmptyString, ".osd", "*.osd", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
 		if (fn.IsEmpty())
 			return;
 
-		wxLogMessage("Exporting NIF slider data of '%s' for shape '%s' to '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
-		if (project->SaveSliderNIF(activeSlider, activeItem->GetShape(), fn.ToUTF8().data())) {
-			wxLogError("Failed to export NIF file '%s'!", fn);
-			wxMessageBox(_("Failed to export NIF file!"), _("Error"), wxICON_ERROR);
-		}
-	}
-
-	ApplySliders();
-}
-
-void OutfitStudioFrame::OnSliderExportBSD(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-	if (!bEditSlider) {
-		wxMessageBox(_("There is no slider in edit mode to export data from!"), _("Error"));
-		return;
-	}
-
-	if (selectedItems.size() > 1) {
-		wxString dir = wxDirSelector(_("Export .bsd slider data to directory"), wxEmptyString, wxDD_DEFAULT_STYLE, wxDefaultPosition, this);
-		if (dir.IsEmpty())
+		wxLogMessage("Exporting OSD file to '%s'...", fn);
+		if (!project->SaveSliderData(fn.ToUTF8().data()))
+		{
+			wxLogError("Failed to export OSD file to '%s'!", fn);
+			wxMessageBox(_("Failed to export OSD file!"), _("Error"), wxICON_ERROR);
 			return;
-
-		for (auto &i : selectedItems) {
-			std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + i->GetShape()->name.get() + "_" + activeSlider + ".bsd";
-			wxLogMessage("Exporting BSD slider data of '%s' for shape '%s' to '%s'...", activeSlider, i->GetShape()->name.get(), targetFile);
-			project->SaveSliderBSD(activeSlider, i->GetShape(), targetFile);
 		}
 	}
-	else {
-		wxString fn = wxFileSelector(_("Export .bsd slider data"), wxEmptyString, wxEmptyString, ".bsd", "*.bsd", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
+
+	void OutfitStudioFrame::OnSliderExportTRI(wxCommandEvent& WXUNUSED(event)) {
+		if (!project->GetWorkNif()->IsValid())
+		{
+			wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
+			return;
+		}
+
+		wxString fn = wxFileSelector(_("Export .tri morphs"), wxEmptyString, wxEmptyString, ".tri", "*.tri", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
 		if (fn.IsEmpty())
 			return;
 
-		wxLogMessage("Exporting BSD slider data of '%s' for shape '%s' to '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
-		project->SaveSliderBSD(activeSlider, activeItem->GetShape(), fn.ToUTF8().data());
+		wxLogMessage("Exporting TRI morphs to '%s'...", fn);
+		if (!project->WriteMorphTRI(fn.ToUTF8().data()))
+		{
+			wxLogError("Failed to export TRI file to '%s'!", fn);
+			wxMessageBox(_("Failed to export TRI file!"), _("Error"), wxICON_ERROR);
+			return;
+		}
 	}
 
-	ApplySliders();
-}
+	void OutfitStudioFrame::OnSliderExportToOBJs(wxCommandEvent& WXUNUSED(event)) {
+		if (!project->GetWorkNif()->IsValid())
+		{
+			wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
+			return;
+		}
 
-void OutfitStudioFrame::OnSliderExportOBJ(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-	if (!bEditSlider) {
-		wxMessageBox(_("There is no slider in edit mode to export data from!"), _("Error"));
-		return;
-	}
-
-	if (selectedItems.size() > 1) {
 		wxString dir = wxDirSelector(_("Export .obj slider data to directory"), wxEmptyString, wxDD_DEFAULT_STYLE, wxDefaultPosition, this);
 		if (dir.IsEmpty())
 			return;
 
-		for (auto &i : selectedItems) {
-			std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + i->GetShape()->name.get() + "_" + activeSlider + ".obj";
-			wxLogMessage("Exporting OBJ slider data of '%s' for shape '%s' to '%s'...", activeSlider, i->GetShape()->name.get(), targetFile);
-			project->SaveSliderOBJ(activeSlider, i->GetShape(), targetFile);
+		std::vector<std::string> sliderList;
+		project->GetSliderList(sliderList);
+
+		wxLogMessage("Exporting sliders to OBJ files in '%s'...", dir);
+		for (auto &shape : project->GetWorkNif()->GetShapes())
+		{
+			for (auto &slider : sliderList)
+			{
+				std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + shape->name.get() + "_" + slider + ".obj";
+				wxLogMessage("Exporting OBJ slider data of '%s' for shape '%s' to '%s'...", slider, shape->name.get(), targetFile);
+				if (project->SaveSliderOBJ(slider, shape, targetFile, true))
+					wxLogError("Failed to export OBJ file '%s'!", targetFile);
+			}
 		}
 	}
-	else {
-		wxString fn = wxFileSelector(_("Export .obj slider data"), wxEmptyString, wxEmptyString, ".obj", "*.obj", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
-		if (fn.IsEmpty())
+
+	void OutfitStudioFrame::OnClearSlider(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
 			return;
-
-		wxLogMessage("Exporting OBJ slider data of '%s' for shape '%s' to '%s'...", activeSlider, activeItem->GetShape()->name.get(), fn);
-		if (project->SaveSliderOBJ(activeSlider, activeItem->GetShape(), fn.ToUTF8().data())) {
-			wxLogError("Failed to export OBJ file '%s'!", fn);
-			wxMessageBox(_("Failed to export OBJ file!"), _("Error"), wxICON_ERROR);
-		}
-	}
-
-	ApplySliders();
-}
-
-void OutfitStudioFrame::OnSliderExportOSD(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetWorkNif()->IsValid()) {
-		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
-		return;
-	}
-
-	wxString fn = wxFileSelector(_("Export .osd file"), wxEmptyString, wxEmptyString, ".osd", "*.osd", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
-	if (fn.IsEmpty())
-		return;
-
-	wxLogMessage("Exporting OSD file to '%s'...", fn);
-	if (!project->SaveSliderData(fn.ToUTF8().data())) {
-		wxLogError("Failed to export OSD file to '%s'!", fn);
-		wxMessageBox(_("Failed to export OSD file!"), _("Error"), wxICON_ERROR);
-		return;
-	}
-}
-
-void OutfitStudioFrame::OnSliderExportTRI(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetWorkNif()->IsValid()) {
-		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
-		return;
-	}
-
-	wxString fn = wxFileSelector(_("Export .tri morphs"), wxEmptyString, wxEmptyString, ".tri", "*.tri", wxFD_SAVE | wxFD_OVERWRITE_PROMPT, this);
-	if (fn.IsEmpty())
-		return;
-
-	wxLogMessage("Exporting TRI morphs to '%s'...", fn);
-	if (!project->WriteMorphTRI(fn.ToUTF8().data())) {
-		wxLogError("Failed to export TRI file to '%s'!", fn);
-		wxMessageBox(_("Failed to export TRI file!"), _("Error"), wxICON_ERROR);
-		return;
-	}
-}
-
-void OutfitStudioFrame::OnSliderExportToOBJs(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetWorkNif()->IsValid()) {
-		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
-		return;
-	}
-
-	wxString dir = wxDirSelector(_("Export .obj slider data to directory"), wxEmptyString, wxDD_DEFAULT_STYLE, wxDefaultPosition, this);
-	if (dir.IsEmpty())
-		return;
-
-	std::vector<std::string> sliderList;
-	project->GetSliderList(sliderList);
-
-	wxLogMessage("Exporting sliders to OBJ files in '%s'...", dir);
-	for (auto &shape : project->GetWorkNif()->GetShapes()) {
-		for (auto &slider : sliderList) {
-			std::string targetFile = std::string(dir.ToUTF8()) + PathSepStr + shape->name.get() + "_" + slider + ".obj";
-			wxLogMessage("Exporting OBJ slider data of '%s' for shape '%s' to '%s'...", slider, shape->name.get(), targetFile);
-			if (project->SaveSliderOBJ(slider, shape, targetFile, true))
-				wxLogError("Failed to export OBJ file '%s'!", targetFile);
-		}
-	}
-}
-
-void OutfitStudioFrame::OnClearSlider(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-
-	int result;
-	if (selectedItems.size() > 1) {
-		wxString prompt = _("Are you sure you wish to clear the unmasked slider data for the selected shapes?  This action cannot be undone.");
-		result = wxMessageBox(prompt, _("Confirm data erase"), wxYES_NO | wxICON_WARNING, this);
-	}
-	else {
-		wxString prompt = wxString::Format(_("Are you sure you wish to clear the unmasked slider data for the shape '%s'?  This action cannot be undone."), activeItem->GetShape()->name.get());
-		result = wxMessageBox(prompt, _("Confirm data erase"), wxYES_NO | wxICON_WARNING, this);
-	}
-
-	if (result != wxYES)
-		return;
-
-	auto clearSlider = [&](const std::string& sliderName) {
-		std::unordered_map<uint16_t, float> mask;
-		for (auto &i : selectedItems) {
-			mask.clear();
-			glView->GetShapeMask(mask, i->GetShape()->name.get());
-			if (mask.size() > 0)
-				project->ClearUnmaskedDiff(i->GetShape(), sliderName, &mask);
-			else
-				project->ClearSlider(i->GetShape(), sliderName);
-		}
-	};
-
-	if (!bEditSlider) {
-		wxLogMessage("Clearing slider data of the checked sliders for the selected shapes.");
-		for (auto &sd : sliderDisplays)
-			if (sd.second->sliderNameCheck->Get3StateValue() == wxCheckBoxState::wxCHK_CHECKED)
-				clearSlider(sd.first);
-	}
-	else {
-		wxLogMessage("Clearing slider data of '%s' for the selected shapes.", activeSlider);
-		clearSlider(activeSlider);
-	}
-
-	SetPendingChanges();
-	ApplySliders();
-}
-
-void OutfitStudioFrame::OnNewSlider(wxCommandEvent& WXUNUSED(event)) {
-	NewSlider();
-}
-
-void OutfitStudioFrame::OnNewZapSlider(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-
-	std::string baseName = "New Zap";
-
-	int count = 1;
-	std::string fillName = baseName;
-
-	while (project->ValidSlider(fillName))
-		fillName = wxString::Format("%s %d", baseName, ++count).ToUTF8();
-
-	std::string sliderName;
-	do {
-		sliderName = wxGetTextFromUser(_("Enter a name for the new zap:"), _("Create New Zap"), fillName, this).ToUTF8();
-		if (sliderName.empty())
-			return;
-	} while (project->ValidSlider(sliderName));
-
-	wxLogMessage("Creating new zap '%s'.", sliderName);
-	createSliderGUI(sliderName, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
-
-	std::unordered_map<uint16_t, float> unmasked;
-	for (auto &i : selectedItems) {
-		unmasked.clear();
-		glView->GetShapeUnmasked(unmasked, i->GetShape()->name.get());
-		project->AddZapSlider(sliderName, unmasked, i->GetShape());
-	}
-
-	ShowSliderEffect(sliderName);
-	sliderScroll->FitInside();
-	SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnNewCombinedSlider(wxCommandEvent& WXUNUSED(event)) {
-	std::string baseName = "New Slider";
-
-	int count = 1;
-	std::string fillName = baseName;
-
-	while (project->ValidSlider(fillName))
-		fillName = wxString::Format("%s %d", baseName, ++count).ToUTF8();
-
-	std::string sliderName;
-	do {
-		sliderName = wxGetTextFromUser(_("Enter a name for the new slider:"), _("Create New Slider"), fillName, this).ToUTF8();
-		if (sliderName.empty())
-			return;
-	} while (project->ValidSlider(sliderName));
-
-	wxLogMessage("Creating new combined slider '%s'.", sliderName);
-	createSliderGUI(sliderName, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
-
-	project->AddCombinedSlider(sliderName);
-	sliderScroll->FitInside();
-	SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnSliderNegate(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-	if (!bEditSlider) {
-		wxMessageBox(_("There is no slider in edit mode to negate!"), _("Error"));
-		return;
-	}
-
-	wxLogMessage("Negating slider '%s' for the selected shapes.", activeSlider);
-	for (auto &i : selectedItems)
-		project->NegateSlider(activeSlider, i->GetShape());
-
-	SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnMaskAffected(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-	if (!bEditSlider) {
-		wxMessageBox(_("There is no slider in edit mode to create a mask from!"), _("Error"));
-		return;
-	}
-
-	wxLogMessage("Creating mask for affected vertices of the slider '%s'.", activeSlider);
-	for (auto &i : selectedItems)
-		project->MaskAffected(activeSlider, i->GetShape());
-}
-
-void OutfitStudioFrame::DeleteSliders(bool keepZaps)
-{
-	auto deleteSlider = [&](const std::string& sliderName) {
-		wxLogMessage("Deleting slider '%s'.", sliderName);
-
-		SliderDisplay* sd = sliderDisplays[sliderName];
-		sd->slider->SetValue(0);
-		SetSliderValue(sliderName, 0);
-		ShowSliderEffect(sliderName, true);
-		sd->slider->SetFocus();
-
-		sd->btnSliderEdit->Destroy();
-		sd->btnSliderProp->Destroy();
-		sd->slider->Destroy();
-		sd->sliderName->Destroy();
-		sd->sliderNameCheck->Destroy();
-		sd->sliderReadout->Destroy();
-		sd->sliderPane->Destroy();
-
-		sliderScroll->FitInside();
-		delete sd;
-		project->DeleteSlider(sliderName);
-	};
-
-	if (!bEditSlider) {
-		for (auto it = sliderDisplays.begin(); it != sliderDisplays.end();) {
-			if(keepZaps && project->activeSet[it->first].bZap) {
-				++it;
-				continue;
-			}
-			
-			if (it->second->sliderNameCheck->Get3StateValue() == wxCheckBoxState::wxCHK_CHECKED) {
-				deleteSlider(it->first);
-				it = sliderDisplays.erase(it);
-			}
-			else
-				++it;
-		}
-	}
-	else {
-		deleteSlider(activeSlider);
-		sliderDisplays.erase(activeSlider);
-
-		MenuExitSliderEdit();
-		activeSlider.clear();
-		lastActiveSlider.clear();
-		bEditSlider = false;
-	}
-
-	SetPendingChanges();
-	ApplySliders();
-}
-
-void OutfitStudioFrame::OnDeleteSlider(wxCommandEvent& WXUNUSED(event)) {
-	wxString prompt = _("Are you sure you wish to delete the selected slider(s)?");
-	int result = wxMessageBox(prompt, _("Confirm slider delete"), wxYES_NO | wxICON_WARNING, this);
-	if (result != wxYES)
-		return;
-
-	DeleteSliders();
-}
-
-void OutfitStudioFrame::ShowSliderProperties(const std::string& sliderName) {
-	size_t curSlider = 0;
-	if (!project->SliderIndexFromName(sliderName, curSlider))
-		return;
-
-	wxDialog dlg;
-	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgSliderProp")) {
-		wxTextCtrl* edSliderName = XRCCTRL(dlg, "edSliderName", wxTextCtrl);
-		wxStaticText* lbValLo = XRCCTRL(dlg, "lbValLo", wxStaticText);
-		wxStaticText* lbValHi = XRCCTRL(dlg, "lbValHi", wxStaticText);
-		wxTextCtrl* edValLo = XRCCTRL(dlg, "edValLo", wxTextCtrl);
-		wxTextCtrl* edValHi = XRCCTRL(dlg, "edValHi", wxTextCtrl);
-		wxCheckBox* cbValZapped = XRCCTRL(dlg, "cbValZapped", wxCheckBox);
-		wxCheckBox* chkHidden = XRCCTRL(dlg, "chkHidden", wxCheckBox);
-		wxCheckBox* chkInvert = XRCCTRL(dlg, "chkInvert", wxCheckBox);
-		wxCheckBox* chkZap = XRCCTRL(dlg, "chkZap", wxCheckBox);
-		wxCheckBox* chkUV = XRCCTRL(dlg, "chkUV", wxCheckBox);
-		wxCheckListBox* zapToggleList = XRCCTRL(dlg, "zapToggleList", wxCheckListBox);
-
-		long loVal = (int)(project->SliderDefault(curSlider, false));
-		long hiVal = (int)(project->SliderDefault(curSlider, true));
-
-		edSliderName->SetLabel(wxString::FromUTF8(activeSlider));
-		edValLo->SetValue(wxString::Format("%d", loVal));
-		edValHi->SetValue(wxString::Format("%d", hiVal));
-
-		if (project->SliderHidden(curSlider))
-			chkHidden->SetValue(true);
-
-		if (project->SliderInvert(curSlider))
-			chkInvert->SetValue(true);
-
-		if (project->SliderUV(curSlider))
-			chkUV->SetValue(true);
-
-		if (project->SliderZap(curSlider)) {
-			lbValLo->Hide();
-			lbValHi->Hide();
-			edValLo->Hide();
-			edValHi->Hide();
-			cbValZapped->Show();
-
-			chkZap->SetValue(true);
-			zapToggleList->Enable();
-
-			for (size_t i = 0; i < project->SliderCount(); i++)
-				if (i != curSlider && (project->SliderZap(i) || project->SliderHidden(i)))
-					zapToggleList->Append(wxString::FromUTF8(project->GetSliderName(i)));
-
-			for (auto &s : project->SliderZapToggles(curSlider)) {
-				int stringId = zapToggleList->FindString(s, true);
-				if (stringId != wxNOT_FOUND)
-					zapToggleList->Check(stringId);
-			}
-		}
-		else {
-			cbValZapped->Hide();
-
-			if (!project->mGenWeights) {
-				lbValLo->Hide();
-				edValLo->Hide();
-				lbValHi->SetLabel("Default");
-			}
 		}
 
-		if (hiVal > 0 || loVal > 0)
-			cbValZapped->Set3StateValue(wxCheckBoxState::wxCHK_CHECKED);
+		int result;
+		if (selectedItems.size() > 1)
+		{
+			wxString prompt = _("Are you sure you wish to clear the unmasked slider data for the selected shapes?  This action cannot be undone.");
+			result = wxMessageBox(prompt, _("Confirm data erase"), wxYES_NO | wxICON_WARNING, this);
+		}
 		else
-			cbValZapped->Set3StateValue(wxCheckBoxState::wxCHK_UNCHECKED);
+		{
+			wxString prompt = wxString::Format(_("Are you sure you wish to clear the unmasked slider data for the shape '%s'?  This action cannot be undone."), activeItem->GetShape()->name.get());
+			result = wxMessageBox(prompt, _("Confirm data erase"), wxYES_NO | wxICON_WARNING, this);
+		}
 
-		chkZap->Bind(wxEVT_CHECKBOX, [&](wxCommandEvent& event) {
-			bool checked = event.IsChecked();
+		if (result != wxYES)
+			return;
 
-			lbValLo->Show(!checked);
-			lbValHi->Show(!checked);
-			edValLo->Show(!checked);
-			edValHi->Show(!checked);
-			cbValZapped->Show(checked);
-			zapToggleList->Enable(checked);
+		auto clearSlider = [&](const std::string& sliderName)
+		{
+			std::unordered_map<uint16_t, float> mask;
+			for (auto &i : selectedItems)
+			{
+				mask.clear();
+				glView->GetShapeMask(mask, i->GetShape()->name.get());
+				if (mask.size() > 0)
+					project->ClearUnmaskedDiff(i->GetShape(), sliderName, &mask);
+				else
+					project->ClearSlider(i->GetShape(), sliderName);
+			}
+		};
 
-			dlg.Layout();
-		});
+		if (!bEditSlider)
+		{
+			wxLogMessage("Clearing slider data of the checked sliders for the selected shapes.");
+			for (auto &sd : sliderDisplays)
+				if (sd.second->sliderNameCheck->Get3StateValue() == wxCheckBoxState::wxCHK_CHECKED)
+					clearSlider(sd.first);
+		}
+		else
+		{
+			wxLogMessage("Clearing slider data of '%s' for the selected shapes.", activeSlider);
+			clearSlider(activeSlider);
+		}
 
-		XRCCTRL(dlg, "wxID_CANCEL", wxButton)->SetFocus();
+		SetPendingChanges();
+		ApplySliders();
+	}
 
-		if (dlg.ShowModal() == wxID_OK) {
-			if (chkZap->IsChecked()) {
-				if (cbValZapped->IsChecked()) {
-					loVal = 100;
-					hiVal = 100;
+	void OutfitStudioFrame::OnNewSlider(wxCommandEvent& WXUNUSED(event))
+	{
+		NewSlider();
+	}
+
+	void OutfitStudioFrame::OnNewZapSlider(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+
+		std::string baseName = "New Zap";
+
+		int count = 1;
+		std::string fillName = baseName;
+
+		while (project->ValidSlider(fillName))
+			fillName = wxString::Format("%s %d", baseName, ++count).ToUTF8();
+
+		std::string sliderName;
+		do
+		{
+			sliderName = wxGetTextFromUser(_("Enter a name for the new zap:"), _("Create New Zap"), fillName, this).ToUTF8();
+			if (sliderName.empty())
+				return;
+		} while (project->ValidSlider(sliderName));
+
+		wxLogMessage("Creating new zap '%s'.", sliderName);
+		createSliderGUI(sliderName, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
+
+		std::unordered_map<uint16_t, float> unmasked;
+		for (auto &i : selectedItems)
+		{
+			unmasked.clear();
+			glView->GetShapeUnmasked(unmasked, i->GetShape()->name.get());
+			project->AddZapSlider(sliderName, unmasked, i->GetShape());
+		}
+
+		ShowSliderEffect(sliderName);
+		sliderScroll->FitInside();
+		SetPendingChanges();
+	}
+
+	void OutfitStudioFrame::OnNewCombinedSlider(wxCommandEvent& WXUNUSED(event)) {
+		std::string baseName = "New Slider";
+
+		int count = 1;
+		std::string fillName = baseName;
+
+		while (project->ValidSlider(fillName))
+			fillName = wxString::Format("%s %d", baseName, ++count).ToUTF8();
+
+		std::string sliderName;
+		do
+		{
+			sliderName = wxGetTextFromUser(_("Enter a name for the new slider:"), _("Create New Slider"), fillName, this).ToUTF8();
+			if (sliderName.empty())
+				return;
+		} while (project->ValidSlider(sliderName));
+
+		wxLogMessage("Creating new combined slider '%s'.", sliderName);
+		createSliderGUI(sliderName, project->SliderCount(), sliderScroll, sliderScroll->GetSizer());
+
+		project->AddCombinedSlider(sliderName);
+		sliderScroll->FitInside();
+		SetPendingChanges();
+	}
+
+	void OutfitStudioFrame::OnSliderNegate(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+		if (!bEditSlider)
+		{
+			wxMessageBox(_("There is no slider in edit mode to negate!"), _("Error"));
+			return;
+		}
+
+		wxLogMessage("Negating slider '%s' for the selected shapes.", activeSlider);
+		for (auto &i : selectedItems)
+			project->NegateSlider(activeSlider, i->GetShape());
+
+		SetPendingChanges();
+	}
+
+	void OutfitStudioFrame::OnMaskAffected(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+		if (!bEditSlider)
+		{
+			wxMessageBox(_("There is no slider in edit mode to create a mask from!"), _("Error"));
+			return;
+		}
+
+		wxLogMessage("Creating mask for affected vertices of the slider '%s'.", activeSlider);
+		for (auto &i : selectedItems)
+			project->MaskAffected(activeSlider, i->GetShape());
+	}
+
+	void OutfitStudioFrame::DeleteSliders(bool keepZaps)
+	{
+		auto deleteSlider = [&](const std::string& sliderName)
+		{
+			wxLogMessage("Deleting slider '%s'.", sliderName);
+
+			SliderDisplay* sd = sliderDisplays[sliderName];
+			sd->slider->SetValue(0);
+			SetSliderValue(sliderName, 0);
+			ShowSliderEffect(sliderName, true);
+			sd->slider->SetFocus();
+
+			sd->btnSliderEdit->Destroy();
+			sd->btnSliderProp->Destroy();
+			sd->slider->Destroy();
+			sd->sliderName->Destroy();
+			sd->sliderNameCheck->Destroy();
+			sd->sliderReadout->Destroy();
+			sd->sliderPane->Destroy();
+
+			sliderScroll->FitInside();
+			delete sd;
+			project->DeleteSlider(sliderName);
+		};
+
+		if (!bEditSlider)
+		{
+			for (auto it = sliderDisplays.begin(); it != sliderDisplays.end();)
+			{
+				if(keepZaps && project->activeSet[it->first].bZap)
+				{
+					++it;
+					continue;
 				}
-				else {
-					loVal = 0;
-					hiVal = 0;
+			
+				if (it->second->sliderNameCheck->Get3StateValue() == wxCheckBoxState::wxCHK_CHECKED)
+				{
+					deleteSlider(it->first);
+					it = sliderDisplays.erase(it);
+				}
+				else
+					++it;
+			}
+		}
+		else
+		{
+			deleteSlider(activeSlider);
+			sliderDisplays.erase(activeSlider);
+
+			MenuExitSliderEdit();
+			activeSlider.clear();
+			lastActiveSlider.clear();
+			bEditSlider = false;
+		}
+
+		SetPendingChanges();
+		ApplySliders();
+	}
+
+	void OutfitStudioFrame::OnDeleteSlider(wxCommandEvent& WXUNUSED(event)) {
+		wxString prompt = _("Are you sure you wish to delete the selected slider(s)?");
+		int result = wxMessageBox(prompt, _("Confirm slider delete"), wxYES_NO | wxICON_WARNING, this);
+		if (result != wxYES)
+			return;
+
+		DeleteSliders();
+	}
+
+	void OutfitStudioFrame::ShowSliderProperties(const std::string& sliderName) {
+		size_t curSlider = 0;
+		if (!project->SliderIndexFromName(sliderName, curSlider))
+			return;
+
+		wxDialog dlg;
+		if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgSliderProp"))
+		{
+			wxTextCtrl* edSliderName = XRCCTRL(dlg, "edSliderName", wxTextCtrl);
+			wxStaticText* lbValLo = XRCCTRL(dlg, "lbValLo", wxStaticText);
+			wxStaticText* lbValHi = XRCCTRL(dlg, "lbValHi", wxStaticText);
+			wxTextCtrl* edValLo = XRCCTRL(dlg, "edValLo", wxTextCtrl);
+			wxTextCtrl* edValHi = XRCCTRL(dlg, "edValHi", wxTextCtrl);
+			wxCheckBox* cbValZapped = XRCCTRL(dlg, "cbValZapped", wxCheckBox);
+			wxCheckBox* chkHidden = XRCCTRL(dlg, "chkHidden", wxCheckBox);
+			wxCheckBox* chkInvert = XRCCTRL(dlg, "chkInvert", wxCheckBox);
+			wxCheckBox* chkZap = XRCCTRL(dlg, "chkZap", wxCheckBox);
+			wxCheckBox* chkUV = XRCCTRL(dlg, "chkUV", wxCheckBox);
+			wxCheckListBox* zapToggleList = XRCCTRL(dlg, "zapToggleList", wxCheckListBox);
+
+			long loVal = (int)(project->SliderDefault(curSlider, false));
+			long hiVal = (int)(project->SliderDefault(curSlider, true));
+
+			edSliderName->SetLabel(wxString::FromUTF8(activeSlider));
+			edValLo->SetValue(wxString::Format("%d", loVal));
+			edValHi->SetValue(wxString::Format("%d", hiVal));
+
+			if (project->SliderHidden(curSlider))
+				chkHidden->SetValue(true);
+
+			if (project->SliderInvert(curSlider))
+				chkInvert->SetValue(true);
+
+			if (project->SliderUV(curSlider))
+				chkUV->SetValue(true);
+
+			if (project->SliderZap(curSlider))
+			{
+				lbValLo->Hide();
+				lbValHi->Hide();
+				edValLo->Hide();
+				edValHi->Hide();
+				cbValZapped->Show();
+
+				chkZap->SetValue(true);
+				zapToggleList->Enable();
+
+				for (size_t i = 0; i < project->SliderCount(); i++)
+					if (i != curSlider && (project->SliderZap(i) || project->SliderHidden(i)))
+						zapToggleList->Append(wxString::FromUTF8(project->GetSliderName(i)));
+
+				for (auto &s : project->SliderZapToggles(curSlider))
+				{
+					int stringId = zapToggleList->FindString(s, true);
+					if (stringId != wxNOT_FOUND)
+						zapToggleList->Check(stringId);
+				}
+			}
+			else
+			{
+				cbValZapped->Hide();
+
+				if (!project->mGenWeights)
+				{
+					lbValLo->Hide();
+					edValLo->Hide();
+					lbValHi->SetLabel("Default");
+				}
+			}
+
+			if (hiVal > 0 || loVal > 0)
+				cbValZapped->Set3StateValue(wxCheckBoxState::wxCHK_CHECKED);
+			else
+				cbValZapped->Set3StateValue(wxCheckBoxState::wxCHK_UNCHECKED);
+
+			chkZap->Bind(wxEVT_CHECKBOX, [&](wxCommandEvent& event)
+			{
+				bool checked = event.IsChecked();
+
+				lbValLo->Show(!checked);
+				lbValHi->Show(!checked);
+				edValLo->Show(!checked);
+				edValHi->Show(!checked);
+				cbValZapped->Show(checked);
+				zapToggleList->Enable(checked);
+
+				dlg.Layout();
+			});
+
+			XRCCTRL(dlg, "wxID_CANCEL", wxButton)->SetFocus();
+
+			if (dlg.ShowModal() == wxID_OK)
+			{
+				if (chkZap->IsChecked())
+				{
+					if (cbValZapped->IsChecked())
+					{
+						loVal = 100;
+						hiVal = 100;
+					}
+					else
+					{
+						loVal = 0;
+						hiVal = 0;
+					}
+
+					wxArrayString zapToggles;
+					wxArrayInt toggled;
+					zapToggleList->GetCheckedItems(toggled);
+					for (auto &i : toggled)
+						zapToggles.Add(zapToggleList->GetString(i));
+
+					project->SetSliderZapToggles(curSlider, zapToggles);
+				}
+				else
+				{
+					edValLo->GetValue().ToLong(&loVal);
+					edValHi->GetValue().ToLong(&hiVal);
 				}
 
-				wxArrayString zapToggles;
-				wxArrayInt toggled;
-				zapToggleList->GetCheckedItems(toggled);
-				for (auto &i : toggled)
-					zapToggles.Add(zapToggleList->GetString(i));
+				project->SetSliderZap(curSlider, chkZap->GetValue());
+				project->SetSliderInvert(curSlider, chkInvert->GetValue());
+				project->SetSliderHidden(curSlider, chkHidden->GetValue());
+				project->SetSliderUV(curSlider, chkUV->GetValue());
+				project->SetSliderDefault(curSlider, loVal, false);
+				project->SetSliderDefault(curSlider, hiVal, true);
 
-				project->SetSliderZapToggles(curSlider, zapToggles);
+				std::string newSliderName{ edSliderName->GetValue().ToUTF8() };
+				if (sliderName != newSliderName && !project->ValidSlider(newSliderName))
+				{
+					project->SetSliderName(curSlider, newSliderName);
+					SliderDisplay* d = sliderDisplays[sliderName];
+					sliderDisplays[newSliderName] = d;
+					sliderDisplays.erase(sliderName);
+
+					wxString sn = wxString::FromUTF8(newSliderName);
+					d->slider->SetName(sn + "|slider");
+					d->sliderName->SetName(sn + "|lbl");
+					d->btnSliderEdit->SetName(sn + "|btn");
+					d->btnSliderProp->SetName(sn + "|btnSliderProp");
+					d->btnMinus->SetName(sn + "|btnMinus");
+					d->btnPlus->SetName(sn + "|btnPlus");
+					d->sliderNameCheck->SetName(sn + "|check");
+					d->sliderReadout->SetName(sn + "|readout");
+					d->sliderName->SetLabel(sn);
+
+					if (sliderName == activeSlider)
+						activeSlider = std::move(newSliderName);
+				}
+
+				SetPendingChanges();
 			}
-			else {
-				edValLo->GetValue().ToLong(&loVal);
-				edValHi->GetValue().ToLong(&hiVal);
-			}
+		}
+	}
 
-			project->SetSliderZap(curSlider, chkZap->GetValue());
-			project->SetSliderInvert(curSlider, chkInvert->GetValue());
-			project->SetSliderHidden(curSlider, chkHidden->GetValue());
-			project->SetSliderUV(curSlider, chkUV->GetValue());
-			project->SetSliderDefault(curSlider, loVal, false);
-			project->SetSliderDefault(curSlider, hiVal, true);
+	void OutfitStudioFrame::OnSliderProperties(wxCommandEvent& WXUNUSED(event)) {
+		if (!bEditSlider)
+		{
+			wxMessageBox(_("There is no slider in edit mode to show properties for!"), _("Error"));
+			return;
+		}
 
-			std::string newSliderName{ edSliderName->GetValue().ToUTF8() };
-			if (sliderName != newSliderName && !project->ValidSlider(newSliderName)) {
-				project->SetSliderName(curSlider, newSliderName);
-				SliderDisplay* d = sliderDisplays[sliderName];
-				sliderDisplays[newSliderName] = d;
-				sliderDisplays.erase(sliderName);
+		ShowSliderProperties(activeSlider);
+	}
 
-				wxString sn = wxString::FromUTF8(newSliderName);
-				d->slider->SetName(sn + "|slider");
-				d->sliderName->SetName(sn + "|lbl");
-				d->btnSliderEdit->SetName(sn + "|btn");
-				d->btnSliderProp->SetName(sn + "|btnSliderProp");
-				d->btnMinus->SetName(sn + "|btnMinus");
-				d->btnPlus->SetName(sn + "|btnPlus");
-				d->sliderNameCheck->SetName(sn + "|check");
-				d->sliderReadout->SetName(sn + "|readout");
-				d->sliderName->SetLabel(sn);
+	void OutfitStudioFrame::ConformSliders(NiShape* shape, const ConformOptions& options, bool silent) {
+		if (project->IsBaseShape(shape))
+			return;
 
-				if (sliderName == activeSlider)
-					activeSlider = std::move(newSliderName);
-			}
+		std::string shapeName = shape->name.get();
+		wxLogMessage("Conforming '%s'...", shapeName);
+		if(!silent)
+			UpdateProgress(50, _("Conforming: ") + shapeName);
+
+		mesh* m = glView->GetMesh(shapeName);
+		if (m)
+		{
+			project->morpher.CopyMeshMask(m, shapeName);
+			project->ConformShape(shape, options);
+		}
+		if(!silent)
+			UpdateProgress(99);
+	}
+
+	void OutfitStudioFrame::OnSliderConform(wxCommandEvent& WXUNUSED(event)) {
+		if (!project->GetBaseShape())
+			return;
+
+		ConformOptions options;
+		if (ShowConform(options))
+		{
+			wxLogMessage("Conforming...");
+			ZeroSliders();
+
+			StartProgress(_("Initializing data..."));
+			project->InitConform();
+
+			for (auto &i : selectedItems)
+				ConformSliders(i->GetShape(), options);
+
+			project->morpher.ClearProximityCache();
+			project->morpher.UnlinkRefDiffData();
+
+			if (statusBar)
+				statusBar->SetStatusText(_("Shape(s) conformed."));
 
 			SetPendingChanges();
-		}
-	}
-}
 
-void OutfitStudioFrame::OnSliderProperties(wxCommandEvent& WXUNUSED(event)) {
-	if (!bEditSlider) {
-		wxMessageBox(_("There is no slider in edit mode to show properties for!"), _("Error"));
-		return;
-	}
-
-	ShowSliderProperties(activeSlider);
-}
-
-void OutfitStudioFrame::ConformSliders(NiShape* shape, const ConformOptions& options) {
-	if (project->IsBaseShape(shape))
-		return;
-
-	std::string shapeName = shape->name.get();
-	wxLogMessage("Conforming '%s'...", shapeName);
-	UpdateProgress(50, _("Conforming: ") + shapeName);
-
-	mesh* m = glView->GetMesh(shapeName);
-	if (m) {
-		project->morpher.CopyMeshMask(m, shapeName);
-		project->ConformShape(shape, options);
-	}
-
-	UpdateProgress(99);
-}
-
-void OutfitStudioFrame::OnSliderConform(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetBaseShape())
-		return;
-
-	ConformOptions options;
-	if (ShowConform(options)) {
-		wxLogMessage("Conforming...");
-		ZeroSliders();
-
-		StartProgress(_("Initializing data..."));
-		project->InitConform();
-
-		for (auto &i : selectedItems)
-			ConformSliders(i->GetShape(), options);
-
-		project->morpher.ClearProximityCache();
-		project->morpher.UnlinkRefDiffData();
-
-		if (statusBar)
-			statusBar->SetStatusText(_("Shape(s) conformed."));
-
-		SetPendingChanges();
-
-		wxLogMessage("%zu shape(s) conformed.", selectedItems.size());
-		UpdateProgress(100, _("Finished"));
-		EndProgress();
-	}
-}
-
-void OutfitStudioFrame::OnSliderConformAll(wxCommandEvent& WXUNUSED(event)) {
-	if (!project->GetBaseShape())
-		return;
-
-	ConformOptions options;
-	if (ShowConform(options)) {
-		wxLogMessage("Conforming all shapes...");
-		ZeroSliders();
-
-		auto shapes = project->GetWorkNif()->GetShapes();
-
-		StartProgress(_("Conforming all shapes..."));
-		project->InitConform();
-
-		int inc = 100 / shapes.size() - 1;
-		int pos = 0;
-
-		for (auto &shape : shapes) {
-			UpdateProgress(pos * inc, _("Conforming: ") + shape->name.get());
-			StartSubProgress(pos * inc, pos * inc + inc);
-			ConformSliders(shape, options);
-			pos++;
+			wxLogMessage("%zu shape(s) conformed.", selectedItems.size());
+			UpdateProgress(100, _("Finished"));
 			EndProgress();
 		}
-
-		project->morpher.ClearProximityCache();
-		project->morpher.UnlinkRefDiffData();
-
-		if (statusBar)
-			statusBar->SetStatusText(_("All shapes conformed."));
-
-		SetPendingChanges();
-
-		wxLogMessage("All shapes conformed.");
-		UpdateProgress(100, _("Finished"));
-		EndProgress();
 	}
-}
 
-bool OutfitStudioFrame::ShowConform(ConformOptions& options) {
-	wxDialog dlg;
-	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgConforming")) {
-		XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->Bind(wxEVT_SLIDER, [&dlg](wxCommandEvent&) {
-			float changed = XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->GetValue() / 1000.0f;
-			XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", changed));
-		});
+	void OutfitStudioFrame::OnSliderConformAll(wxCommandEvent& WXUNUSED(event)) {
+		if (!project->GetBaseShape())
+			return;
 
-		XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->Bind(wxEVT_TEXT, [&dlg](wxCommandEvent&) {
-			float changed = atof(XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->GetValue().c_str());
-			XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->SetValue(changed * 1000);
-		});
+		ConformOptions options;
+		if (ShowConform(options))
+		{
+			wxLogMessage("Conforming all shapes...");
+			ZeroSliders();
 
-		XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Bind(wxEVT_SLIDER, [&dlg](wxCommandEvent&) {
-			int changed = XRCCTRL(dlg, "maxResultsSlider", wxSlider)->GetValue();
-			XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->ChangeValue(wxString::Format("%d", changed));
-		});
+			auto shapes = project->GetWorkNif()->GetShapes();
 
-		XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->Bind(wxEVT_CHECKBOX, [&dlg](wxCommandEvent&) {
-			bool noTargetLimit = XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->IsChecked();
-			XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->Enable(!noTargetLimit);
-			XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Enable(!noTargetLimit);
+			StartProgress(_("Conforming all shapes..."));
+			project->InitConform();
 
-			if (noTargetLimit) {
+			int inc = 100 / shapes.size() - 1;
+			int pos = 0;
+
+			for (auto &shape : shapes)
+			{
+				UpdateProgress(pos * inc, _("Conforming: ") + shape->name.get());
+				StartSubProgress(pos * inc, pos * inc + inc);
+				ConformSliders(shape, options);
+				pos++;
+				EndProgress();
+			}
+
+			project->morpher.ClearProximityCache();
+			project->morpher.UnlinkRefDiffData();
+
+			if (statusBar)
+				statusBar->SetStatusText(_("All shapes conformed."));
+
+			SetPendingChanges();
+
+			wxLogMessage("All shapes conformed.");
+			UpdateProgress(100, _("Finished"));
+			EndProgress();
+		}
+	}
+
+	int OutfitStudioFrame::ConformShapes(std::vector<NiShape*> shapes, bool silent) {
+		if (!project->GetBaseShape())
+			return 1;
+
+		ConformOptions options;
+		if (ShowConform(options, silent))
+		{
+			wxLogMessage("Conforming Shapes.");
+		
+			ZeroSliders();
+
+			project->InitConform();
+
+			int inc = 100 / shapes.size() - 1;
+			int pos = 0;
+
+			for (auto &shape : shapes)
+			{
+				wxLogMessage(_("Conforming: ") + shape->name.get());
+				if(!silent)
+					StartSubProgress(pos * inc, pos * inc + inc);
+				ConformSliders(shape, options, silent);
+				pos++;
+				if(!silent)
+					EndProgress();
+			}
+
+			project->morpher.ClearProximityCache();
+			project->morpher.UnlinkRefDiffData();
+
+			SetPendingChanges();
+
+			wxLogMessage("All shapes conformed.");
+			return 0;
+		}
+		return 1;
+	}
+
+	bool OutfitStudioFrame::ShowConform(ConformOptions& options, bool silent) {
+		wxDialog dlg;
+		if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgConforming"))
+		{
+			XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->Bind(wxEVT_SLIDER, [&dlg](wxCommandEvent&)
+			{
+				float changed = XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->GetValue() / 1000.0f;
+				XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", changed));
+			});
+
+			XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->Bind(wxEVT_TEXT, [&dlg](wxCommandEvent&)
+			{
+				float changed = atof(XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->GetValue().c_str());
+				XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->SetValue(changed * 1000);
+			});
+
+			XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Bind(wxEVT_SLIDER, [&dlg](wxCommandEvent&)
+			{
+				int changed = XRCCTRL(dlg, "maxResultsSlider", wxSlider)->GetValue();
+				XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->ChangeValue(wxString::Format("%d", changed));
+			});
+
+			XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->Bind(wxEVT_CHECKBOX, [&dlg](wxCommandEvent&)
+			{
+				bool noTargetLimit = XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->IsChecked();
+				XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->Enable(!noTargetLimit);
+				XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Enable(!noTargetLimit);
+
+				if (noTargetLimit)
+				{
+					XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->ChangeValue("5.00000");
+					XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->SetValue(5000);
+				}
+			});
+
+			XRCCTRL(dlg, "presetDefault", wxButton)->Bind(wxEVT_BUTTON, [&dlg](wxCommandEvent&)
+			{
+				XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->SetValue(false);
+				XRCCTRL(dlg, "noSqueeze", wxCheckBox)->SetValue(false);
+				XRCCTRL(dlg, "solidMode", wxCheckBox)->SetValue(false);
+				XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->ChangeValue("10.00000");
+				XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->SetValue(10000);
+				XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->Enable();
+				XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Enable();
+				XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->ChangeValue("10");
+				XRCCTRL(dlg, "maxResultsSlider", wxSlider)->SetValue(10);
+			});
+
+			XRCCTRL(dlg, "presetEvenMovement", wxButton)->Bind(wxEVT_BUTTON, [&dlg](wxCommandEvent&)
+			{
+				XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->SetValue(true);
+				XRCCTRL(dlg, "noSqueeze", wxCheckBox)->SetValue(true);
+				XRCCTRL(dlg, "solidMode", wxCheckBox)->SetValue(false);
+				XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->Disable();
+				XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Disable();
 				XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->ChangeValue("5.00000");
 				XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->SetValue(5000);
-			}
-		});
+			});
 
-		XRCCTRL(dlg, "presetDefault", wxButton)->Bind(wxEVT_BUTTON, [&dlg](wxCommandEvent&) {
-			XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->SetValue(false);
-			XRCCTRL(dlg, "noSqueeze", wxCheckBox)->SetValue(false);
-			XRCCTRL(dlg, "solidMode", wxCheckBox)->SetValue(false);
-			XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->ChangeValue("10.00000");
-			XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->SetValue(10000);
-			XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->Enable();
-			XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Enable();
-			XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->ChangeValue("10");
-			XRCCTRL(dlg, "maxResultsSlider", wxSlider)->SetValue(10);
-		});
+			XRCCTRL(dlg, "presetSolidObject", wxButton)->Bind(wxEVT_BUTTON, [&dlg](wxCommandEvent&)
+			{
+				XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->SetValue(true);
+				XRCCTRL(dlg, "noSqueeze", wxCheckBox)->SetValue(false);
+				XRCCTRL(dlg, "solidMode", wxCheckBox)->SetValue(true);
+				XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->Disable();
+				XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Disable();
+				XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->ChangeValue("10.00000");
+				XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->SetValue(10000);
+			});
 
-		XRCCTRL(dlg, "presetEvenMovement", wxButton)->Bind(wxEVT_BUTTON, [&dlg](wxCommandEvent&) {
-			XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->SetValue(true);
-			XRCCTRL(dlg, "noSqueeze", wxCheckBox)->SetValue(true);
-			XRCCTRL(dlg, "solidMode", wxCheckBox)->SetValue(false);
-			XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->Disable();
-			XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Disable();
-			XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->ChangeValue("5.00000");
-			XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->SetValue(5000);
-		});
+			dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
 
-		XRCCTRL(dlg, "presetSolidObject", wxButton)->Bind(wxEVT_BUTTON, [&dlg](wxCommandEvent&) {
-			XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->SetValue(true);
-			XRCCTRL(dlg, "noSqueeze", wxCheckBox)->SetValue(false);
-			XRCCTRL(dlg, "solidMode", wxCheckBox)->SetValue(true);
-			XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->Disable();
-			XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Disable();
-			XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->ChangeValue("10.00000");
-			XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->SetValue(10000);
-		});
+			if (silent || dlg.ShowModal() == wxID_OK)
+			{
+				options.proximityRadius = atof(XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->GetValue().c_str());
 
-		dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
+				bool noTargetLimit = XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->IsChecked();
+				if (!noTargetLimit)
+					options.maxResults = atol(XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->GetValue().c_str());
+				else
+					options.maxResults = std::numeric_limits<int>::max();
 
-		if (dlg.ShowModal() == wxID_OK) {
-			options.proximityRadius = atof(XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->GetValue().c_str());
-
-			bool noTargetLimit = XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->IsChecked();
-			if (!noTargetLimit)
-				options.maxResults = atol(XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->GetValue().c_str());
-			else
-				options.maxResults = std::numeric_limits<int>::max();
-
-			options.noSqueeze = XRCCTRL(dlg, "noSqueeze", wxCheckBox)->IsChecked();
-			options.solidMode = XRCCTRL(dlg, "solidMode", wxCheckBox)->IsChecked();
-			options.axisX = XRCCTRL(dlg, "axisX", wxCheckBox)->IsChecked();
-			options.axisY = XRCCTRL(dlg, "axisY", wxCheckBox)->IsChecked();
-			options.axisZ = XRCCTRL(dlg, "axisZ", wxCheckBox)->IsChecked();
-			return true;
-		}
-	}
-
-	return false;
-}
-
-void OutfitStudioFrame::OnInvertUV(wxCommandEvent& event) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-
-	bool invertX = (event.GetId() == XRCID("uvInvertX"));
-	bool invertY = (event.GetId() == XRCID("uvInvertY"));
-
-	for (auto &i : selectedItems) {
-		project->GetWorkNif()->InvertUVsForShape(i->GetShape(), invertX, invertY);
-	}
-
-	RefreshGUIFromProj();
-	SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnMirror(wxCommandEvent& event) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-
-	bool mirrorX = (event.GetId() == XRCID("mirrorX"));
-	bool mirrorY = (event.GetId() == XRCID("mirrorY"));
-	bool mirrorZ = (event.GetId() == XRCID("mirrorZ"));
-
-	for (auto &i : selectedItems) {
-		project->GetWorkNif()->MirrorShape(i->GetShape(), mirrorX, mirrorY, mirrorZ);
-	}
-
-	RefreshGUIFromProj();
-	SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnRenameShape(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-
-	std::string newShapeName;
-	do {
-		std::string result{wxGetTextFromUser(_("Please enter a new unique name for the shape."), _("Rename Shape")).ToUTF8()};
-		if (result.empty())
-			return;
-
-		newShapeName = std::move(result);
-	} while (project->IsValidShape(newShapeName));
-
-	std::string shapeName = activeItem->GetShape()->name.get();
-	wxLogMessage("Renaming shape '%s' to '%s'.", shapeName, newShapeName);
-	project->RenameShape(activeItem->GetShape(), newShapeName);
-	glView->RenameShape(shapeName, newShapeName);
-
-	outfitShapes->SetItemText(activeItem->GetId(), wxString::FromUTF8(newShapeName));
-	SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnSetReference(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-
-	auto shape = activeItem->GetShape();
-	if (!project->IsBaseShape(shape))
-		project->SetBaseShape(shape);
-	else
-		project->SetBaseShape(nullptr);
-
-	if (shape)
-		project->SetTextures(shape);
-
-	RefreshGUIFromProj();
-	SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnEnterClose(wxKeyEvent& event) {
-	if (event.GetKeyCode() == WXK_RETURN) {
-		wxDialog* parent = (wxDialog*)((wxWindow*)event.GetEventObject())->GetParent();
-		if (!parent)
-			return;
-
-		parent->Close();
-		parent->SetReturnCode(wxID_OK);
-	}
-	else
-		event.Skip();
-}
-
-void OutfitStudioFrame::OnMoveShape(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-
-	if (!CheckEditableState())
-		return;
-
-	wxDialog dlg;
-	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgMoveShape")) {
-		Vector3 previewMove;
-
-		auto updateMovePreview = [&]() {
-			std::unordered_map<uint16_t, float> mask;
-			std::unordered_map<uint16_t, float>* mptr = nullptr;
-			std::vector<Vector3> verts;
-
-			if (!previewMove.IsZero()) {
-				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
-				if (curState) {
-					glView->ApplyUndoState(curState, true, false);
-					glView->GetUndoHistory()->PopState();
-				}
-			}
-
-			Vector3 changed;
-			changed.x = atof(XRCCTRL(dlg, "msTextX", wxTextCtrl)->GetValue().c_str());
-			changed.y = atof(XRCCTRL(dlg, "msTextY", wxTextCtrl)->GetValue().c_str());
-			changed.z = atof(XRCCTRL(dlg, "msTextZ", wxTextCtrl)->GetValue().c_str());
-
-			bool mirrorAxisX = XRCCTRL(dlg, "mirrorAxisX", wxCheckBox)->IsChecked();
-			bool mirrorAxisY = XRCCTRL(dlg, "mirrorAxisY", wxCheckBox)->IsChecked();
-			bool mirrorAxisZ = XRCCTRL(dlg, "mirrorAxisZ", wxCheckBox)->IsChecked();
-
-			UndoStateProject *usp = glView->GetUndoHistory()->PushState();
-			usp->undoType = UT_VERTPOS;
-
-			for (auto &sel : selectedItems) {
-				mask.clear();
-				mptr = nullptr;
-
-				NiShape* shape = sel->GetShape();
-				project->GetLiveVerts(shape, verts);
-				glView->GetShapeMask(mask, shape->name.get());
-
-				if (!mask.empty())
-					mptr = &mask;
-
-				UndoStateShape uss;
-				uss.shapeName = shape->name.get();
-
-				for (size_t i = 0; i < verts.size(); i++) {
-					Vector3& vertPos = verts[i];
-					Vector3 diff = changed;
-
-					if (mptr)
-						diff *= 1.0f - mask[i];
-
-					if (diff.IsZero(true))
-						continue;
-
-					if (mirrorAxisX && vertPos.x < 0.0f)
-						diff.x = -diff.x;
-					if (mirrorAxisY && vertPos.y < 0.0f)
-						diff.y = -diff.y;
-					if (mirrorAxisZ && vertPos.z < 0.0f)
-						diff.z = -diff.z;
-
-					Vector3 newPos = vertPos + diff;
-					uss.pointStartState[i] = mesh::VecToMeshCoords(vertPos);
-					uss.pointEndState[i] = mesh::VecToMeshCoords(newPos);
-				}
-
-				usp->usss.push_back(std::move(uss));
-			}
-
-			if (bEditSlider) {
-				usp->sliderName = activeSlider;
-
-				float sliderscale = project->SliderValue(activeSlider);
-				if (sliderscale == 0.0)
-					sliderscale = 1.0;
-
-				usp->sliderscale = sliderscale;
-			}
-
-			glView->ApplyUndoState(usp, false);
-
-			previewMove = changed;
-
-			if (glView->GetTransformMode())
-				glView->ShowTransformTool();
-		};
-
-		auto sliderMoved = [&](wxCommandEvent&) {
-			Vector3 slider;
-			slider.x = XRCCTRL(dlg, "msSliderX", wxSlider)->GetValue() / 1000.0f;
-			slider.y = XRCCTRL(dlg, "msSliderY", wxSlider)->GetValue() / 1000.0f;
-			slider.z = XRCCTRL(dlg, "msSliderZ", wxSlider)->GetValue() / 1000.0f;
-
-			XRCCTRL(dlg, "msTextX", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", slider.x));
-			XRCCTRL(dlg, "msTextY", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", slider.y));
-			XRCCTRL(dlg, "msTextZ", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", slider.z));
-
-			updateMovePreview();
-		};
-
-		auto textChanged = [&](wxCommandEvent&) {
-			Vector3 changed;
-			changed.x = atof(XRCCTRL(dlg, "msTextX", wxTextCtrl)->GetValue().c_str());
-			changed.y = atof(XRCCTRL(dlg, "msTextY", wxTextCtrl)->GetValue().c_str());
-			changed.z = atof(XRCCTRL(dlg, "msTextZ", wxTextCtrl)->GetValue().c_str());
-
-			XRCCTRL(dlg, "msSliderX", wxSlider)->SetValue(changed.x * 1000);
-			XRCCTRL(dlg, "msSliderY", wxSlider)->SetValue(changed.y * 1000);
-			XRCCTRL(dlg, "msSliderZ", wxSlider)->SetValue(changed.z * 1000);
-
-			updateMovePreview();
-		};
-
-		auto mirrorAxisChanged = [&](wxCommandEvent&) {
-			updateMovePreview();
-		};
-
-		XRCCTRL(dlg, "msSliderX", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
-		XRCCTRL(dlg, "msSliderY", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
-		XRCCTRL(dlg, "msSliderZ", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
-
-		XRCCTRL(dlg, "msTextX", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
-		XRCCTRL(dlg, "msTextY", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
-		XRCCTRL(dlg, "msTextZ", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
-
-		XRCCTRL(dlg, "mirrorAxisX", wxCheckBox)->Bind(wxEVT_CHECKBOX, mirrorAxisChanged);
-		XRCCTRL(dlg, "mirrorAxisY", wxCheckBox)->Bind(wxEVT_CHECKBOX, mirrorAxisChanged);
-		XRCCTRL(dlg, "mirrorAxisZ", wxCheckBox)->Bind(wxEVT_CHECKBOX, mirrorAxisChanged);
-		dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
-
-		if (dlg.ShowModal() != wxID_OK) {
-			if (!previewMove.IsZero()) {
-				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
-				if (curState) {
-					glView->ApplyUndoState(curState, true);
-					glView->GetUndoHistory()->PopState();
-				}
+				options.noSqueeze = XRCCTRL(dlg, "noSqueeze", wxCheckBox)->IsChecked();
+				options.solidMode = XRCCTRL(dlg, "solidMode", wxCheckBox)->IsChecked();
+				options.axisX = XRCCTRL(dlg, "axisX", wxCheckBox)->IsChecked();
+				options.axisY = XRCCTRL(dlg, "axisY", wxCheckBox)->IsChecked();
+				options.axisZ = XRCCTRL(dlg, "axisZ", wxCheckBox)->IsChecked();
+				return true;
 			}
 		}
 
-		UpdateUndoTools();
-	}
-}
-
-void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
+		return false;
 	}
 
-	if (!CheckEditableState())
-		return;
+	void OutfitStudioFrame::OnInvertUV(wxCommandEvent& event) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
 
-	wxDialog dlg;
-	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgScaleShape")) {
-		Vector3 previewScale(1.0f, 1.0f, 1.0f);
+		bool invertX = (event.GetId() == XRCID("uvInvertX"));
+		bool invertY = (event.GetId() == XRCID("uvInvertY"));
 
-		auto updateScalePreview = [&]() {
-			std::unordered_map<uint16_t, float> mask;
-			std::unordered_map<uint16_t, float>* mptr = nullptr;
-			std::vector<Vector3> verts;
+		for (auto &i : selectedItems)
+		{
+			project->GetWorkNif()->InvertUVsForShape(i->GetShape(), invertX, invertY);
+		}
 
-			if (previewScale != Vector3(1.0f, 1.0f, 1.0f)) {
-				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
-				if (curState) {
-					glView->ApplyUndoState(curState, true, false);
-					glView->GetUndoHistory()->PopState();
+		RefreshGUIFromProj();
+		SetPendingChanges();
+	}
+
+	void OutfitStudioFrame::OnMirror(wxCommandEvent& event) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+
+		bool mirrorX = (event.GetId() == XRCID("mirrorX"));
+		bool mirrorY = (event.GetId() == XRCID("mirrorY"));
+		bool mirrorZ = (event.GetId() == XRCID("mirrorZ"));
+
+		for (auto &i : selectedItems)
+		{
+			project->GetWorkNif()->MirrorShape(i->GetShape(), mirrorX, mirrorY, mirrorZ);
+		}
+
+		RefreshGUIFromProj();
+		SetPendingChanges();
+	}
+
+	void OutfitStudioFrame::OnRenameShape(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+
+		std::string newShapeName;
+		do
+		{
+			std::string result{wxGetTextFromUser(_("Please enter a new unique name for the shape."), _("Rename Shape")).ToUTF8()};
+			if (result.empty())
+				return;
+
+			newShapeName = std::move(result);
+		} while (project->IsValidShape(newShapeName));
+
+		std::string shapeName = activeItem->GetShape()->name.get();
+		wxLogMessage("Renaming shape '%s' to '%s'.", shapeName, newShapeName);
+		project->RenameShape(activeItem->GetShape(), newShapeName);
+		glView->RenameShape(shapeName, newShapeName);
+
+		outfitShapes->SetItemText(activeItem->GetId(), wxString::FromUTF8(newShapeName));
+		SetPendingChanges();
+	}
+
+	void OutfitStudioFrame::OnSetReference(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+
+		auto shape = activeItem->GetShape();
+		if (!project->IsBaseShape(shape))
+			project->SetBaseShape(shape);
+		else
+			project->SetBaseShape(nullptr);
+
+		if (shape)
+			project->SetTextures(shape);
+
+		RefreshGUIFromProj();
+		SetPendingChanges();
+	}
+
+	void OutfitStudioFrame::OnEnterClose(wxKeyEvent& event)
+	{
+		if (event.GetKeyCode() == WXK_RETURN)
+		{
+			wxDialog* parent = (wxDialog*)((wxWindow*)event.GetEventObject())->GetParent();
+			if (!parent)
+				return;
+
+			parent->Close();
+			parent->SetReturnCode(wxID_OK);
+		}
+		else
+			event.Skip();
+	}
+
+	void OutfitStudioFrame::OnMoveShape(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+
+		if (!CheckEditableState())
+			return;
+
+		wxDialog dlg;
+		if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgMoveShape"))
+		{
+			Vector3 previewMove;
+
+			auto updateMovePreview = [&]()
+			{
+				std::unordered_map<uint16_t, float> mask;
+				std::unordered_map<uint16_t, float>* mptr = nullptr;
+				std::vector<Vector3> verts;
+
+				if (!previewMove.IsZero())
+				{
+					UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
+					if (curState)
+					{
+						glView->ApplyUndoState(curState, true, false);
+						glView->GetUndoHistory()->PopState();
+					}
+				}
+
+				Vector3 changed;
+				changed.x = atof(XRCCTRL(dlg, "msTextX", wxTextCtrl)->GetValue().c_str());
+				changed.y = atof(XRCCTRL(dlg, "msTextY", wxTextCtrl)->GetValue().c_str());
+				changed.z = atof(XRCCTRL(dlg, "msTextZ", wxTextCtrl)->GetValue().c_str());
+
+				bool mirrorAxisX = XRCCTRL(dlg, "mirrorAxisX", wxCheckBox)->IsChecked();
+				bool mirrorAxisY = XRCCTRL(dlg, "mirrorAxisY", wxCheckBox)->IsChecked();
+				bool mirrorAxisZ = XRCCTRL(dlg, "mirrorAxisZ", wxCheckBox)->IsChecked();
+
+				UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+				usp->undoType = UT_VERTPOS;
+
+				for (auto &sel : selectedItems)
+				{
+					mask.clear();
+					mptr = nullptr;
+
+					NiShape* shape = sel->GetShape();
+					project->GetLiveVerts(shape, verts);
+					glView->GetShapeMask(mask, shape->name.get());
+
+					if (!mask.empty())
+						mptr = &mask;
+
+					UndoStateShape uss;
+					uss.shapeName = shape->name.get();
+
+					for (size_t i = 0; i < verts.size(); i++)
+					{
+						Vector3& vertPos = verts[i];
+						Vector3 diff = changed;
+
+						if (mptr)
+							diff *= 1.0f - mask[i];
+
+						if (diff.IsZero(true))
+							continue;
+
+						if (mirrorAxisX && vertPos.x < 0.0f)
+							diff.x = -diff.x;
+						if (mirrorAxisY && vertPos.y < 0.0f)
+							diff.y = -diff.y;
+						if (mirrorAxisZ && vertPos.z < 0.0f)
+							diff.z = -diff.z;
+
+						Vector3 newPos = vertPos + diff;
+						uss.pointStartState[i] = mesh::VecToMeshCoords(vertPos);
+						uss.pointEndState[i] = mesh::VecToMeshCoords(newPos);
+					}
+
+					usp->usss.push_back(std::move(uss));
+				}
+
+				if (bEditSlider)
+				{
+					usp->sliderName = activeSlider;
+
+					float sliderscale = project->SliderValue(activeSlider);
+					if (sliderscale == 0.0)
+						sliderscale = 1.0;
+
+					usp->sliderscale = sliderscale;
+				}
+
+				glView->ApplyUndoState(usp, false);
+
+				previewMove = changed;
+
+				if (glView->GetTransformMode())
+					glView->ShowTransformTool();
+			};
+
+			auto sliderMoved = [&](wxCommandEvent&)
+			{
+				Vector3 slider;
+				slider.x = XRCCTRL(dlg, "msSliderX", wxSlider)->GetValue() / 1000.0f;
+				slider.y = XRCCTRL(dlg, "msSliderY", wxSlider)->GetValue() / 1000.0f;
+				slider.z = XRCCTRL(dlg, "msSliderZ", wxSlider)->GetValue() / 1000.0f;
+
+				XRCCTRL(dlg, "msTextX", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", slider.x));
+				XRCCTRL(dlg, "msTextY", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", slider.y));
+				XRCCTRL(dlg, "msTextZ", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", slider.z));
+
+				updateMovePreview();
+			};
+
+			auto textChanged = [&](wxCommandEvent&)
+			{
+				Vector3 changed;
+				changed.x = atof(XRCCTRL(dlg, "msTextX", wxTextCtrl)->GetValue().c_str());
+				changed.y = atof(XRCCTRL(dlg, "msTextY", wxTextCtrl)->GetValue().c_str());
+				changed.z = atof(XRCCTRL(dlg, "msTextZ", wxTextCtrl)->GetValue().c_str());
+
+				XRCCTRL(dlg, "msSliderX", wxSlider)->SetValue(changed.x * 1000);
+				XRCCTRL(dlg, "msSliderY", wxSlider)->SetValue(changed.y * 1000);
+				XRCCTRL(dlg, "msSliderZ", wxSlider)->SetValue(changed.z * 1000);
+
+				updateMovePreview();
+			};
+
+			auto mirrorAxisChanged = [&](wxCommandEvent&)
+			{
+				updateMovePreview();
+			};
+
+			XRCCTRL(dlg, "msSliderX", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
+			XRCCTRL(dlg, "msSliderY", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
+			XRCCTRL(dlg, "msSliderZ", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
+
+			XRCCTRL(dlg, "msTextX", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
+			XRCCTRL(dlg, "msTextY", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
+			XRCCTRL(dlg, "msTextZ", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
+
+			XRCCTRL(dlg, "mirrorAxisX", wxCheckBox)->Bind(wxEVT_CHECKBOX, mirrorAxisChanged);
+			XRCCTRL(dlg, "mirrorAxisY", wxCheckBox)->Bind(wxEVT_CHECKBOX, mirrorAxisChanged);
+			XRCCTRL(dlg, "mirrorAxisZ", wxCheckBox)->Bind(wxEVT_CHECKBOX, mirrorAxisChanged);
+			dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
+
+			if (dlg.ShowModal() != wxID_OK)
+			{
+				if (!previewMove.IsZero())
+				{
+					UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
+					if (curState)
+					{
+						glView->ApplyUndoState(curState, true);
+						glView->GetUndoHistory()->PopState();
+					}
 				}
 			}
 
-			Vector3 scale;
-			scale.x = atof(XRCCTRL(dlg, "ssTextX", wxTextCtrl)->GetValue().c_str());
-			scale.y = atof(XRCCTRL(dlg, "ssTextY", wxTextCtrl)->GetValue().c_str());
-			scale.z = atof(XRCCTRL(dlg, "ssTextZ", wxTextCtrl)->GetValue().c_str());
+			UpdateUndoTools();
+		}
+	}
 
-			Vector3 origin;
-			int originSelection = XRCCTRL(dlg, "origin", wxChoice)->GetCurrentSelection();
-			if (originSelection == 1) {
-				// Center of selected shape(s), respecting mask
-				origin = glView->gls.GetActiveCenter();
-				origin = mesh::VecToNifCoords(origin);
-			}
+	void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
 
-			UndoStateProject *usp = glView->GetUndoHistory()->PushState();
-			usp->undoType = UT_VERTPOS;
+		if (!CheckEditableState())
+			return;
 
-			for (auto &sel : selectedItems) {
-				mask.clear();
-				mptr = nullptr;
+		wxDialog dlg;
+		if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgScaleShape"))
+		{
+			Vector3 previewScale(1.0f, 1.0f, 1.0f);
 
-				NiShape* shape = sel->GetShape();
-				project->GetLiveVerts(shape, verts);
-				glView->GetShapeMask(mask, shape->name.get());
+			auto updateScalePreview = [&]()
+			{
+				std::unordered_map<uint16_t, float> mask;
+				std::unordered_map<uint16_t, float>* mptr = nullptr;
+				std::vector<Vector3> verts;
 
-				if (!mask.empty())
-					mptr = &mask;
-
-				UndoStateShape uss;
-				uss.shapeName = shape->name.get();
-
-				Matrix4 xform;
-				xform.PushTranslate(origin);
-				xform.PushScale(scale.x, scale.y, scale.z);
-				xform.PushTranslate(origin * -1.0f);
-
-				for (size_t i = 0; i < verts.size(); i++) {
-					Vector3& vertPos = verts[i];
-					Vector3 diff = xform * vertPos - vertPos;
-
-					if (mptr)
-						diff *= 1.0f - mask[i];
-
-					if (diff.IsZero(true))
-						continue;
-
-					Vector3 newPos = vertPos + diff;
-					uss.pointStartState[i] = mesh::VecToMeshCoords(vertPos);
-					uss.pointEndState[i] = mesh::VecToMeshCoords(newPos);
+				if (previewScale != Vector3(1.0f, 1.0f, 1.0f))
+				{
+					UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
+					if (curState)
+					{
+						glView->ApplyUndoState(curState, true, false);
+						glView->GetUndoHistory()->PopState();
+					}
 				}
 
-				usp->usss.push_back(std::move(uss));
-			}
+				Vector3 scale;
+				scale.x = atof(XRCCTRL(dlg, "ssTextX", wxTextCtrl)->GetValue().c_str());
+				scale.y = atof(XRCCTRL(dlg, "ssTextY", wxTextCtrl)->GetValue().c_str());
+				scale.z = atof(XRCCTRL(dlg, "ssTextZ", wxTextCtrl)->GetValue().c_str());
 
-			if (bEditSlider) {
-				usp->sliderName = activeSlider;
+				Vector3 origin;
+				int originSelection = XRCCTRL(dlg, "origin", wxChoice)->GetCurrentSelection();
+				if (originSelection == 1)
+				{
+					// Center of selected shape(s), respecting mask
+					origin = glView->gls.GetActiveCenter();
+					origin = mesh::VecToNifCoords(origin);
+				}
 
-				float sliderscale = project->SliderValue(activeSlider);
-				if (sliderscale == 0.0)
-					sliderscale = 1.0;
+				UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+				usp->undoType = UT_VERTPOS;
 
-				usp->sliderscale = sliderscale;
-			}
+				for (auto &sel : selectedItems)
+				{
+					mask.clear();
+					mptr = nullptr;
 
-			glView->ApplyUndoState(usp, false);
+					NiShape* shape = sel->GetShape();
+					project->GetLiveVerts(shape, verts);
+					glView->GetShapeMask(mask, shape->name.get());
 
-			previewScale = scale;
+					if (!mask.empty())
+						mptr = &mask;
 
-			if (glView->GetTransformMode())
-				glView->ShowTransformTool();
-		};
+					UndoStateShape uss;
+					uss.shapeName = shape->name.get();
 
-		auto sliderMoved = [&](wxCommandEvent& event) {
-			Vector3 scale(1.0f, 1.0f, 1.0f);
+					Matrix4 xform;
+					xform.PushTranslate(origin);
+					xform.PushScale(scale.x, scale.y, scale.z);
+					xform.PushTranslate(origin * -1.0f);
 
-			bool uniform = XRCCTRL(dlg, "ssUniform", wxCheckBox)->IsChecked();
-			if (uniform) {
-				float uniformValue = ((wxSlider*)event.GetEventObject())->GetValue() / 1000.0f;
-				scale = Vector3(uniformValue, uniformValue, uniformValue);
+					for (size_t i = 0; i < verts.size(); i++)
+					{
+						Vector3& vertPos = verts[i];
+						Vector3 diff = xform * vertPos - vertPos;
+
+						if (mptr)
+							diff *= 1.0f - mask[i];
+
+						if (diff.IsZero(true))
+							continue;
+
+						Vector3 newPos = vertPos + diff;
+						uss.pointStartState[i] = mesh::VecToMeshCoords(vertPos);
+						uss.pointEndState[i] = mesh::VecToMeshCoords(newPos);
+					}
+
+					usp->usss.push_back(std::move(uss));
+				}
+
+				if (bEditSlider)
+				{
+					usp->sliderName = activeSlider;
+
+					float sliderscale = project->SliderValue(activeSlider);
+					if (sliderscale == 0.0)
+						sliderscale = 1.0;
+
+					usp->sliderscale = sliderscale;
+				}
+
+				glView->ApplyUndoState(usp, false);
+
+				previewScale = scale;
+
+				if (glView->GetTransformMode())
+					glView->ShowTransformTool();
+			};
+
+			auto sliderMoved = [&](wxCommandEvent& event)
+			{
+				Vector3 scale(1.0f, 1.0f, 1.0f);
+
+				bool uniform = XRCCTRL(dlg, "ssUniform", wxCheckBox)->IsChecked();
+				if (uniform)
+				{
+					float uniformValue = ((wxSlider*)event.GetEventObject())->GetValue() / 1000.0f;
+					scale = Vector3(uniformValue, uniformValue, uniformValue);
+
+					XRCCTRL(dlg, "ssSliderX", wxSlider)->SetValue(scale.x * 1000);
+					XRCCTRL(dlg, "ssSliderY", wxSlider)->SetValue(scale.y * 1000);
+					XRCCTRL(dlg, "ssSliderZ", wxSlider)->SetValue(scale.z * 1000);
+				}
+				else
+				{
+					scale.x = XRCCTRL(dlg, "ssSliderX", wxSlider)->GetValue() / 1000.0f;
+					scale.y = XRCCTRL(dlg, "ssSliderY", wxSlider)->GetValue() / 1000.0f;
+					scale.z = XRCCTRL(dlg, "ssSliderZ", wxSlider)->GetValue() / 1000.0f;
+				}
+
+				XRCCTRL(dlg, "ssTextX", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.x));
+				XRCCTRL(dlg, "ssTextY", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.y));
+				XRCCTRL(dlg, "ssTextZ", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.z));
+
+				updateScalePreview();
+			};
+
+			auto textChanged = [&](wxCommandEvent& event)
+			{
+				Vector3 scale(1.0f, 1.0f, 1.0f);
+
+				bool uniform = XRCCTRL(dlg, "ssUniform", wxCheckBox)->IsChecked();
+				if (uniform)
+				{
+					float uniformValue = atof(((wxTextCtrl*)event.GetEventObject())->GetValue().c_str());
+					scale = Vector3(uniformValue, uniformValue, uniformValue);
+
+					XRCCTRL(dlg, "ssTextX", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.x));
+					XRCCTRL(dlg, "ssTextY", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.y));
+					XRCCTRL(dlg, "ssTextZ", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.z));
+				}
+				else
+				{
+					scale.x = atof(XRCCTRL(dlg, "ssTextX", wxTextCtrl)->GetValue().c_str());
+					scale.y = atof(XRCCTRL(dlg, "ssTextY", wxTextCtrl)->GetValue().c_str());
+					scale.z = atof(XRCCTRL(dlg, "ssTextZ", wxTextCtrl)->GetValue().c_str());
+				}
+
+				if (scale.x < 0.01f)
+				{
+					scale.x = 0.01f;
+					XRCCTRL(dlg, "ssTextX", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.x));
+				}
+
+				if (scale.y < 0.01f)
+				{
+					scale.y = 0.01f;
+					XRCCTRL(dlg, "ssTextY", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.y));
+				}
+
+				if (scale.z < 0.01f)
+				{
+					scale.z = 0.01f;
+					XRCCTRL(dlg, "ssTextZ", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.z));
+				}
 
 				XRCCTRL(dlg, "ssSliderX", wxSlider)->SetValue(scale.x * 1000);
 				XRCCTRL(dlg, "ssSliderY", wxSlider)->SetValue(scale.y * 1000);
 				XRCCTRL(dlg, "ssSliderZ", wxSlider)->SetValue(scale.z * 1000);
-			}
-			else {
-				scale.x = XRCCTRL(dlg, "ssSliderX", wxSlider)->GetValue() / 1000.0f;
-				scale.y = XRCCTRL(dlg, "ssSliderY", wxSlider)->GetValue() / 1000.0f;
-				scale.z = XRCCTRL(dlg, "ssSliderZ", wxSlider)->GetValue() / 1000.0f;
-			}
 
-			XRCCTRL(dlg, "ssTextX", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.x));
-			XRCCTRL(dlg, "ssTextY", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.y));
-			XRCCTRL(dlg, "ssTextZ", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.z));
+				updateScalePreview();
+			};
 
-			updateScalePreview();
-		};
+			auto originChanged = [&](wxCommandEvent&)
+			{
+				updateScalePreview();
+			};
 
-		auto textChanged = [&](wxCommandEvent& event) {
-			Vector3 scale(1.0f, 1.0f, 1.0f);
+			XRCCTRL(dlg, "ssSliderX", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
+			XRCCTRL(dlg, "ssSliderY", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
+			XRCCTRL(dlg, "ssSliderZ", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
+			XRCCTRL(dlg, "ssTextX", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
+			XRCCTRL(dlg, "ssTextY", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
+			XRCCTRL(dlg, "ssTextZ", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
+			XRCCTRL(dlg, "origin", wxChoice)->Bind(wxEVT_CHOICE, originChanged);
+			dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
 
-			bool uniform = XRCCTRL(dlg, "ssUniform", wxCheckBox)->IsChecked();
-			if (uniform) {
-				float uniformValue = atof(((wxTextCtrl*)event.GetEventObject())->GetValue().c_str());
-				scale = Vector3(uniformValue, uniformValue, uniformValue);
-
-				XRCCTRL(dlg, "ssTextX", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.x));
-				XRCCTRL(dlg, "ssTextY", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.y));
-				XRCCTRL(dlg, "ssTextZ", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.z));
-			}
-			else {
-				scale.x = atof(XRCCTRL(dlg, "ssTextX", wxTextCtrl)->GetValue().c_str());
-				scale.y = atof(XRCCTRL(dlg, "ssTextY", wxTextCtrl)->GetValue().c_str());
-				scale.z = atof(XRCCTRL(dlg, "ssTextZ", wxTextCtrl)->GetValue().c_str());
-			}
-
-			if (scale.x < 0.01f) {
-				scale.x = 0.01f;
-				XRCCTRL(dlg, "ssTextX", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.x));
-			}
-
-			if (scale.y < 0.01f) {
-				scale.y = 0.01f;
-				XRCCTRL(dlg, "ssTextY", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.y));
-			}
-
-			if (scale.z < 0.01f) {
-				scale.z = 0.01f;
-				XRCCTRL(dlg, "ssTextZ", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", scale.z));
-			}
-
-			XRCCTRL(dlg, "ssSliderX", wxSlider)->SetValue(scale.x * 1000);
-			XRCCTRL(dlg, "ssSliderY", wxSlider)->SetValue(scale.y * 1000);
-			XRCCTRL(dlg, "ssSliderZ", wxSlider)->SetValue(scale.z * 1000);
-
-			updateScalePreview();
-		};
-
-		auto originChanged = [&](wxCommandEvent&) {
-			updateScalePreview();
-		};
-
-		XRCCTRL(dlg, "ssSliderX", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
-		XRCCTRL(dlg, "ssSliderY", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
-		XRCCTRL(dlg, "ssSliderZ", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
-		XRCCTRL(dlg, "ssTextX", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
-		XRCCTRL(dlg, "ssTextY", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
-		XRCCTRL(dlg, "ssTextZ", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
-		XRCCTRL(dlg, "origin", wxChoice)->Bind(wxEVT_CHOICE, originChanged);
-		dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
-
-		if (dlg.ShowModal() != wxID_OK) {
-			if (previewScale != Vector3(1.0f, 1.0f, 1.0f)) {
-				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
-				if (curState) {
-					glView->ApplyUndoState(curState, true);
-					glView->GetUndoHistory()->PopState();
+			if (dlg.ShowModal() != wxID_OK)
+			{
+				if (previewScale != Vector3(1.0f, 1.0f, 1.0f))
+				{
+					UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
+					if (curState)
+					{
+						glView->ApplyUndoState(curState, true);
+						glView->GetUndoHistory()->PopState();
+					}
 				}
 			}
+
+			UpdateUndoTools();
+		}
+	}
+
+	void OutfitStudioFrame::OnRotateShape(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
 		}
 
-		UpdateUndoTools();
+		if (!CheckEditableState())
+			return;
+
+		wxDialog dlg;
+		if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgRotateShape"))
+		{
+			Vector3 previewRotation;
+
+			auto updateRotationPreview = [&]()
+			{
+				std::unordered_map<uint16_t, float> mask;
+				std::unordered_map<uint16_t, float>* mptr = nullptr;
+				std::vector<Vector3> verts;
+
+				if (!previewRotation.IsZero())
+				{
+					UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
+					if (curState)
+					{
+						glView->ApplyUndoState(curState, true, false);
+						glView->GetUndoHistory()->PopState();
+					}
+				}
+
+				Vector3 angle;
+				angle.x = atof(XRCCTRL(dlg, "rsTextX", wxTextCtrl)->GetValue().c_str());
+				angle.y = atof(XRCCTRL(dlg, "rsTextY", wxTextCtrl)->GetValue().c_str());
+				angle.z = atof(XRCCTRL(dlg, "rsTextZ", wxTextCtrl)->GetValue().c_str());
+
+				Vector3 origin;
+				int originSelection = XRCCTRL(dlg, "origin", wxChoice)->GetCurrentSelection();
+				if (originSelection == 1)
+				{
+					// Center of selected shape(s), respecting mask
+					origin = glView->gls.GetActiveCenter();
+					origin = mesh::VecToNifCoords(origin);
+				}
+
+				UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+				usp->undoType = UT_VERTPOS;
+
+				for (auto &sel : selectedItems)
+				{
+					mask.clear();
+					mptr = nullptr;
+
+					NiShape* shape = sel->GetShape();
+					project->GetLiveVerts(shape, verts);
+					glView->GetShapeMask(mask, shape->name.get());
+
+					if (!mask.empty())
+						mptr = &mask;
+
+					UndoStateShape uss;
+					uss.shapeName = shape->name.get();
+
+					Matrix4 xform;
+					xform.PushTranslate(origin);
+					xform.PushRotate(angle.x * DEG2RAD, Vector3(1.0f, 0.0f, 0.0f));
+					xform.PushRotate(angle.y * DEG2RAD, Vector3(0.0f, 1.0f, 0.0f));
+					xform.PushRotate(angle.z * DEG2RAD, Vector3(0.0f, 0.0f, 1.0f));
+					xform.PushTranslate(origin * -1.0f);
+
+					for (size_t i = 0; i < verts.size(); i++)
+					{
+						Vector3& vertPos = verts[i];
+						Vector3 diff = xform * vertPos - vertPos;
+
+						if (mptr)
+							diff *= 1.0f - mask[i];
+
+						if (diff.IsZero(true))
+							continue;
+
+						Vector3 newPos = vertPos + diff;
+						uss.pointStartState[i] = mesh::VecToMeshCoords(vertPos);
+						uss.pointEndState[i] = mesh::VecToMeshCoords(newPos);
+					}
+
+					usp->usss.push_back(std::move(uss));
+				}
+
+				if (bEditSlider)
+				{
+					usp->sliderName = activeSlider;
+
+					float sliderscale = project->SliderValue(activeSlider);
+					if (sliderscale == 0.0)
+						sliderscale = 1.0;
+
+					usp->sliderscale = sliderscale;
+				}
+
+				glView->ApplyUndoState(usp, false);
+
+				previewRotation = angle;
+
+				if (glView->GetTransformMode())
+					glView->ShowTransformTool();
+			};
+
+			auto sliderMoved = [&](wxCommandEvent&)
+			{
+				Vector3 angle;
+				angle.x = XRCCTRL(dlg, "rsSliderX", wxSlider)->GetValue() / 100.0f;
+				angle.y = XRCCTRL(dlg, "rsSliderY", wxSlider)->GetValue() / 100.0f;
+				angle.z = XRCCTRL(dlg, "rsSliderZ", wxSlider)->GetValue() / 100.0f;
+
+				XRCCTRL(dlg, "rsTextX", wxTextCtrl)->ChangeValue(wxString::Format("%0.4f", angle.x));
+				XRCCTRL(dlg, "rsTextY", wxTextCtrl)->ChangeValue(wxString::Format("%0.4f", angle.y));
+				XRCCTRL(dlg, "rsTextZ", wxTextCtrl)->ChangeValue(wxString::Format("%0.4f", angle.z));
+
+				updateRotationPreview();
+			};
+
+			auto textChanged = [&](wxCommandEvent&)
+			{
+				Vector3 angle;
+				angle.x = atof(XRCCTRL(dlg, "rsTextX", wxTextCtrl)->GetValue().c_str());
+				angle.y = atof(XRCCTRL(dlg, "rsTextY", wxTextCtrl)->GetValue().c_str());
+				angle.z = atof(XRCCTRL(dlg, "rsTextZ", wxTextCtrl)->GetValue().c_str());
+
+				XRCCTRL(dlg, "rsSliderX", wxSlider)->SetValue(angle.x * 100);
+				XRCCTRL(dlg, "rsSliderY", wxSlider)->SetValue(angle.y * 100);
+				XRCCTRL(dlg, "rsSliderZ", wxSlider)->SetValue(angle.z * 100);
+
+				updateRotationPreview();
+			};
+
+			auto originChanged = [&](wxCommandEvent&)
+			{
+				updateRotationPreview();
+			};
+
+			XRCCTRL(dlg, "rsSliderX", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
+			XRCCTRL(dlg, "rsSliderY", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
+			XRCCTRL(dlg, "rsSliderZ", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
+			XRCCTRL(dlg, "rsTextX", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
+			XRCCTRL(dlg, "rsTextY", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
+			XRCCTRL(dlg, "rsTextZ", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
+			XRCCTRL(dlg, "origin", wxChoice)->Bind(wxEVT_CHOICE, originChanged);
+			dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
+
+			if (dlg.ShowModal() != wxID_OK)
+			{
+				if (!previewRotation.IsZero())
+				{
+					UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
+					if (curState)
+					{
+						glView->ApplyUndoState(curState, true);
+						glView->GetUndoHistory()->PopState();
+					}
+				}
+			}
+
+			UpdateUndoTools();
+		}
 	}
-}
 
-void OutfitStudioFrame::OnRotateShape(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
+	void OutfitStudioFrame::OnDeleteVerts(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
 
-	if (!CheckEditableState())
-		return;
+		if (bEditSlider)
+		{
+			wxMessageBox(_("You're currently editing slider data, please exit the slider's edit mode (pencil button) and try again."));
+			return;
+		}
 
-	wxDialog dlg;
-	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgRotateShape")) {
-		Vector3 previewRotation;
+		// Prepare the undo data and determine if any shapes are being deleted.
+		UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+		usp->undoType = UT_MESH;
+		std::vector<NiShape *> delShapes;
+		for (auto &i : selectedItems)
+		{
+			if (editUV && editUV->shape == i->GetShape())
+				editUV->Close();
 
-		auto updateRotationPreview = [&]() {
 			std::unordered_map<uint16_t, float> mask;
-			std::unordered_map<uint16_t, float>* mptr = nullptr;
-			std::vector<Vector3> verts;
-
-			if (!previewRotation.IsZero()) {
-				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
-				if (curState) {
-					glView->ApplyUndoState(curState, true, false);
-					glView->GetUndoHistory()->PopState();
-				}
-			}
-
-			Vector3 angle;
-			angle.x = atof(XRCCTRL(dlg, "rsTextX", wxTextCtrl)->GetValue().c_str());
-			angle.y = atof(XRCCTRL(dlg, "rsTextY", wxTextCtrl)->GetValue().c_str());
-			angle.z = atof(XRCCTRL(dlg, "rsTextZ", wxTextCtrl)->GetValue().c_str());
-
-			Vector3 origin;
-			int originSelection = XRCCTRL(dlg, "origin", wxChoice)->GetCurrentSelection();
-			if (originSelection == 1) {
-				// Center of selected shape(s), respecting mask
-				origin = glView->gls.GetActiveCenter();
-				origin = mesh::VecToNifCoords(origin);
-			}
-
-			UndoStateProject *usp = glView->GetUndoHistory()->PushState();
-			usp->undoType = UT_VERTPOS;
-
-			for (auto &sel : selectedItems) {
-				mask.clear();
-				mptr = nullptr;
-
-				NiShape* shape = sel->GetShape();
-				project->GetLiveVerts(shape, verts);
-				glView->GetShapeMask(mask, shape->name.get());
-
-				if (!mask.empty())
-					mptr = &mask;
-
-				UndoStateShape uss;
-				uss.shapeName = shape->name.get();
-
-				Matrix4 xform;
-				xform.PushTranslate(origin);
-				xform.PushRotate(angle.x * DEG2RAD, Vector3(1.0f, 0.0f, 0.0f));
-				xform.PushRotate(angle.y * DEG2RAD, Vector3(0.0f, 1.0f, 0.0f));
-				xform.PushRotate(angle.z * DEG2RAD, Vector3(0.0f, 0.0f, 1.0f));
-				xform.PushTranslate(origin * -1.0f);
-
-				for (size_t i = 0; i < verts.size(); i++) {
-					Vector3& vertPos = verts[i];
-					Vector3 diff = xform * vertPos - vertPos;
-
-					if (mptr)
-						diff *= 1.0f - mask[i];
-
-					if (diff.IsZero(true))
-						continue;
-
-					Vector3 newPos = vertPos + diff;
-					uss.pointStartState[i] = mesh::VecToMeshCoords(vertPos);
-					uss.pointEndState[i] = mesh::VecToMeshCoords(newPos);
-				}
-
+			glView->GetShapeUnmasked(mask, i->GetShape()->name.get());
+			UndoStateShape uss;
+			uss.shapeName = i->GetShape()->name.get();
+			if (project->PrepareDeleteVerts(i->GetShape(), mask, uss))
+				delShapes.push_back(i->GetShape());
+			else
 				usp->usss.push_back(std::move(uss));
-			}
-
-			if (bEditSlider) {
-				usp->sliderName = activeSlider;
-
-				float sliderscale = project->SliderValue(activeSlider);
-				if (sliderscale == 0.0)
-					sliderscale = 1.0;
-
-				usp->sliderscale = sliderscale;
-			}
-
-			glView->ApplyUndoState(usp, false);
-
-			previewRotation = angle;
-
-			if (glView->GetTransformMode())
-				glView->ShowTransformTool();
-		};
-
-		auto sliderMoved = [&](wxCommandEvent&) {
-			Vector3 angle;
-			angle.x = XRCCTRL(dlg, "rsSliderX", wxSlider)->GetValue() / 100.0f;
-			angle.y = XRCCTRL(dlg, "rsSliderY", wxSlider)->GetValue() / 100.0f;
-			angle.z = XRCCTRL(dlg, "rsSliderZ", wxSlider)->GetValue() / 100.0f;
-
-			XRCCTRL(dlg, "rsTextX", wxTextCtrl)->ChangeValue(wxString::Format("%0.4f", angle.x));
-			XRCCTRL(dlg, "rsTextY", wxTextCtrl)->ChangeValue(wxString::Format("%0.4f", angle.y));
-			XRCCTRL(dlg, "rsTextZ", wxTextCtrl)->ChangeValue(wxString::Format("%0.4f", angle.z));
-
-			updateRotationPreview();
-		};
-
-		auto textChanged = [&](wxCommandEvent&) {
-			Vector3 angle;
-			angle.x = atof(XRCCTRL(dlg, "rsTextX", wxTextCtrl)->GetValue().c_str());
-			angle.y = atof(XRCCTRL(dlg, "rsTextY", wxTextCtrl)->GetValue().c_str());
-			angle.z = atof(XRCCTRL(dlg, "rsTextZ", wxTextCtrl)->GetValue().c_str());
-
-			XRCCTRL(dlg, "rsSliderX", wxSlider)->SetValue(angle.x * 100);
-			XRCCTRL(dlg, "rsSliderY", wxSlider)->SetValue(angle.y * 100);
-			XRCCTRL(dlg, "rsSliderZ", wxSlider)->SetValue(angle.z * 100);
-
-			updateRotationPreview();
-		};
-
-		auto originChanged = [&](wxCommandEvent&) {
-			updateRotationPreview();
-		};
-
-		XRCCTRL(dlg, "rsSliderX", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
-		XRCCTRL(dlg, "rsSliderY", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
-		XRCCTRL(dlg, "rsSliderZ", wxSlider)->Bind(wxEVT_SLIDER, sliderMoved);
-		XRCCTRL(dlg, "rsTextX", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
-		XRCCTRL(dlg, "rsTextY", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
-		XRCCTRL(dlg, "rsTextZ", wxTextCtrl)->Bind(wxEVT_TEXT, textChanged);
-		XRCCTRL(dlg, "origin", wxChoice)->Bind(wxEVT_CHOICE, originChanged);
-		dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
-
-		if (dlg.ShowModal() != wxID_OK) {
-			if (!previewRotation.IsZero()) {
-				UndoStateProject *curState = glView->GetUndoHistory()->GetBackState();
-				if (curState) {
-					glView->ApplyUndoState(curState, true);
-					glView->GetUndoHistory()->PopState();
-				}
-			}
 		}
 
-		UpdateUndoTools();
-	}
-}
+		// Confirm deleting shapes; then delete them.
+		if (!delShapes.empty())
+		{
+			if (wxMessageBox(_("Are you sure you wish to delete parts of the selected shapes?"), _("Confirm Delete"), wxYES_NO) == wxNO)
+				return;
+			for (NiShape *shape : delShapes)
+				project->DeleteShape(shape);
+		}
 
-void OutfitStudioFrame::OnDeleteVerts(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
+		// Now do the vertex deletion
+		for (auto &uss : usp->usss)
+		{
+			NiShape *shape = project->GetWorkNif()->FindBlockByName<NiShape>(uss.shapeName);
+			if (!shape)
+				continue;
+			project->ApplyShapeMeshUndo(shape, uss, false);
+		}
 
-	if (bEditSlider) {
-		wxMessageBox(_("You're currently editing slider data, please exit the slider's edit mode (pencil button) and try again."));
-		return;
-	}
+		project->GetWorkAnim()->CleanupBones();
 
-	// Prepare the undo data and determine if any shapes are being deleted.
-	UndoStateProject *usp = glView->GetUndoHistory()->PushState();
-	usp->undoType = UT_MESH;
-	std::vector<NiShape *> delShapes;
-	for (auto &i : selectedItems) {
-		if (editUV && editUV->shape == i->GetShape())
-			editUV->Close();
+		RefreshGUIFromProj(false);
+		SetPendingChanges();
 
-		std::unordered_map<uint16_t, float> mask;
-		glView->GetShapeUnmasked(mask, i->GetShape()->name.get());
-		UndoStateShape uss;
-		uss.shapeName = i->GetShape()->name.get();
-		if (project->PrepareDeleteVerts(i->GetShape(), mask, uss))
-			delShapes.push_back(i->GetShape());
-		else
-			usp->usss.push_back(std::move(uss));
+		glView->ClearActiveMask();
+		ApplySliders();
 	}
 
-	// Confirm deleting shapes; then delete them.
-	if (!delShapes.empty()) {
-		if (wxMessageBox(_("Are you sure you wish to delete parts of the selected shapes?"), _("Confirm Delete"), wxYES_NO) == wxNO)
-			return;
-		for (NiShape *shape : delShapes)
-			project->DeleteShape(shape);
-	}
-
-	// Now do the vertex deletion
-	for (auto &uss : usp->usss) {
-		NiShape *shape = project->GetWorkNif()->FindBlockByName<NiShape>(uss.shapeName);
-		if (!shape)
-			continue;
-		project->ApplyShapeMeshUndo(shape, uss, false);
-	}
-
-	project->GetWorkAnim()->CleanupBones();
-
-	RefreshGUIFromProj(false);
-	SetPendingChanges();
-
-	glView->ClearActiveMask();
-	ApplySliders();
-}
-
-void OutfitStudioFrame::OnSeparateVerts(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-
-	if (bEditSlider) {
-		wxMessageBox(_("You're currently editing slider data, please exit the slider's edit mode (pencil button) and try again."));
-		return;
-	}
-
-	std::unordered_map<uint16_t, float> masked;
-	glView->GetShapeMask(masked, activeItem->GetShape()->name.get());
-	if (masked.empty())
-		return;
-
-	std::string newShapeName;
-	do {
-		std::string result{wxGetTextFromUser(_("Please enter a unique name for the new separated shape."), _("Separate Vertices...")).ToUTF8()};
-		if (result.empty())
-			return;
-
-		newShapeName = std::move(result);
-	} while (project->IsValidShape(newShapeName));
-
-	if (editUV && editUV->shape == activeItem->GetShape())
-		editUV->Close();
-
-	auto newShape = project->DuplicateShape(activeItem->GetShape(), newShapeName);
-
-	UndoStateProject *usp = glView->GetUndoHistory()->PushState();
-	usp->undoType = UT_MESH;
-	usp->usss.resize(2);
-	usp->usss[0].shapeName = activeItem->GetShape()->name.get();
-	usp->usss[1].shapeName = newShapeName;
-
-	std::unordered_map<uint16_t, float> unmasked = masked;
-	glView->InvertMaskTris(unmasked, activeItem->GetShape()->name.get());
-
-	project->PrepareDeleteVerts(activeItem->GetShape(), masked, usp->usss[0]);
-	project->PrepareDeleteVerts(newShape, unmasked, usp->usss[1]);
-
-	project->ApplyShapeMeshUndo(activeItem->GetShape(), usp->usss[0], false);
-	project->ApplyShapeMeshUndo(newShape, usp->usss[1], false);
-
-	project->SetTextures();
-	RefreshGUIFromProj(false);
-	SetPendingChanges();
-
-	glView->ClearActiveMask();
-	ApplySliders();
-}
-
-void OutfitStudioFrame::CheckCopyGeo(wxDialog &dlg) {
-	wxStaticText *errors = XRCCTRL(dlg, "copyGeometryErrors", wxStaticText);
-	wxChoice *sourceChoice = XRCCTRL(dlg, "sourceChoice", wxChoice);
-	wxChoice *targetChoice = XRCCTRL(dlg, "targetChoice", wxChoice);
-
-	std::string source = sourceChoice->GetString(sourceChoice->GetSelection()).ToStdString();
-	std::string target = targetChoice->GetString(targetChoice->GetSelection()).ToStdString();
-
-	MergeCheckErrors e;
-	project->CheckMerge(source, target, e);
-	XRCCTRL(dlg, "wxID_OK", wxButton)->Enable(e.canMerge);
-
-	if (e.canMerge) {
-		errors->SetLabel(_("No errors found!"));
-		dlg.SetSize(dlg.GetBestSize());
-		return;
-	}
-
-	wxString msg;
-	msg << _("Errors:");
-	if (e.shapesSame)
-		msg << "\n- " << _("Target must be different from source.");
-	if (e.partitionsMismatch)
-		msg << "\n- " << _("Partitions do not match. Make sure the amount of partitions and their slots match up.");
-	if (e.segmentsMismatch)
-		msg << "\n- " << _("Segments do not match. Make sure the amount of segments, sub segments and their info as well as the segmentation file match.");
-	if (e.tooManyVertices)
-		msg << "\n- " << _("Resulting shape would have too many vertices.");
-	if (e.tooManyTriangles)
-		msg << "\n- " << _("Resulting shape would have too many triangles.");
-	if (e.shaderMismatch)
-		msg << "\n- " << _("Shaders do not match. Make sure both shapes either have or don't have a shader and their shader type matches.");
-	if (e.textureMismatch)
-		msg << "\n- " << _("Base texture doesn't match. Make sure both shapes have the same base/diffuse texture path.");
-	if (e.alphaPropMismatch)
-		msg << "\n- " << _("Alpha property mismatch. Make sure both shapes either have or don't have an alpha property and their flags + threshold match.");
-
-	errors->SetLabel(msg);
-	dlg.SetSize(dlg.GetBestSize());
-}
-
-void OutfitStudioFrame::OnCopyGeo(wxCommandEvent& WXUNUSED(event)) {
-	if (bEditSlider) {
-		wxMessageBox(_("You're currently editing slider data, please exit the slider's edit mode (pencil button) and try again."));
-		return;
-	}
-
-	wxDialog dlg;
-	if (!wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgCopyGeometry"))
-		return;
-
-	wxChoice *sourceChoice = XRCCTRL(dlg, "sourceChoice", wxChoice);
-	wxChoice *targetChoice = XRCCTRL(dlg, "targetChoice", wxChoice);
-	if (!sourceChoice || !targetChoice)
-		return;
-
-	std::string sourceShapeName;
-	if (activeItem)
-		sourceShapeName = activeItem->GetShape()->name.get();
-
-	std::vector<std::string> shapeList = GetShapeList();
-	if (shapeList.size() < 2)
-		return;
-
-	for (const std::string &shape : shapeList) {
-		sourceChoice->AppendString(shape);
-		targetChoice->AppendString(shape);
-		if (shape == sourceShapeName)
-			sourceChoice->SetSelection(sourceChoice->GetCount() - 1);
-	}
-
-	if (sourceChoice->GetSelection() == wxNOT_FOUND)
-		sourceChoice->SetSelection(0);
-	if (sourceChoice->GetSelection() == 0)
-		targetChoice->SetSelection(1);
-	else
-		targetChoice->SetSelection(0);
-
-	sourceChoice->Bind(wxEVT_CHOICE, [this,&dlg](wxCommandEvent&) {
-		CheckCopyGeo(dlg);
-	});
-	targetChoice->Bind(wxEVT_CHOICE, [this,&dlg](wxCommandEvent&) {
-		CheckCopyGeo(dlg);
-	});
-	CheckCopyGeo(dlg);
-
-	if (dlg.ShowModal() != wxID_OK)
-		return;
-
-	sourceShapeName = sourceChoice->GetString(sourceChoice->GetSelection()).ToStdString();
-	std::string targetShapeName = targetChoice->GetString(targetChoice->GetSelection()).ToStdString();
-
-	NiShape *sourceShape = project->GetWorkNif()->FindBlockByName<NiShape>(sourceShapeName);
-	if (!sourceShape)
-		return;
-	NiShape *targetShape = project->GetWorkNif()->FindBlockByName<NiShape>(targetShapeName);
-	if (!targetShape)
-		return;
-
-	UndoStateProject *usp = glView->GetUndoHistory()->PushState();
-	usp->undoType = UT_MESH;
-	usp->usss.resize(1);
-	usp->usss[0].shapeName = targetShapeName;
-
-	project->PrepareCopyGeo(sourceShape, targetShape, usp->usss[0]);
-
-	project->ApplyShapeMeshUndo(targetShape, usp->usss[0], false);
-
-	if (XRCCTRL(dlg, "checkDeleteSource", wxCheckBox)->IsChecked())
-		project->DeleteShape(sourceShape);
-
-	RefreshGUIFromProj(false);
-	SetPendingChanges();
-	ApplySliders();
-}
-
-void OutfitStudioFrame::OnDupeShape(wxCommandEvent& WXUNUSED(event)) {
-	std::string newName;
-	wxTreeItemId subitem;
-	if (activeItem) {
-		if (!outfitRoot.IsOk()) {
-			wxMessageBox(_("You can only copy shapes into an outfit, and there is no outfit in the current project. Load one first!"));
+	void OutfitStudioFrame::OnSeparateVerts(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
 			return;
 		}
 
-		do {
-			std::string result{wxGetTextFromUser(_("Please enter a unique name for the duplicated shape."), _("Duplicate Shape")).ToUTF8()};
+		if (bEditSlider)
+		{
+			wxMessageBox(_("You're currently editing slider data, please exit the slider's edit mode (pencil button) and try again."));
+			return;
+		}
+
+		std::unordered_map<uint16_t, float> masked;
+		glView->GetShapeMask(masked, activeItem->GetShape()->name.get());
+		if (masked.empty())
+			return;
+
+		std::string newShapeName;
+		do
+		{
+			std::string result{wxGetTextFromUser(_("Please enter a unique name for the new separated shape."), _("Separate Vertices...")).ToUTF8()};
 			if (result.empty())
 				return;
 
-			newName = std::move(result);
-		} while (project->IsValidShape(newName));
+			newShapeName = std::move(result);
+		} while (project->IsValidShape(newShapeName));
 
-		wxLogMessage("Duplicating shape '%s' as '%s'.", activeItem->GetShape()->name.get(), newName);
-		project->ClearBoneScale();
-
-		auto shape = project->DuplicateShape(activeItem->GetShape(), newName);
-		if (shape) {
-			glView->AddMeshFromNif(project->GetWorkNif(), newName);
-			UpdateMeshFromSet(shape);
-			project->SetTextures(shape);
-
-			MaterialFile matFile;
-			bool hasMatFile = project->GetShapeMaterialFile(shape, matFile);
-			glView->SetMeshTextures(newName, project->GetShapeTextures(shape), hasMatFile, matFile);
-
-			subitem = outfitShapes->AppendItem(outfitRoot, wxString::FromUTF8(newName));
-			outfitShapes->SetItemState(subitem, 0);
-			outfitShapes->SetItemData(subitem, new ShapeItemData(shape));
-
-			outfitShapes->UnselectAll();
-			outfitShapes->SelectItem(subitem);
-			SetPendingChanges();
-		}
-	}
-}
-
-void OutfitStudioFrame::OnDeleteShape(wxCommandEvent& WXUNUSED(event)) {
-	if (bEditSlider) {
-		wxCommandEvent evt;
-		OnDeleteSlider(evt);
-		return;
-	}
-
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-
-	if (wxMessageBox(_("Are you sure you wish to delete the selected shapes?  This action cannot be undone."), _("Confirm Delete"), wxYES_NO) == wxNO)
-		return;
-
-	std::vector<ShapeItemData> selected;
-	for (auto &i : selectedItems)
-		selected.push_back(*i);
-
-	activeItem = nullptr;
-	selectedItems.clear();
-
-	for (auto &i : selected) {
-		if (editUV && editUV->shape == i.GetShape())
+		if (editUV && editUV->shape == activeItem->GetShape())
 			editUV->Close();
 
-		std::string shapeName = i.GetShape()->name.get();
-		wxLogMessage("Deleting shape '%s'.", shapeName);
-		project->DeleteShape(i.GetShape());
-		glView->DeleteMesh(shapeName);
-		wxTreeItemId item = i.GetId();
-		outfitShapes->Delete(item);
+		auto newShape = project->DuplicateShape(activeItem->GetShape(), newShapeName);
+
+		UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+		usp->undoType = UT_MESH;
+		usp->usss.resize(2);
+		usp->usss[0].shapeName = activeItem->GetShape()->name.get();
+		usp->usss[1].shapeName = newShapeName;
+
+		std::unordered_map<uint16_t, float> unmasked = masked;
+		glView->InvertMaskTris(unmasked, activeItem->GetShape()->name.get());
+
+		project->PrepareDeleteVerts(activeItem->GetShape(), masked, usp->usss[0]);
+		project->PrepareDeleteVerts(newShape, unmasked, usp->usss[1]);
+
+		project->ApplyShapeMeshUndo(activeItem->GetShape(), usp->usss[0], false);
+		project->ApplyShapeMeshUndo(newShape, usp->usss[1], false);
+
+		project->SetTextures();
+		RefreshGUIFromProj(false);
+		SetPendingChanges();
+
+		glView->ClearActiveMask();
+		ApplySliders();
 	}
 
-	SetPendingChanges();
-	UpdateAnimationGUI();
-	glView->Render();
-}
+	void OutfitStudioFrame::CheckCopyGeo(wxDialog &dlg) {
+		wxStaticText *errors = XRCCTRL(dlg, "copyGeometryErrors", wxStaticText);
+		wxChoice *sourceChoice = XRCCTRL(dlg, "sourceChoice", wxChoice);
+		wxChoice *targetChoice = XRCCTRL(dlg, "targetChoice", wxChoice);
 
-void OutfitStudioFrame::OnAddBone(wxCommandEvent& WXUNUSED(event)) {
-	wxDialog dlg;
-	if (!wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgSkeletonBones"))
-		return;
+		std::string source = sourceChoice->GetString(sourceChoice->GetSelection()).ToStdString();
+		std::string target = targetChoice->GetString(targetChoice->GetSelection()).ToStdString();
 
-	dlg.SetSize(450, 470);
-	dlg.CenterOnParent();
+		MergeCheckErrors e;
+		project->CheckMerge(source, target, e);
+		XRCCTRL(dlg, "wxID_OK", wxButton)->Enable(e.canMerge);
 
-	wxTreeCtrl* boneTree = XRCCTRL(dlg, "boneTree", wxTreeCtrl);
+		if (e.canMerge)
+		{
+			errors->SetLabel(_("No errors found!"));
+			dlg.SetSize(dlg.GetBestSize());
+			return;
+		}
 
-	std::function<void(wxTreeItemId, AnimBone*)> fAddBoneChildren = [&](wxTreeItemId treeParent, AnimBone* boneParent) {
-		for (auto &cb : boneParent->children) {
-			if (!cb->boneName.empty()) {
-				auto newItem = boneTree->AppendItem(treeParent, cb->boneName);
-				fAddBoneChildren(newItem, cb);
-				if (cb->boneName == contextBone)
-					boneTree->SelectItem(newItem);
+		wxString msg;
+		msg << _("Errors:");
+		if (e.shapesSame)
+			msg << "\n- " << _("Target must be different from source.");
+		if (e.partitionsMismatch)
+			msg << "\n- " << _("Partitions do not match. Make sure the amount of partitions and their slots match up.");
+		if (e.segmentsMismatch)
+			msg << "\n- " << _("Segments do not match. Make sure the amount of segments, sub segments and their info as well as the segmentation file match.");
+		if (e.tooManyVertices)
+			msg << "\n- " << _("Resulting shape would have too many vertices.");
+		if (e.tooManyTriangles)
+			msg << "\n- " << _("Resulting shape would have too many triangles.");
+		if (e.shaderMismatch)
+			msg << "\n- " << _("Shaders do not match. Make sure both shapes either have or don't have a shader and their shader type matches.");
+		if (e.textureMismatch)
+			msg << "\n- " << _("Base texture doesn't match. Make sure both shapes have the same base/diffuse texture path.");
+		if (e.alphaPropMismatch)
+			msg << "\n- " << _("Alpha property mismatch. Make sure both shapes either have or don't have an alpha property and their flags + threshold match.");
+
+		errors->SetLabel(msg);
+		dlg.SetSize(dlg.GetBestSize());
+	}
+
+	void OutfitStudioFrame::OnCopyGeo(wxCommandEvent& WXUNUSED(event)) {
+		if (bEditSlider)
+		{
+			wxMessageBox(_("You're currently editing slider data, please exit the slider's edit mode (pencil button) and try again."));
+			return;
+		}
+
+		wxDialog dlg;
+		if (!wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgCopyGeometry"))
+			return;
+
+		wxChoice *sourceChoice = XRCCTRL(dlg, "sourceChoice", wxChoice);
+		wxChoice *targetChoice = XRCCTRL(dlg, "targetChoice", wxChoice);
+		if (!sourceChoice || !targetChoice)
+			return;
+
+		std::string sourceShapeName;
+		if (activeItem)
+			sourceShapeName = activeItem->GetShape()->name.get();
+
+		std::vector<std::string> shapeList = GetShapeList();
+		if (shapeList.size() < 2)
+			return;
+
+		for (const std::string &shape : shapeList)
+		{
+			sourceChoice->AppendString(shape);
+			targetChoice->AppendString(shape);
+			if (shape == sourceShapeName)
+				sourceChoice->SetSelection(sourceChoice->GetCount() - 1);
+		}
+
+		if (sourceChoice->GetSelection() == wxNOT_FOUND)
+			sourceChoice->SetSelection(0);
+		if (sourceChoice->GetSelection() == 0)
+			targetChoice->SetSelection(1);
+		else
+			targetChoice->SetSelection(0);
+
+		sourceChoice->Bind(wxEVT_CHOICE, [this,&dlg](wxCommandEvent&)
+		{
+			CheckCopyGeo(dlg);
+		});
+		targetChoice->Bind(wxEVT_CHOICE, [this,&dlg](wxCommandEvent&)
+		{
+			CheckCopyGeo(dlg);
+		});
+		CheckCopyGeo(dlg);
+
+		if (dlg.ShowModal() != wxID_OK)
+			return;
+
+		sourceShapeName = sourceChoice->GetString(sourceChoice->GetSelection()).ToStdString();
+		std::string targetShapeName = targetChoice->GetString(targetChoice->GetSelection()).ToStdString();
+
+		NiShape *sourceShape = project->GetWorkNif()->FindBlockByName<NiShape>(sourceShapeName);
+		if (!sourceShape)
+			return;
+		NiShape *targetShape = project->GetWorkNif()->FindBlockByName<NiShape>(targetShapeName);
+		if (!targetShape)
+			return;
+
+		UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+		usp->undoType = UT_MESH;
+		usp->usss.resize(1);
+		usp->usss[0].shapeName = targetShapeName;
+
+		project->PrepareCopyGeo(sourceShape, targetShape, usp->usss[0]);
+
+		project->ApplyShapeMeshUndo(targetShape, usp->usss[0], false);
+
+		if (XRCCTRL(dlg, "checkDeleteSource", wxCheckBox)->IsChecked())
+			project->DeleteShape(sourceShape);
+
+		RefreshGUIFromProj(false);
+		SetPendingChanges();
+		ApplySliders();
+	}
+
+	void OutfitStudioFrame::OnDupeShape(wxCommandEvent& WXUNUSED(event)) {
+		std::string newName;
+		wxTreeItemId subitem;
+		if (activeItem)
+		{
+			if (!outfitRoot.IsOk())
+			{
+				wxMessageBox(_("You can only copy shapes into an outfit, and there is no outfit in the current project. Load one first!"));
+				return;
+			}
+
+			do
+			{
+				std::string result{wxGetTextFromUser(_("Please enter a unique name for the duplicated shape."), _("Duplicate Shape")).ToUTF8()};
+				if (result.empty())
+					return;
+
+				newName = std::move(result);
+			} while (project->IsValidShape(newName));
+
+			wxLogMessage("Duplicating shape '%s' as '%s'.", activeItem->GetShape()->name.get(), newName);
+			project->ClearBoneScale();
+
+			auto shape = project->DuplicateShape(activeItem->GetShape(), newName);
+			if (shape)
+			{
+				glView->AddMeshFromNif(project->GetWorkNif(), newName);
+				UpdateMeshFromSet(shape);
+				project->SetTextures(shape);
+
+				MaterialFile matFile;
+				bool hasMatFile = project->GetShapeMaterialFile(shape, matFile);
+				glView->SetMeshTextures(newName, project->GetShapeTextures(shape), hasMatFile, matFile);
+
+				subitem = outfitShapes->AppendItem(outfitRoot, wxString::FromUTF8(newName));
+				outfitShapes->SetItemState(subitem, 0);
+				outfitShapes->SetItemData(subitem, new ShapeItemData(shape));
+
+				outfitShapes->UnselectAll();
+				outfitShapes->SelectItem(subitem);
+				SetPendingChanges();
+			}
+		}
+	}
+
+	void OutfitStudioFrame::OnDeleteShape(wxCommandEvent& WXUNUSED(event)) {
+		if (bEditSlider)
+		{
+			wxCommandEvent evt;
+			OnDeleteSlider(evt);
+			return;
+		}
+
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+
+		if (wxMessageBox(_("Are you sure you wish to delete the selected shapes?  This action cannot be undone."), _("Confirm Delete"), wxYES_NO) == wxNO)
+			return;
+
+		std::vector<ShapeItemData> selected;
+		for (auto &i : selectedItems)
+			selected.push_back(*i);
+
+		activeItem = nullptr;
+		selectedItems.clear();
+
+		for (auto &i : selected)
+		{
+			if (editUV && editUV->shape == i.GetShape())
+				editUV->Close();
+
+			std::string shapeName = i.GetShape()->name.get();
+			wxLogMessage("Deleting shape '%s'.", shapeName);
+			project->DeleteShape(i.GetShape());
+			glView->DeleteMesh(shapeName);
+			wxTreeItemId item = i.GetId();
+			outfitShapes->Delete(item);
+		}
+
+		SetPendingChanges();
+		UpdateAnimationGUI();
+		glView->Render();
+	}
+
+	void OutfitStudioFrame::OnAddBone(wxCommandEvent& WXUNUSED(event)) {
+		wxDialog dlg;
+		if (!wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgSkeletonBones"))
+			return;
+
+		dlg.SetSize(450, 470);
+		dlg.CenterOnParent();
+
+		wxTreeCtrl* boneTree = XRCCTRL(dlg, "boneTree", wxTreeCtrl);
+
+		std::function<void(wxTreeItemId, AnimBone*)> fAddBoneChildren = [&](wxTreeItemId treeParent, AnimBone* boneParent)
+		{
+			for (auto &cb : boneParent->children)
+			{
+				if (!cb->boneName.empty())
+				{
+					auto newItem = boneTree->AppendItem(treeParent, cb->boneName);
+					fAddBoneChildren(newItem, cb);
+					if (cb->boneName == contextBone)
+						boneTree->SelectItem(newItem);
+				}
+				else
+					fAddBoneChildren(treeParent, cb);
+			}
+		};
+
+		AnimBone* rb = AnimSkeleton::getInstance().GetRootBonePtr();
+		wxTreeItemId rt = boneTree->AddRoot(rb->boneName);
+		fAddBoneChildren(rt, rb);
+
+		if (dlg.ShowModal() == wxID_OK)
+		{
+			wxArrayTreeItemIds sel;
+			boneTree->GetSelections(sel);
+			for (size_t i = 0; i < sel.size(); i++)
+			{
+				std::string bone = boneTree->GetItemText(sel[i]);
+				wxLogMessage("Adding bone '%s' to project.", bone);
+
+				project->AddBoneRef(bone);
+				wxTreeItemId item = outfitBones->AppendItem(bonesRoot, bone);
+				outfitBones->SetItemState(item, 0);
+				cXMirrorBone->AppendString(bone);
+				cPoseBone->AppendString(bone);
+			}
+
+			glView->UpdateBones();
+			UpdateBoneCounts();
+			SetPendingChanges();
+			glView->Render();
+		}
+	}
+
+	void OutfitStudioFrame::FillParentBoneChoice(wxDialog &dlg, const std::string &selBone) {
+		wxChoice *cParentBone = XRCCTRL(dlg, "cParentBone", wxChoice);
+		cParentBone->AppendString("(none)");
+
+		std::set<std::string> boneSet;
+		for (auto selItem : selectedItems)
+		{
+			const std::vector<std::string> &bones = project->GetWorkAnim()->shapeBones[selItem->GetShape()->name.get()];
+			for (const std::string &b : bones)
+				boneSet.insert(b);
+		}
+
+		for (auto &bone : boneSet)
+		{
+			cParentBone->AppendString(bone);
+			if (bone == selBone)
+				cParentBone->SetSelection(cParentBone->GetCount() - 1);
+		}
+
+		if (cParentBone->GetSelection() == wxNOT_FOUND)
+		{
+			if (selBone.empty())
+			{
+				cParentBone->SetSelection(0);
 			}
 			else
-				fAddBoneChildren(treeParent, cb);
+			{
+				cParentBone->AppendString(selBone);
+				cParentBone->SetSelection(cParentBone->GetCount() - 1);
+			}
 		}
-	};
+	}
 
-	AnimBone* rb = AnimSkeleton::getInstance().GetRootBonePtr();
-	wxTreeItemId rt = boneTree->AddRoot(rb->boneName);
-	fAddBoneChildren(rt, rb);
+	void OutfitStudioFrame::GetBoneDlgData(wxDialog &dlg, MatTransform &xform, std::string &parentBone) {
+		xform.translation.x = atof(XRCCTRL(dlg, "textX", wxTextCtrl)->GetValue().c_str());
+		xform.translation.y = atof(XRCCTRL(dlg, "textY", wxTextCtrl)->GetValue().c_str());
+		xform.translation.z = atof(XRCCTRL(dlg, "textZ", wxTextCtrl)->GetValue().c_str());
 
-	if (dlg.ShowModal() == wxID_OK) {
-		wxArrayTreeItemIds sel;
-		boneTree->GetSelections(sel);
-		for (size_t i = 0; i < sel.size(); i++) {
-			std::string bone = boneTree->GetItemText(sel[i]);
-			wxLogMessage("Adding bone '%s' to project.", bone);
+		Vector3 rotvec;
+		rotvec.x = atof(XRCCTRL(dlg, "textRX", wxTextCtrl)->GetValue().c_str());
+		rotvec.y = atof(XRCCTRL(dlg, "textRY", wxTextCtrl)->GetValue().c_str());
+		rotvec.z = atof(XRCCTRL(dlg, "textRZ", wxTextCtrl)->GetValue().c_str());
+		xform.rotation = RotVecToMat(rotvec);
 
-			project->AddBoneRef(bone);
-			wxTreeItemId item = outfitBones->AppendItem(bonesRoot, bone);
-			outfitBones->SetItemState(item, 0);
-			cXMirrorBone->AppendString(bone);
-			cPoseBone->AppendString(bone);
+		wxChoice *cParentBone = XRCCTRL(dlg, "cParentBone", wxChoice);
+		int pBChoice = cParentBone->GetSelection();
+		if (pBChoice != wxNOT_FOUND)
+			parentBone = cParentBone->GetString(pBChoice).ToStdString();
+
+		if (parentBone == "(none)")
+			parentBone = std::string();
+	}
+
+	void OutfitStudioFrame::OnAddCustomBone(wxCommandEvent& WXUNUSED(event)) {
+		wxDialog dlg;
+		if (!wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgCustomBone"))
+			return;
+
+		dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
+		FillParentBoneChoice(dlg, contextBone);
+
+		if (dlg.ShowModal() != wxID_OK)
+			return;
+
+		wxString bone = XRCCTRL(dlg, "boneName", wxTextCtrl)->GetValue();
+		if (bone.empty())
+		{
+			wxMessageBox(_("No bone name was entered!"), _("Error"), wxICON_INFORMATION, this);
+			return;
 		}
+
+		wxTreeItemIdValue cookie;
+		wxTreeItemId item = outfitBones->GetFirstChild(bonesRoot, cookie);
+		while (item.IsOk())
+		{
+			if (outfitBones->GetItemText(item) == bone)
+			{
+				wxMessageBox(wxString::Format(_("Bone '%s' already exists in the project!"), bone), _("Error"), wxICON_INFORMATION, this);
+				return;
+			}
+			item = outfitBones->GetNextChild(bonesRoot, cookie);
+		}
+
+		MatTransform xform;
+		std::string parentBone;
+		GetBoneDlgData(dlg, xform, parentBone);
+
+		wxLogMessage("Adding custom bone '%s' to project.", bone);
+		project->AddCustomBoneRef(bone.ToStdString(), parentBone, xform);
+		wxTreeItemId newItem = outfitBones->AppendItem(bonesRoot, bone);
+		outfitBones->SetItemState(newItem, 0);
+		cXMirrorBone->AppendString(bone);
+		cPoseBone->AppendString(bone);
 
 		glView->UpdateBones();
 		UpdateBoneCounts();
 		SetPendingChanges();
 		glView->Render();
 	}
-}
 
-void OutfitStudioFrame::FillParentBoneChoice(wxDialog &dlg, const std::string &selBone) {
-	wxChoice *cParentBone = XRCCTRL(dlg, "cParentBone", wxChoice);
-	cParentBone->AppendString("(none)");
-
-	std::set<std::string> boneSet;
-	for (auto selItem : selectedItems) {
-		const std::vector<std::string> &bones = project->GetWorkAnim()->shapeBones[selItem->GetShape()->name.get()];
-		for (const std::string &b : bones)
-			boneSet.insert(b);
-	}
-
-	for (auto &bone : boneSet) {
-		cParentBone->AppendString(bone);
-		if (bone == selBone)
-			cParentBone->SetSelection(cParentBone->GetCount() - 1);
-	}
-
-	if (cParentBone->GetSelection() == wxNOT_FOUND) {
-		if (selBone.empty()) {
-			cParentBone->SetSelection(0);
-		}
-		else {
-			cParentBone->AppendString(selBone);
-			cParentBone->SetSelection(cParentBone->GetCount() - 1);
-		}
-	}
-}
-
-void OutfitStudioFrame::GetBoneDlgData(wxDialog &dlg, MatTransform &xform, std::string &parentBone) {
-	xform.translation.x = atof(XRCCTRL(dlg, "textX", wxTextCtrl)->GetValue().c_str());
-	xform.translation.y = atof(XRCCTRL(dlg, "textY", wxTextCtrl)->GetValue().c_str());
-	xform.translation.z = atof(XRCCTRL(dlg, "textZ", wxTextCtrl)->GetValue().c_str());
-
-	Vector3 rotvec;
-	rotvec.x = atof(XRCCTRL(dlg, "textRX", wxTextCtrl)->GetValue().c_str());
-	rotvec.y = atof(XRCCTRL(dlg, "textRY", wxTextCtrl)->GetValue().c_str());
-	rotvec.z = atof(XRCCTRL(dlg, "textRZ", wxTextCtrl)->GetValue().c_str());
-	xform.rotation = RotVecToMat(rotvec);
-
-	wxChoice *cParentBone = XRCCTRL(dlg, "cParentBone", wxChoice);
-	int pBChoice = cParentBone->GetSelection();
-	if (pBChoice != wxNOT_FOUND)
-		parentBone = cParentBone->GetString(pBChoice).ToStdString();
-
-	if (parentBone == "(none)")
-		parentBone = std::string();
-}
-
-void OutfitStudioFrame::OnAddCustomBone(wxCommandEvent& WXUNUSED(event)) {
-	wxDialog dlg;
-	if (!wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgCustomBone"))
-		return;
-
-	dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
-	FillParentBoneChoice(dlg, contextBone);
-
-	if (dlg.ShowModal() != wxID_OK)
-		return;
-
-	wxString bone = XRCCTRL(dlg, "boneName", wxTextCtrl)->GetValue();
-	if (bone.empty()) {
-		wxMessageBox(_("No bone name was entered!"), _("Error"), wxICON_INFORMATION, this);
-		return;
-	}
-
-	wxTreeItemIdValue cookie;
-	wxTreeItemId item = outfitBones->GetFirstChild(bonesRoot, cookie);
-	while (item.IsOk()) {
-		if (outfitBones->GetItemText(item) == bone) {
-			wxMessageBox(wxString::Format(_("Bone '%s' already exists in the project!"), bone), _("Error"), wxICON_INFORMATION, this);
+	void OutfitStudioFrame::OnEditBone(wxCommandEvent& WXUNUSED(event)) {
+		AnimBone *bPtr = AnimSkeleton::getInstance().GetBonePtr(contextBone);
+		if (!bPtr)
 			return;
-		}
-		item = outfitBones->GetNextChild(bonesRoot, cookie);
-	}
 
-	MatTransform xform;
-	std::string parentBone;
-	GetBoneDlgData(dlg, xform, parentBone);
-
-	wxLogMessage("Adding custom bone '%s' to project.", bone);
-	project->AddCustomBoneRef(bone.ToStdString(), parentBone, xform);
-	wxTreeItemId newItem = outfitBones->AppendItem(bonesRoot, bone);
-	outfitBones->SetItemState(newItem, 0);
-	cXMirrorBone->AppendString(bone);
-	cPoseBone->AppendString(bone);
-
-	glView->UpdateBones();
-	UpdateBoneCounts();
-	SetPendingChanges();
-	glView->Render();
-}
-
-void OutfitStudioFrame::OnEditBone(wxCommandEvent& WXUNUSED(event)) {
-	AnimBone *bPtr = AnimSkeleton::getInstance().GetBonePtr(contextBone);
-	if (!bPtr)
-		return;
-
-	wxDialog dlg;
-	if (!wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgCustomBone"))
-		return;
-
-	dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
-
-	if (bPtr->parent)
-		FillParentBoneChoice(dlg, bPtr->parent->boneName);
-	else
-		FillParentBoneChoice(dlg);
-
-	wxTextCtrl *boneNameTC = XRCCTRL(dlg, "boneName", wxTextCtrl);
-	boneNameTC->SetValue(bPtr->boneName);
-	boneNameTC->Disable();
-
-	Vector3 rotvec = RotMatToVec(bPtr->xformToParent.rotation);
-	XRCCTRL(dlg, "textX", wxTextCtrl)->SetValue(wxString() << bPtr->xformToParent.translation.x);
-	XRCCTRL(dlg, "textY", wxTextCtrl)->SetValue(wxString() << bPtr->xformToParent.translation.y);
-	XRCCTRL(dlg, "textZ", wxTextCtrl)->SetValue(wxString() << bPtr->xformToParent.translation.z);
-	XRCCTRL(dlg, "textRX", wxTextCtrl)->SetValue(wxString() << rotvec.x);
-	XRCCTRL(dlg, "textRY", wxTextCtrl)->SetValue(wxString() << rotvec.y);
-	XRCCTRL(dlg, "textRZ", wxTextCtrl)->SetValue(wxString() << rotvec.z);
-
-	if (bPtr->isStandardBone) {
-		dlg.SetLabel("View Standard Bone");
-		XRCCTRL(dlg, "textX", wxTextCtrl)->Disable();
-		XRCCTRL(dlg, "textY", wxTextCtrl)->Disable();
-		XRCCTRL(dlg, "textZ", wxTextCtrl)->Disable();
-		XRCCTRL(dlg, "textRX", wxTextCtrl)->Disable();
-		XRCCTRL(dlg, "textRY", wxTextCtrl)->Disable();
-		XRCCTRL(dlg, "textRZ", wxTextCtrl)->Disable();
-		XRCCTRL(dlg, "cParentBone", wxChoice)->Disable();
-		XRCCTRL(dlg, "wxID_OK", wxButton)->Disable();
-	}
-	else {
-		dlg.SetLabel("Edit Custom Bone");
-	}
-
-	if (dlg.ShowModal() != wxID_OK)
-		return;
-
-	MatTransform xform;
-	std::string parentBone;
-	GetBoneDlgData(dlg, xform, parentBone);
-
-	project->ModifyCustomBone(bPtr, parentBone, xform);
-	glView->UpdateBones();
-	ApplyPose();
-	SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnDeleteBone(wxCommandEvent& WXUNUSED(event)) {
-	wxArrayTreeItemIds selItems;
-	outfitBones->GetSelections(selItems);
-	for (size_t i = 0; i < selItems.size(); i++) {
-		std::string bone = outfitBones->GetItemText(selItems[i]);
-		wxLogMessage("Deleting bone '%s' from project.", bone);
-
-		project->DeleteBone(bone);
-		activeBone.clear();
-
-		outfitBones->Delete(selItems[i]);
-		lastSelectedBones.erase(bone);
-		lastNormalizeBones.erase(bone);
-	}
-
-	glView->UpdateBones();
-	ReselectBone();
-	CalcAutoXMirrorBone();
-	glView->GetUndoHistory()->ClearHistory();
-	UpdateBoneCounts();
-	SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnDeleteBoneFromSelected(wxCommandEvent& WXUNUSED(event)) {
-	wxArrayTreeItemIds selItems;
-	outfitBones->GetSelections(selItems);
-	for (size_t i = 0; i < selItems.size(); i++) {
-		std::string bone = outfitBones->GetItemText(selItems[i]);
-		wxLogMessage("Deleting weights of bone '%s' from selected shapes.", bone);
-
-		for (auto &s : selectedItems)
-			project->GetWorkAnim()->RemoveShapeBone(s->GetShape()->name.get(), bone);
-	}
-
-	glView->UpdateBones();
-	ReselectBone();
-	glView->GetUndoHistory()->ClearHistory();
-	HighlightBoneNamesWithWeights();
-	UpdateBoneCounts();
-	SetPendingChanges();
-}
-
-bool OutfitStudioFrame::HasUnweightedCheck() {
-	std::vector<std::string> unweighted;
-	if (project->HasUnweighted(&unweighted)) {
-		std::string shapesJoin = JoinStrings(unweighted, "; ");
-		wxLogWarning(wxString::Format("Unweighted vertices found on shapes: %s", shapesJoin));
-
-		int error = wxMessageBox(wxString::Format("%s\n \n%s", _("The following shapes have unweighted vertices, which can cause issues. The affected vertices have been put under a mask. Do you want to save anyway?"), shapesJoin), _("Unweighted Vertices"), wxYES_NO | wxICON_WARNING, this);
-		if (error != wxYES)
-			return true;
-	}
-
-	return false;
-}
-
-bool OutfitStudioFrame::ShowWeightCopy(WeightCopyOptions& options) {
-	wxDialog dlg;
-	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgCopyWeights")) {
-		XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->Bind(wxEVT_SLIDER, [&dlg](wxCommandEvent&) {
-			float changed = XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->GetValue() / 1000.0f;
-			XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", changed));
-		});
-
-		XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->Bind(wxEVT_TEXT, [&dlg](wxCommandEvent&) {
-			float changed = atof(XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->GetValue().c_str());
-			XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->SetValue(changed * 1000);
-		});
-
-		XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Bind(wxEVT_SLIDER, [&dlg](wxCommandEvent&) {
-			int changed = XRCCTRL(dlg, "maxResultsSlider", wxSlider)->GetValue();
-			XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->ChangeValue(wxString::Format("%d", changed));
-		});
-
-		XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->Bind(wxEVT_TEXT, [&dlg](wxCommandEvent&) {
-			int changed = atol(XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->GetValue().c_str());
-			XRCCTRL(dlg, "maxResultsSlider", wxSlider)->SetValue(changed);
-		});
-
-		XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->Bind(wxEVT_CHECKBOX, [&dlg](wxCommandEvent&) {
-			bool noTargetLimit = XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->IsChecked();
-			XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->Enable(!noTargetLimit);
-			XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Enable(!noTargetLimit);
-		});
-
-		wxCheckBox *cbCopySkinTrans = XRCCTRL(dlg, "cbCopySkinTrans", wxCheckBox);
-		wxCheckBox *cbTransformGeo = XRCCTRL(dlg, "cbTransformGeo", wxCheckBox);
-		if (options.showSkinTransOption) {
-			cbCopySkinTrans->SetValue(options.doSkinTransCopy);
-			cbTransformGeo->SetValue(options.doTransformGeo);
-			cbCopySkinTrans->Show();
-			cbTransformGeo->Show();
-			XRCCTRL(dlg, "copyTransDescription", wxStaticText)->Show();
-		}
+		wxDialog dlg;
+		if (!wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgCustomBone"))
+			return;
 
 		dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
 
-		dlg.SetSize(dlg.GetBestSize());
-		
-		if (dlg.ShowModal() == wxID_OK) {
-			options.proximityRadius = atof(XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->GetValue().c_str());
+		if (bPtr->parent)
+			FillParentBoneChoice(dlg, bPtr->parent->boneName);
+		else
+			FillParentBoneChoice(dlg);
 
-			bool noTargetLimit = XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->IsChecked();
-			if (!noTargetLimit)
-				options.maxResults = atol(XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->GetValue().c_str());
-			else
-				options.maxResults = std::numeric_limits<int>::max();
+		wxTextCtrl *boneNameTC = XRCCTRL(dlg, "boneName", wxTextCtrl);
+		boneNameTC->SetValue(bPtr->boneName);
+		boneNameTC->Disable();
 
-			if (options.showSkinTransOption) {
-				options.doSkinTransCopy = cbCopySkinTrans->IsChecked();
-				options.doTransformGeo = cbTransformGeo->IsChecked();
+		Vector3 rotvec = RotMatToVec(bPtr->xformToParent.rotation);
+		XRCCTRL(dlg, "textX", wxTextCtrl)->SetValue(wxString() << bPtr->xformToParent.translation.x);
+		XRCCTRL(dlg, "textY", wxTextCtrl)->SetValue(wxString() << bPtr->xformToParent.translation.y);
+		XRCCTRL(dlg, "textZ", wxTextCtrl)->SetValue(wxString() << bPtr->xformToParent.translation.z);
+		XRCCTRL(dlg, "textRX", wxTextCtrl)->SetValue(wxString() << rotvec.x);
+		XRCCTRL(dlg, "textRY", wxTextCtrl)->SetValue(wxString() << rotvec.y);
+		XRCCTRL(dlg, "textRZ", wxTextCtrl)->SetValue(wxString() << rotvec.z);
+
+		if (bPtr->isStandardBone)
+		{
+			dlg.SetLabel("View Standard Bone");
+			XRCCTRL(dlg, "textX", wxTextCtrl)->Disable();
+			XRCCTRL(dlg, "textY", wxTextCtrl)->Disable();
+			XRCCTRL(dlg, "textZ", wxTextCtrl)->Disable();
+			XRCCTRL(dlg, "textRX", wxTextCtrl)->Disable();
+			XRCCTRL(dlg, "textRY", wxTextCtrl)->Disable();
+			XRCCTRL(dlg, "textRZ", wxTextCtrl)->Disable();
+			XRCCTRL(dlg, "cParentBone", wxChoice)->Disable();
+			XRCCTRL(dlg, "wxID_OK", wxButton)->Disable();
+		}
+		else
+		{
+			dlg.SetLabel("Edit Custom Bone");
+		}
+
+		if (dlg.ShowModal() != wxID_OK)
+			return;
+
+		MatTransform xform;
+		std::string parentBone;
+		GetBoneDlgData(dlg, xform, parentBone);
+
+		project->ModifyCustomBone(bPtr, parentBone, xform);
+		glView->UpdateBones();
+		ApplyPose();
+		SetPendingChanges();
+	}
+
+	void OutfitStudioFrame::OnDeleteBone(wxCommandEvent& WXUNUSED(event)) {
+		wxArrayTreeItemIds selItems;
+		outfitBones->GetSelections(selItems);
+		for (size_t i = 0; i < selItems.size(); i++)
+		{
+			std::string bone = outfitBones->GetItemText(selItems[i]);
+			wxLogMessage("Deleting bone '%s' from project.", bone);
+
+			project->DeleteBone(bone);
+			activeBone.clear();
+
+			outfitBones->Delete(selItems[i]);
+			lastSelectedBones.erase(bone);
+			lastNormalizeBones.erase(bone);
+		}
+
+		glView->UpdateBones();
+		ReselectBone();
+		CalcAutoXMirrorBone();
+		glView->GetUndoHistory()->ClearHistory();
+		UpdateBoneCounts();
+		SetPendingChanges();
+	}
+
+	void OutfitStudioFrame::OnDeleteBoneFromSelected(wxCommandEvent& WXUNUSED(event)) {
+		wxArrayTreeItemIds selItems;
+		outfitBones->GetSelections(selItems);
+		for (size_t i = 0; i < selItems.size(); i++)
+		{
+			std::string bone = outfitBones->GetItemText(selItems[i]);
+			wxLogMessage("Deleting weights of bone '%s' from selected shapes.", bone);
+
+			for (auto &s : selectedItems)
+				project->GetWorkAnim()->RemoveShapeBone(s->GetShape()->name.get(), bone);
+		}
+
+		glView->UpdateBones();
+		ReselectBone();
+		glView->GetUndoHistory()->ClearHistory();
+		HighlightBoneNamesWithWeights();
+		UpdateBoneCounts();
+		SetPendingChanges();
+	}
+
+	bool OutfitStudioFrame::HasUnweightedCheck() {
+		std::vector<std::string> unweighted;
+		if (project->HasUnweighted(&unweighted))
+		{
+			std::string shapesJoin = JoinStrings(unweighted, "; ");
+			wxLogWarning(wxString::Format("Unweighted vertices found on shapes: %s", shapesJoin));
+
+			int error = wxMessageBox(wxString::Format("%s\n \n%s", _("The following shapes have unweighted vertices, which can cause issues. The affected vertices have been put under a mask. Do you want to save anyway?"), shapesJoin), _("Unweighted Vertices"), wxYES_NO | wxICON_WARNING, this);
+			if (error != wxYES)
+				return true;
+		}
+
+		return false;
+	}
+
+	bool OutfitStudioFrame::ShowWeightCopy(WeightCopyOptions& options, bool silent) {
+		wxDialog dlg;
+		if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgCopyWeights"))
+		{
+			XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->Bind(wxEVT_SLIDER, [&dlg](wxCommandEvent&)
+			{
+				float changed = XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->GetValue() / 1000.0f;
+				XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->ChangeValue(wxString::Format("%0.5f", changed));
+			});
+
+			XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->Bind(wxEVT_TEXT, [&dlg](wxCommandEvent&)
+			{
+				float changed = atof(XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->GetValue().c_str());
+				XRCCTRL(dlg, "proximityRadiusSlider", wxSlider)->SetValue(changed * 1000);
+			});
+
+			XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Bind(wxEVT_SLIDER, [&dlg](wxCommandEvent&)
+			{
+				int changed = XRCCTRL(dlg, "maxResultsSlider", wxSlider)->GetValue();
+				XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->ChangeValue(wxString::Format("%d", changed));
+			});
+
+			XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->Bind(wxEVT_TEXT, [&dlg](wxCommandEvent&)
+			{
+				int changed = atol(XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->GetValue().c_str());
+				XRCCTRL(dlg, "maxResultsSlider", wxSlider)->SetValue(changed);
+			});
+
+			XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->Bind(wxEVT_CHECKBOX, [&dlg](wxCommandEvent&)
+			{
+				bool noTargetLimit = XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->IsChecked();
+				XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->Enable(!noTargetLimit);
+				XRCCTRL(dlg, "maxResultsSlider", wxSlider)->Enable(!noTargetLimit);
+			});
+
+			wxCheckBox *cbCopySkinTrans = XRCCTRL(dlg, "cbCopySkinTrans", wxCheckBox);
+			wxCheckBox *cbTransformGeo = XRCCTRL(dlg, "cbTransformGeo", wxCheckBox);
+			if (options.showSkinTransOption)
+			{
+				cbCopySkinTrans->SetValue(options.doSkinTransCopy);
+				cbTransformGeo->SetValue(options.doTransformGeo);
+				cbCopySkinTrans->Show();
+				cbTransformGeo->Show();
+				XRCCTRL(dlg, "copyTransDescription", wxStaticText)->Show();
 			}
 
-			return true;
+			dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
+
+			dlg.SetSize(dlg.GetBestSize());
+		
+			if (silent || dlg.ShowModal() == wxID_OK)
+			{
+				options.proximityRadius = atof(XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->GetValue().c_str());
+
+				bool noTargetLimit = XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->IsChecked();
+				if (!noTargetLimit)
+					options.maxResults = atol(XRCCTRL(dlg, "maxResultsText", wxTextCtrl)->GetValue().c_str());
+				else
+					options.maxResults = std::numeric_limits<int>::max();
+
+				if (options.showSkinTransOption)
+				{
+					options.doSkinTransCopy = cbCopySkinTrans->IsChecked();
+					options.doTransformGeo = cbTransformGeo->IsChecked();
+				}
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	void OutfitStudioFrame::ReselectBone() {
+		wxArrayTreeItemIds selItems;
+		outfitBones->GetSelections(selItems);
+		if (!selItems.empty())
+		{
+			wxTreeEvent treeEvent(wxEVT_TREE_SEL_CHANGED, outfitBones, selItems.front());
+			OnBoneSelect(treeEvent);
 		}
 	}
 
-	return false;
-}
+	void OutfitStudioFrame::CalcCopySkinTransOption(WeightCopyOptions &options) {
+		// This function calculates whether the "copy global-to-skin transform
+		// from base shape" checkbox should be shown and what the default value
+		// for the "transform-geometry" checkbox should be
 
-void OutfitStudioFrame::ReselectBone() {
-	wxArrayTreeItemIds selItems;
-	outfitBones->GetSelections(selItems);
-	if (!selItems.empty()) {
-		wxTreeEvent treeEvent(wxEVT_TREE_SEL_CHANGED, outfitBones, selItems.front());
-		OnBoneSelect(treeEvent);
-	}
-}
+		NifFile *nif = project->GetWorkNif();
+		NiShape *baseShape = project->GetBaseShape();
+		if (!baseShape)
+			return;
 
-void OutfitStudioFrame::CalcCopySkinTransOption(WeightCopyOptions &options) {
-	// This function calculates whether the "copy global-to-skin transform
-	// from base shape" checkbox should be shown and what the default value
-	// for the "transform-geometry" checkbox should be
+		AnimInfo &workAnim = *project->GetWorkAnim();
 
-	NifFile *nif = project->GetWorkNif();
-	NiShape *baseShape = project->GetBaseShape();
-	if (!baseShape)
-		return;
+		if (!workAnim.HasSkinnedShape(baseShape))
+			return;
 
-	AnimInfo &workAnim = *project->GetWorkAnim();
+		const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[baseShape->name.get()].xformGlobalToSkin;
 
-	if (!workAnim.HasSkinnedShape(baseShape))
-		return;
-
-	const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[baseShape->name.get()].xformGlobalToSkin;
-
-	// Check if any shape's skin CS is different from the base shape's
-	for (size_t i = 0; i < selectedItems.size(); i++) {
-		NiShape *shape = selectedItems[i]->GetShape();
-		if (shape == baseShape)
-			continue;
-
-		if (!workAnim.HasSkinnedShape(shape))
-			continue;
-
-		if (!workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(baseXformGlobalToSkin)) {
-			options.showSkinTransOption = true;
-			break;
-		}
-	}
-
-	if (!options.showSkinTransOption)
-		// They're all the same, so hide the option
-		return;
-
-	options.doSkinTransCopy = true;
-
-	// As a first step in calculating a good default for the transform-geometry option,
-	// find the average vertex position of the base shape in its own skin coordinates
-	Vector3 baseAvg;
-
-	const std::vector<Vector3> &baseVerts = *nif->GetVertsForShape(baseShape);
-	for (size_t i = 0; i < baseVerts.size(); ++i)
-		baseAvg += baseVerts[i];
-
-	if (baseVerts.size())
-		baseAvg /= static_cast<uint32_t>(baseVerts.size());
-
-	// Now check if any shape would be better aligned by changing its global-to-skin transform
-	for (size_t i = 0; i < selectedItems.size(); i++) {
-		NiShape *shape = selectedItems[i]->GetShape();
-		if (shape == baseShape)
-			continue;
-
-		const MatTransform &globalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
-		if (globalToSkin.IsNearlyEqualTo(baseXformGlobalToSkin))
-			continue;
-
-		const std::vector<Vector3> &verts = *nif->GetVertsForShape(shape);
-		if (verts.empty())
-			continue;
-
-		// Calculate old average and new average.
-		MatTransform skinToGlobal = globalToSkin.InverseTransform();
-		MatTransform skinToBaseSkin = baseXformGlobalToSkin.ComposeTransforms(skinToGlobal);
-
-		Vector3 oldAvg, newAvg;
-		for (size_t j = 0; j < verts.size(); ++j) {
-			oldAvg += skinToBaseSkin.ApplyTransform(verts[j]);
-			newAvg += verts[j];
-		}
-
-		oldAvg /= static_cast<uint32_t>(verts.size());
-		newAvg /= static_cast<uint32_t>(verts.size());
-
-		// Check whether old or new is closer to the base shape.
-		// If new is farther away, then transforming the geometry would be a good idea
-		if (newAvg.DistanceTo(baseAvg) > oldAvg.DistanceTo(baseAvg)) {
-			options.doTransformGeo = true;
-			break;
-		}
-	}
-}
-
-void OutfitStudioFrame::OnCopyBoneWeight(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-
-	if (!project->GetBaseShape()) {
-		wxMessageBox(_("There is no reference shape!"), _("Error"));
-		return;
-	}
-
-	WeightCopyOptions options;
-	CalcCopySkinTransOption(options);
-	AnimInfo &workAnim = *project->GetWorkAnim();
-
-	if (ShowWeightCopy(options)) {
-		StartProgress(_("Copying bone weights..."));
-
-		UndoStateProject *usp = glView->GetUndoHistory()->PushState();
-		usp->undoType = UT_WEIGHT;
-
-		std::vector<std::string> baseBones = workAnim.shapeBones[project->GetBaseShape()->name.get()];
-		std::sort(baseBones.begin(), baseBones.end());
-		std::unordered_map<uint16_t, float> mask;
-		for (size_t i = 0; i < selectedItems.size(); i++) {
+		// Check if any shape's skin CS is different from the base shape's
+		for (size_t i = 0; i < selectedItems.size(); i++)
+		{
 			NiShape *shape = selectedItems[i]->GetShape();
-			if (!project->IsBaseShape(shape)) {
-				wxLogMessage("Copying bone weights to '%s'...", shape->name.get());
+			if (shape == baseShape)
+				continue;
 
-				if (options.doSkinTransCopy) {
+			if (!workAnim.HasSkinnedShape(shape))
+				continue;
+
+			if (!workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin.IsNearlyEqualTo(baseXformGlobalToSkin))
+			{
+				options.showSkinTransOption = true;
+				break;
+			}
+		}
+
+		if (!options.showSkinTransOption)
+			// They're all the same, so hide the option
+			return;
+
+		options.doSkinTransCopy = true;
+
+		// As a first step in calculating a good default for the transform-geometry option,
+		// find the average vertex position of the base shape in its own skin coordinates
+		Vector3 baseAvg;
+
+		const std::vector<Vector3> &baseVerts = *nif->GetVertsForShape(baseShape);
+		for (size_t i = 0; i < baseVerts.size(); ++i)
+			baseAvg += baseVerts[i];
+
+		if (baseVerts.size())
+			baseAvg /= static_cast<uint32_t>(baseVerts.size());
+
+		// Now check if any shape would be better aligned by changing its global-to-skin transform
+		for (size_t i = 0; i < selectedItems.size(); i++)
+		{
+			NiShape *shape = selectedItems[i]->GetShape();
+			if (shape == baseShape)
+				continue;
+
+			const MatTransform &globalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
+			if (globalToSkin.IsNearlyEqualTo(baseXformGlobalToSkin))
+				continue;
+
+			const std::vector<Vector3> &verts = *nif->GetVertsForShape(shape);
+			if (verts.empty())
+				continue;
+
+			// Calculate old average and new average.
+			MatTransform skinToGlobal = globalToSkin.InverseTransform();
+			MatTransform skinToBaseSkin = baseXformGlobalToSkin.ComposeTransforms(skinToGlobal);
+
+			Vector3 oldAvg, newAvg;
+			for (size_t j = 0; j < verts.size(); ++j)
+			{
+				oldAvg += skinToBaseSkin.ApplyTransform(verts[j]);
+				newAvg += verts[j];
+			}
+
+			oldAvg /= static_cast<uint32_t>(verts.size());
+			newAvg /= static_cast<uint32_t>(verts.size());
+
+			// Check whether old or new is closer to the base shape.
+			// If new is farther away, then transforming the geometry would be a good idea
+			if (newAvg.DistanceTo(baseAvg) > oldAvg.DistanceTo(baseAvg))
+			{
+				options.doTransformGeo = true;
+				break;
+			}
+		}
+	}
+
+	void OutfitStudioFrame::OnCopyBoneWeight(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+
+		if (!project->GetBaseShape())
+		{
+			wxMessageBox(_("There is no reference shape!"), _("Error"));
+			return;
+		}
+
+		WeightCopyOptions options;
+		CalcCopySkinTransOption(options);
+		AnimInfo &workAnim = *project->GetWorkAnim();
+
+		if (ShowWeightCopy(options))
+		{
+			StartProgress(_("Copying bone weights..."));
+
+			UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+			usp->undoType = UT_WEIGHT;
+
+			std::vector<std::string> baseBones = workAnim.shapeBones[project->GetBaseShape()->name.get()];
+			std::sort(baseBones.begin(), baseBones.end());
+			std::unordered_map<uint16_t, float> mask;
+			for (size_t i = 0; i < selectedItems.size(); i++)
+			{
+				NiShape *shape = selectedItems[i]->GetShape();
+				if (!project->IsBaseShape(shape))
+				{
+					wxLogMessage("Copying bone weights to '%s'...", shape->name.get());
+
+					if (options.doSkinTransCopy)
+					{
+						const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->name.get()].xformGlobalToSkin;
+						const MatTransform &oldXformGlobalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
+
+						if (options.doTransformGeo && !baseXformGlobalToSkin.IsNearlyEqualTo(oldXformGlobalToSkin))
+							project->ApplyTransformToShapeGeometry(shape, baseXformGlobalToSkin.ComposeTransforms(oldXformGlobalToSkin.InverseTransform()));
+
+						workAnim.ChangeGlobalToSkinTransform(shape->name.get(), baseXformGlobalToSkin);
+						project->GetWorkNif()->SetShapeTransformGlobalToSkin(shape, baseXformGlobalToSkin);
+					}
+
+					usp->usss.resize(usp->usss.size() + 1);
+					usp->usss.back().shapeName = shape->name.get();
+
+					mask.clear();
+					glView->GetShapeMask(mask, shape->name.get());
+
+					std::vector<std::string> bones = workAnim.shapeBones[shape->name.get()];
+					std::vector<std::string> mergedBones = baseBones;
+
+					for (auto b : bones)
+						if (!std::binary_search(baseBones.begin(), baseBones.end(), b))
+							mergedBones.push_back(b);
+
+					std::vector<std::string> lockedBones;
+					project->CopyBoneWeights(shape, options.proximityRadius, options.maxResults, mask, mergedBones, baseBones.size(), lockedBones, usp->usss.back(), false);
+				}
+				else
+					wxMessageBox(_("Sorry, you can't copy weights from the reference shape to itself. Skipping this shape."), _("Can't copy weights"), wxICON_WARNING);
+			}
+
+			if (options.doSkinTransCopy || options.doTransformGeo)
+				RefreshGUIFromProj();
+
+			ActiveShapesUpdated(usp, false);
+			project->morpher.ClearProximityCache();
+
+			UpdateUndoTools();
+
+			UpdateProgress(100, _("Finished"));
+			EndProgress();
+		}
+
+		workAnim.CleanupBones();
+		UpdateAnimationGUI();
+	}
+
+	void OutfitStudioFrame::MaskWeightedOnShape(std::string& shapeName) const
+	{
+		mesh* m = glView->GetMesh(shapeName);
+		auto& bones = project->GetWorkAnim()->shapeBones;
+		if (bones.find(shapeName) != bones.end())
+		{
+			for (auto &b : bones[shapeName])
+			{
+				auto weights = project->GetWorkAnim()->GetWeightsPtr(shapeName, b);
+				if (weights)
+				{
+					for (auto &bw : *weights)
+						if (bw.second > 0.0f)
+							m->vcolors[bw.first].x = 1.0f;
+				}
+			}
+		}
+		glView->Refresh();
+	}
+
+	int OutfitStudioFrame::CopyBoneWeightForShapes(std::vector<NiShape*> shapes, int addedRadius, bool maskWeighted, bool silent) {
+
+		if (!project->GetBaseShape())
+		{
+			wxLogMessage("There is no reference shape!");
+			return 1;
+		}
+
+		WeightCopyOptions options;
+		CalcCopySkinTransOption(options);
+		AnimInfo &workAnim = *project->GetWorkAnim();
+
+		if (ShowWeightCopy(options, silent))
+		{
+			UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+			usp->undoType = UT_WEIGHT;
+
+			std::vector<std::string> baseBones = workAnim.shapeBones[project->GetBaseShape()->name.get()];
+			std::sort(baseBones.begin(), baseBones.end());
+			std::unordered_map<uint16_t, float> mask;
+			for (size_t i = 0; i < shapes.size(); i++)
+			{
+				NiShape *shape = shapes[i];
+				if (project->IsBaseShape(shape))
+					continue;
+
+				auto& shapeName = shape->name.get();
+				wxLogMessage("Copying bone weights to '%s'...", shapeName);
+
+				if (options.doSkinTransCopy)
+				{
 					const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->name.get()].xformGlobalToSkin;
-					const MatTransform &oldXformGlobalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
+					const MatTransform &oldXformGlobalToSkin = workAnim.shapeSkinning[shapeName].xformGlobalToSkin;
 
 					if (options.doTransformGeo && !baseXformGlobalToSkin.IsNearlyEqualTo(oldXformGlobalToSkin))
 						project->ApplyTransformToShapeGeometry(shape, baseXformGlobalToSkin.ComposeTransforms(oldXformGlobalToSkin.InverseTransform()));
 
-					workAnim.ChangeGlobalToSkinTransform(shape->name.get(), baseXformGlobalToSkin);
+					workAnim.ChangeGlobalToSkinTransform(shapeName, baseXformGlobalToSkin);
 					project->GetWorkNif()->SetShapeTransformGlobalToSkin(shape, baseXformGlobalToSkin);
 				}
 
 				usp->usss.resize(usp->usss.size() + 1);
-				usp->usss.back().shapeName = shape->name.get();
+				usp->usss.back().shapeName = shapeName;
 
 				mask.clear();
-				glView->GetShapeMask(mask, shape->name.get());
+				if(maskWeighted) {
+					MaskWeightedOnShape(shapeName);
+				}
+				glView->GetShapeMask(mask, shapeName);
 
-				std::vector<std::string> bones = workAnim.shapeBones[shape->name.get()];
+				std::vector<std::string> bones = workAnim.shapeBones[shapeName];
 				std::vector<std::string> mergedBones = baseBones;
 
 				for (auto b : bones)
@@ -9273,665 +10080,678 @@ void OutfitStudioFrame::OnCopyBoneWeight(wxCommandEvent& WXUNUSED(event)) {
 						mergedBones.push_back(b);
 
 				std::vector<std::string> lockedBones;
-				project->CopyBoneWeights(shape, options.proximityRadius, options.maxResults, mask, mergedBones, baseBones.size(), lockedBones, usp->usss.back(), false);
+				project->CopyBoneWeights(shape, options.proximityRadius + addedRadius, options.maxResults, mask, mergedBones, baseBones.size(), lockedBones, usp->usss.back(), false, silent);
 			}
-			else
-				wxMessageBox(_("Sorry, you can't copy weights from the reference shape to itself. Skipping this shape."), _("Can't copy weights"), wxICON_WARNING);
+
+			if (options.doSkinTransCopy || options.doTransformGeo)
+				RefreshGUIFromProj();
+
+			ActiveShapesUpdated(usp, false);
+			project->morpher.ClearProximityCache();
 		}
 
-		if (options.doSkinTransCopy || options.doTransformGeo)
-			RefreshGUIFromProj();
-
-		ActiveShapesUpdated(usp, false);
-		project->morpher.ClearProximityCache();
-
-		UpdateUndoTools();
-
-		UpdateProgress(100, _("Finished"));
-		EndProgress();
+		workAnim.CleanupBones();
+		UpdateAnimationGUI();
+		return 0;
 	}
 
-	workAnim.CleanupBones();
-	UpdateAnimationGUI();
-}
+	void OutfitStudioFrame::OnCopySelectedWeight(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
 
-void OutfitStudioFrame::OnCopySelectedWeight(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
+		if (!project->GetBaseShape())
+		{
+			wxMessageBox(_("There is no reference shape!"), _("Error"));
+			return;
+		}
 
-	if (!project->GetBaseShape()) {
-		wxMessageBox(_("There is no reference shape!"), _("Error"));
-		return;
-	}
+		std::vector<std::string> boneList = GetSelectedBones();
+		int nSelBones = boneList.size();
+		if (nSelBones < 1)
+			return;
 
-	std::vector<std::string> boneList = GetSelectedBones();
-	int nSelBones = boneList.size();
-	if (nSelBones < 1)
-		return;
+		std::unordered_set<std::string> selBones{ boneList.begin(), boneList.end() };
 
-	std::unordered_set<std::string> selBones{ boneList.begin(), boneList.end() };
+		std::string bonesString;
+		for (std::string &boneName : boneList)
+			bonesString += "'" + boneName + "' ";
 
-	std::string bonesString;
-	for (std::string &boneName : boneList)
-		bonesString += "'" + boneName + "' ";
-
-	std::vector<std::string> normBones, notNormBones, lockedBones;
-	GetNormalizeBones(&normBones, &notNormBones);
-	for (auto &bone : normBones)
-		if (!selBones.count(bone))
-			boneList.push_back(bone);
-
-	bool bHasNormBones = static_cast<int>(boneList.size()) > nSelBones;
-	if (bHasNormBones) {
-		for (auto &bone : notNormBones)
-			if (!selBones.count(bone))
-				lockedBones.push_back(bone);
-	}
-	else {
-		for (auto &bone : notNormBones)
+		std::vector<std::string> normBones, notNormBones, lockedBones;
+		GetNormalizeBones(&normBones, &notNormBones);
+		for (auto &bone : normBones)
 			if (!selBones.count(bone))
 				boneList.push_back(bone);
-	}
 
-	WeightCopyOptions options;
-	CalcCopySkinTransOption(options);
-	AnimInfo &workAnim = *project->GetWorkAnim();
-
-	if (ShowWeightCopy(options)) {
-		StartProgress(_("Copying selected bone weights..."));
-
-		UndoStateProject *usp = glView->GetUndoHistory()->PushState();
-		usp->undoType = UT_WEIGHT;
-		std::unordered_map<uint16_t, float> mask;
-		for (size_t i = 0; i < selectedItems.size(); i++) {
-			NiShape *shape = selectedItems[i]->GetShape();
-			if (!project->IsBaseShape(shape)) {
-				wxLogMessage("Copying selected bone weights to '%s' for %s...", shape->name.get(), bonesString);
-				if (options.doSkinTransCopy) {
-					const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->name.get()].xformGlobalToSkin;
-					const MatTransform &oldXformGlobalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
-
-					if (options.doTransformGeo && !baseXformGlobalToSkin.IsNearlyEqualTo(oldXformGlobalToSkin))
-						project->ApplyTransformToShapeGeometry(shape, baseXformGlobalToSkin.ComposeTransforms(oldXformGlobalToSkin.InverseTransform()));
-
-					workAnim.ChangeGlobalToSkinTransform(shape->name.get(), baseXformGlobalToSkin);
-					project->GetWorkNif()->SetShapeTransformGlobalToSkin(shape, baseXformGlobalToSkin);
-				}
-
-				usp->usss.resize(usp->usss.size() + 1);
-				usp->usss.back().shapeName = shape->name.get();
-
-				mask.clear();
-				glView->GetShapeMask(mask, shape->name.get());
-
-				project->CopyBoneWeights(shape, options.proximityRadius, options.maxResults, mask, boneList, nSelBones, lockedBones, usp->usss.back(), bHasNormBones);
-			}
-			else
-				wxMessageBox(_("Sorry, you can't copy weights from the reference shape to itself. Skipping this shape."), _("Can't copy weights"), wxICON_WARNING);
+		bool bHasNormBones = static_cast<int>(boneList.size()) > nSelBones;
+		if (bHasNormBones)
+		{
+			for (auto &bone : notNormBones)
+				if (!selBones.count(bone))
+					lockedBones.push_back(bone);
+		}
+		else
+		{
+			for (auto &bone : notNormBones)
+				if (!selBones.count(bone))
+					boneList.push_back(bone);
 		}
 
-		if (options.doSkinTransCopy || options.doTransformGeo)
-			RefreshGUIFromProj();
+		WeightCopyOptions options;
+		CalcCopySkinTransOption(options);
+		AnimInfo &workAnim = *project->GetWorkAnim();
 
-		ActiveShapesUpdated(usp, false);
-		project->morpher.ClearProximityCache();
+		if (ShowWeightCopy(options))
+		{
+			StartProgress(_("Copying selected bone weights..."));
 
-		UpdateUndoTools();
+			UndoStateProject *usp = glView->GetUndoHistory()->PushState();
+			usp->undoType = UT_WEIGHT;
+			std::unordered_map<uint16_t, float> mask;
+			for (size_t i = 0; i < selectedItems.size(); i++)
+			{
+				NiShape *shape = selectedItems[i]->GetShape();
+				if (!project->IsBaseShape(shape))
+				{
+					wxLogMessage("Copying selected bone weights to '%s' for %s...", shape->name.get(), bonesString);
+					if (options.doSkinTransCopy)
+					{
+						const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->name.get()].xformGlobalToSkin;
+						const MatTransform &oldXformGlobalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
+
+						if (options.doTransformGeo && !baseXformGlobalToSkin.IsNearlyEqualTo(oldXformGlobalToSkin))
+							project->ApplyTransformToShapeGeometry(shape, baseXformGlobalToSkin.ComposeTransforms(oldXformGlobalToSkin.InverseTransform()));
+
+						workAnim.ChangeGlobalToSkinTransform(shape->name.get(), baseXformGlobalToSkin);
+						project->GetWorkNif()->SetShapeTransformGlobalToSkin(shape, baseXformGlobalToSkin);
+					}
+
+					usp->usss.resize(usp->usss.size() + 1);
+					usp->usss.back().shapeName = shape->name.get();
+
+					mask.clear();
+					glView->GetShapeMask(mask, shape->name.get());
+
+					project->CopyBoneWeights(shape, options.proximityRadius, options.maxResults, mask, boneList, nSelBones, lockedBones, usp->usss.back(), bHasNormBones);
+				}
+				else
+					wxMessageBox(_("Sorry, you can't copy weights from the reference shape to itself. Skipping this shape."), _("Can't copy weights"), wxICON_WARNING);
+			}
+
+			if (options.doSkinTransCopy || options.doTransformGeo)
+				RefreshGUIFromProj();
+
+			ActiveShapesUpdated(usp, false);
+			project->morpher.ClearProximityCache();
+
+			UpdateUndoTools();
+
+			UpdateProgress(100, _("Finished"));
+			EndProgress();
+		}
+
+		workAnim.CleanupBones();
+		UpdateAnimationGUI();
+	}
+
+	void OutfitStudioFrame::OnTransferSelectedWeight(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+
+		auto baseShape = project->GetBaseShape();
+		if (!baseShape)
+		{
+			wxMessageBox(_("There is no reference shape!"), _("Error"));
+			return;
+		}
+
+		if (project->IsBaseShape(activeItem->GetShape()))
+		{
+			wxMessageBox(_("Sorry, you can't copy weights from the reference shape to itself."), _("Error"));
+			return;
+		}
+
+		int baseVertCount = project->GetVertexCount(baseShape);
+		int workVertCount = project->GetVertexCount(activeItem->GetShape());
+		if (baseVertCount != workVertCount)
+		{
+			wxMessageBox(_("The vertex count of the reference and chosen shape is not the same!"), _("Error"));
+			return;
+		}
+
+		std::vector<std::string> selectedBones = GetSelectedBones();
+		if (selectedBones.size() < 1)
+			return;
+
+		std::string bonesString;
+		for (std::string &boneName : selectedBones)
+			bonesString += "'" + boneName + "' ";
+
+		wxLogMessage("Transferring selected bone weights to '%s' for %s...", activeItem->GetShape()->name.get(), bonesString);
+		StartProgress(_("Transferring bone weights..."));
+
+		std::unordered_map<uint16_t, float> mask;
+		glView->GetActiveMask(mask);
+		project->TransferSelectedWeights(activeItem->GetShape(), &mask, &selectedBones);
+
+		UpdateAnimationGUI();
 
 		UpdateProgress(100, _("Finished"));
 		EndProgress();
+
+		SetPendingChanges();
 	}
 
-	workAnim.CleanupBones();
-	UpdateAnimationGUI();
-}
+	void OutfitStudioFrame::OnMaskWeighted(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
 
-void OutfitStudioFrame::OnTransferSelectedWeight(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
+		for (auto &i : selectedItems)
+		{
+			std::string shapeName = i->GetShape()->name.get();
+			mesh* m = glView->GetMesh(shapeName);
+			if (!m)
+				continue;
+
+			m->ColorChannelFill(0, 0.0f);
+
+			auto& bones = project->GetWorkAnim()->shapeBones;
+			if (bones.find(shapeName) != bones.end())
+			{
+				for (auto &b : bones[shapeName])
+				{
+					auto weights = project->GetWorkAnim()->GetWeightsPtr(shapeName, b);
+					if (weights)
+					{
+						for (auto &bw : *weights)
+							if (bw.second > 0.0f)
+								m->vcolors[bw.first].x = 1.0f;
+					}
+				}
+			}
+		}
+
+		glView->Refresh();
 	}
 
-	auto baseShape = project->GetBaseShape();
-	if (!baseShape) {
-		wxMessageBox(_("There is no reference shape!"), _("Error"));
-		return;
-	}
+	void OutfitStudioFrame::OnMaskBoneWeighted(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
 
-	if (project->IsBaseShape(activeItem->GetShape())) {
-		wxMessageBox(_("Sorry, you can't copy weights from the reference shape to itself."), _("Error"));
-		return;
-	}
+		for (auto &i : selectedItems)
+		{
+			std::string shapeName = i->GetShape()->name.get();
+			mesh* m = glView->GetMesh(shapeName);
+			if (!m || !m->vcolors)
+				continue;
 
-	int baseVertCount = project->GetVertexCount(baseShape);
-	int workVertCount = project->GetVertexCount(activeItem->GetShape());
-	if (baseVertCount != workVertCount) {
-		wxMessageBox(_("The vertex count of the reference and chosen shape is not the same!"), _("Error"));
-		return;
-	}
+			m->ColorChannelFill(0, 0.0f);
 
-	std::vector<std::string> selectedBones = GetSelectedBones();
-	if (selectedBones.size() < 1)
-		return;
-
-	std::string bonesString;
-	for (std::string &boneName : selectedBones)
-		bonesString += "'" + boneName + "' ";
-
-	wxLogMessage("Transferring selected bone weights to '%s' for %s...", activeItem->GetShape()->name.get(), bonesString);
-	StartProgress(_("Transferring bone weights..."));
-
-	std::unordered_map<uint16_t, float> mask;
-	glView->GetActiveMask(mask);
-	project->TransferSelectedWeights(activeItem->GetShape(), &mask, &selectedBones);
-
-	UpdateAnimationGUI();
-
-	UpdateProgress(100, _("Finished"));
-	EndProgress();
-
-	SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnMaskWeighted(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-
-	for (auto &i : selectedItems) {
-		std::string shapeName = i->GetShape()->name.get();
-		mesh* m = glView->GetMesh(shapeName);
-		if (!m)
-			continue;
-
-		m->ColorChannelFill(0, 0.0f);
-
-		auto& bones = project->GetWorkAnim()->shapeBones;
-		if (bones.find(shapeName) != bones.end()) {
-			for (auto &b : bones[shapeName]) {
+			for (auto &b : GetSelectedBones())
+			{
 				auto weights = project->GetWorkAnim()->GetWeightsPtr(shapeName, b);
-				if (weights) {
+				if (weights)
+				{
 					for (auto &bw : *weights)
 						if (bw.second > 0.0f)
 							m->vcolors[bw.first].x = 1.0f;
 				}
 			}
 		}
+
+		glView->Refresh();
 	}
 
-	glView->Refresh();
-}
-
-void OutfitStudioFrame::OnMaskBoneWeighted(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
+	void OutfitStudioFrame::OnResetTransforms(wxCommandEvent& WXUNUSED(event)) {
+		project->ResetTransforms();
+		RefreshGUIFromProj();
+		SetPendingChanges();
 	}
 
-	for (auto &i : selectedItems) {
-		std::string shapeName = i->GetShape()->name.get();
-		mesh* m = glView->GetMesh(shapeName);
-		if (!m || !m->vcolors)
-			continue;
+	void OutfitStudioFrame::OnDeleteUnreferencedNodes(wxCommandEvent& WXUNUSED(event)) {
+		int deletionCount = 0;
+		auto workNif = project->GetWorkNif();
+		if (workNif)
+			workNif->DeleteUnreferencedNodes(&deletionCount);
 
-		m->ColorChannelFill(0, 0.0f);
+		if (deletionCount > 0)
+			SetPendingChanges();
 
-		for (auto &b : GetSelectedBones()) {
-			auto weights = project->GetWorkAnim()->GetWeightsPtr(shapeName, b);
-			if (weights) {
-				for (auto &bw : *weights)
-					if (bw.second > 0.0f)
-						m->vcolors[bw.first].x = 1.0f;
-			}
+		wxString msg = wxString::Format(_("%d unreferenced nodes were deleted."), deletionCount);
+		wxMessageBox(msg, _("Delete Unreferenced Nodes"));
+	}
+
+	void OutfitStudioFrame::OnRemoveSkinning(wxCommandEvent& WXUNUSED(event)) {
+		project->RemoveSkinning();
+		RefreshGUIFromProj();
+		SetPendingChanges();
+	}
+
+	void OutfitStudioFrame::OnShapeProperties(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+
+		auto shape = activeItem->GetShape();
+		if (shape)
+		{
+			ShapeProperties prop(this, project->GetWorkNif(), shape);
+			prop.ShowModal();
 		}
 	}
 
-	glView->Refresh();
-}
-
-void OutfitStudioFrame::OnResetTransforms(wxCommandEvent& WXUNUSED(event)) {
-	project->ResetTransforms();
-	RefreshGUIFromProj();
-	SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnDeleteUnreferencedNodes(wxCommandEvent& WXUNUSED(event)) {
-	int deletionCount = 0;
-	auto workNif = project->GetWorkNif();
-	if (workNif)
-		workNif->DeleteUnreferencedNodes(&deletionCount);
-
-	if (deletionCount > 0)
-		SetPendingChanges();
-
-	wxString msg = wxString::Format(_("%d unreferenced nodes were deleted."), deletionCount);
-	wxMessageBox(msg, _("Delete Unreferenced Nodes"));
-}
-
-void OutfitStudioFrame::OnRemoveSkinning(wxCommandEvent& WXUNUSED(event)) {
-	project->RemoveSkinning();
-	RefreshGUIFromProj();
-	SetPendingChanges();
-}
-
-void OutfitStudioFrame::OnShapeProperties(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
-	}
-
-	auto shape = activeItem->GetShape();
-	if (shape) {
-		ShapeProperties prop(this, project->GetWorkNif(), shape);
-		prop.ShowModal();
-	}
-}
-
-void OutfitStudioFrame::OnMaskLess(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-		return;
-
-	glView->MaskLess();
-
-	if (glView->GetTransformMode())
-		glView->ShowTransformTool();
-	else
-		glView->Render();
-}
-
-void OutfitStudioFrame::OnMaskMore(wxCommandEvent& WXUNUSED(event)) {
-	if (!activeItem)
-		return;
-
-	glView->MaskMore();
-
-	if (glView->GetTransformMode())
-		glView->ShowTransformTool();
-	else
-		glView->Render();
-}
-
-void OutfitStudioFrame::OnNPWizChangeSliderSetFile(wxFileDirPickerEvent& event) {
-	std::string fn = event.GetPath();
-	std::vector<std::string> shapes;
-	wxWindow* npWiz = ((wxFilePickerCtrl*)event.GetEventObject())->GetParent();
-	wxChoice* setNameChoice = (wxChoice*)XRCCTRL((*npWiz), "npSliderSetName", wxChoice);
-	wxChoice* refShapeChoice = (wxChoice*)XRCCTRL((*npWiz), "npRefShapeName", wxChoice);
-	XRCCTRL((*npWiz), "npRefIsSliderset", wxRadioButton)->SetValue(true);
-	setNameChoice->Clear();
-	refShapeChoice->Clear();
-
-	if (fn.rfind(".osp") != std::string::npos || fn.rfind(".xml") != std::string::npos) {
-		SliderSetFile ssf(fn);
-		if (ssf.fail())
+	void OutfitStudioFrame::OnMaskLess(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
 			return;
 
-		std::vector<std::string> setNames;
-		ssf.GetSetNames(setNames);
+		glView->MaskLess();
 
-		for (auto &sn : setNames)
-			setNameChoice->AppendString(sn);
+		if (glView->GetTransformMode())
+			glView->ShowTransformTool();
+		else
+			glView->Render();
+	}
 
-		if (!setNames.empty()) {
-			setNameChoice->SetSelection(0);
-			ssf.SetShapes(setNames.front(), shapes);
-			for (auto &rsn : shapes)
+	void OutfitStudioFrame::OnMaskMore(wxCommandEvent& WXUNUSED(event)) {
+		if (!activeItem)
+			return;
+
+		glView->MaskMore();
+
+		if (glView->GetTransformMode())
+			glView->ShowTransformTool();
+		else
+			glView->Render();
+	}
+
+	void OutfitStudioFrame::OnNPWizChangeSliderSetFile(wxFileDirPickerEvent& event) {
+		std::string fn = event.GetPath();
+		std::vector<std::string> shapes;
+		wxWindow* npWiz = ((wxFilePickerCtrl*)event.GetEventObject())->GetParent();
+		wxChoice* setNameChoice = (wxChoice*)XRCCTRL((*npWiz), "npSliderSetName", wxChoice);
+		wxChoice* refShapeChoice = (wxChoice*)XRCCTRL((*npWiz), "npRefShapeName", wxChoice);
+		XRCCTRL((*npWiz), "npRefIsSliderset", wxRadioButton)->SetValue(true);
+		setNameChoice->Clear();
+		refShapeChoice->Clear();
+
+		if (fn.rfind(".osp") != std::string::npos || fn.rfind(".xml") != std::string::npos)
+		{
+			SliderSetFile ssf(fn);
+			if (ssf.fail())
+				return;
+
+			std::vector<std::string> setNames;
+			ssf.GetSetNames(setNames);
+
+			for (auto &sn : setNames)
+				setNameChoice->AppendString(sn);
+
+			if (!setNames.empty())
+			{
+				setNameChoice->SetSelection(0);
+				ssf.SetShapes(setNames.front(), shapes);
+				for (auto &rsn : shapes)
+					refShapeChoice->AppendString(rsn);
+
+				refShapeChoice->SetSelection(0);
+			}
+		}
+		else if (fn.rfind(".nif") != std::string::npos)
+		{
+			std::fstream file;
+			PlatformUtil::OpenFileStream(file, fn, std::ios::in | std::ios::binary);
+
+			NifFile checkFile;
+			if (checkFile.Load(file))
+				return;
+
+			for (auto &rsn : checkFile.GetShapeNames())
 				refShapeChoice->AppendString(rsn);
 
 			refShapeChoice->SetSelection(0);
 		}
 	}
-	else if (fn.rfind(".nif") != std::string::npos) {
-		std::fstream file;
-		PlatformUtil::OpenFileStream(file, fn, std::ios::in | std::ios::binary);
 
-		NifFile checkFile;
-		if (checkFile.Load(file))
+	void OutfitStudioFrame::OnNPWizChangeSetNameChoice(wxCommandEvent& event) {
+		wxWindow* npWiz = ((wxChoice*)event.GetEventObject())->GetParent();
+		wxFilePickerCtrl* file = (wxFilePickerCtrl*)XRCCTRL((*npWiz), "npSliderSetFile", wxFilePickerCtrl);
+		if (!file)
 			return;
 
-		for (auto &rsn : checkFile.GetShapeNames())
+		std::string fn = file->GetPath();
+		SliderSetFile ssf(fn);
+		if (ssf.fail())
+			return;
+
+		std::vector<std::string> shapes;
+		wxChoice* chooser = (wxChoice*)event.GetEventObject();
+		ssf.SetShapes(chooser->GetStringSelection().ToStdString(), shapes);
+		wxChoice* refShapeChoice = (wxChoice*)XRCCTRL((*npWiz), "npRefShapeName", wxChoice);
+		refShapeChoice->Clear();
+
+		for (auto &rsn : shapes)
 			refShapeChoice->AppendString(rsn);
 
 		refShapeChoice->SetSelection(0);
 	}
-}
 
-void OutfitStudioFrame::OnNPWizChangeSetNameChoice(wxCommandEvent& event) {
-	wxWindow* npWiz = ((wxChoice*)event.GetEventObject())->GetParent();
-	wxFilePickerCtrl* file = (wxFilePickerCtrl*)XRCCTRL((*npWiz), "npSliderSetFile", wxFilePickerCtrl);
-	if (!file)
-		return;
-
-	std::string fn = file->GetPath();
-	SliderSetFile ssf(fn);
-	if (ssf.fail())
-		return;
-
-	std::vector<std::string> shapes;
-	wxChoice* chooser = (wxChoice*)event.GetEventObject();
-	ssf.SetShapes(chooser->GetStringSelection().ToStdString(), shapes);
-	wxChoice* refShapeChoice = (wxChoice*)XRCCTRL((*npWiz), "npRefShapeName", wxChoice);
-	refShapeChoice->Clear();
-
-	for (auto &rsn : shapes)
-		refShapeChoice->AppendString(rsn);
-
-	refShapeChoice->SetSelection(0);
-}
-
-void OutfitStudioFrame::OnLoadOutfitFP_File(wxFileDirPickerEvent& event) {
-	wxWindow* win = ((wxDialog*)event.GetEventObject())->GetParent();
-	XRCCTRL((*win), "npWorkFile", wxRadioButton)->SetValue(true);
-}
-
-void OutfitStudioFrame::OnLoadOutfitFP_Texture(wxFileDirPickerEvent& event) {
-	wxWindow* win = ((wxDialog*)event.GetEventObject())->GetParent();
-	XRCCTRL((*win), "npTexFile", wxRadioButton)->SetValue(true);
-}
-
-void OutfitStudioFrame::OnRecalcNormals(wxCommandEvent& WXUNUSED(event)) {
-	for (auto &s : selectedItems)
-		glView->RecalcNormals(s->GetShape()->name.get());
-
-	glView->Render();
-}
-
-void OutfitStudioFrame::OnSmoothNormalSeams(wxCommandEvent& event) {
-	bool enable = event.IsChecked();
-	glView->SetNormalSeamSmoothMode(enable);
-
-	for (auto &s : selectedItems)
-		project->activeSet.SetSmoothSeamNormals(s->GetShape()->name.get(), enable);
-
-	glView->Render();
-}
-
-void OutfitStudioFrame::OnLockNormals(wxCommandEvent& event) {
-	bool enable = event.IsChecked();
-	glView->SetLockNormalsMode(enable);
-
-	for (auto &s : selectedItems)
-		project->activeSet.SetLockNormals(s->GetShape()->name.get(), enable);
-}
-
-void OutfitStudioFrame::OnEditUV(wxCommandEvent& WXUNUSED(event)) {
-	if (editUV)
-		return;
-
-	if (!activeItem) {
-		wxMessageBox(_("There is no shape selected!"), _("Error"));
-		return;
+	void OutfitStudioFrame::OnLoadOutfitFP_File(wxFileDirPickerEvent& event) {
+		wxWindow* win = ((wxDialog*)event.GetEventObject())->GetParent();
+		XRCCTRL((*win), "npWorkFile", wxRadioButton)->SetValue(true);
 	}
 
-	auto shape = activeItem->GetShape();
-	mesh* m = glView->GetMesh(shape->name.get());
-	if (shape && m) {
-		editUV = new EditUV(this, project->GetWorkNif(), shape, m, activeSlider);
-
-		editUV->Bind(wxEVT_CLOSE_WINDOW, [&](wxCloseEvent& event) {
-			editUV = nullptr;
-			event.Skip();
-		});
-
-		editUV->CenterOnParent();
-		editUV->Show();
+	void OutfitStudioFrame::OnLoadOutfitFP_Texture(wxFileDirPickerEvent& event) {
+		wxWindow* win = ((wxDialog*)event.GetEventObject())->GetParent();
+		XRCCTRL((*win), "npTexFile", wxRadioButton)->SetValue(true);
 	}
-}
 
-void OutfitStudioFrame::OnSelectMask(wxCommandEvent& WXUNUSED(event)) {
-	wxChoice* cMaskName = (wxChoice*)FindWindowByName("cMaskName");
-	int maskSel = cMaskName->GetSelection();
-	if (maskSel != wxNOT_FOUND) {
-		auto maskData = (std::map<std::string, std::unordered_map<uint16_t, float>>*)cMaskName->GetClientData(maskSel);
-		for (auto mask : (*maskData)) {
-			glView->SetShapeMask(mask.second, mask.first);
+	void OutfitStudioFrame::OnRecalcNormals(wxCommandEvent& WXUNUSED(event)) {
+		for (auto &s : selectedItems)
+			glView->RecalcNormals(s->GetShape()->name.get());
+
+		glView->Render();
+	}
+
+	void OutfitStudioFrame::OnSmoothNormalSeams(wxCommandEvent& event) {
+		bool enable = event.IsChecked();
+		glView->SetNormalSeamSmoothMode(enable);
+
+		for (auto &s : selectedItems)
+			project->activeSet.SetSmoothSeamNormals(s->GetShape()->name.get(), enable);
+
+		glView->Render();
+	}
+
+	void OutfitStudioFrame::OnLockNormals(wxCommandEvent& event) {
+		bool enable = event.IsChecked();
+		glView->SetLockNormalsMode(enable);
+
+		for (auto &s : selectedItems)
+			project->activeSet.SetLockNormals(s->GetShape()->name.get(), enable);
+	}
+
+	void OutfitStudioFrame::OnEditUV(wxCommandEvent& WXUNUSED(event)) {
+		if (editUV)
+			return;
+
+		if (!activeItem)
+		{
+			wxMessageBox(_("There is no shape selected!"), _("Error"));
+			return;
+		}
+
+		auto shape = activeItem->GetShape();
+		mesh* m = glView->GetMesh(shape->name.get());
+		if (shape && m)
+		{
+			editUV = new EditUV(this, project->GetWorkNif(), shape, m, activeSlider);
+
+			editUV->Bind(wxEVT_CLOSE_WINDOW, [&](wxCloseEvent& event)
+			{
+				editUV = nullptr;
+				event.Skip();
+			});
+
+			editUV->CenterOnParent();
+			editUV->Show();
 		}
 	}
 
-	glView->Render();
-}
+	void OutfitStudioFrame::OnSelectMask(wxCommandEvent& WXUNUSED(event)) {
+		wxChoice* cMaskName = (wxChoice*)FindWindowByName("cMaskName");
+		int maskSel = cMaskName->GetSelection();
+		if (maskSel != wxNOT_FOUND)
+		{
+			auto maskData = (std::map<std::string, std::unordered_map<uint16_t, float>>*)cMaskName->GetClientData(maskSel);
+			for (auto mask : (*maskData))
+			{
+				glView->SetShapeMask(mask.second, mask.first);
+			}
+		}
 
-void OutfitStudioFrame::OnSaveMask(wxCommandEvent& WXUNUSED(event)) {
-	wxChoice* cMaskName = (wxChoice*)FindWindowByName("cMaskName");
-	int maskSel = cMaskName->GetSelection();
-	if (maskSel != wxNOT_FOUND) {
+		glView->Render();
+	}
+
+	void OutfitStudioFrame::OnSaveMask(wxCommandEvent& WXUNUSED(event)) {
+		wxChoice* cMaskName = (wxChoice*)FindWindowByName("cMaskName");
+		int maskSel = cMaskName->GetSelection();
+		if (maskSel != wxNOT_FOUND)
+		{
+			auto maskData = new std::map<std::string, std::unordered_map<uint16_t, float>>();
+
+			std::vector<std::string> shapes = GetShapeList();
+			for (auto &s : shapes)
+			{
+				std::unordered_map<uint16_t, float> mask;
+				glView->GetShapeMask(mask, s);
+				(*maskData)[s] = std::move(mask);
+			}
+
+			cMaskName->SetClientData(maskSel, maskData);
+		}
+		else
+		{
+			wxCommandEvent evt;
+			OnSaveAsMask(evt);
+		}
+	}
+
+	void OutfitStudioFrame::OnSaveAsMask(wxCommandEvent& WXUNUSED(event)) {
+		wxChoice* cMaskName = (wxChoice*)FindWindowByName("cMaskName");
+
+		wxString maskName;
+		do
+		{
+			maskName = wxGetTextFromUser(_("Please enter a new unique name for the mask."), _("New Mask"));
+			if (maskName.empty())
+				return;
+
+		} while (cMaskName->FindString(maskName) != wxNOT_FOUND);
+
 		auto maskData = new std::map<std::string, std::unordered_map<uint16_t, float>>();
 
 		std::vector<std::string> shapes = GetShapeList();
-		for (auto &s : shapes) {
+		for (auto &s : shapes)
+		{
 			std::unordered_map<uint16_t, float> mask;
 			glView->GetShapeMask(mask, s);
 			(*maskData)[s] = std::move(mask);
 		}
 
-		cMaskName->SetClientData(maskSel, maskData);
-	}
-	else {
-		wxCommandEvent evt;
-		OnSaveAsMask(evt);
-	}
-}
+		int maskSel = cMaskName->Append(maskName, maskData);
+		cMaskName->SetSelection(maskSel);
 
-void OutfitStudioFrame::OnSaveAsMask(wxCommandEvent& WXUNUSED(event)) {
-	wxChoice* cMaskName = (wxChoice*)FindWindowByName("cMaskName");
-
-	wxString maskName;
-	do {
-		maskName = wxGetTextFromUser(_("Please enter a new unique name for the mask."), _("New Mask"));
-		if (maskName.empty())
-			return;
-
-	} while (cMaskName->FindString(maskName) != wxNOT_FOUND);
-
-	auto maskData = new std::map<std::string, std::unordered_map<uint16_t, float>>();
-
-	std::vector<std::string> shapes = GetShapeList();
-	for (auto &s : shapes) {
-		std::unordered_map<uint16_t, float> mask;
-		glView->GetShapeMask(mask, s);
-		(*maskData)[s] = std::move(mask);
 	}
 
-	int maskSel = cMaskName->Append(maskName, maskData);
-	cMaskName->SetSelection(maskSel);
-
-}
-
-void OutfitStudioFrame::OnDeleteMask(wxCommandEvent& WXUNUSED(event)) {
-	wxChoice* cMaskName = (wxChoice*)FindWindowByName("cMaskName");
-	int maskSel = cMaskName->GetSelection();
-	if (maskSel != wxNOT_FOUND) {
-		cMaskName->Delete(maskSel);
+	void OutfitStudioFrame::OnDeleteMask(wxCommandEvent& WXUNUSED(event)) {
+		wxChoice* cMaskName = (wxChoice*)FindWindowByName("cMaskName");
+		int maskSel = cMaskName->GetSelection();
+		if (maskSel != wxNOT_FOUND)
+		{
+			cMaskName->Delete(maskSel);
+		}
 	}
-}
 
-void OutfitStudioFrame::OnPaneCollapse(wxCollapsiblePaneEvent& WXUNUSED(event)) {
-	wxWindow* parentPanel = FindWindowByName("bottomSplitPanel");
-	parentPanel->Layout();
-}
-
-void OutfitStudioFrame::ApplyPose() {
-	for (auto &shape : project->GetWorkNif()->GetShapes()) {
-		std::vector<Vector3> verts;
-		project->GetLiveVerts(shape, verts);
-		glView->UpdateMeshVertices(shape->name.get(), &verts, true, true, false);
+	void OutfitStudioFrame::OnPaneCollapse(wxCollapsiblePaneEvent& WXUNUSED(event)) {
+		wxWindow* parentPanel = FindWindowByName("bottomSplitPanel");
+		parentPanel->Layout();
 	}
-	if (!activeBone.empty()) {
-		int boneScalePos = boneScale->GetValue();
-		if (boneScalePos != 0)
-			project->ApplyBoneScale(activeBone, boneScalePos);
+
+	void OutfitStudioFrame::ApplyPose() {
+		for (auto &shape : project->GetWorkNif()->GetShapes())
+		{
+			std::vector<Vector3> verts;
+			project->GetLiveVerts(shape, verts);
+			glView->UpdateMeshVertices(shape->name.get(), &verts, true, true, false);
+		}
+		if (!activeBone.empty())
+		{
+			int boneScalePos = boneScale->GetValue();
+			if (boneScalePos != 0)
+				project->ApplyBoneScale(activeBone, boneScalePos);
+		}
+		glView->Render();
 	}
-	glView->Render();
-}
 
-AnimBone *OutfitStudioFrame::GetPoseBonePtr() {
-	int selind = cPoseBone->GetSelection();
-	if (selind == wxNOT_FOUND) return nullptr;
-	std::string poseBone = cPoseBone->GetString(selind).ToStdString();
-	return AnimSkeleton::getInstance().GetBonePtr(poseBone);
-}
-
-void OutfitStudioFrame::PoseToGUI() {
-	AnimBone *bone = GetPoseBonePtr();
-	if (bone) {
-		rxPoseSlider->SetValue(bone->poseRotVec.x * 100);
-		ryPoseSlider->SetValue(bone->poseRotVec.y * 100);
-		rzPoseSlider->SetValue(bone->poseRotVec.z * 100);
-		txPoseSlider->SetValue(bone->poseTranVec.x * 100);
-		tyPoseSlider->SetValue(bone->poseTranVec.y * 100);
-		tzPoseSlider->SetValue(bone->poseTranVec.z * 100);
-		rxPoseText->ChangeValue(wxString() << bone->poseRotVec.x);
-		ryPoseText->ChangeValue(wxString() << bone->poseRotVec.y);
-		rzPoseText->ChangeValue(wxString() << bone->poseRotVec.z);
-		txPoseText->ChangeValue(wxString() << bone->poseTranVec.x);
-		tyPoseText->ChangeValue(wxString() << bone->poseTranVec.y);
-		tzPoseText->ChangeValue(wxString() << bone->poseTranVec.z);
+	AnimBone *OutfitStudioFrame::GetPoseBonePtr() {
+		int selind = cPoseBone->GetSelection();
+		if (selind == wxNOT_FOUND) return nullptr;
+		std::string poseBone = cPoseBone->GetString(selind).ToStdString();
+		return AnimSkeleton::getInstance().GetBonePtr(poseBone);
 	}
-	else {
-		rxPoseSlider->SetValue(0);
-		ryPoseSlider->SetValue(0);
-		rzPoseSlider->SetValue(0);
-		txPoseSlider->SetValue(0);
-		tyPoseSlider->SetValue(0);
-		tzPoseSlider->SetValue(0);
-		rxPoseText->ChangeValue("0");
-		ryPoseText->ChangeValue("0");
-		rzPoseText->ChangeValue("0");
-		txPoseText->ChangeValue("0");
-		tyPoseText->ChangeValue("0");
-		tzPoseText->ChangeValue("0");
+
+	void OutfitStudioFrame::PoseToGUI() {
+		AnimBone *bone = GetPoseBonePtr();
+		if (bone)
+		{
+			rxPoseSlider->SetValue(bone->poseRotVec.x * 100);
+			ryPoseSlider->SetValue(bone->poseRotVec.y * 100);
+			rzPoseSlider->SetValue(bone->poseRotVec.z * 100);
+			txPoseSlider->SetValue(bone->poseTranVec.x * 100);
+			tyPoseSlider->SetValue(bone->poseTranVec.y * 100);
+			tzPoseSlider->SetValue(bone->poseTranVec.z * 100);
+			rxPoseText->ChangeValue(wxString() << bone->poseRotVec.x);
+			ryPoseText->ChangeValue(wxString() << bone->poseRotVec.y);
+			rzPoseText->ChangeValue(wxString() << bone->poseRotVec.z);
+			txPoseText->ChangeValue(wxString() << bone->poseTranVec.x);
+			tyPoseText->ChangeValue(wxString() << bone->poseTranVec.y);
+			tzPoseText->ChangeValue(wxString() << bone->poseTranVec.z);
+		}
+		else
+		{
+			rxPoseSlider->SetValue(0);
+			ryPoseSlider->SetValue(0);
+			rzPoseSlider->SetValue(0);
+			txPoseSlider->SetValue(0);
+			tyPoseSlider->SetValue(0);
+			tzPoseSlider->SetValue(0);
+			rxPoseText->ChangeValue("0");
+			ryPoseText->ChangeValue("0");
+			rzPoseText->ChangeValue("0");
+			txPoseText->ChangeValue("0");
+			tyPoseText->ChangeValue("0");
+			tzPoseText->ChangeValue("0");
+		}
+		if (project->bPose != cbPose->GetValue())
+			cbPose->SetValue(project->bPose);
 	}
-	if (project->bPose != cbPose->GetValue())
-		cbPose->SetValue(project->bPose);
-}
 
-void OutfitStudioFrame::OnPoseBoneChanged(wxCommandEvent& WXUNUSED(event)) {
-	PoseToGUI();
-}
+	void OutfitStudioFrame::OnPoseBoneChanged(wxCommandEvent& WXUNUSED(event))
+	{
+		PoseToGUI();
+	}
 
-void OutfitStudioFrame::OnPoseValChanged(int cind, float val) {
-	// Called when any pose slider or text control is changed.
-	AnimBone *bone = GetPoseBonePtr();
-	if (!bone) return;
-	if (cind < 3)
-		bone->poseRotVec[cind] = val;
-	else
-		bone->poseTranVec[cind-3] = val;
-	bone->UpdatePoseTransform();
-	ApplyPose();
-}
-
-void OutfitStudioFrame::OnAnyPoseSlider(wxScrollEvent &e, wxTextCtrl *t, int cind) {
-	float val = e.GetPosition() * 0.01f;
-	t->ChangeValue(wxString() << val);
-	OnPoseValChanged(cind, val);
-}
-
-void OutfitStudioFrame::OnRXPoseSlider(wxScrollEvent& e) {
-	OnAnyPoseSlider(e, rxPoseText, 0);
-}
-void OutfitStudioFrame::OnRYPoseSlider(wxScrollEvent& e) {
-	OnAnyPoseSlider(e, ryPoseText, 1);
-}
-void OutfitStudioFrame::OnRZPoseSlider(wxScrollEvent& e) {
-	OnAnyPoseSlider(e, rzPoseText, 2);
-}
-void OutfitStudioFrame::OnTXPoseSlider(wxScrollEvent& e) {
-	OnAnyPoseSlider(e, txPoseText, 3);
-}
-void OutfitStudioFrame::OnTYPoseSlider(wxScrollEvent& e) {
-	OnAnyPoseSlider(e, tyPoseText, 4);
-}
-void OutfitStudioFrame::OnTZPoseSlider(wxScrollEvent& e) {
-	OnAnyPoseSlider(e, tzPoseText, 5);
-}
-
-void OutfitStudioFrame::OnAnyPoseTextChanged(wxTextCtrl *t, wxSlider *s, int cind) {
-	if (!t || !s) return;
-	double val;
-	if (!t->GetValue().ToDouble(&val))
-		return;
-	s->SetValue(val*100);
-	OnPoseValChanged(cind, val);
-}
-
-void OutfitStudioFrame::OnRXPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
-	OnAnyPoseTextChanged(rxPoseText, rxPoseSlider, 0);
-}
-void OutfitStudioFrame::OnRYPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
-	OnAnyPoseTextChanged(ryPoseText, ryPoseSlider, 1);
-}
-void OutfitStudioFrame::OnRZPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
-	OnAnyPoseTextChanged(rzPoseText, rzPoseSlider, 2);
-}
-void OutfitStudioFrame::OnTXPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
-	OnAnyPoseTextChanged(txPoseText, txPoseSlider, 3);
-}
-void OutfitStudioFrame::OnTYPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
-	OnAnyPoseTextChanged(tyPoseText, tyPoseSlider, 4);
-}
-void OutfitStudioFrame::OnTZPoseTextChanged(wxCommandEvent& WXUNUSED(event)) {
-	OnAnyPoseTextChanged(tzPoseText, tzPoseSlider, 5);
-}
-
-void OutfitStudioFrame::OnResetBonePose(wxCommandEvent& WXUNUSED(event)) {
-	AnimBone *bone = GetPoseBonePtr();
-	if (!bone) return;
-	bone->poseRotVec = Vector3(0,0,0);
-	bone->poseTranVec = Vector3(0,0,0);
-	bone->UpdatePoseTransform();
-	PoseToGUI();
-	ApplyPose();
-}
-
-void OutfitStudioFrame::OnResetAllPose(wxCommandEvent& WXUNUSED(event)) {
-	wxMessageDialog dlg(this, _("Reset all bone poses?"), _("Reset Pose"), wxOK | wxCANCEL | wxICON_WARNING | wxCANCEL_DEFAULT);
-	dlg.SetOKCancelLabels(_("Reset"), _("Cancel"));
-	if (dlg.ShowModal() != wxID_OK)
-		return;
-
-	std::vector<std::string> bones;
-	project->GetActiveBones(bones);
-
-	for (const std::string &boneName : bones) {
-		AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
-		if (!bone)
-			continue;
-
-		if (bone->poseRotVec.IsZero() && bone->poseTranVec.IsZero())
-			continue;
-
-		bone->poseRotVec = Vector3(0.0f, 0.0f, 0.0f);
-		bone->poseTranVec = Vector3(0.0f, 0.0f, 0.0f);
+	void OutfitStudioFrame::OnPoseValChanged(int cind, float val) {
+		// Called when any pose slider or text control is changed.
+		AnimBone *bone = GetPoseBonePtr();
+		if (!bone) return;
+		if (cind < 3)
+			bone->poseRotVec[cind] = val;
+		else
+			bone->poseTranVec[cind-3] = val;
 		bone->UpdatePoseTransform();
+		ApplyPose();
 	}
 
-	PoseToGUI();
-	ApplyPose();
-}
+	void OutfitStudioFrame::OnAnyPoseSlider(wxScrollEvent &e, wxTextCtrl *t, int cind) {
+		float val = e.GetPosition() * 0.01f;
+		t->ChangeValue(wxString() << val);
+		OnPoseValChanged(cind, val);
+	}
 
-void OutfitStudioFrame::OnPoseToMesh(wxCommandEvent& WXUNUSED(event)) {
-	if (project->bPose) {
-		wxMessageDialog dlg(this, _("Permanently apply the pose to the mesh?"), _("Apply Pose to Mesh"), wxOK | wxCANCEL | wxICON_WARNING | wxCANCEL_DEFAULT);
-		dlg.SetOKCancelLabels(_("Apply"), _("Cancel"));
+	void OutfitStudioFrame::OnRXPoseSlider(wxScrollEvent& e)
+	{
+		OnAnyPoseSlider(e, rxPoseText, 0);
+	}
+	void OutfitStudioFrame::OnRYPoseSlider(wxScrollEvent& e)
+	{
+		OnAnyPoseSlider(e, ryPoseText, 1);
+	}
+	void OutfitStudioFrame::OnRZPoseSlider(wxScrollEvent& e)
+	{
+		OnAnyPoseSlider(e, rzPoseText, 2);
+	}
+	void OutfitStudioFrame::OnTXPoseSlider(wxScrollEvent& e)
+	{
+		OnAnyPoseSlider(e, txPoseText, 3);
+	}
+	void OutfitStudioFrame::OnTYPoseSlider(wxScrollEvent& e)
+	{
+		OnAnyPoseSlider(e, tyPoseText, 4);
+	}
+	void OutfitStudioFrame::OnTZPoseSlider(wxScrollEvent& e)
+	{
+		OnAnyPoseSlider(e, tzPoseText, 5);
+	}
+
+	void OutfitStudioFrame::OnAnyPoseTextChanged(wxTextCtrl *t, wxSlider *s, int cind) {
+		if (!t || !s) return;
+		double val;
+		if (!t->GetValue().ToDouble(&val))
+			return;
+		s->SetValue(val*100);
+		OnPoseValChanged(cind, val);
+	}
+
+	void OutfitStudioFrame::OnRXPoseTextChanged(wxCommandEvent& WXUNUSED(event))
+	{
+		OnAnyPoseTextChanged(rxPoseText, rxPoseSlider, 0);
+	}
+	void OutfitStudioFrame::OnRYPoseTextChanged(wxCommandEvent& WXUNUSED(event))
+	{
+		OnAnyPoseTextChanged(ryPoseText, ryPoseSlider, 1);
+	}
+	void OutfitStudioFrame::OnRZPoseTextChanged(wxCommandEvent& WXUNUSED(event))
+	{
+		OnAnyPoseTextChanged(rzPoseText, rzPoseSlider, 2);
+	}
+	void OutfitStudioFrame::OnTXPoseTextChanged(wxCommandEvent& WXUNUSED(event))
+	{
+		OnAnyPoseTextChanged(txPoseText, txPoseSlider, 3);
+	}
+	void OutfitStudioFrame::OnTYPoseTextChanged(wxCommandEvent& WXUNUSED(event))
+	{
+		OnAnyPoseTextChanged(tyPoseText, tyPoseSlider, 4);
+	}
+	void OutfitStudioFrame::OnTZPoseTextChanged(wxCommandEvent& WXUNUSED(event))
+	{
+		OnAnyPoseTextChanged(tzPoseText, tzPoseSlider, 5);
+	}
+
+	void OutfitStudioFrame::OnResetBonePose(wxCommandEvent& WXUNUSED(event)) {
+		AnimBone *bone = GetPoseBonePtr();
+		if (!bone) return;
+		bone->poseRotVec = Vector3(0,0,0);
+		bone->poseTranVec = Vector3(0,0,0);
+		bone->UpdatePoseTransform();
+		PoseToGUI();
+		ApplyPose();
+	}
+
+	void OutfitStudioFrame::OnResetAllPose(wxCommandEvent& WXUNUSED(event)) {
+		wxMessageDialog dlg(this, _("Reset all bone poses?"), _("Reset Pose"), wxOK | wxCANCEL | wxICON_WARNING | wxCANCEL_DEFAULT);
+		dlg.SetOKCancelLabels(_("Reset"), _("Cancel"));
 		if (dlg.ShowModal() != wxID_OK)
 			return;
-
-		for (auto &s : project->GetWorkNif()->GetShapes()) {
-			UpdateShapeSource(s);
-			project->RefreshMorphShape(s);
-		}
-
-		project->InvalidateBoneScaleCache();
-		boneScale->SetValue(0);
 
 		std::vector<std::string> bones;
 		project->GetActiveBones(bones);
 
-		for (const std::string &boneName : bones) {
+		for (const std::string &boneName : bones)
+		{
 			AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
 			if (!bone)
 				continue;
@@ -9946,62 +10766,163 @@ void OutfitStudioFrame::OnPoseToMesh(wxCommandEvent& WXUNUSED(event)) {
 
 		PoseToGUI();
 		ApplyPose();
-		SetPendingChanges();
 	}
-}
 
-void OutfitStudioFrame::OnPoseCheckBox(wxCommandEvent& e) {
-	project->bPose = e.IsChecked();
+	void OutfitStudioFrame::OnPoseToMesh(wxCommandEvent& WXUNUSED(event))
+	{
+		if (project->bPose)
+		{
+			wxMessageDialog dlg(this, _("Permanently apply the pose to the mesh?"), _("Apply Pose to Mesh"), wxOK | wxCANCEL | wxICON_WARNING | wxCANCEL_DEFAULT);
+			dlg.SetOKCancelLabels(_("Apply"), _("Cancel"));
+			if (dlg.ShowModal() != wxID_OK)
+				return;
 
-	auto poseToMesh = (wxButton*)FindWindowByName("poseToMesh");
-	poseToMesh->Enable(project->bPose);
-
-	ApplyPose();
-}
-
-void OutfitStudioFrame::OnSelectPose(wxCommandEvent& WXUNUSED(event)) {
-	wxChoice* cPoseName = (wxChoice*)FindWindowByName("cPoseName");
-	int poseSel = cPoseName->GetSelection();
-	if (poseSel != wxNOT_FOUND) {
-		auto poseData = reinterpret_cast<PoseData*>(cPoseName->GetClientData(poseSel));
-
-		std::vector<std::string> bones;
-		project->GetActiveBones(bones);
-
-		for (const auto &boneName : bones) {
-			AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
-			if (!bone)
-				continue;
-
-			auto poseBoneData = std::find_if(poseData->boneData.begin(), poseData->boneData.end(), [&boneName](const PoseBoneData& rt) { return rt.name == boneName; });
-			if (poseBoneData != poseData->boneData.end()) {
-				bone->poseRotVec = poseBoneData->rotation;
-				bone->poseTranVec = poseBoneData->translation;
+			for (auto &s : project->GetWorkNif()->GetShapes())
+			{
+				UpdateShapeSource(s);
+				project->RefreshMorphShape(s);
 			}
-			else {
+
+			project->InvalidateBoneScaleCache();
+			boneScale->SetValue(0);
+
+			std::vector<std::string> bones;
+			project->GetActiveBones(bones);
+
+			for (const std::string &boneName : bones)
+			{
+				AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
+				if (!bone)
+					continue;
+
+				if (bone->poseRotVec.IsZero() && bone->poseTranVec.IsZero())
+					continue;
+
 				bone->poseRotVec = Vector3(0.0f, 0.0f, 0.0f);
 				bone->poseTranVec = Vector3(0.0f, 0.0f, 0.0f);
+				bone->UpdatePoseTransform();
 			}
 
-			bone->UpdatePoseTransform();
+			PoseToGUI();
+			ApplyPose();
+			SetPendingChanges();
 		}
+	}
 
-		PoseToGUI();
+	void OutfitStudioFrame::OnPoseCheckBox(wxCommandEvent& e) {
+		project->bPose = e.IsChecked();
+
+		auto poseToMesh = (wxButton*)FindWindowByName("poseToMesh");
+		poseToMesh->Enable(project->bPose);
+
 		ApplyPose();
 	}
-}
 
-void OutfitStudioFrame::OnSavePose(wxCommandEvent& WXUNUSED(event)) {
-	wxChoice* cPoseName = (wxChoice*)FindWindowByName("cPoseName");
-	int poseSel = cPoseName->GetSelection();
-	if (poseSel != wxNOT_FOUND) {
-		auto poseData = reinterpret_cast<PoseData*>(cPoseName->GetClientData(poseSel));
-		poseData->boneData.clear();
+	void OutfitStudioFrame::OnSelectPose(wxCommandEvent& WXUNUSED(event)) {
+		wxChoice* cPoseName = (wxChoice*)FindWindowByName("cPoseName");
+		int poseSel = cPoseName->GetSelection();
+		if (poseSel != wxNOT_FOUND)
+		{
+			auto poseData = reinterpret_cast<PoseData*>(cPoseName->GetClientData(poseSel));
+
+			std::vector<std::string> bones;
+			project->GetActiveBones(bones);
+
+			for (const auto &boneName : bones)
+			{
+				AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
+				if (!bone)
+					continue;
+
+				auto poseBoneData = std::find_if(poseData->boneData.begin(), poseData->boneData.end(), [&boneName](const PoseBoneData& rt) { return rt.name == boneName; });
+				if (poseBoneData != poseData->boneData.end())
+				{
+					bone->poseRotVec = poseBoneData->rotation;
+					bone->poseTranVec = poseBoneData->translation;
+				}
+				else
+				{
+					bone->poseRotVec = Vector3(0.0f, 0.0f, 0.0f);
+					bone->poseTranVec = Vector3(0.0f, 0.0f, 0.0f);
+				}
+
+				bone->UpdatePoseTransform();
+			}
+
+			PoseToGUI();
+			ApplyPose();
+		}
+	}
+
+	void OutfitStudioFrame::OnSavePose(wxCommandEvent& WXUNUSED(event)) {
+		wxChoice* cPoseName = (wxChoice*)FindWindowByName("cPoseName");
+		int poseSel = cPoseName->GetSelection();
+		if (poseSel != wxNOT_FOUND)
+		{
+			auto poseData = reinterpret_cast<PoseData*>(cPoseName->GetClientData(poseSel));
+			poseData->boneData.clear();
+
+			std::vector<std::string> bones;
+			project->GetActiveBones(bones);
+
+			for (const auto &boneName : bones)
+			{
+				AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
+				if (!bone)
+					continue;
+
+				if (bone->poseRotVec.IsZero() && bone->poseTranVec.IsZero())
+					continue;
+
+				PoseBoneData poseBoneData{};
+				poseBoneData.name = bone->boneName;
+				poseBoneData.rotation = bone->poseRotVec;
+				poseBoneData.translation = bone->poseTranVec;
+				poseData->boneData.push_back(poseBoneData);
+			}
+
+			cPoseName->SetClientData(poseSel, poseData);
+
+			wxString dirName = wxString::FromUTF8(GetProjectPath()) + "/PoseData";
+			wxFileName::Mkdir(dirName, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+
+			wxString fileName = dirName + "/" + wxString::FromUTF8(poseData->name) + ".xml";
+
+			PoseDataFile poseDataFile;
+			poseDataFile.New(fileName.ToUTF8().data());
+
+			std::vector<PoseData> poses;
+			poses.push_back(*poseData);
+
+			poseDataFile.SetData(poses);
+			poseDataFile.Save();
+		}
+		else
+		{
+			wxCommandEvent evt;
+			OnSaveAsPose(evt);
+		}
+	}
+
+	void OutfitStudioFrame::OnSaveAsPose(wxCommandEvent& WXUNUSED(event)) {
+		wxChoice* cPoseName = (wxChoice*)FindWindowByName("cPoseName");
+
+		wxString poseName;
+		do
+		{
+			poseName = wxGetTextFromUser(_("Please enter a new unique name for the pose."), _("New Pose"));
+			if (poseName.empty())
+				return;
+
+		} while (cPoseName->FindString(poseName) != wxNOT_FOUND);
+
+		auto poseData = new PoseData(poseName.ToUTF8().data());
 
 		std::vector<std::string> bones;
 		project->GetActiveBones(bones);
 
-		for (const auto &boneName : bones) {
+		for (const auto &boneName : bones)
+		{
 			AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
 			if (!bone)
 				continue;
@@ -10016,7 +10937,8 @@ void OutfitStudioFrame::OnSavePose(wxCommandEvent& WXUNUSED(event)) {
 			poseData->boneData.push_back(poseBoneData);
 		}
 
-		cPoseName->SetClientData(poseSel, poseData);
+		int poseSel = cPoseName->Append(poseName, poseData);
+		cPoseName->SetSelection(poseSel);
 
 		wxString dirName = wxString::FromUTF8(GetProjectPath()) + "/PoseData";
 		wxFileName::Mkdir(dirName, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
@@ -10032,650 +10954,422 @@ void OutfitStudioFrame::OnSavePose(wxCommandEvent& WXUNUSED(event)) {
 		poseDataFile.SetData(poses);
 		poseDataFile.Save();
 	}
-	else {
-		wxCommandEvent evt;
-		OnSaveAsPose(evt);
-	}
-}
 
-void OutfitStudioFrame::OnSaveAsPose(wxCommandEvent& WXUNUSED(event)) {
-	wxChoice* cPoseName = (wxChoice*)FindWindowByName("cPoseName");
+	void OutfitStudioFrame::OnDeletePose(wxCommandEvent& WXUNUSED(event)) {
+		wxChoice* cPoseName = (wxChoice*)FindWindowByName("cPoseName");
+		int poseSel = cPoseName->GetSelection();
+		if (poseSel != wxNOT_FOUND)
+		{
+			auto poseData = reinterpret_cast<PoseData*>(cPoseName->GetClientData(poseSel));
 
-	wxString poseName;
-	do {
-		poseName = wxGetTextFromUser(_("Please enter a new unique name for the pose."), _("New Pose"));
-		if (poseName.empty())
-			return;
-
-	} while (cPoseName->FindString(poseName) != wxNOT_FOUND);
-
-	auto poseData = new PoseData(poseName.ToUTF8().data());
-
-	std::vector<std::string> bones;
-	project->GetActiveBones(bones);
-
-	for (const auto &boneName : bones) {
-		AnimBone *bone = AnimSkeleton::getInstance().GetBonePtr(boneName);
-		if (!bone)
-			continue;
-
-		if (bone->poseRotVec.IsZero() && bone->poseTranVec.IsZero())
-			continue;
-
-		PoseBoneData poseBoneData{};
-		poseBoneData.name = bone->boneName;
-		poseBoneData.rotation = bone->poseRotVec;
-		poseBoneData.translation = bone->poseTranVec;
-		poseData->boneData.push_back(poseBoneData);
-	}
-
-	int poseSel = cPoseName->Append(poseName, poseData);
-	cPoseName->SetSelection(poseSel);
-
-	wxString dirName = wxString::FromUTF8(GetProjectPath()) + "/PoseData";
-	wxFileName::Mkdir(dirName, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
-
-	wxString fileName = dirName + "/" + wxString::FromUTF8(poseData->name) + ".xml";
-
-	PoseDataFile poseDataFile;
-	poseDataFile.New(fileName.ToUTF8().data());
-
-	std::vector<PoseData> poses;
-	poses.push_back(*poseData);
-
-	poseDataFile.SetData(poses);
-	poseDataFile.Save();
-}
-
-void OutfitStudioFrame::OnDeletePose(wxCommandEvent& WXUNUSED(event)) {
-	wxChoice* cPoseName = (wxChoice*)FindWindowByName("cPoseName");
-	int poseSel = cPoseName->GetSelection();
-	if (poseSel != wxNOT_FOUND) {
-		auto poseData = reinterpret_cast<PoseData*>(cPoseName->GetClientData(poseSel));
-
-		wxString prompt = wxString::Format(_("Are you sure you wish to delete the pose '%s'?"), cPoseName->GetStringSelection());
-		int result = wxMessageBox(prompt, _("Confirm pose delete"), wxYES_NO | wxICON_WARNING, this);
-		if (result != wxYES)
-			return;
-
-		wxString fileName = wxString::FromUTF8(GetProjectPath()) + "/PoseData/" + wxString::FromUTF8(poseData->name) + ".xml";
-		wxRemoveFile(fileName);
-
-		cPoseName->Delete(poseSel);
-	}
-}
-
-
-wxBEGIN_EVENT_TABLE(wxGLPanel, wxGLCanvas)
-	EVT_PAINT(wxGLPanel::OnPaint)
-	EVT_SIZE(wxGLPanel::OnSize)
-	EVT_MOUSEWHEEL(wxGLPanel::OnMouseWheel)
-	EVT_MOTION(wxGLPanel::OnMouseMove)
-	EVT_LEFT_DOWN(wxGLPanel::OnLeftDown)
-	EVT_LEFT_DCLICK(wxGLPanel::OnLeftDown)
-	EVT_LEFT_UP(wxGLPanel::OnLeftUp)
-	EVT_MIDDLE_DOWN(wxGLPanel::OnMiddleDown)
-	EVT_MIDDLE_UP(wxGLPanel::OnMiddleUp)
-	EVT_RIGHT_DOWN(wxGLPanel::OnRightDown)
-	EVT_RIGHT_UP(wxGLPanel::OnRightUp)
-	EVT_CHAR_HOOK(wxGLPanel::OnKeys)
-	EVT_IDLE(wxGLPanel::OnIdle)
-	EVT_MOUSE_CAPTURE_LOST(wxGLPanel::OnCaptureLost)
-wxEND_EVENT_TABLE()
-
-wxGLPanel::wxGLPanel(wxWindow* parent, const wxSize& size, const wxGLAttributes& attribs)
-	: wxGLCanvas(parent, attribs, wxID_ANY, wxDefaultPosition, size, wxFULL_REPAINT_ON_RESIZE) {
-
-	context = std::make_unique<wxGLContext>(this, nullptr, &GLSurface::GetGLContextAttribs());
-}
-
-wxGLPanel::~wxGLPanel() {
-	Cleanup();
-	gls.RenderOneFrame();
-}
-
-void wxGLPanel::OnShown() {
-	if (!context->IsOK()) {
-		wxLogError("Outfit Studio: OpenGL context is not OK.");
-		wxMessageBox(_("Outfit Studio: OpenGL context is not OK."), _("OpenGL Error"), wxICON_ERROR, os);
-	}
-
-	gls.Initialize(this, context.get());
-	auto size = GetSize();
-	gls.SetStartingView(Vector3(0.0f, -5.0f, -15.0f), Vector3(15.0f, 0.0f, 0.0f), size.GetWidth(), size.GetHeight());
-	gls.SetMaskVisible();
-
-	int ambient = Config.GetIntValue("Lights/Ambient");
-	int frontal = Config.GetIntValue("Lights/Frontal");
-
-	int directional0 = Config.GetIntValue("Lights/Directional0");
-	int directional0X = Config.GetIntValue("Lights/Directional0.x");
-	int directional0Y = Config.GetIntValue("Lights/Directional0.y");
-	int directional0Z = Config.GetIntValue("Lights/Directional0.z");
-
-	int directional1 = Config.GetIntValue("Lights/Directional1");
-	int directional1X = Config.GetIntValue("Lights/Directional1.x");
-	int directional1Y = Config.GetIntValue("Lights/Directional1.y");
-	int directional1Z = Config.GetIntValue("Lights/Directional1.z");
-
-	int directional2 = Config.GetIntValue("Lights/Directional2");
-	int directional2X = Config.GetIntValue("Lights/Directional2.x");
-	int directional2Y = Config.GetIntValue("Lights/Directional2.y");
-	int directional2Z = Config.GetIntValue("Lights/Directional2.z");
-
-	Vector3 directional0Dir = Vector3(directional0X / 100.0f, directional0Y / 100.0f, directional0Z / 100.0f);
-	Vector3 directional1Dir = Vector3(directional1X / 100.0f, directional1Y / 100.0f, directional1Z / 100.0f);
-	Vector3 directional2Dir = Vector3(directional2X / 100.0f, directional2Y / 100.0f, directional2Z / 100.0f);
-
-	UpdateLights(ambient, frontal, directional0, directional1, directional2, directional0Dir, directional1Dir, directional2Dir);
-
-	if (Config.Exists("Rendering/ColorBackground")) {
-		int colorBackgroundR = Config.GetIntValue("Rendering/ColorBackground.r");
-		int colorBackgroundG = Config.GetIntValue("Rendering/ColorBackground.g");
-		int colorBackgroundB = Config.GetIntValue("Rendering/ColorBackground.b");
-		gls.SetBackgroundColor(Vector3(colorBackgroundR / 255.0f, colorBackgroundG / 255.0f, colorBackgroundB / 255.0f));
-	}
-
-	if (Config.Exists("Rendering/ColorWire")) {
-		int colorWireR = Config.GetIntValue("Rendering/ColorWire.r");
-		int colorWireG = Config.GetIntValue("Rendering/ColorWire.g");
-		int colorWireB = Config.GetIntValue("Rendering/ColorWire.b");
-		gls.SetWireColor(Vector3(colorWireR / 255.0f, colorWireG / 255.0f, colorWireB / 255.0f));
-	}
-
-	os->MeshesFromProj();
-
-	UpdateFloor();
-	UpdateNodes();
-	UpdateBones();
-
-	Render();
-}
-
-void wxGLPanel::SetNotifyWindow(wxWindow* win) {
-	os = dynamic_cast<OutfitStudioFrame*>(win);
-}
-
-void wxGLPanel::AddMeshFromNif(NifFile* nif, const std::string& shapeName) {
-	std::vector<std::string> shapeList = nif->GetShapeNames();
-
-	for (size_t i = 0; i < shapeList.size(); i++) {
-		if (!shapeName.empty() && shapeList[i] != shapeName)
-			continue;
-
-		mesh* m = gls.AddMeshFromNif(nif, shapeList[i]);
-		if (!m)
-			continue;
-
-		NiShape* shape = nif->FindBlockByName<NiShape>(shapeList[i]);
-		if (shape && shape->IsSkinned()) {
-			// Overwrite skin matrix with the one from AnimInfo
-			const auto skinning = os->project->GetWorkAnim()->shapeSkinning.find(shapeList[i]);
-			if (skinning != os->project->GetWorkAnim()->shapeSkinning.end()) {
-				MatTransform gts = skinning->second.xformGlobalToSkin;
-				gts.translation = mesh::VecToMeshCoords(gts.translation);
-				m->matModel = glm::inverse(mesh::TransformToMatrix4(gts));
-			}
-		}
-
-		m->BuildTriAdjacency();
-		m->BuildEdgeList();
-		m->ColorFill(Vector3());
-
-		if (extInitialized) {
-			gls.SetContext();
-			m->CreateBuffers();
-		}
-	}
-}
-
-void wxGLPanel::SetMeshTextures(const std::string& shapeName, const std::vector<std::string>& textureFiles, const bool hasMatFile, const MaterialFile& matFile, const bool reloadTextures) {
-	mesh* m = gls.GetMesh(shapeName);
-	if (!m)
-		return;
-	
-	std::string vShader = Config["AppDir"] + "/res/shaders/default.vert";
-	std::string fShader = Config["AppDir"] + "/res/shaders/default.frag";
-
-	auto targetGame = (TargetGame)Config.GetIntValue("TargetGame");
-	if (targetGame == FO4 || targetGame == FO4VR || targetGame == FO76) {
-		vShader = Config["AppDir"] + "/res/shaders/fo4_default.vert";
-		fShader = Config["AppDir"] + "/res/shaders/fo4_default.frag";
-	}
-	else if (targetGame == OB) {
-		vShader = Config["AppDir"] + "/res/shaders/ob_default.vert";
-		fShader = Config["AppDir"] + "/res/shaders/ob_default.frag";
-	}
-
-	GLMaterial* mat = gls.AddMaterial(textureFiles, vShader, fShader, reloadTextures);
-	if (mat) {
-		m->material = mat;
-		
-		if (hasMatFile)
-			m->UpdateFromMaterialFile(matFile);
-
-		gls.UpdateShaders(m);
-	}
-}
-
-void wxGLPanel::UpdateMeshVertices(const std::string& shapeName, std::vector<Vector3>* verts, bool updateBVH, bool recalcNormals, bool render, std::vector<Vector2>* uvs) {
-	mesh* m = gls.GetMesh(shapeName);
-	if (m) {
-		gls.Update(m, verts, uvs);
-
-		if (updateBVH)
-			BVHUpdateQueue.insert(m);
-
-		if (recalcNormals)
-			m->SmoothNormals();
-	}
-
-	if (render)
-		gls.RenderOneFrame();
-}
-
-void wxGLPanel::RecalculateMeshBVH(const std::string& shapeName) {
-	gls.RecalculateMeshBVH(shapeName);
-}
-
-void wxGLPanel::ShowShape(const std::string& shapeName, bool show) {
-	gls.SetMeshVisibility(shapeName, show);
-}
-
-void wxGLPanel::SetActiveShapes(const std::vector<std::string>& shapeNames) {
-	gls.SetActiveMeshes(shapeNames);
-}
-
-void wxGLPanel::SetSelectedShape(const std::string& shapeName) {
-	gls.SetSelectedMesh(shapeName);
-}
-
-void wxGLPanel::SetActiveTool(ToolID brushID) {
-	activeTool = brushID;
-
-	switch (brushID) {
-	case ToolID::MaskBrush:
-		activeBrush = &maskBrush;
-		break;
-	case ToolID::InflateBrush:
-		activeBrush = &standardBrush;
-		break;
-	case ToolID::DeflateBrush:
-		activeBrush = &deflateBrush;
-		break;
-	case ToolID::MoveBrush:
-		activeBrush = &moveBrush;
-		break;
-	case ToolID::SmoothBrush:
-		activeBrush = &smoothBrush;
-		break;
-	case ToolID::UndiffBrush:
-		activeBrush = &undiffBrush;
-		break;
-	case ToolID::WeightBrush:
-		activeBrush = &weightBrush;
-		break;
-	case ToolID::ColorBrush:
-		activeBrush = &colorBrush;
-		break;
-	case ToolID::AlphaBrush:
-		activeBrush = &alphaBrush;
-		break;
-	default:
-		activeBrush = nullptr;
-		break;
-	}
-}
-
-void wxGLPanel::SetLastTool(ToolID tool) {
-	lastTool = tool;
-}
-
-void wxGLPanel::OnKeys(wxKeyEvent& event) {
-	if (!event.HasAnyModifiers()) {
-		if (event.GetUnicodeKey() == 'V') {
-			wxPoint cursorPos(event.GetPosition());
-
-			int vertIndex;
-			if (!gls.GetCursorVertex(cursorPos.x, cursorPos.y, &vertIndex))
+			wxString prompt = wxString::Format(_("Are you sure you wish to delete the pose '%s'?"), cPoseName->GetStringSelection());
+			int result = wxMessageBox(prompt, _("Confirm pose delete"), wxYES_NO | wxICON_WARNING, this);
+			if (result != wxYES)
 				return;
 
-			wxDialog dlg;
-			if (wxXmlResource::Get()->LoadDialog(&dlg, os, "dlgMoveVertex")) {
-				NiShape* shape = os->activeItem->GetShape();
+			wxString fileName = wxString::FromUTF8(GetProjectPath()) + "/PoseData/" + wxString::FromUTF8(poseData->name) + ".xml";
+			wxRemoveFile(fileName);
 
-				std::vector<Vector3> verts;
-				os->project->GetLiveVerts(shape, verts);
+			cPoseName->Delete(poseSel);
+		}
+	}
 
-				Vector3 oldPos = verts[vertIndex];
-				XRCCTRL(dlg, "posX", wxTextCtrl)->SetLabel(wxString::Format("%0.5f", oldPos.x));
-				XRCCTRL(dlg, "posY", wxTextCtrl)->SetLabel(wxString::Format("%0.5f", oldPos.y));
-				XRCCTRL(dlg, "posZ", wxTextCtrl)->SetLabel(wxString::Format("%0.5f", oldPos.z));
 
-				if (dlg.ShowModal() == wxID_OK) {
-					Vector3 newPos;
-					newPos.x = atof(XRCCTRL(dlg, "posX", wxTextCtrl)->GetValue().c_str());
-					newPos.y = atof(XRCCTRL(dlg, "posY", wxTextCtrl)->GetValue().c_str());
-					newPos.z = atof(XRCCTRL(dlg, "posZ", wxTextCtrl)->GetValue().c_str());
+	wxBEGIN_EVENT_TABLE(wxGLPanel, wxGLCanvas)
+		EVT_PAINT(wxGLPanel::OnPaint)
+		EVT_SIZE(wxGLPanel::OnSize)
+		EVT_MOUSEWHEEL(wxGLPanel::OnMouseWheel)
+		EVT_MOTION(wxGLPanel::OnMouseMove)
+		EVT_LEFT_DOWN(wxGLPanel::OnLeftDown)
+		EVT_LEFT_DCLICK(wxGLPanel::OnLeftDown)
+		EVT_LEFT_UP(wxGLPanel::OnLeftUp)
+		EVT_MIDDLE_DOWN(wxGLPanel::OnMiddleDown)
+		EVT_MIDDLE_UP(wxGLPanel::OnMiddleUp)
+		EVT_RIGHT_DOWN(wxGLPanel::OnRightDown)
+		EVT_RIGHT_UP(wxGLPanel::OnRightUp)
+		EVT_CHAR_HOOK(wxGLPanel::OnKeys)
+		EVT_IDLE(wxGLPanel::OnIdle)
+		EVT_MOUSE_CAPTURE_LOST(wxGLPanel::OnCaptureLost)
+		wxEND_EVENT_TABLE()
 
-					// Move vertex in shape directly
-					if (!os->bEditSlider)
-						os->project->MoveVertex(shape, newPos, vertIndex);
+	wxGLPanel::wxGLPanel(wxWindow* parent, const wxSize& size, const wxGLAttributes& attribs)
+		: wxGLCanvas(parent, attribs, wxID_ANY, wxDefaultPosition, size, wxFULL_REPAINT_ON_RESIZE)
+	{
 
-					// To mesh coordinates
-					oldPos = mesh::VecToMeshCoords(oldPos);
-					newPos = mesh::VecToMeshCoords(newPos);
+		context = std::make_unique<wxGLContext>(this, nullptr, &GLSurface::GetGLContextAttribs());
+	}
 
-					UndoStateShape uss;
-					uss.shapeName = shape->name.get();
-					uss.pointStartState[vertIndex] = oldPos;
-					uss.pointEndState[vertIndex] = newPos;
+	wxGLPanel::~wxGLPanel() {
+		Cleanup();
+		gls.RenderOneFrame();
+	}
 
-					// Push changes onto undo stack and execute
-					UndoStateProject *usp = GetUndoHistory()->PushState();
-					usp->undoType = UT_VERTPOS;
-					usp->usss.push_back(std::move(uss));
+	void wxGLPanel::OnShown() {
+		if (!context->IsOK())
+		{
+			wxLogError("Outfit Studio: OpenGL context is not OK.");
+			wxMessageBox(_("Outfit Studio: OpenGL context is not OK."), _("OpenGL Error"), wxICON_ERROR, os);
+		}
 
-					if (os->bEditSlider) {
-						usp->sliderName = os->activeSlider;
+		gls.Initialize(this, context.get());
+		auto size = GetSize();
+		gls.SetStartingView(Vector3(0.0f, -5.0f, -15.0f), Vector3(15.0f, 0.0f, 0.0f), size.GetWidth(), size.GetHeight());
+		gls.SetMaskVisible();
 
-						float sliderscale = os->project->SliderValue(os->activeSlider);
-						if (sliderscale == 0.0)
-							sliderscale = 1.0;
+		int ambient = Config.GetIntValue("Lights/Ambient");
+		int frontal = Config.GetIntValue("Lights/Frontal");
 
-						usp->sliderscale = sliderscale;
+		int directional0 = Config.GetIntValue("Lights/Directional0");
+		int directional0X = Config.GetIntValue("Lights/Directional0.x");
+		int directional0Y = Config.GetIntValue("Lights/Directional0.y");
+		int directional0Z = Config.GetIntValue("Lights/Directional0.z");
+
+		int directional1 = Config.GetIntValue("Lights/Directional1");
+		int directional1X = Config.GetIntValue("Lights/Directional1.x");
+		int directional1Y = Config.GetIntValue("Lights/Directional1.y");
+		int directional1Z = Config.GetIntValue("Lights/Directional1.z");
+
+		int directional2 = Config.GetIntValue("Lights/Directional2");
+		int directional2X = Config.GetIntValue("Lights/Directional2.x");
+		int directional2Y = Config.GetIntValue("Lights/Directional2.y");
+		int directional2Z = Config.GetIntValue("Lights/Directional2.z");
+
+		Vector3 directional0Dir = Vector3(directional0X / 100.0f, directional0Y / 100.0f, directional0Z / 100.0f);
+		Vector3 directional1Dir = Vector3(directional1X / 100.0f, directional1Y / 100.0f, directional1Z / 100.0f);
+		Vector3 directional2Dir = Vector3(directional2X / 100.0f, directional2Y / 100.0f, directional2Z / 100.0f);
+
+		UpdateLights(ambient, frontal, directional0, directional1, directional2, directional0Dir, directional1Dir, directional2Dir);
+
+		if (Config.Exists("Rendering/ColorBackground"))
+		{
+			int colorBackgroundR = Config.GetIntValue("Rendering/ColorBackground.r");
+			int colorBackgroundG = Config.GetIntValue("Rendering/ColorBackground.g");
+			int colorBackgroundB = Config.GetIntValue("Rendering/ColorBackground.b");
+			gls.SetBackgroundColor(Vector3(colorBackgroundR / 255.0f, colorBackgroundG / 255.0f, colorBackgroundB / 255.0f));
+		}
+
+		if (Config.Exists("Rendering/ColorWire"))
+		{
+			int colorWireR = Config.GetIntValue("Rendering/ColorWire.r");
+			int colorWireG = Config.GetIntValue("Rendering/ColorWire.g");
+			int colorWireB = Config.GetIntValue("Rendering/ColorWire.b");
+			gls.SetWireColor(Vector3(colorWireR / 255.0f, colorWireG / 255.0f, colorWireB / 255.0f));
+		}
+
+		os->MeshesFromProj();
+
+		UpdateFloor();
+		UpdateNodes();
+		UpdateBones();
+
+		Render();
+	}
+
+	void wxGLPanel::SetNotifyWindow(wxWindow* win)
+	{
+		os = dynamic_cast<OutfitStudioFrame*>(win);
+	}
+
+	void wxGLPanel::AddMeshFromNif(NifFile* nif, const std::string& shapeName) {
+		std::vector<std::string> shapeList = nif->GetShapeNames();
+
+		for (size_t i = 0; i < shapeList.size(); i++)
+		{
+			if (!shapeName.empty() && shapeList[i] != shapeName)
+				continue;
+
+			mesh* m = gls.AddMeshFromNif(nif, shapeList[i]);
+			if (!m)
+				continue;
+
+			NiShape* shape = nif->FindBlockByName<NiShape>(shapeList[i]);
+			if (shape && shape->IsSkinned())
+			{
+				// Overwrite skin matrix with the one from AnimInfo
+				const auto skinning = os->project->GetWorkAnim()->shapeSkinning.find(shapeList[i]);
+				if (skinning != os->project->GetWorkAnim()->shapeSkinning.end())
+				{
+					MatTransform gts = skinning->second.xformGlobalToSkin;
+					gts.translation = mesh::VecToMeshCoords(gts.translation);
+					m->matModel = glm::inverse(mesh::TransformToMatrix4(gts));
+				}
+			}
+
+			m->BuildTriAdjacency();
+			m->BuildEdgeList();
+			m->ColorFill(Vector3());
+
+			if (extInitialized)
+			{
+				gls.SetContext();
+				m->CreateBuffers();
+			}
+		}
+	}
+
+	void wxGLPanel::SetMeshTextures(const std::string& shapeName, const std::vector<std::string>& textureFiles, const bool hasMatFile, const MaterialFile& matFile, const bool reloadTextures) {
+		mesh* m = gls.GetMesh(shapeName);
+		if (!m)
+			return;
+	
+		std::string vShader = Config["AppDir"] + "/res/shaders/default.vert";
+		std::string fShader = Config["AppDir"] + "/res/shaders/default.frag";
+
+		auto targetGame = (TargetGame)Config.GetIntValue("TargetGame");
+		if (targetGame == FO4 || targetGame == FO4VR || targetGame == FO76)
+		{
+			vShader = Config["AppDir"] + "/res/shaders/fo4_default.vert";
+			fShader = Config["AppDir"] + "/res/shaders/fo4_default.frag";
+		}
+		else if (targetGame == OB)
+		{
+			vShader = Config["AppDir"] + "/res/shaders/ob_default.vert";
+			fShader = Config["AppDir"] + "/res/shaders/ob_default.frag";
+		}
+
+		GLMaterial* mat = gls.AddMaterial(textureFiles, vShader, fShader, reloadTextures);
+		if (mat)
+		{
+			m->material = mat;
+		
+			if (hasMatFile)
+				m->UpdateFromMaterialFile(matFile);
+
+			gls.UpdateShaders(m);
+		}
+	}
+
+	void wxGLPanel::UpdateMeshVertices(const std::string& shapeName, std::vector<Vector3>* verts, bool updateBVH, bool recalcNormals, bool render, std::vector<Vector2>* uvs) {
+		mesh* m = gls.GetMesh(shapeName);
+		if (m)
+		{
+			gls.Update(m, verts, uvs);
+
+			if (updateBVH)
+				BVHUpdateQueue.insert(m);
+
+			if (recalcNormals)
+				m->SmoothNormals();
+		}
+
+		if (render)
+			gls.RenderOneFrame();
+	}
+
+	void wxGLPanel::RecalculateMeshBVH(const std::string& shapeName)
+	{
+		gls.RecalculateMeshBVH(shapeName);
+	}
+
+	void wxGLPanel::ShowShape(const std::string& shapeName, bool show)
+	{
+		gls.SetMeshVisibility(shapeName, show);
+	}
+
+	void wxGLPanel::SetActiveShapes(const std::vector<std::string>& shapeNames)
+	{
+		gls.SetActiveMeshes(shapeNames);
+	}
+
+	void wxGLPanel::SetSelectedShape(const std::string& shapeName)
+	{
+		gls.SetSelectedMesh(shapeName);
+	}
+
+	void wxGLPanel::SetActiveTool(ToolID brushID) {
+		activeTool = brushID;
+
+		switch (brushID)
+		{
+		case ToolID::MaskBrush:
+			activeBrush = &maskBrush;
+			break;
+		case ToolID::InflateBrush:
+			activeBrush = &standardBrush;
+			break;
+		case ToolID::DeflateBrush:
+			activeBrush = &deflateBrush;
+			break;
+		case ToolID::MoveBrush:
+			activeBrush = &moveBrush;
+			break;
+		case ToolID::SmoothBrush:
+			activeBrush = &smoothBrush;
+			break;
+		case ToolID::UndiffBrush:
+			activeBrush = &undiffBrush;
+			break;
+		case ToolID::WeightBrush:
+			activeBrush = &weightBrush;
+			break;
+		case ToolID::ColorBrush:
+			activeBrush = &colorBrush;
+			break;
+		case ToolID::AlphaBrush:
+			activeBrush = &alphaBrush;
+			break;
+		default:
+			activeBrush = nullptr;
+			break;
+		}
+	}
+
+	void wxGLPanel::SetLastTool(ToolID tool)
+	{
+		lastTool = tool;
+	}
+
+	void wxGLPanel::OnKeys(wxKeyEvent& event) {
+		if (!event.HasAnyModifiers())
+		{
+			if (event.GetUnicodeKey() == 'V')
+			{
+				wxPoint cursorPos(event.GetPosition());
+
+				int vertIndex;
+				if (!gls.GetCursorVertex(cursorPos.x, cursorPos.y, &vertIndex))
+					return;
+
+				wxDialog dlg;
+				if (wxXmlResource::Get()->LoadDialog(&dlg, os, "dlgMoveVertex"))
+				{
+					NiShape* shape = os->activeItem->GetShape();
+
+					std::vector<Vector3> verts;
+					os->project->GetLiveVerts(shape, verts);
+
+					Vector3 oldPos = verts[vertIndex];
+					XRCCTRL(dlg, "posX", wxTextCtrl)->SetLabel(wxString::Format("%0.5f", oldPos.x));
+					XRCCTRL(dlg, "posY", wxTextCtrl)->SetLabel(wxString::Format("%0.5f", oldPos.y));
+					XRCCTRL(dlg, "posZ", wxTextCtrl)->SetLabel(wxString::Format("%0.5f", oldPos.z));
+
+					if (dlg.ShowModal() == wxID_OK)
+					{
+						Vector3 newPos;
+						newPos.x = atof(XRCCTRL(dlg, "posX", wxTextCtrl)->GetValue().c_str());
+						newPos.y = atof(XRCCTRL(dlg, "posY", wxTextCtrl)->GetValue().c_str());
+						newPos.z = atof(XRCCTRL(dlg, "posZ", wxTextCtrl)->GetValue().c_str());
+
+						// Move vertex in shape directly
+						if (!os->bEditSlider)
+							os->project->MoveVertex(shape, newPos, vertIndex);
+
+						// To mesh coordinates
+						oldPos = mesh::VecToMeshCoords(oldPos);
+						newPos = mesh::VecToMeshCoords(newPos);
+
+						UndoStateShape uss;
+						uss.shapeName = shape->name.get();
+						uss.pointStartState[vertIndex] = oldPos;
+						uss.pointEndState[vertIndex] = newPos;
+
+						// Push changes onto undo stack and execute
+						UndoStateProject *usp = GetUndoHistory()->PushState();
+						usp->undoType = UT_VERTPOS;
+						usp->usss.push_back(std::move(uss));
+
+						if (os->bEditSlider)
+						{
+							usp->sliderName = os->activeSlider;
+
+							float sliderscale = os->project->SliderValue(os->activeSlider);
+							if (sliderscale == 0.0)
+								sliderscale = 1.0;
+
+							usp->sliderscale = sliderscale;
+						}
+
+						ApplyUndoState(usp, false);
+						os->UpdateUndoTools();
 					}
 
-					ApplyUndoState(usp, false);
-					os->UpdateUndoTools();
+					if (transformMode)
+						ShowTransformTool();
 				}
+			}
+			else if (event.GetUnicodeKey() == '0')
+				os->SelectTool(ToolID::Select);
+			else if (event.GetUnicodeKey() == '1')
+				os->SelectTool(ToolID::MaskBrush);
+			else if (event.GetUnicodeKey() == '2')
+				os->SelectTool(ToolID::InflateBrush);
+			else if (event.GetUnicodeKey() == '3')
+				os->SelectTool(ToolID::DeflateBrush);
+			else if (event.GetUnicodeKey() == '4')
+				os->SelectTool(ToolID::MoveBrush);
+			else if (event.GetUnicodeKey() == '5')
+				os->SelectTool(ToolID::SmoothBrush);
+			else if (event.GetUnicodeKey() == '6')
+				os->SelectTool(ToolID::UndiffBrush);
+			else if (event.GetUnicodeKey() == '7')
+				os->SelectTool(ToolID::WeightBrush);
+			else if (event.GetUnicodeKey() == '8')
+				os->SelectTool(ToolID::ColorBrush);
+			else if (event.GetUnicodeKey() == '9')
+				os->SelectTool(ToolID::AlphaBrush);
+			else if (event.GetKeyCode() == WXK_SPACE)
+			{
+				if (event.ControlDown())
+				{
+					if (!os->activeSlider.empty())
+					{
+						os->ExitSliderEdit();
+					}
+					else
+					{
+						os->EnterSliderEdit();
+						os->ScrollToActiveSlider();
+					}
+				}
+				else
+				{
+					if (os->brushSettingsPopup)
+					{
+						os->CloseBrushSettings();
+					}
+					else
+					{
+						bool transient = Config.GetBoolValue("Input/BrushSettingsNearCursor");
+						os->PopupBrushSettings(transient);
+					}
+				}
+			}
+			else if (event.GetKeyCode() == WXK_ESCAPE)
+				os->CloseBrushSettings();
+		}
 
-				if (transformMode)
-					ShowTransformTool();
-			}
-		}
-		else if (event.GetUnicodeKey() == '0')
-			os->SelectTool(ToolID::Select);
-		else if (event.GetUnicodeKey() == '1')
-			os->SelectTool(ToolID::MaskBrush);
-		else if (event.GetUnicodeKey() == '2')
-			os->SelectTool(ToolID::InflateBrush);
-		else if (event.GetUnicodeKey() == '3')
-			os->SelectTool(ToolID::DeflateBrush);
-		else if (event.GetUnicodeKey() == '4')
-			os->SelectTool(ToolID::MoveBrush);
-		else if (event.GetUnicodeKey() == '5')
-			os->SelectTool(ToolID::SmoothBrush);
-		else if (event.GetUnicodeKey() == '6')
-			os->SelectTool(ToolID::UndiffBrush);
-		else if (event.GetUnicodeKey() == '7')
-			os->SelectTool(ToolID::WeightBrush);
-		else if (event.GetUnicodeKey() == '8')
-			os->SelectTool(ToolID::ColorBrush);
-		else if (event.GetUnicodeKey() == '9')
-			os->SelectTool(ToolID::AlphaBrush);
-		else if (event.GetKeyCode() == WXK_SPACE) {
-			if (event.ControlDown()) {
-				if (!os->activeSlider.empty()) {
-					os->ExitSliderEdit();
-				}
-				else {
-					os->EnterSliderEdit();
-					os->ScrollToActiveSlider();
-				}
-			}
-			else {
-				if (os->brushSettingsPopup) {
-					os->CloseBrushSettings();
-				}
-				else {
-					bool transient = Config.GetBoolValue("Input/BrushSettingsNearCursor");
-					os->PopupBrushSettings(transient);
-				}
-			}
-		}
-		else if (event.GetKeyCode() == WXK_ESCAPE)
-			os->CloseBrushSettings();
+		event.Skip();
 	}
 
-	event.Skip();
-}
+	bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
+		// Check if brush strokes are currently allowed
+		if (activeBrush == &weightBrush)
+		{
+			std::string activeBone = os->GetActiveBone();
+			if (activeBone.empty())
+				return false;
+		}
 
-bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
-	// Check if brush strokes are currently allowed
-	if (activeBrush == &weightBrush) {
-		std::string activeBone = os->GetActiveBone();
-		if (activeBone.empty())
+		Vector3 o;
+		Vector3 n;
+		Vector3 d;
+		Vector3 s;
+
+		TweakPickInfo tpi;
+		bool hit = gls.CollideMeshes(screenPos.x, screenPos.y, tpi.origin, tpi.normal, false, nullptr, bGlobalBrushCollision, &tpi.facet);
+		if (!hit)
 			return false;
-	}
 
-	Vector3 o;
-	Vector3 n;
-	Vector3 d;
-	Vector3 s;
+		if (!os->CheckEditableState())
+			return false;
 
-	TweakPickInfo tpi;
-	bool hit = gls.CollideMeshes(screenPos.x, screenPos.y, tpi.origin, tpi.normal, false, nullptr, bGlobalBrushCollision, &tpi.facet);
-	if (!hit)
-		return false;
-
-	if (!os->CheckEditableState())
-		return false;
-
-	if (activeBrush->isMirrored()) {
-		if (!gls.CollideMeshes(screenPos.x, screenPos.y, o, n, true, nullptr, bGlobalBrushCollision, &tpi.facetM))
-			tpi.facetM = -1;
-	}
-
-	tpi.normal.Normalize();
-
-	Vector3 v;
-	Vector3 vo;
-	gls.GetPickRay(screenPos.x, screenPos.y, nullptr, v, vo);
-
-	v = v * -1.0f;
-	tpi.view = v;
-
-	savedBrush = activeBrush;
-
-	if (wxGetKeyState(WXK_CONTROL)) {
-		if (wxGetKeyState(WXK_ALT) && !segmentMode) {
-			UnMaskBrush.setStrength(-maskBrush.getStrength());
-			activeBrush = &UnMaskBrush;
-		}
-		else {
-			activeBrush = &maskBrush;
-		}
-	}
-	else if (activeBrush == &weightBrush) {
-		std::vector<std::string> normBones, notNormBones, brushBones, lockedBones;
-		os->GetNormalizeBones(&normBones, &notNormBones);
-
-		std::string activeBone = os->GetActiveBone();
-		std::string xMirrorBone = os->GetXMirrorBone();
-		brushBones.push_back(activeBone);
-
-		if (!xMirrorBone.empty())
-			brushBones.push_back(xMirrorBone);
-
-		bool bHasNormBones = false;
-		for (auto &bone : normBones) {
-			if (bone != activeBone && bone != xMirrorBone) {
-				brushBones.push_back(bone);
-				bHasNormBones = true;
-			}
+		if (activeBrush->isMirrored())
+		{
+			if (!gls.CollideMeshes(screenPos.x, screenPos.y, o, n, true, nullptr, bGlobalBrushCollision, &tpi.facetM))
+				tpi.facetM = -1;
 		}
 
-		if (bHasNormBones) {
-			for (auto &bone : notNormBones)
-				if (bone != activeBone && bone != xMirrorBone)
-					lockedBones.push_back(bone);
-		}
-		else {
-			for (auto &bone : notNormBones)
-				if (bone != activeBone && bone != xMirrorBone)
-					brushBones.push_back(bone);
-		}
-
-		if (wxGetKeyState(WXK_ALT)) {
-			unweightBrush.animInfo = os->project->GetWorkAnim();
-			unweightBrush.boneNames = brushBones;
-			unweightBrush.lockedBoneNames = lockedBones;
-			unweightBrush.bSpreadWeight = bHasNormBones;
-			unweightBrush.bXMirrorBone = !xMirrorBone.empty();
-			unweightBrush.bNormalizeWeights = weightBrush.bNormalizeWeights;
-			unweightBrush.setStrength(-weightBrush.getStrength());
-			unweightBrush.setMirror(weightBrush.isMirrored());
-			unweightBrush.setConnected(weightBrush.isConnected());
-			activeBrush = &unweightBrush;
-		}
-		else if (wxGetKeyState(WXK_SHIFT)) {
-			smoothWeightBrush.animInfo = os->project->GetWorkAnim();
-			smoothWeightBrush.boneNames = brushBones;
-			smoothWeightBrush.lockedBoneNames = lockedBones;
-			smoothWeightBrush.bSpreadWeight = bHasNormBones;
-			smoothWeightBrush.bXMirrorBone = !xMirrorBone.empty();
-			smoothWeightBrush.bNormalizeWeights = weightBrush.bNormalizeWeights;
-			smoothWeightBrush.setStrength(weightBrush.getStrength() * 15.0f);
-			smoothWeightBrush.setMirror(weightBrush.isMirrored());
-			smoothWeightBrush.setConnected(weightBrush.isConnected());
-			activeBrush = &smoothWeightBrush;
-		}
-		else {
-			weightBrush.animInfo = os->project->GetWorkAnim();
-			weightBrush.boneNames = brushBones;
-			weightBrush.lockedBoneNames = lockedBones;
-			weightBrush.bSpreadWeight = bHasNormBones;
-			weightBrush.bXMirrorBone = !xMirrorBone.empty();
-		}
-	}
-	else if (wxGetKeyState(WXK_ALT) && !segmentMode) {
-		if (activeBrush == &standardBrush) {
-			deflateBrush.setMirror(activeBrush->isMirrored());
-			deflateBrush.setConnected(activeBrush->isConnected());
-			activeBrush = &deflateBrush;
-		}
-		else if (activeBrush == &deflateBrush) {
-			standardBrush.setMirror(activeBrush->isMirrored());
-			standardBrush.setConnected(activeBrush->isConnected());
-			activeBrush = &standardBrush;
-		}
-		else if (activeBrush == &maskBrush) {
-			UnMaskBrush.setStrength(-activeBrush->getStrength());
-			UnMaskBrush.setMirror(activeBrush->isMirrored());
-			UnMaskBrush.setConnected(activeBrush->isConnected());
-			activeBrush = &UnMaskBrush;
-		}
-		else if (activeBrush == &colorBrush) {
-			uncolorBrush.setStrength(-activeBrush->getStrength());
-			uncolorBrush.setMirror(activeBrush->isMirrored());
-			uncolorBrush.setConnected(activeBrush->isConnected());
-			activeBrush = &uncolorBrush;
-		}
-		else if (activeBrush == &alphaBrush) {
-			unalphaBrush.setStrength(-activeBrush->getStrength());
-			unalphaBrush.setMirror(activeBrush->isMirrored());
-			unalphaBrush.setConnected(activeBrush->isConnected());
-			activeBrush = &unalphaBrush;
-		}
-	}
-	else if (activeBrush == &maskBrush && wxGetKeyState(WXK_SHIFT)) {
-		smoothMaskBrush.setStrength(activeBrush->getStrength() * 15.0f);
-		smoothMaskBrush.setMirror(activeBrush->isMirrored());
-		smoothMaskBrush.setConnected(activeBrush->isConnected());
-		activeBrush = &smoothMaskBrush;
-	}
-	else if (activeBrush != &weightBrush && activeBrush != &maskBrush && wxGetKeyState(WXK_SHIFT)) {
-		smoothBrush.setMirror(activeBrush->isMirrored());
-		smoothBrush.setConnected(activeBrush->isConnected());
-		activeBrush = &smoothBrush;
-	}
-
-	activeBrush->setRadius(brushSize);
-
-	if (activeBrush->Type() == TBT_WEIGHT) {
-		for (auto &sel : os->GetSelectedItems()) {
-			os->project->GetWorkNif()->CreateSkinning(sel->GetShape());
-
-			int boneIndex = os->project->GetWorkAnim()->GetShapeBoneIndex(sel->GetShape()->name.get(), os->GetActiveBone());
-			if (boneIndex < 0)
-				os->project->AddBoneRef(os->GetActiveBone());
-		}
-	}
-
-	activeStroke = std::make_unique<TweakStroke>(gls.GetActiveMeshes(), activeBrush, *undoHistory.PushState());
-
-	if (os->bEditSlider) {
-		activeStroke->usp.sliderName = os->activeSlider;
-		float sliderscale = os->project->SliderValue(os->activeSlider);
-		if (sliderscale == 0.0)
-			sliderscale = 1.0;
-
-		activeStroke->usp.sliderscale = sliderscale;
-	}
-
-	if (activeBrush->Type() == TBT_UNDIFF) {
-		std::vector<mesh*> refMeshes = activeStroke->GetRefMeshes();
-
-		std::vector<std::vector<Vector3>> positionData;
-		positionData.resize(refMeshes.size());
-
-		for (size_t i = 0; i < refMeshes.size(); i++) {
-			// Get base vertex positions, not current mesh position
-			mesh* m = refMeshes[i];
-			std::vector<Vector3> basePosition;
-
-			auto workNif = os->project->GetWorkNif();
-			auto shape = workNif->FindBlockByName<NiShape>(m->shapeName);
-			if (shape)
-				workNif->GetVertsForShape(shape, basePosition);
-
-			for (auto &p : basePosition)
-				p = mesh::VecToMeshCoords(p);
-
-			positionData[i] = std::move(basePosition);
-		}
-
-		activeStroke->beginStroke(tpi, positionData);
-	}
-	else
-		activeStroke->beginStroke(tpi);
-
-	if (activeBrush->Type() != TBT_MOVE)
-		activeStroke->updateStroke(tpi);
-
-	return true;
-}
-
-void wxGLPanel::UpdateBrushStroke(const wxPoint& screenPos) {
-	Vector3 o;
-	Vector3 n;
-	Vector3 d;	// Mirror pick ray direction.
-	Vector3 s;	// Mirror pick ray origin.
-
-	TweakPickInfo tpi;
-
-	if (activeStroke) {
-		bool hit = gls.UpdateCursor(screenPos.x, screenPos.y, bGlobalBrushCollision);
-		gls.RenderOneFrame();
-
-		if (activeBrush->Type() == TBT_MOVE) {
-			Vector3 pn;
-			float pd;
-			((TB_Move*)activeBrush)->GetWorkingPlane(pn, pd);
-			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, pn, pd);
-		}
-		else {
-			if (!hit)
-				return;
-
-			gls.CollideMeshes(screenPos.x, screenPos.y, tpi.origin, tpi.normal, false, nullptr, bGlobalBrushCollision, &tpi.facet);
-			if (activeBrush->isMirrored()) {
-				if (!gls.CollideMeshes(screenPos.x, screenPos.y, o, n, true, nullptr, bGlobalBrushCollision, &tpi.facetM))
-					tpi.facetM = -1;
-			}
-			tpi.normal.Normalize();
-		}
+		tpi.normal.Normalize();
 
 		Vector3 v;
 		Vector3 vo;
@@ -10683,129 +11377,340 @@ void wxGLPanel::UpdateBrushStroke(const wxPoint& screenPos) {
 
 		v = v * -1.0f;
 		tpi.view = v;
-		activeStroke->updateStroke(tpi);
 
-		if (activeBrush->Type() == TBT_WEIGHT) {
-			std::string selectedBone = os->GetActiveBone();
-			if (!selectedBone.empty()) {
-				os->ActiveShapesUpdated(undoHistory.GetCurState(), false);
+		savedBrush = activeBrush;
 
-				int boneScalePos = os->boneScale->GetValue();
-				if (boneScalePos != 0)
-					os->project->ApplyBoneScale(selectedBone, boneScalePos);
+		if (wxGetKeyState(WXK_CONTROL))
+		{
+			if (wxGetKeyState(WXK_ALT) && !segmentMode)
+			{
+				UnMaskBrush.setStrength(-maskBrush.getStrength());
+				activeBrush = &UnMaskBrush;
+			}
+			else
+			{
+				activeBrush = &maskBrush;
+			}
+		}
+		else if (activeBrush == &weightBrush)
+		{
+			std::vector<std::string> normBones, notNormBones, brushBones, lockedBones;
+			os->GetNormalizeBones(&normBones, &notNormBones);
+
+			std::string activeBone = os->GetActiveBone();
+			std::string xMirrorBone = os->GetXMirrorBone();
+			brushBones.push_back(activeBone);
+
+			if (!xMirrorBone.empty())
+				brushBones.push_back(xMirrorBone);
+
+			bool bHasNormBones = false;
+			for (auto &bone : normBones)
+			{
+				if (bone != activeBone && bone != xMirrorBone)
+				{
+					brushBones.push_back(bone);
+					bHasNormBones = true;
+				}
+			}
+
+			if (bHasNormBones)
+			{
+				for (auto &bone : notNormBones)
+					if (bone != activeBone && bone != xMirrorBone)
+						lockedBones.push_back(bone);
+			}
+			else
+			{
+				for (auto &bone : notNormBones)
+					if (bone != activeBone && bone != xMirrorBone)
+						brushBones.push_back(bone);
+			}
+
+			if (wxGetKeyState(WXK_ALT))
+			{
+				unweightBrush.animInfo = os->project->GetWorkAnim();
+				unweightBrush.boneNames = brushBones;
+				unweightBrush.lockedBoneNames = lockedBones;
+				unweightBrush.bSpreadWeight = bHasNormBones;
+				unweightBrush.bXMirrorBone = !xMirrorBone.empty();
+				unweightBrush.bNormalizeWeights = weightBrush.bNormalizeWeights;
+				unweightBrush.setStrength(-weightBrush.getStrength());
+				unweightBrush.setMirror(weightBrush.isMirrored());
+				unweightBrush.setConnected(weightBrush.isConnected());
+				activeBrush = &unweightBrush;
+			}
+			else if (wxGetKeyState(WXK_SHIFT))
+			{
+				smoothWeightBrush.animInfo = os->project->GetWorkAnim();
+				smoothWeightBrush.boneNames = brushBones;
+				smoothWeightBrush.lockedBoneNames = lockedBones;
+				smoothWeightBrush.bSpreadWeight = bHasNormBones;
+				smoothWeightBrush.bXMirrorBone = !xMirrorBone.empty();
+				smoothWeightBrush.bNormalizeWeights = weightBrush.bNormalizeWeights;
+				smoothWeightBrush.setStrength(weightBrush.getStrength() * 15.0f);
+				smoothWeightBrush.setMirror(weightBrush.isMirrored());
+				smoothWeightBrush.setConnected(weightBrush.isConnected());
+				activeBrush = &smoothWeightBrush;
+			}
+			else
+			{
+				weightBrush.animInfo = os->project->GetWorkAnim();
+				weightBrush.boneNames = brushBones;
+				weightBrush.lockedBoneNames = lockedBones;
+				weightBrush.bSpreadWeight = bHasNormBones;
+				weightBrush.bXMirrorBone = !xMirrorBone.empty();
+			}
+		}
+		else if (wxGetKeyState(WXK_ALT) && !segmentMode)
+		{
+			if (activeBrush == &standardBrush)
+			{
+				deflateBrush.setMirror(activeBrush->isMirrored());
+				deflateBrush.setConnected(activeBrush->isConnected());
+				activeBrush = &deflateBrush;
+			}
+			else if (activeBrush == &deflateBrush)
+			{
+				standardBrush.setMirror(activeBrush->isMirrored());
+				standardBrush.setConnected(activeBrush->isConnected());
+				activeBrush = &standardBrush;
+			}
+			else if (activeBrush == &maskBrush)
+			{
+				UnMaskBrush.setStrength(-activeBrush->getStrength());
+				UnMaskBrush.setMirror(activeBrush->isMirrored());
+				UnMaskBrush.setConnected(activeBrush->isConnected());
+				activeBrush = &UnMaskBrush;
+			}
+			else if (activeBrush == &colorBrush)
+			{
+				uncolorBrush.setStrength(-activeBrush->getStrength());
+				uncolorBrush.setMirror(activeBrush->isMirrored());
+				uncolorBrush.setConnected(activeBrush->isConnected());
+				activeBrush = &uncolorBrush;
+			}
+			else if (activeBrush == &alphaBrush)
+			{
+				unalphaBrush.setStrength(-activeBrush->getStrength());
+				unalphaBrush.setMirror(activeBrush->isMirrored());
+				unalphaBrush.setConnected(activeBrush->isConnected());
+				activeBrush = &unalphaBrush;
+			}
+		}
+		else if (activeBrush == &maskBrush && wxGetKeyState(WXK_SHIFT))
+		{
+			smoothMaskBrush.setStrength(activeBrush->getStrength() * 15.0f);
+			smoothMaskBrush.setMirror(activeBrush->isMirrored());
+			smoothMaskBrush.setConnected(activeBrush->isConnected());
+			activeBrush = &smoothMaskBrush;
+		}
+		else if (activeBrush != &weightBrush && activeBrush != &maskBrush && wxGetKeyState(WXK_SHIFT))
+		{
+			smoothBrush.setMirror(activeBrush->isMirrored());
+			smoothBrush.setConnected(activeBrush->isConnected());
+			activeBrush = &smoothBrush;
+		}
+
+		activeBrush->setRadius(brushSize);
+
+		if (activeBrush->Type() == TBT_WEIGHT)
+		{
+			for (auto &sel : os->GetSelectedItems())
+			{
+				os->project->GetWorkNif()->CreateSkinning(sel->GetShape());
+
+				int boneIndex = os->project->GetWorkAnim()->GetShapeBoneIndex(sel->GetShape()->name.get(), os->GetActiveBone());
+				if (boneIndex < 0)
+					os->project->AddBoneRef(os->GetActiveBone());
 			}
 		}
 
-		if (transformMode)
-			ShowTransformTool();
+		activeStroke = std::make_unique<TweakStroke>(gls.GetActiveMeshes(), activeBrush, *undoHistory.PushState());
 
-		if (segmentMode) {
-			os->ShowSegment(nullptr, true);
-			os->ShowPartition(nullptr, true);
+		if (os->bEditSlider)
+		{
+			activeStroke->usp.sliderName = os->activeSlider;
+			float sliderscale = os->project->SliderValue(os->activeSlider);
+			if (sliderscale == 0.0)
+				sliderscale = 1.0;
+
+			activeStroke->usp.sliderscale = sliderscale;
 		}
+
+		if (activeBrush->Type() == TBT_UNDIFF)
+		{
+			std::vector<mesh*> refMeshes = activeStroke->GetRefMeshes();
+
+			std::vector<std::vector<Vector3>> positionData;
+			positionData.resize(refMeshes.size());
+
+			for (size_t i = 0; i < refMeshes.size(); i++)
+			{
+				// Get base vertex positions, not current mesh position
+				mesh* m = refMeshes[i];
+				std::vector<Vector3> basePosition;
+
+				auto workNif = os->project->GetWorkNif();
+				auto shape = workNif->FindBlockByName<NiShape>(m->shapeName);
+				if (shape)
+					workNif->GetVertsForShape(shape, basePosition);
+
+				for (auto &p : basePosition)
+					p = mesh::VecToMeshCoords(p);
+
+				positionData[i] = std::move(basePosition);
+			}
+
+			activeStroke->beginStroke(tpi, positionData);
+		}
+		else
+			activeStroke->beginStroke(tpi);
+
+		if (activeBrush->Type() != TBT_MOVE)
+			activeStroke->updateStroke(tpi);
+
+		return true;
 	}
-}
 
-void wxGLPanel::EndBrushStroke() {
-	if (activeStroke) {
-		activeStroke->endStroke();
+	void wxGLPanel::UpdateBrushStroke(const wxPoint& screenPos) {
+		Vector3 o;
+		Vector3 n;
+		Vector3 d;	// Mirror pick ray direction.
+		Vector3 s;	// Mirror pick ray origin.
 
-		int brushType = activeStroke->BrushType();
-		if (brushType != TBT_MASK) {
-			os->ActiveShapesUpdated(undoHistory.GetCurState());
+		TweakPickInfo tpi;
 
-			if (brushType == TBT_WEIGHT) {
+		if (activeStroke)
+		{
+			bool hit = gls.UpdateCursor(screenPos.x, screenPos.y, bGlobalBrushCollision);
+			gls.RenderOneFrame();
+
+			if (activeBrush->Type() == TBT_MOVE)
+			{
+				Vector3 pn;
+				float pd;
+				((TB_Move*)activeBrush)->GetWorkingPlane(pn, pd);
+				gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, pn, pd);
+			}
+			else
+			{
+				if (!hit)
+					return;
+
+				gls.CollideMeshes(screenPos.x, screenPos.y, tpi.origin, tpi.normal, false, nullptr, bGlobalBrushCollision, &tpi.facet);
+				if (activeBrush->isMirrored())
+				{
+					if (!gls.CollideMeshes(screenPos.x, screenPos.y, o, n, true, nullptr, bGlobalBrushCollision, &tpi.facetM))
+						tpi.facetM = -1;
+				}
+				tpi.normal.Normalize();
+			}
+
+			Vector3 v;
+			Vector3 vo;
+			gls.GetPickRay(screenPos.x, screenPos.y, nullptr, v, vo);
+
+			v = v * -1.0f;
+			tpi.view = v;
+			activeStroke->updateStroke(tpi);
+
+			if (activeBrush->Type() == TBT_WEIGHT)
+			{
 				std::string selectedBone = os->GetActiveBone();
-				if (!selectedBone.empty()) {
+				if (!selectedBone.empty())
+				{
+					os->ActiveShapesUpdated(undoHistory.GetCurState(), false);
+
 					int boneScalePos = os->boneScale->GetValue();
 					if (boneScalePos != 0)
-						os->project->ApplyBoneScale(selectedBone, boneScalePos, true);
-
-					os->HighlightBoneNamesWithWeights();
-					os->UpdateBoneCounts();
+						os->project->ApplyBoneScale(selectedBone, boneScalePos);
 				}
 			}
 
-			if (!os->bEditSlider && brushType != TBT_WEIGHT && brushType != TBT_COLOR && brushType != TBT_ALPHA) {
-				for (auto &s : os->project->GetWorkNif()->GetShapes()) {
-					os->UpdateShapeSource(s);
-					os->project->RefreshMorphShape(s);
-				}
+			if (transformMode)
+				ShowTransformTool();
+
+			if (segmentMode)
+			{
+				os->ShowSegment(nullptr, true);
+				os->ShowPartition(nullptr, true);
 			}
 		}
-
-		activeStroke = nullptr;
-		activeBrush = savedBrush;
-
-		if (transformMode)
-			ShowTransformTool();
-
-		if (segmentMode) {
-			os->ShowSegment(nullptr, true);
-			os->ShowPartition(nullptr, true);
-
-			if (os->currentTabButton)
-				os->currentTabButton->SetPendingChanges();
-		}
-
-		os->UpdateUndoTools();
 	}
-}
 
-bool wxGLPanel::StartTransform(const wxPoint& screenPos) {
-	TweakPickInfo tpi;
-	mesh* hitMesh;
-	bool hit = gls.CollideOverlay(screenPos.x, screenPos.y, tpi.origin, tpi.normal, &hitMesh, &tpi.facet);
-	if (!hit)
-		return false;
+	void wxGLPanel::EndBrushStroke()
+	{
+		if (activeStroke)
+		{
+			activeStroke->endStroke();
 
-	if (!os->CheckEditableState())
-		return false;
+			int brushType = activeStroke->BrushType();
+			if (brushType != TBT_MASK)
+			{
+				os->ActiveShapesUpdated(undoHistory.GetCurState());
 
-	tpi.center = xformCenter;
+				if (brushType == TBT_WEIGHT)
+				{
+					std::string selectedBone = os->GetActiveBone();
+					if (!selectedBone.empty())
+					{
+						int boneScalePos = os->boneScale->GetValue();
+						if (boneScalePos != 0)
+							os->project->ApplyBoneScale(selectedBone, boneScalePos, true);
 
-	std::string mname = hitMesh->shapeName;
-	if (mname.find("Move") != std::string::npos) {
-		translateBrush.SetXFormType(0);
-		switch (mname[0]) {
-		case 'X':
-			tpi.view = Vector3(1.0f, 0.0f, 0.0f);
-			tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
-			break;
-		case 'Y':
-			tpi.view = Vector3(0.0f, 1.0f, 0.0f);
-			tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
-			break;
-		case 'Z':
-			tpi.view = Vector3(0.0f, 0.0f, 1.0f);
-			tpi.normal = Vector3(1.0f, 0.0f, 0.0f);
-			break;
-		}
-	}
-	else if (mname.find("Rotate") != std::string::npos) {
-		translateBrush.SetXFormType(1);
-		switch (mname[0]) {
-		case 'X':
-			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(1.0f, 0.0f, 0.0f), tpi.center.x);
-			//tpi.view = Vector3(0.0f, 1.0f, 0.0f);
-			tpi.normal = Vector3(1.0f, 0.0f, 0.0f);
-			break;
-		case 'Y':
-			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(0.0f, 1.0f, 0.0f), tpi.center.y);
-			//tpi.view = Vector3(-1.0f, 0.0f, 0.0f);
-			tpi.normal = Vector3(0.0f, 1.0f, 0.0f);
-			break;
-		case 'Z':
-			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(0.0f, 0.0f, 1.0f), tpi.center.z);
-			//tpi.view = Vector3(-1.0f, 0.0f, 0.0f);
-			tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
-			break;
+						os->HighlightBoneNamesWithWeights();
+						os->UpdateBoneCounts();
+					}
+				}
+
+				if (!os->bEditSlider && brushType != TBT_WEIGHT && brushType != TBT_COLOR && brushType != TBT_ALPHA)
+				{
+					for (auto &s : os->project->GetWorkNif()->GetShapes())
+					{
+						os->UpdateShapeSource(s);
+						os->project->RefreshMorphShape(s);
+					}
+				}
+			}
+
+			activeStroke = nullptr;
+			activeBrush = savedBrush;
+
+			if (transformMode)
+				ShowTransformTool();
+
+			if (segmentMode)
+			{
+				os->ShowSegment(nullptr, true);
+				os->ShowPartition(nullptr, true);
+
+				if (os->currentTabButton)
+					os->currentTabButton->SetPendingChanges();
+			}
+
+			os->UpdateUndoTools();
 		}
 	}
-	else if (mname.find("Scale") != std::string::npos) {
-		if (mname.find("Uniform") == std::string::npos) {
-			translateBrush.SetXFormType(2);
-			switch (mname[0]) {
+
+	bool wxGLPanel::StartTransform(const wxPoint& screenPos) {
+		TweakPickInfo tpi;
+		mesh* hitMesh;
+		bool hit = gls.CollideOverlay(screenPos.x, screenPos.y, tpi.origin, tpi.normal, &hitMesh, &tpi.facet);
+		if (!hit)
+			return false;
+
+		if (!os->CheckEditableState())
+			return false;
+
+		tpi.center = xformCenter;
+
+		std::string mname = hitMesh->shapeName;
+		if (mname.find("Move") != std::string::npos)
+		{
+			translateBrush.SetXFormType(0);
+			switch (mname[0])
+			{
 			case 'X':
 				tpi.view = Vector3(1.0f, 0.0f, 0.0f);
 				tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
@@ -10820,1582 +11725,1780 @@ bool wxGLPanel::StartTransform(const wxPoint& screenPos) {
 				break;
 			}
 		}
-		else {
-			translateBrush.SetXFormType(3);
-			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(1.0f, 0.0f, 0.0f), tpi.center.x);
-			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(0.0f, 1.0f, 0.0f), tpi.center.y);
-			gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(0.0f, 0.0f, 1.0f), tpi.center.z);
-			tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
+		else if (mname.find("Rotate") != std::string::npos)
+		{
+			translateBrush.SetXFormType(1);
+			switch (mname[0])
+			{
+			case 'X':
+				gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(1.0f, 0.0f, 0.0f), tpi.center.x);
+				//tpi.view = Vector3(0.0f, 1.0f, 0.0f);
+				tpi.normal = Vector3(1.0f, 0.0f, 0.0f);
+				break;
+			case 'Y':
+				gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(0.0f, 1.0f, 0.0f), tpi.center.y);
+				//tpi.view = Vector3(-1.0f, 0.0f, 0.0f);
+				tpi.normal = Vector3(0.0f, 1.0f, 0.0f);
+				break;
+			case 'Z':
+				gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(0.0f, 0.0f, 1.0f), tpi.center.z);
+				//tpi.view = Vector3(-1.0f, 0.0f, 0.0f);
+				tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
+				break;
+			}
 		}
-	}
-	else
-		return false;
-
-	activeStroke = std::make_unique<TweakStroke>(gls.GetActiveMeshes(), &translateBrush, *undoHistory.PushState());
-
-	if (os->bEditSlider) {
-		activeStroke->usp.sliderName = os->activeSlider;
-
-		float sliderscale = os->project->SliderValue(os->activeSlider);
-		if (sliderscale == 0.0)
-			sliderscale = 1.0;
-
-		activeStroke->usp.sliderscale = sliderscale;
-	}
-
-	activeStroke->beginStroke(tpi);
-
-	XMoveMesh->bVisible = false;
-	YMoveMesh->bVisible = false;
-	ZMoveMesh->bVisible = false;
-	XRotateMesh->bVisible = false;
-	YRotateMesh->bVisible = false;
-	ZRotateMesh->bVisible = false;
-	XScaleMesh->bVisible = false;
-	YScaleMesh->bVisible = false;
-	ZScaleMesh->bVisible = false;
-	ScaleUniformMesh->bVisible = false;
-	hitMesh->bVisible = true;
-	return true;
-}
-
-void wxGLPanel::UpdateTransform(const wxPoint& screenPos) {
-	TweakPickInfo tpi;
-	Vector3 pn;
-	float pd;
-
-	translateBrush.GetWorkingPlane(pn, pd);
-	gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, pn, pd);
-
-	activeStroke->updateStroke(tpi);
-
-	ShowTransformTool();
-}
-
-void wxGLPanel::EndTransform() {
-	activeStroke->endStroke();
-	activeStroke = nullptr;
-
-	os->ActiveShapesUpdated(undoHistory.GetCurState());
-	if (!os->bEditSlider) {
-		for (auto &s : os->project->GetWorkNif()->GetShapes()) {
-			os->UpdateShapeSource(s);
-			os->project->RefreshMorphShape(s);
+		else if (mname.find("Scale") != std::string::npos)
+		{
+			if (mname.find("Uniform") == std::string::npos)
+			{
+				translateBrush.SetXFormType(2);
+				switch (mname[0])
+				{
+				case 'X':
+					tpi.view = Vector3(1.0f, 0.0f, 0.0f);
+					tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
+					break;
+				case 'Y':
+					tpi.view = Vector3(0.0f, 1.0f, 0.0f);
+					tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
+					break;
+				case 'Z':
+					tpi.view = Vector3(0.0f, 0.0f, 1.0f);
+					tpi.normal = Vector3(1.0f, 0.0f, 0.0f);
+					break;
+				}
+			}
+			else
+			{
+				translateBrush.SetXFormType(3);
+				gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(1.0f, 0.0f, 0.0f), tpi.center.x);
+				gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(0.0f, 1.0f, 0.0f), tpi.center.y);
+				gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, Vector3(0.0f, 0.0f, 1.0f), tpi.center.z);
+				tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
+			}
 		}
-	}
+		else
+			return false;
 
-	ShowTransformTool();
-	os->UpdateUndoTools();
-}
+		activeStroke = std::make_unique<TweakStroke>(gls.GetActiveMeshes(), &translateBrush, *undoHistory.PushState());
 
-bool wxGLPanel::StartPivotPosition(const wxPoint& screenPos) {
-	TweakPickInfo tpi;
-	mesh* hitMesh;
-	bool hit = gls.CollideOverlay(screenPos.x, screenPos.y, tpi.origin, tpi.normal, &hitMesh, &tpi.facet);
-	if (!hit)
-		return false;
+		if (os->bEditSlider)
+		{
+			activeStroke->usp.sliderName = os->activeSlider;
 
-	tpi.center = pivotPosition;
+			float sliderscale = os->project->SliderValue(os->activeSlider);
+			if (sliderscale == 0.0)
+				sliderscale = 1.0;
 
-	std::string mname = hitMesh->shapeName;
-	if (mname.find("PivotMesh") != std::string::npos) {
-		translateBrush.SetXFormType(0);
-		switch (mname[0]) {
-		case 'X':
-			tpi.view = Vector3(1.0f, 0.0f, 0.0f);
-			tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
-			break;
-		case 'Y':
-			tpi.view = Vector3(0.0f, 1.0f, 0.0f);
-			tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
-			break;
-		case 'Z':
-			tpi.view = Vector3(0.0f, 0.0f, 1.0f);
-			tpi.normal = Vector3(1.0f, 0.0f, 0.0f);
-			break;
+			activeStroke->usp.sliderscale = sliderscale;
 		}
-	}
-	else
-		return false;
 
-	std::vector<mesh*> strokeMeshes{ hitMesh };
-	activeStroke = std::make_unique<TweakStroke>(strokeMeshes, &translateBrush, *undoHistory.PushState());
-	activeStroke->beginStroke(tpi);
+		activeStroke->beginStroke(tpi);
 
-	XPivotMesh->bVisible = false;
-	YPivotMesh->bVisible = false;
-	ZPivotMesh->bVisible = false;
-	PivotCenterMesh->bVisible = false;
-	hitMesh->bVisible = true;
-	return true;
-}
-
-void wxGLPanel::UpdatePivotPosition(const wxPoint& screenPos) {
-	TweakPickInfo tpi;
-	Vector3 pn;
-	float pd;
-
-	translateBrush.GetWorkingPlane(pn, pd);
-	gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, pn, pd);
-
-	activeStroke->updateStroke(tpi);
-}
-
-void wxGLPanel::EndPivotPosition() {
-	activeStroke->endStroke();
-
-	std::vector<mesh*> refMeshes = activeStroke->GetRefMeshes();
-	if (refMeshes.size() > 0) {
-		UndoStateShape &uss = activeStroke->usp.usss[0];
-		if (uss.pointStartState.size() > 0 && uss.pointEndState.size() > 0) {
-			Vector3& pivotStartStatePos = uss.pointStartState[0];
-			Vector3& pivotEndStatePos = uss.pointEndState[0];
-			Vector3 pivotDiff = pivotEndStatePos - pivotStartStatePos;
-			pivotPosition += pivotDiff;
-		}
+		XMoveMesh->bVisible = false;
+		YMoveMesh->bVisible = false;
+		ZMoveMesh->bVisible = false;
+		XRotateMesh->bVisible = false;
+		YRotateMesh->bVisible = false;
+		ZRotateMesh->bVisible = false;
+		XScaleMesh->bVisible = false;
+		YScaleMesh->bVisible = false;
+		ZScaleMesh->bVisible = false;
+		ScaleUniformMesh->bVisible = false;
+		hitMesh->bVisible = true;
+		return true;
 	}
 
-	activeStroke = nullptr;
-	ShowPivot();
-}
+	void wxGLPanel::UpdateTransform(const wxPoint& screenPos) {
+		TweakPickInfo tpi;
+		Vector3 pn;
+		float pd;
 
-bool wxGLPanel::SelectVertex(const wxPoint& screenPos) {
-	int vertIndex;
-	if (!gls.GetCursorVertex(screenPos.x, screenPos.y, &vertIndex))
-		return false;
+		translateBrush.GetWorkingPlane(pn, pd);
+		gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, pn, pd);
 
-	if (os->activeItem) {
-		mesh* m = GetMesh(os->activeItem->GetShape()->name.get());
-		if (m) {
-			if (wxGetKeyState(WXK_CONTROL))
-				m->vcolors[vertIndex].x = 1.0f;
-			else if (!segmentMode)
-				m->vcolors[vertIndex].x = 0.0f;
+		activeStroke->updateStroke(tpi);
 
-			m->QueueUpdate(mesh::UpdateType::VertexColors);
-		}
-	}
-
-	if (transformMode)
 		ShowTransformTool();
+	}
 
-	return true;
-}
+	void wxGLPanel::EndTransform() {
+		activeStroke->endStroke();
+		activeStroke = nullptr;
 
-bool wxGLPanel::StartPickVertex() {
-	if (hoverMeshName.empty() || hoverPoint < 0)
-		return false;
+		os->ActiveShapesUpdated(undoHistory.GetCurState());
+		if (!os->bEditSlider)
+		{
+			for (auto &s : os->project->GetWorkNif()->GetShapes())
+			{
+				os->UpdateShapeSource(s);
+				os->project->RefreshMorphShape(s);
+			}
+		}
 
-	mouseDownMeshName = hoverMeshName;
-	mouseDownPoint = hoverPoint;
-	return true;
-}
+		ShowTransformTool();
+		os->UpdateUndoTools();
+	}
 
-void wxGLPanel::UpdatePickVertex(const wxPoint& screenPos) {
-	bool hit = gls.UpdateCursor(screenPos.x, screenPos.y, bGlobalBrushCollision, &hoverMeshName, &hoverPoint);
-	if (!hit || hoverMeshName != mouseDownMeshName || hoverPoint != mouseDownPoint)
+	bool wxGLPanel::StartPivotPosition(const wxPoint& screenPos) {
+		TweakPickInfo tpi;
+		mesh* hitMesh;
+		bool hit = gls.CollideOverlay(screenPos.x, screenPos.y, tpi.origin, tpi.normal, &hitMesh, &tpi.facet);
+		if (!hit)
+			return false;
+
+		tpi.center = pivotPosition;
+
+		std::string mname = hitMesh->shapeName;
+		if (mname.find("PivotMesh") != std::string::npos)
+		{
+			translateBrush.SetXFormType(0);
+			switch (mname[0])
+			{
+			case 'X':
+				tpi.view = Vector3(1.0f, 0.0f, 0.0f);
+				tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
+				break;
+			case 'Y':
+				tpi.view = Vector3(0.0f, 1.0f, 0.0f);
+				tpi.normal = Vector3(0.0f, 0.0f, 1.0f);
+				break;
+			case 'Z':
+				tpi.view = Vector3(0.0f, 0.0f, 1.0f);
+				tpi.normal = Vector3(1.0f, 0.0f, 0.0f);
+				break;
+			}
+		}
+		else
+			return false;
+
+		std::vector<mesh*> strokeMeshes{ hitMesh };
+		activeStroke = std::make_unique<TweakStroke>(strokeMeshes, &translateBrush, *undoHistory.PushState());
+		activeStroke->beginStroke(tpi);
+
+		XPivotMesh->bVisible = false;
+		YPivotMesh->bVisible = false;
+		ZPivotMesh->bVisible = false;
+		PivotCenterMesh->bVisible = false;
+		hitMesh->bVisible = true;
+		return true;
+	}
+
+	void wxGLPanel::UpdatePivotPosition(const wxPoint& screenPos) {
+		TweakPickInfo tpi;
+		Vector3 pn;
+		float pd;
+
+		translateBrush.GetWorkingPlane(pn, pd);
+		gls.CollidePlane(screenPos.x, screenPos.y, tpi.origin, pn, pd);
+
+		activeStroke->updateStroke(tpi);
+	}
+
+	void wxGLPanel::EndPivotPosition() {
+		activeStroke->endStroke();
+
+		std::vector<mesh*> refMeshes = activeStroke->GetRefMeshes();
+		if (refMeshes.size() > 0)
+		{
+			UndoStateShape &uss = activeStroke->usp.usss[0];
+			if (uss.pointStartState.size() > 0 && uss.pointEndState.size() > 0)
+			{
+				Vector3& pivotStartStatePos = uss.pointStartState[0];
+				Vector3& pivotEndStatePos = uss.pointEndState[0];
+				Vector3 pivotDiff = pivotEndStatePos - pivotStartStatePos;
+				pivotPosition += pivotDiff;
+			}
+		}
+
+		activeStroke = nullptr;
+		ShowPivot();
+	}
+
+	bool wxGLPanel::SelectVertex(const wxPoint& screenPos) {
+		int vertIndex;
+		if (!gls.GetCursorVertex(screenPos.x, screenPos.y, &vertIndex))
+			return false;
+
+		if (os->activeItem)
+		{
+			mesh* m = GetMesh(os->activeItem->GetShape()->name.get());
+			if (m)
+			{
+				if (wxGetKeyState(WXK_CONTROL))
+					m->vcolors[vertIndex].x = 1.0f;
+				else if (!segmentMode)
+					m->vcolors[vertIndex].x = 0.0f;
+
+				m->QueueUpdate(mesh::UpdateType::VertexColors);
+			}
+		}
+
+		if (transformMode)
+			ShowTransformTool();
+
+		return true;
+	}
+
+	bool wxGLPanel::StartPickVertex() {
+		if (hoverMeshName.empty() || hoverPoint < 0)
+			return false;
+
+		mouseDownMeshName = hoverMeshName;
+		mouseDownPoint = hoverPoint;
+		return true;
+	}
+
+	void wxGLPanel::UpdatePickVertex(const wxPoint& screenPos) {
+		bool hit = gls.UpdateCursor(screenPos.x, screenPos.y, bGlobalBrushCollision, &hoverMeshName, &hoverPoint);
+		if (!hit || hoverMeshName != mouseDownMeshName || hoverPoint != mouseDownPoint)
+			gls.HidePointCursor();
+
+		gls.RenderOneFrame();
+	}
+
+	void wxGLPanel::EndPickVertex() {
+		if (hoverMeshName != mouseDownMeshName || hoverPoint != mouseDownPoint)
+			return;
+
+		// Clear PickVertex state so no accidents can happen
+		hoverMeshName.clear();
 		gls.HidePointCursor();
 
-	gls.RenderOneFrame();
-}
-
-void wxGLPanel::EndPickVertex() {
-	if (hoverMeshName != mouseDownMeshName || hoverPoint != mouseDownPoint)
-		return;
-
-	// Clear PickVertex state so no accidents can happen
-	hoverMeshName.clear();
-	gls.HidePointCursor();
-
-	if (activeTool == ToolID::CollapseVertex)
-		ClickCollapseVertex();
-}
-
-void wxGLPanel::ClickCollapseVertex() {
-	mesh *m = GetMesh(mouseDownMeshName);
-	if (!m || mouseDownPoint < 0)
-		return;
-
-	auto workNif = os->project->GetWorkNif();
-	if (!workNif)
-		return;
-
-	NiShape *shape = workNif->FindBlockByName<NiShape>(mouseDownMeshName);
-	if (!shape)
-		return;
-
-	// Make list of this vertex and its welded vertices.
-	std::vector<uint16_t> verts;
-	verts.push_back(mouseDownPoint);
-	if (m->weldVerts.find(mouseDownPoint) != m->weldVerts.end())
-		for (int wv : m->weldVerts[mouseDownPoint])
-			verts.push_back(wv);
-
-	std::sort(verts.begin(), verts.end());
-
-	// Prepare list of changes
-	UndoStateShape uss;
-	uss.shapeName = mouseDownMeshName;
-	if (!os->project->PrepareCollapseVertex(shape, uss, verts)) {
-		wxMessageBox(_("The vertex picked has more than three connections."), _("Error"), wxICON_ERROR, os);
-		return;
+		if (activeTool == ToolID::CollapseVertex)
+			ClickCollapseVertex();
 	}
 
-	// Push changes onto undo stack and execute.
-	UndoStateProject *usp = GetUndoHistory()->PushState();
-	usp->undoType = UT_MESH;
-	usp->usss.push_back(std::move(uss));
-	ApplyUndoState(usp, false);
+	void wxGLPanel::ClickCollapseVertex() {
+		mesh *m = GetMesh(mouseDownMeshName);
+		if (!m || mouseDownPoint < 0)
+			return;
 
-	os->UpdateUndoTools();
-}
+		auto workNif = os->project->GetWorkNif();
+		if (!workNif)
+			return;
 
-bool wxGLPanel::StartPickEdge() {
-	if (hoverMeshName.empty() || (hoverEdge.p1 == 0 && hoverEdge.p2 == 0))
-		return false;
+		NiShape *shape = workNif->FindBlockByName<NiShape>(mouseDownMeshName);
+		if (!shape)
+			return;
 
-	mouseDownMeshName = hoverMeshName;
-	mouseDownEdge = hoverEdge;
-	return true;
-}
+		// Make list of this vertex and its welded vertices.
+		std::vector<uint16_t> verts;
+		verts.push_back(mouseDownPoint);
+		if (m->weldVerts.find(mouseDownPoint) != m->weldVerts.end())
+			for (int wv : m->weldVerts[mouseDownPoint])
+				verts.push_back(wv);
 
-void wxGLPanel::UpdatePickEdge(const wxPoint& screenPos) {
-	bool hit = gls.UpdateCursor(screenPos.x, screenPos.y, bGlobalBrushCollision, &hoverMeshName, &hoverPoint, nullptr, nullptr, &hoverEdge);
-	if (!hit || hoverMeshName != mouseDownMeshName || !hoverEdge.CompareIndices(mouseDownEdge))
+		std::sort(verts.begin(), verts.end());
+
+		// Prepare list of changes
+		UndoStateShape uss;
+		uss.shapeName = mouseDownMeshName;
+		if (!os->project->PrepareCollapseVertex(shape, uss, verts))
+		{
+			wxMessageBox(_("The vertex picked has more than three connections."), _("Error"), wxICON_ERROR, os);
+			return;
+		}
+
+		// Push changes onto undo stack and execute.
+		UndoStateProject *usp = GetUndoHistory()->PushState();
+		usp->undoType = UT_MESH;
+		usp->usss.push_back(std::move(uss));
+		ApplyUndoState(usp, false);
+
+		os->UpdateUndoTools();
+	}
+
+	bool wxGLPanel::StartPickEdge() {
+		if (hoverMeshName.empty() || (hoverEdge.p1 == 0 && hoverEdge.p2 == 0))
+			return false;
+
+		mouseDownMeshName = hoverMeshName;
+		mouseDownEdge = hoverEdge;
+		return true;
+	}
+
+	void wxGLPanel::UpdatePickEdge(const wxPoint& screenPos) {
+		bool hit = gls.UpdateCursor(screenPos.x, screenPos.y, bGlobalBrushCollision, &hoverMeshName, &hoverPoint, nullptr, nullptr, &hoverEdge);
+		if (!hit || hoverMeshName != mouseDownMeshName || !hoverEdge.CompareIndices(mouseDownEdge))
+			gls.HideSegCursor();
+
+		gls.RenderOneFrame();
+	}
+
+	void wxGLPanel::EndPickEdge() {
+		if (hoverMeshName != mouseDownMeshName || !hoverEdge.CompareIndices(mouseDownEdge))
+			return;
+
+		// Clear PickEdge state so no accidents can happen
+		hoverMeshName.clear();
 		gls.HideSegCursor();
 
-	gls.RenderOneFrame();
-}
-
-void wxGLPanel::EndPickEdge() {
-	if (hoverMeshName != mouseDownMeshName || !hoverEdge.CompareIndices(mouseDownEdge))
-		return;
-
-	// Clear PickEdge state so no accidents can happen
-	hoverMeshName.clear();
-	gls.HideSegCursor();
-
-	if (activeTool == ToolID::FlipEdge)
-		ClickFlipEdge();
-	if (activeTool == ToolID::SplitEdge)
-		ClickSplitEdge();
-}
-
-void wxGLPanel::ClickFlipEdge() {
-	if (mouseDownMeshName.empty() || mouseDownEdge.p1 < 0 || mouseDownEdge.p1 == mouseDownEdge.p2)
-		return;
-
-	NiShape *shape = os->project->GetWorkNif()->FindBlockByName<NiShape>(mouseDownMeshName);
-	if (!shape)
-		return;
-
-	// Prepare list of changes
-	UndoStateShape uss;
-	uss.shapeName = mouseDownMeshName;
-	if (!os->project->PrepareFlipEdge(shape, uss, mouseDownEdge)) {
-		wxMessageBox(_("The edge picked is on the surface boundary.  Pick an interior edge."), _("Error"), wxICON_ERROR, os);
-		return;
+		if (activeTool == ToolID::FlipEdge)
+			ClickFlipEdge();
+		if (activeTool == ToolID::SplitEdge)
+			ClickSplitEdge();
 	}
 
-	// Push changes onto undo stack and execute.
-	UndoStateProject *usp = GetUndoHistory()->PushState();
-	usp->undoType = UT_MESH;
-	usp->usss.push_back(std::move(uss));
-	ApplyUndoState(usp, false);
+	void wxGLPanel::ClickFlipEdge() {
+		if (mouseDownMeshName.empty() || mouseDownEdge.p1 < 0 || mouseDownEdge.p1 == mouseDownEdge.p2)
+			return;
 
-	os->UpdateUndoTools();
-}
+		NiShape *shape = os->project->GetWorkNif()->FindBlockByName<NiShape>(mouseDownMeshName);
+		if (!shape)
+			return;
 
-void wxGLPanel::ClickSplitEdge() {
-	if (mouseDownMeshName.empty() || mouseDownEdge.p1 < 0 || mouseDownEdge.p1 == mouseDownEdge.p2)
-		return;
-
-	mesh *m = GetMesh(mouseDownMeshName);
-	if (!m)
-		return;
-
-	auto workNif = os->project->GetWorkNif();
-	if (!workNif)
-		return;
-
-	NiShape *shape = workNif->FindBlockByName<NiShape>(mouseDownMeshName);
-	if (!shape)
-		return;
-
-	uint16_t maxVertIndex = std::numeric_limits<uint16_t>().max();
-	uint32_t maxTriIndex = std::numeric_limits<uint16_t>().max();
-
-	if (workNif->GetHeader().GetVersion().IsFO4() || workNif->GetHeader().GetVersion().IsFO76())
-		maxTriIndex = std::numeric_limits<uint32_t>().max();
-
-	if (shape->GetNumVertices() > maxVertIndex - 2) {
-		wxMessageBox(_("The shape has reached the vertex count limit."), _("Error"), wxICON_ERROR, os);
-		return;
-	}
-
-	if (shape->GetNumTriangles() > maxTriIndex - 2) {
-		wxMessageBox(_("The shape has reached the triangle count limit."), _("Error"), wxICON_ERROR, os);
-		return;
-	}
-
-	// Collect welded vertices
-	uint16_t p1 = mouseDownEdge.p1;
-	uint16_t p2 = mouseDownEdge.p2;
-	std::vector<uint16_t> p1s(1, p1);
-	std::vector<uint16_t> p2s(1, p2);
-
-	auto wvit = m->weldVerts.find(p1);
-	if (wvit != m->weldVerts.end())
-		std::copy(wvit->second.begin(), wvit->second.end(), std::back_inserter(p1s));
-
-	wvit = m->weldVerts.find(p2);
-	if (wvit != m->weldVerts.end())
-		std::copy(wvit->second.begin(), wvit->second.end(), std::back_inserter(p2s));
-
-	// Prepare list of changes
-	UndoStateShape uss;
-	uss.shapeName = mouseDownMeshName;
-	if (!os->project->PrepareSplitEdge(shape, uss, p1s, p2s)) {
-		wxMessageBox(_("The edge picked has multiple triangles of the same orientation.  Correct the orientations before splitting."), _("Error"), wxICON_ERROR, os);
-		return;
-	}
-
-	// Push changes onto undo stack and execute.
-	UndoStateProject *usp = GetUndoHistory()->PushState();
-	usp->undoType = UT_MESH;
-	usp->usss.push_back(std::move(uss));
-	ApplyUndoState(usp, false);
-
-	os->UpdateUndoTools();
-}
-
-bool wxGLPanel::RestoreMode(UndoStateProject *usp) {
-	bool modeChanged = false;
-	int undoType = usp->undoType;
-	if (undoType == UT_VERTPOS  && os->activeSlider != usp->sliderName) {
-		os->EnterSliderEdit(usp->sliderName);
-		modeChanged = true;
-	}
-	if ((undoType != UT_VERTPOS || usp->sliderName.empty()) && os->bEditSlider) {
-		os->ExitSliderEdit();
-		modeChanged = true;
-	}
-	if (undoType == UT_VERTPOS && !usp->sliderName.empty() && usp->sliderscale != os->project->SliderValue(usp->sliderName)) {
-		os->SetSliderValue(usp->sliderName, usp->sliderscale * 100);
-		os->ApplySliders();
-		modeChanged = true;
-	}
-	if (undoType == UT_VERTPOS && usp->sliderName.empty() && !os->project->AllSlidersZero()) {
-		os->ZeroSliders();
-		modeChanged = true;
-	}
-	return modeChanged;
-}
-
-void wxGLPanel::ApplyUndoState(UndoStateProject *usp, bool bUndo, bool bRender) {
-	int undoType = usp->undoType;
-	if (undoType == UT_WEIGHT) {
-		for (auto &uss : usp->usss) {
-			mesh *m = GetMesh(uss.shapeName);
-			if (!m)
-				continue;
-
-			for (auto &bw : uss.boneWeights) {
-				if (bw.boneName != os->GetActiveBone())
-					continue;
-
-				for (auto &wIt : bw.weights)
-					m->vcolors[wIt.first].y = bUndo ? wIt.second.startVal : wIt.second.endVal;
-			}
-
-			m->QueueUpdate(mesh::UpdateType::VertexColors);
+		// Prepare list of changes
+		UndoStateShape uss;
+		uss.shapeName = mouseDownMeshName;
+		if (!os->project->PrepareFlipEdge(shape, uss, mouseDownEdge))
+		{
+			wxMessageBox(_("The edge picked is on the surface boundary.  Pick an interior edge."), _("Error"), wxICON_ERROR, os);
+			return;
 		}
 
-		os->ActiveShapesUpdated(usp, bUndo);
+		// Push changes onto undo stack and execute.
+		UndoStateProject *usp = GetUndoHistory()->PushState();
+		usp->undoType = UT_MESH;
+		usp->usss.push_back(std::move(uss));
+		ApplyUndoState(usp, false);
 
-		std::string activeBone = os->GetActiveBone();
-		if (!activeBone.empty()) {
-			int boneScalePos = os->boneScale->GetValue();
-			if (boneScalePos != 0)
-				os->project->ApplyBoneScale(activeBone, boneScalePos, true);
-		}
+		os->UpdateUndoTools();
 	}
-	else if (undoType == UT_MASK || undoType == UT_COLOR) {
-		for (auto &uss : usp->usss) {
-			mesh *m = GetMesh(uss.shapeName);
-			if (!m)
-				continue;
 
-			for (auto &pit : (bUndo ? uss.pointStartState : uss.pointEndState))
-				m->vcolors[pit.first] = pit.second;
+	void wxGLPanel::ClickSplitEdge() {
+		if (mouseDownMeshName.empty() || mouseDownEdge.p1 < 0 || mouseDownEdge.p1 == mouseDownEdge.p2)
+			return;
 
-			m->QueueUpdate(mesh::UpdateType::VertexColors);
+		mesh *m = GetMesh(mouseDownMeshName);
+		if (!m)
+			return;
+
+		auto workNif = os->project->GetWorkNif();
+		if (!workNif)
+			return;
+
+		NiShape *shape = workNif->FindBlockByName<NiShape>(mouseDownMeshName);
+		if (!shape)
+			return;
+
+		uint16_t maxVertIndex = std::numeric_limits<uint16_t>().max();
+		uint32_t maxTriIndex = std::numeric_limits<uint16_t>().max();
+
+		if (workNif->GetHeader().GetVersion().IsFO4() || workNif->GetHeader().GetVersion().IsFO76())
+			maxTriIndex = std::numeric_limits<uint32_t>().max();
+
+		if (shape->GetNumVertices() > maxVertIndex - 2)
+		{
+			wxMessageBox(_("The shape has reached the vertex count limit."), _("Error"), wxICON_ERROR, os);
+			return;
 		}
 
-		if (undoType != UT_MASK)
-			os->ActiveShapesUpdated(usp, bUndo);
+		if (shape->GetNumTriangles() > maxTriIndex - 2)
+		{
+			wxMessageBox(_("The shape has reached the triangle count limit."), _("Error"), wxICON_ERROR, os);
+			return;
+		}
+
+		// Collect welded vertices
+		uint16_t p1 = mouseDownEdge.p1;
+		uint16_t p2 = mouseDownEdge.p2;
+		std::vector<uint16_t> p1s(1, p1);
+		std::vector<uint16_t> p2s(1, p2);
+
+		auto wvit = m->weldVerts.find(p1);
+		if (wvit != m->weldVerts.end())
+			std::copy(wvit->second.begin(), wvit->second.end(), std::back_inserter(p1s));
+
+		wvit = m->weldVerts.find(p2);
+		if (wvit != m->weldVerts.end())
+			std::copy(wvit->second.begin(), wvit->second.end(), std::back_inserter(p2s));
+
+		// Prepare list of changes
+		UndoStateShape uss;
+		uss.shapeName = mouseDownMeshName;
+		if (!os->project->PrepareSplitEdge(shape, uss, p1s, p2s))
+		{
+			wxMessageBox(_("The edge picked has multiple triangles of the same orientation.  Correct the orientations before splitting."), _("Error"), wxICON_ERROR, os);
+			return;
+		}
+
+		// Push changes onto undo stack and execute.
+		UndoStateProject *usp = GetUndoHistory()->PushState();
+		usp->undoType = UT_MESH;
+		usp->usss.push_back(std::move(uss));
+		ApplyUndoState(usp, false);
+
+		os->UpdateUndoTools();
 	}
-	else if (undoType == UT_ALPHA) {
-		for (auto &uss : usp->usss) {
-			mesh *m = GetMesh(uss.shapeName);
-			if (!m)
-				continue;
 
-			for (auto &pit : (bUndo ? uss.pointStartState : uss.pointEndState))
-				m->valpha[pit.first] = pit.second.x;
-
-			m->QueueUpdate(mesh::UpdateType::VertexAlpha);
+	bool wxGLPanel::RestoreMode(UndoStateProject *usp) {
+		bool modeChanged = false;
+		int undoType = usp->undoType;
+		if (undoType == UT_VERTPOS  && os->activeSlider != usp->sliderName)
+		{
+			os->EnterSliderEdit(usp->sliderName);
+			modeChanged = true;
 		}
-
-		os->ActiveShapesUpdated(usp, bUndo);
+		if ((undoType != UT_VERTPOS || usp->sliderName.empty()) && os->bEditSlider)
+		{
+			os->ExitSliderEdit();
+			modeChanged = true;
+		}
+		if (undoType == UT_VERTPOS && !usp->sliderName.empty() && usp->sliderscale != os->project->SliderValue(usp->sliderName))
+		{
+			os->SetSliderValue(usp->sliderName, usp->sliderscale * 100);
+			os->ApplySliders();
+			modeChanged = true;
+		}
+		if (undoType == UT_VERTPOS && usp->sliderName.empty() && !os->project->AllSlidersZero())
+		{
+			os->ZeroSliders();
+			modeChanged = true;
+		}
+		return modeChanged;
 	}
-	else if (undoType == UT_VERTPOS) {
-		for (auto &uss : usp->usss) {
-			mesh *m = GetMesh(uss.shapeName);
-			if (!m)
-				continue;
 
-			for (auto &pit : (bUndo ? uss.pointStartState : uss.pointEndState))
-				m->verts[pit.first] = pit.second;
-
-			m->SmoothNormals();
-			BVHUpdateQueue.insert(m);
-
-			m->QueueUpdate(mesh::UpdateType::Position);
-		}
-
-		os->ActiveShapesUpdated(usp, bUndo);
-
-		if (usp->sliderName.empty()) {
-			for (auto &uss : usp->usss) {
+	void wxGLPanel::ApplyUndoState(UndoStateProject *usp, bool bUndo, bool bRender) {
+		int undoType = usp->undoType;
+		if (undoType == UT_WEIGHT)
+		{
+			for (auto &uss : usp->usss)
+			{
 				mesh *m = GetMesh(uss.shapeName);
 				if (!m)
 					continue;
 
-				auto shape = os->project->GetWorkNif()->FindBlockByName<NiShape>(uss.shapeName);
-				if (shape)
-					os->project->UpdateShapeFromMesh(shape, m);
+				for (auto &bw : uss.boneWeights)
+				{
+					if (bw.boneName != os->GetActiveBone())
+						continue;
+
+					for (auto &wIt : bw.weights)
+						m->vcolors[wIt.first].y = bUndo ? wIt.second.startVal : wIt.second.endVal;
+				}
+
+				m->QueueUpdate(mesh::UpdateType::VertexColors);
+			}
+
+			os->ActiveShapesUpdated(usp, bUndo);
+
+			std::string activeBone = os->GetActiveBone();
+			if (!activeBone.empty())
+			{
+				int boneScalePos = os->boneScale->GetValue();
+				if (boneScalePos != 0)
+					os->project->ApplyBoneScale(activeBone, boneScalePos, true);
+			}
+		}
+		else if (undoType == UT_MASK || undoType == UT_COLOR)
+		{
+			for (auto &uss : usp->usss)
+			{
+				mesh *m = GetMesh(uss.shapeName);
+				if (!m)
+					continue;
+
+				for (auto &pit : (bUndo ? uss.pointStartState : uss.pointEndState))
+					m->vcolors[pit.first] = pit.second;
+
+				m->QueueUpdate(mesh::UpdateType::VertexColors);
+			}
+
+			if (undoType != UT_MASK)
+				os->ActiveShapesUpdated(usp, bUndo);
+		}
+		else if (undoType == UT_ALPHA)
+		{
+			for (auto &uss : usp->usss)
+			{
+				mesh *m = GetMesh(uss.shapeName);
+				if (!m)
+					continue;
+
+				for (auto &pit : (bUndo ? uss.pointStartState : uss.pointEndState))
+					m->valpha[pit.first] = pit.second.x;
+
+				m->QueueUpdate(mesh::UpdateType::VertexAlpha);
+			}
+
+			os->ActiveShapesUpdated(usp, bUndo);
+		}
+		else if (undoType == UT_VERTPOS)
+		{
+			for (auto &uss : usp->usss)
+			{
+				mesh *m = GetMesh(uss.shapeName);
+				if (!m)
+					continue;
+
+				for (auto &pit : (bUndo ? uss.pointStartState : uss.pointEndState))
+					m->verts[pit.first] = pit.second;
+
+				m->SmoothNormals();
+				BVHUpdateQueue.insert(m);
+
+				m->QueueUpdate(mesh::UpdateType::Position);
+			}
+
+			os->ActiveShapesUpdated(usp, bUndo);
+
+			if (usp->sliderName.empty())
+			{
+				for (auto &uss : usp->usss)
+				{
+					mesh *m = GetMesh(uss.shapeName);
+					if (!m)
+						continue;
+
+					auto shape = os->project->GetWorkNif()->FindBlockByName<NiShape>(uss.shapeName);
+					if (shape)
+						os->project->UpdateShapeFromMesh(shape, m);
+				}
+			}
+		}
+		else if (undoType == UT_MESH)
+		{
+			for (auto &uss : usp->usss)
+			{
+				NiShape *shape = os->project->GetWorkNif()->FindBlockByName<NiShape>(uss.shapeName);
+				if (!shape)
+					continue;
+
+				os->project->ApplyShapeMeshUndo(shape, uss, bUndo);
+			}
+
+			os->RefreshGUIFromProj(false);
+			ClearActiveMask();
+			os->ApplySliders();
+		}
+
+		if (bRender)
+		{
+			if (transformMode)
+				ShowTransformTool();
+			else
+				Render();
+		}
+	}
+
+	bool wxGLPanel::UndoStroke() {
+		UndoStateProject *curState = undoHistory.GetCurState();
+		if (!curState)
+			return false;
+		if (RestoreMode(curState))
+			return true;
+		if (!undoHistory.BackStepHistory())
+			return false;
+
+		ApplyUndoState(curState, true);
+
+		return true;
+	}
+
+	bool wxGLPanel::RedoStroke() {
+		UndoStateProject *curState = undoHistory.GetNextState();
+		if (!curState)
+			return false;
+		if (RestoreMode(curState))
+			return true;
+		if (!undoHistory.ForwardStepHistory())
+			return false;
+
+		ApplyUndoState(curState, false);
+
+		return true;
+	}
+
+	void wxGLPanel::ShowRotationCenter(bool show)
+	{
+		if (show)
+		{
+			RotationCenterMesh = gls.AddVis3dSphere(gls.camRotOffset, 0.15f, Vector3(1.0f, 0.0f, 1.0f), "RotationCenterMesh");
+			RotationCenterMesh->prop.alpha = 0.5f;
+			RotationCenterMesh->bVisible = true;
+
+			RotationCenterMeshRingX = gls.AddVis3dRing(gls.camRotOffset, Vector3(1.0f, 0.0f, 0.0f), 0.35f, 0.01f, Vector3(1.0f, 0.0f, 0.0f), "RotationCenterMeshRingX");
+			RotationCenterMeshRingX->prop.alpha = 0.5f;
+			RotationCenterMeshRingX->bVisible = true;
+
+			RotationCenterMeshRingY = gls.AddVis3dRing(gls.camRotOffset, Vector3(0.0f, 1.0f, 0.0f), 0.35f, 0.01f, Vector3(0.0f, 1.0f, 0.0f), "RotationCenterMeshRingY");
+			RotationCenterMeshRingY->prop.alpha = 0.5f;
+			RotationCenterMeshRingY->bVisible = true;
+
+			RotationCenterMeshRingZ = gls.AddVis3dRing(gls.camRotOffset, Vector3(0.0f, 0.0f, 1.0f), 0.35f, 0.01f, Vector3(0.0f, 0.0f, 1.0f), "RotationCenterMeshRingZ");
+			RotationCenterMeshRingZ->prop.alpha = 0.5f;
+			RotationCenterMeshRingZ->bVisible = true;
+		}
+		else
+		{
+			if (RotationCenterMesh)
+			{
+				RotationCenterMesh->bVisible = false;
+				RotationCenterMeshRingX->bVisible = false;
+				RotationCenterMeshRingY->bVisible = false;
+				RotationCenterMeshRingZ->bVisible = false;
 			}
 		}
 	}
-	else if (undoType == UT_MESH) {
-		for (auto &uss : usp->usss) {
-			NiShape *shape = os->project->GetWorkNif()->FindBlockByName<NiShape>(uss.shapeName);
-			if (!shape)
-				continue;
 
-			os->project->ApplyShapeMeshUndo(shape, uss, bUndo);
-		}
-
-		os->RefreshGUIFromProj(false);
-		ClearActiveMask();
-		os->ApplySliders();
-	}
-
-	if (bRender) {
-		if (transformMode)
-			ShowTransformTool();
+	void wxGLPanel::ShowTransformTool(bool show) {
+		if (pivotMode)
+			xformCenter = pivotPosition;
 		else
-			Render();
-	}
-}
+			xformCenter = gls.GetActiveCenter();
 
-bool wxGLPanel::UndoStroke() {
-	UndoStateProject *curState = undoHistory.GetCurState();
-	if (!curState)
-		return false;
-	if (RestoreMode(curState))
-		return true;
-	if (!undoHistory.BackStepHistory())
-		return false;
+		if (show)
+		{
+			XMoveMesh = gls.AddVis3dArrow(xformCenter, Vector3(1.0f, 0.0f, 0.0f), 0.04f, 0.15f, 1.75f, Vector3(1.0f, 0.0f, 0.0f), "XMoveMesh");
+			YMoveMesh = gls.AddVis3dArrow(xformCenter, Vector3(0.0f, 1.0f, 0.0f), 0.04f, 0.15f, 1.75f, Vector3(0.0f, 1.0f, 0.0f), "YMoveMesh");
+			ZMoveMesh = gls.AddVis3dArrow(xformCenter, Vector3(0.0f, 0.0f, 1.0f), 0.04f, 0.15f, 1.75f, Vector3(0.0f, 0.0f, 1.0f), "ZMoveMesh");
 
-	ApplyUndoState(curState, true);
+			XRotateMesh = gls.AddVis3dRing(xformCenter, Vector3(1.0f, 0.0f, 0.0f), 1.25f, 0.04f, Vector3(1.0f, 0.0f, 0.0f), "XRotateMesh");
+			YRotateMesh = gls.AddVis3dRing(xformCenter, Vector3(0.0f, 1.0f, 0.0f), 1.25f, 0.04f, Vector3(0.0f, 1.0f, 0.0f), "YRotateMesh");
+			ZRotateMesh = gls.AddVis3dRing(xformCenter, Vector3(0.0f, 0.0f, 1.0f), 1.25f, 0.04f, Vector3(0.0f, 0.0f, 1.0f), "ZRotateMesh");
 
-	return true;
-}
+			XScaleMesh = gls.AddVis3dCube(xformCenter + Vector3(0.75f, 0.0f, 0.0f), Vector3(1.0f, 0.0f, 0.0f), 0.12f, Vector3(1.0f, 0.0f, 0.0f), "XScaleMesh");
+			YScaleMesh = gls.AddVis3dCube(xformCenter + Vector3(0.0f, 0.75f, 0.0f), Vector3(0.0f, 1.0f, 0.0f), 0.12f, Vector3(0.0f, 1.0f, 0.0f), "YScaleMesh");
+			ZScaleMesh = gls.AddVis3dCube(xformCenter + Vector3(0.0f, 0.0f, 0.75f), Vector3(0.0f, 0.0f, 1.0f), 0.12f, Vector3(0.0f, 0.0f, 1.0f), "ZScaleMesh");
+			ScaleUniformMesh = gls.AddVis3dCube(xformCenter, Vector3(1.0f, 0.0f, 0.0f), 0.15f, Vector3(0.0f, 0.0f, 0.0f), "ScaleUniformMesh");
 
-bool wxGLPanel::RedoStroke() {
-	UndoStateProject *curState = undoHistory.GetNextState();
-	if (!curState)
-		return false;
-	if (RestoreMode(curState))
-		return true;
-	if (!undoHistory.ForwardStepHistory())
-		return false;
+			lastCenterDistance = 0.0f;
 
-	ApplyUndoState(curState, false);
+			XMoveMesh->bVisible = true;
+			YMoveMesh->bVisible = true;
+			ZMoveMesh->bVisible = true;
+			XRotateMesh->bVisible = true;
+			YRotateMesh->bVisible = true;
+			ZRotateMesh->bVisible = true;
+			XScaleMesh->bVisible = true;
+			YScaleMesh->bVisible = true;
+			ZScaleMesh->bVisible = true;
+			ScaleUniformMesh->bVisible = true;
 
-	return true;
-}
-
-void wxGLPanel::ShowRotationCenter(bool show) {
-	if (show) {
-		RotationCenterMesh = gls.AddVis3dSphere(gls.camRotOffset, 0.15f, Vector3(1.0f, 0.0f, 1.0f), "RotationCenterMesh");
-		RotationCenterMesh->prop.alpha = 0.5f;
-		RotationCenterMesh->bVisible = true;
-
-		RotationCenterMeshRingX = gls.AddVis3dRing(gls.camRotOffset, Vector3(1.0f, 0.0f, 0.0f), 0.35f, 0.01f, Vector3(1.0f, 0.0f, 0.0f), "RotationCenterMeshRingX");
-		RotationCenterMeshRingX->prop.alpha = 0.5f;
-		RotationCenterMeshRingX->bVisible = true;
-
-		RotationCenterMeshRingY = gls.AddVis3dRing(gls.camRotOffset, Vector3(0.0f, 1.0f, 0.0f), 0.35f, 0.01f, Vector3(0.0f, 1.0f, 0.0f), "RotationCenterMeshRingY");
-		RotationCenterMeshRingY->prop.alpha = 0.5f;
-		RotationCenterMeshRingY->bVisible = true;
-
-		RotationCenterMeshRingZ = gls.AddVis3dRing(gls.camRotOffset, Vector3(0.0f, 0.0f, 1.0f), 0.35f, 0.01f, Vector3(0.0f, 0.0f, 1.0f), "RotationCenterMeshRingZ");
-		RotationCenterMeshRingZ->prop.alpha = 0.5f;
-		RotationCenterMeshRingZ->bVisible = true;
-	}
-	else {
-		if (RotationCenterMesh) {
-			RotationCenterMesh->bVisible = false;
-			RotationCenterMeshRingX->bVisible = false;
-			RotationCenterMeshRingY->bVisible = false;
-			RotationCenterMeshRingZ->bVisible = false;
+			if (XPivotMesh)
+			{
+				XPivotMesh->bVisible = false;
+				YPivotMesh->bVisible = false;
+				ZPivotMesh->bVisible = false;
+				PivotCenterMesh->bVisible = false;
+			}
 		}
-	}
-}
+		else
+		{
+			if (XMoveMesh)
+			{
+				XMoveMesh->bVisible = false;
+				YMoveMesh->bVisible = false;
+				ZMoveMesh->bVisible = false;
+				XRotateMesh->bVisible = false;
+				YRotateMesh->bVisible = false;
+				ZRotateMesh->bVisible = false;
+				XScaleMesh->bVisible = false;
+				YScaleMesh->bVisible = false;
+				ZScaleMesh->bVisible = false;
+				ScaleUniformMesh->bVisible = false;
+			}
 
-void wxGLPanel::ShowTransformTool(bool show) {
-	if (pivotMode)
-		xformCenter = pivotPosition;
-	else
-		xformCenter = gls.GetActiveCenter();
-
-	if (show) {
-		XMoveMesh = gls.AddVis3dArrow(xformCenter, Vector3(1.0f, 0.0f, 0.0f), 0.04f, 0.15f, 1.75f, Vector3(1.0f, 0.0f, 0.0f), "XMoveMesh");
-		YMoveMesh = gls.AddVis3dArrow(xformCenter, Vector3(0.0f, 1.0f, 0.0f), 0.04f, 0.15f, 1.75f, Vector3(0.0f, 1.0f, 0.0f), "YMoveMesh");
-		ZMoveMesh = gls.AddVis3dArrow(xformCenter, Vector3(0.0f, 0.0f, 1.0f), 0.04f, 0.15f, 1.75f, Vector3(0.0f, 0.0f, 1.0f), "ZMoveMesh");
-
-		XRotateMesh = gls.AddVis3dRing(xformCenter, Vector3(1.0f, 0.0f, 0.0f), 1.25f, 0.04f, Vector3(1.0f, 0.0f, 0.0f), "XRotateMesh");
-		YRotateMesh = gls.AddVis3dRing(xformCenter, Vector3(0.0f, 1.0f, 0.0f), 1.25f, 0.04f, Vector3(0.0f, 1.0f, 0.0f), "YRotateMesh");
-		ZRotateMesh = gls.AddVis3dRing(xformCenter, Vector3(0.0f, 0.0f, 1.0f), 1.25f, 0.04f, Vector3(0.0f, 0.0f, 1.0f), "ZRotateMesh");
-
-		XScaleMesh = gls.AddVis3dCube(xformCenter + Vector3(0.75f, 0.0f, 0.0f), Vector3(1.0f, 0.0f, 0.0f), 0.12f, Vector3(1.0f, 0.0f, 0.0f), "XScaleMesh");
-		YScaleMesh = gls.AddVis3dCube(xformCenter + Vector3(0.0f, 0.75f, 0.0f), Vector3(0.0f, 1.0f, 0.0f), 0.12f, Vector3(0.0f, 1.0f, 0.0f), "YScaleMesh");
-		ZScaleMesh = gls.AddVis3dCube(xformCenter + Vector3(0.0f, 0.0f, 0.75f), Vector3(0.0f, 0.0f, 1.0f), 0.12f, Vector3(0.0f, 0.0f, 1.0f), "ZScaleMesh");
-		ScaleUniformMesh = gls.AddVis3dCube(xformCenter, Vector3(1.0f, 0.0f, 0.0f), 0.15f, Vector3(0.0f, 0.0f, 0.0f), "ScaleUniformMesh");
-
-		lastCenterDistance = 0.0f;
-
-		XMoveMesh->bVisible = true;
-		YMoveMesh->bVisible = true;
-		ZMoveMesh->bVisible = true;
-		XRotateMesh->bVisible = true;
-		YRotateMesh->bVisible = true;
-		ZRotateMesh->bVisible = true;
-		XScaleMesh->bVisible = true;
-		YScaleMesh->bVisible = true;
-		ZScaleMesh->bVisible = true;
-		ScaleUniformMesh->bVisible = true;
-
-		if (XPivotMesh) {
-			XPivotMesh->bVisible = false;
-			YPivotMesh->bVisible = false;
-			ZPivotMesh->bVisible = false;
-			PivotCenterMesh->bVisible = false;
-		}
-	}
-	else {
-		if (XMoveMesh) {
-			XMoveMesh->bVisible = false;
-			YMoveMesh->bVisible = false;
-			ZMoveMesh->bVisible = false;
-			XRotateMesh->bVisible = false;
-			YRotateMesh->bVisible = false;
-			ZRotateMesh->bVisible = false;
-			XScaleMesh->bVisible = false;
-			YScaleMesh->bVisible = false;
-			ZScaleMesh->bVisible = false;
-			ScaleUniformMesh->bVisible = false;
+			if (XPivotMesh && pivotMode)
+			{
+				XPivotMesh->bVisible = true;
+				YPivotMesh->bVisible = true;
+				ZPivotMesh->bVisible = true;
+				PivotCenterMesh->bVisible = true;
+			}
 		}
 
-		if (XPivotMesh && pivotMode) {
+		UpdateTransformTool();
+		gls.RenderOneFrame();
+	}
+
+	void wxGLPanel::UpdateTransformTool() {
+		if (!transformMode)
+			return;
+
+		if (!XMoveMesh)
+			return;
+
+		Vector3 unprojected;
+		gls.UnprojectCamera(unprojected);
+
+		if (lastCenterDistance != 0.0f)
+		{
+			float factor = 1.0f / lastCenterDistance;
+			XMoveMesh->ScaleVertices(xformCenter, factor);
+			YMoveMesh->ScaleVertices(xformCenter, factor);
+			ZMoveMesh->ScaleVertices(xformCenter, factor);
+
+			XRotateMesh->ScaleVertices(xformCenter, factor);
+			YRotateMesh->ScaleVertices(xformCenter, factor);
+			ZRotateMesh->ScaleVertices(xformCenter, factor);
+
+			XScaleMesh->ScaleVertices(xformCenter, factor);
+			YScaleMesh->ScaleVertices(xformCenter, factor);
+			ZScaleMesh->ScaleVertices(xformCenter, factor);
+			ScaleUniformMesh->ScaleVertices(xformCenter, factor);
+		}
+
+		lastCenterDistance = unprojected.DistanceTo(xformCenter) / 15.0f;
+
+		XMoveMesh->ScaleVertices(xformCenter, lastCenterDistance);
+		YMoveMesh->ScaleVertices(xformCenter, lastCenterDistance);
+		ZMoveMesh->ScaleVertices(xformCenter, lastCenterDistance);
+
+		XRotateMesh->ScaleVertices(xformCenter, lastCenterDistance);
+		YRotateMesh->ScaleVertices(xformCenter, lastCenterDistance);
+		ZRotateMesh->ScaleVertices(xformCenter, lastCenterDistance);
+
+		XScaleMesh->ScaleVertices(xformCenter, lastCenterDistance);
+		YScaleMesh->ScaleVertices(xformCenter, lastCenterDistance);
+		ZScaleMesh->ScaleVertices(xformCenter, lastCenterDistance);
+		ScaleUniformMesh->ScaleVertices(xformCenter, lastCenterDistance);
+	}
+
+	void wxGLPanel::ShowPivot(bool show) {
+		if (show)
+		{
+			XPivotMesh = gls.AddVis3dArrow(pivotPosition, Vector3(1.0f, 0.0f, 0.0f), 0.03f, 0.1f, 1.0f, Vector3(1.0f, 0.0f, 0.0f), "XPivotMesh");
+			YPivotMesh = gls.AddVis3dArrow(pivotPosition, Vector3(0.0f, 1.0f, 0.0f), 0.03f, 0.1f, 1.0f, Vector3(0.0f, 1.0f, 0.0f), "YPivotMesh");
+			ZPivotMesh = gls.AddVis3dArrow(pivotPosition, Vector3(0.0f, 0.0f, 1.0f), 0.03f, 0.1f, 1.0f, Vector3(0.0f, 0.0f, 1.0f), "ZPivotMesh");
+			PivotCenterMesh = gls.AddVis3dCube(pivotPosition, Vector3(1.0f, 0.0f, 0.0f), 0.075f, Vector3(0.0f, 0.0f, 0.0f), "PivotCenterMesh");
+
 			XPivotMesh->bVisible = true;
 			YPivotMesh->bVisible = true;
 			ZPivotMesh->bVisible = true;
 			PivotCenterMesh->bVisible = true;
+
+			lastCenterPivotDistance = 0.0f;
 		}
-	}
-
-	UpdateTransformTool();
-	gls.RenderOneFrame();
-}
-
-void wxGLPanel::UpdateTransformTool() {
-	if (!transformMode)
-		return;
-
-	if (!XMoveMesh)
-		return;
-
-	Vector3 unprojected;
-	gls.UnprojectCamera(unprojected);
-
-	if (lastCenterDistance != 0.0f) {
-		float factor = 1.0f / lastCenterDistance;
-		XMoveMesh->ScaleVertices(xformCenter, factor);
-		YMoveMesh->ScaleVertices(xformCenter, factor);
-		ZMoveMesh->ScaleVertices(xformCenter, factor);
-
-		XRotateMesh->ScaleVertices(xformCenter, factor);
-		YRotateMesh->ScaleVertices(xformCenter, factor);
-		ZRotateMesh->ScaleVertices(xformCenter, factor);
-
-		XScaleMesh->ScaleVertices(xformCenter, factor);
-		YScaleMesh->ScaleVertices(xformCenter, factor);
-		ZScaleMesh->ScaleVertices(xformCenter, factor);
-		ScaleUniformMesh->ScaleVertices(xformCenter, factor);
-	}
-
-	lastCenterDistance = unprojected.DistanceTo(xformCenter) / 15.0f;
-
-	XMoveMesh->ScaleVertices(xformCenter, lastCenterDistance);
-	YMoveMesh->ScaleVertices(xformCenter, lastCenterDistance);
-	ZMoveMesh->ScaleVertices(xformCenter, lastCenterDistance);
-
-	XRotateMesh->ScaleVertices(xformCenter, lastCenterDistance);
-	YRotateMesh->ScaleVertices(xformCenter, lastCenterDistance);
-	ZRotateMesh->ScaleVertices(xformCenter, lastCenterDistance);
-
-	XScaleMesh->ScaleVertices(xformCenter, lastCenterDistance);
-	YScaleMesh->ScaleVertices(xformCenter, lastCenterDistance);
-	ZScaleMesh->ScaleVertices(xformCenter, lastCenterDistance);
-	ScaleUniformMesh->ScaleVertices(xformCenter, lastCenterDistance);
-}
-
-void wxGLPanel::ShowPivot(bool show) {
-	if (show) {
-		XPivotMesh = gls.AddVis3dArrow(pivotPosition, Vector3(1.0f, 0.0f, 0.0f), 0.03f, 0.1f, 1.0f, Vector3(1.0f, 0.0f, 0.0f), "XPivotMesh");
-		YPivotMesh = gls.AddVis3dArrow(pivotPosition, Vector3(0.0f, 1.0f, 0.0f), 0.03f, 0.1f, 1.0f, Vector3(0.0f, 1.0f, 0.0f), "YPivotMesh");
-		ZPivotMesh = gls.AddVis3dArrow(pivotPosition, Vector3(0.0f, 0.0f, 1.0f), 0.03f, 0.1f, 1.0f, Vector3(0.0f, 0.0f, 1.0f), "ZPivotMesh");
-		PivotCenterMesh = gls.AddVis3dCube(pivotPosition, Vector3(1.0f, 0.0f, 0.0f), 0.075f, Vector3(0.0f, 0.0f, 0.0f), "PivotCenterMesh");
-
-		XPivotMesh->bVisible = true;
-		YPivotMesh->bVisible = true;
-		ZPivotMesh->bVisible = true;
-		PivotCenterMesh->bVisible = true;
-
-		lastCenterPivotDistance = 0.0f;
-	}
-	else {
-		if (XPivotMesh) {
-			XPivotMesh->bVisible = false;
-			YPivotMesh->bVisible = false;
-			ZPivotMesh->bVisible = false;
-			PivotCenterMesh->bVisible = false;
-		}
-	}
-
-	UpdatePivot();
-	gls.RenderOneFrame();
-}
-
-void wxGLPanel::UpdatePivot() {
-	if (!pivotMode)
-		return;
-
-	if (!XPivotMesh)
-		return;
-
-	Vector3 unprojected;
-	gls.UnprojectCamera(unprojected);
-
-	if (lastCenterPivotDistance != 0.0f) {
-		float factor = 1.0f / lastCenterPivotDistance;
-		XPivotMesh->ScaleVertices(pivotPosition, factor);
-		YPivotMesh->ScaleVertices(pivotPosition, factor);
-		ZPivotMesh->ScaleVertices(pivotPosition, factor);
-		PivotCenterMesh->ScaleVertices(pivotPosition, factor);
-	}
-
-	lastCenterPivotDistance = unprojected.DistanceTo(pivotPosition) / 15.0f;
-
-	XPivotMesh->ScaleVertices(pivotPosition, lastCenterPivotDistance);
-	YPivotMesh->ScaleVertices(pivotPosition, lastCenterPivotDistance);
-	ZPivotMesh->ScaleVertices(pivotPosition, lastCenterPivotDistance);
-	PivotCenterMesh->ScaleVertices(pivotPosition, lastCenterPivotDistance);
-}
-
-void wxGLPanel::ShowNodes(bool show) {
-	nodesMode = show;
-
-	for (auto &m : nodesPoints)
-		m->bVisible = show;
-
-	for (auto &m : nodesLines)
-		m->bVisible = show;
-
-	gls.RenderOneFrame();
-}
-
-void wxGLPanel::UpdateNodes() {
-	for (auto &m : nodesPoints)
-		gls.DeleteOverlay(m);
-
-	for (auto &m : nodesLines)
-		gls.DeleteOverlay(m);
-
-	nodesPoints.clear();
-	nodesLines.clear();
-
-	auto workNif = os->project->GetWorkNif();
-
-	std::function<void(NiNode*, NiNode*, const Vector3&, const Vector3&)> addChildNodes = [&](NiNode* node, NiNode* parent, const Vector3& rootPosition, const Vector3& parentPosition) {
-		MatTransform ttg = node->GetTransformToParent();
-		NiNode* parentNode = parent;
-		while (parentNode) {
-			ttg = parentNode->GetTransformToParent().ComposeTransforms(ttg);
-			parentNode = workNif->GetParentNode(parentNode);
-		}
-
-		Vector3 position = ttg.ApplyTransform(rootPosition);
-
-		std::string nodeName = node->name.get();
-		if (!nodeName.empty()) {
-			Vector3 renderPosition = mesh::VecToMeshCoords(position);
-
-			auto pointMesh = gls.AddVisPoint(renderPosition, "P_" + nodeName);
-			if (pointMesh) {
-				pointMesh->bVisible = nodesMode;
-				nodesPoints.push_back(pointMesh);
-			}
-
-			if (parent) {
-				Vector3 renderParentPosition = mesh::VecToMeshCoords(parentPosition);
-
-				auto lineMesh = gls.AddVisSeg(renderParentPosition, renderPosition, "L_" + nodeName);
-				if (lineMesh) {
-					lineMesh->bVisible = nodesMode;
-					nodesLines.push_back(lineMesh);
-				}
+		else
+		{
+			if (XPivotMesh)
+			{
+				XPivotMesh->bVisible = false;
+				YPivotMesh->bVisible = false;
+				ZPivotMesh->bVisible = false;
+				PivotCenterMesh->bVisible = false;
 			}
 		}
 
-		for (auto &child : node->childRefs) {
-			auto childNode = workNif->GetHeader().GetBlock<NiNode>(child);
-			if (childNode)
-				addChildNodes(childNode, node, rootPosition, position);
+		UpdatePivot();
+		gls.RenderOneFrame();
+	}
+
+	void wxGLPanel::UpdatePivot() {
+		if (!pivotMode)
+			return;
+
+		if (!XPivotMesh)
+			return;
+
+		Vector3 unprojected;
+		gls.UnprojectCamera(unprojected);
+
+		if (lastCenterPivotDistance != 0.0f)
+		{
+			float factor = 1.0f / lastCenterPivotDistance;
+			XPivotMesh->ScaleVertices(pivotPosition, factor);
+			YPivotMesh->ScaleVertices(pivotPosition, factor);
+			ZPivotMesh->ScaleVertices(pivotPosition, factor);
+			PivotCenterMesh->ScaleVertices(pivotPosition, factor);
 		}
-	};
 
-	auto rootNode = workNif->GetRootNode();
-	if (rootNode)
-		addChildNodes(rootNode, nullptr, rootNode->transform.translation, rootNode->transform.translation);
+		lastCenterPivotDistance = unprojected.DistanceTo(pivotPosition) / 15.0f;
 
-	UpdateNodeColors();
-}
+		XPivotMesh->ScaleVertices(pivotPosition, lastCenterPivotDistance);
+		YPivotMesh->ScaleVertices(pivotPosition, lastCenterPivotDistance);
+		ZPivotMesh->ScaleVertices(pivotPosition, lastCenterPivotDistance);
+		PivotCenterMesh->ScaleVertices(pivotPosition, lastCenterPivotDistance);
+	}
 
-void wxGLPanel::ShowBones(bool show) {
-	bonesMode = show;
+	void wxGLPanel::ShowNodes(bool show) {
+		nodesMode = show;
 
-	for (auto &m : bonesPoints)
-		m->bVisible = show;
+		for (auto &m : nodesPoints)
+			m->bVisible = show;
 
-	for (auto &m : bonesLines)
-		m->bVisible = show;
+		for (auto &m : nodesLines)
+			m->bVisible = show;
 
-	gls.RenderOneFrame();
-}
+		gls.RenderOneFrame();
+	}
 
-void wxGLPanel::UpdateBones() {
-	for (auto &m : bonesPoints)
-		gls.DeleteOverlay(m);
+	void wxGLPanel::UpdateNodes() {
+		for (auto &m : nodesPoints)
+			gls.DeleteOverlay(m);
 
-	for (auto &m : bonesLines)
-		gls.DeleteOverlay(m);
+		for (auto &m : nodesLines)
+			gls.DeleteOverlay(m);
 
-	bonesPoints.clear();
-	bonesLines.clear();
+		nodesPoints.clear();
+		nodesLines.clear();
 
-	auto workAnim = os->project->GetWorkAnim();
+		auto workNif = os->project->GetWorkNif();
 
-	std::function<bool(AnimBone*, const Vector3&)> addChildBones = [&](AnimBone* parent, const Vector3& rootPosition) {
-		bool anyBoneInSelection = false;
+		std::function<void(NiNode*, NiNode*, const Vector3&, const Vector3&)> addChildNodes = [&](NiNode* node, NiNode* parent, const Vector3& rootPosition, const Vector3& parentPosition)
+		{
+			MatTransform ttg = node->GetTransformToParent();
+			NiNode* parentNode = parent;
+			while (parentNode)
+			{
+				ttg = parentNode->GetTransformToParent().ComposeTransforms(ttg);
+				parentNode = workNif->GetParentNode(parentNode);
+			}
 
-		for (auto &cb : parent->children) {
-			bool childBonesInSelection = addChildBones(cb, rootPosition);
+			Vector3 position = ttg.ApplyTransform(rootPosition);
 
-			if (!cb->boneName.empty()) {
-				bool boneInSelection = false;
-				for (auto &si : os->GetSelectedItems()) {
-					if (workAnim->GetShapeBoneIndex(si->GetShape()->name.get(), cb->boneName) != -1) {
-						boneInSelection = true;
-						break;
-					}
+			std::string nodeName = node->name.get();
+			if (!nodeName.empty())
+			{
+				Vector3 renderPosition = mesh::VecToMeshCoords(position);
+
+				auto pointMesh = gls.AddVisPoint(renderPosition, "P_" + nodeName);
+				if (pointMesh)
+				{
+					pointMesh->bVisible = nodesMode;
+					nodesPoints.push_back(pointMesh);
 				}
 
-				if (boneInSelection || childBonesInSelection) {
-					Vector3 position = cb->xformToGlobal.ApplyTransform(rootPosition);
-					Vector3 parentPosition = parent->xformToGlobal.ApplyTransform(rootPosition);
-					bool matchesParent = position.IsNearlyEqualTo(parentPosition);
-
-					Vector3 renderPosition = mesh::VecToMeshCoords(position);
-
-					auto pointMesh = gls.AddVisPoint(renderPosition, "BP_" + cb->boneName);
-					if (pointMesh) {
-						pointMesh->bVisible = bonesMode;
-						bonesPoints.push_back(pointMesh);
-					}
-
+				if (parent)
+				{
 					Vector3 renderParentPosition = mesh::VecToMeshCoords(parentPosition);
 
-					if (!matchesParent) {
-						auto lineMesh = gls.AddVisSeg(renderParentPosition, renderPosition, "BL_" + cb->boneName);
-						if (lineMesh) {
-							lineMesh->bVisible = bonesMode;
-							bonesLines.push_back(lineMesh);
+					auto lineMesh = gls.AddVisSeg(renderParentPosition, renderPosition, "L_" + nodeName);
+					if (lineMesh)
+					{
+						lineMesh->bVisible = nodesMode;
+						nodesLines.push_back(lineMesh);
+					}
+				}
+			}
+
+			for (auto &child : node->childRefs)
+			{
+				auto childNode = workNif->GetHeader().GetBlock<NiNode>(child);
+				if (childNode)
+					addChildNodes(childNode, node, rootPosition, position);
+			}
+		};
+
+		auto rootNode = workNif->GetRootNode();
+		if (rootNode)
+			addChildNodes(rootNode, nullptr, rootNode->transform.translation, rootNode->transform.translation);
+
+		UpdateNodeColors();
+	}
+
+	void wxGLPanel::ShowBones(bool show) {
+		bonesMode = show;
+
+		for (auto &m : bonesPoints)
+			m->bVisible = show;
+
+		for (auto &m : bonesLines)
+			m->bVisible = show;
+
+		gls.RenderOneFrame();
+	}
+
+	void wxGLPanel::UpdateBones() {
+		for (auto &m : bonesPoints)
+			gls.DeleteOverlay(m);
+
+		for (auto &m : bonesLines)
+			gls.DeleteOverlay(m);
+
+		bonesPoints.clear();
+		bonesLines.clear();
+
+		auto workAnim = os->project->GetWorkAnim();
+
+		std::function<bool(AnimBone*, const Vector3&)> addChildBones = [&](AnimBone* parent, const Vector3& rootPosition)
+		{
+			bool anyBoneInSelection = false;
+
+			for (auto &cb : parent->children)
+			{
+				bool childBonesInSelection = addChildBones(cb, rootPosition);
+
+				if (!cb->boneName.empty())
+				{
+					bool boneInSelection = false;
+					for (auto &si : os->GetSelectedItems())
+					{
+						if (workAnim->GetShapeBoneIndex(si->GetShape()->name.get(), cb->boneName) != -1)
+						{
+							boneInSelection = true;
+							break;
 						}
 					}
 
-					anyBoneInSelection = true;
+					if (boneInSelection || childBonesInSelection)
+					{
+						Vector3 position = cb->xformToGlobal.ApplyTransform(rootPosition);
+						Vector3 parentPosition = parent->xformToGlobal.ApplyTransform(rootPosition);
+						bool matchesParent = position.IsNearlyEqualTo(parentPosition);
+
+						Vector3 renderPosition = mesh::VecToMeshCoords(position);
+
+						auto pointMesh = gls.AddVisPoint(renderPosition, "BP_" + cb->boneName);
+						if (pointMesh)
+						{
+							pointMesh->bVisible = bonesMode;
+							bonesPoints.push_back(pointMesh);
+						}
+
+						Vector3 renderParentPosition = mesh::VecToMeshCoords(parentPosition);
+
+						if (!matchesParent)
+						{
+							auto lineMesh = gls.AddVisSeg(renderParentPosition, renderPosition, "BL_" + cb->boneName);
+							if (lineMesh)
+							{
+								lineMesh->bVisible = bonesMode;
+								bonesLines.push_back(lineMesh);
+							}
+						}
+
+						anyBoneInSelection = true;
+					}
+				}
+			}
+
+			return anyBoneInSelection;
+		};
+
+		AnimBone* rb = AnimSkeleton::getInstance().GetRootBonePtr();
+		if (rb)
+			addChildBones(rb, rb->xformToParent.translation);
+
+		UpdateNodeColors();
+	}
+
+	void wxGLPanel::UpdateNodeColors() {
+		std::string activeBone = os->GetActiveBone();
+
+		for (auto &m : nodesPoints)
+		{
+			auto nodeName = m->shapeName.substr(2, m->shapeName.length() - 2);
+			if (nodeName == activeBone)
+			{
+				m->color.x = 1.0f;
+				m->color.y = 0.0f;
+				m->color.z = 0.0f;
+				m->overlayLayer = OverlayLayer::NodeSelection;
+			}
+			else
+			{
+				m->color.x = 0.0f;
+				m->color.y = 1.0f;
+				m->color.z = 0.0f;
+				m->overlayLayer = OverlayLayer::Default;
+			}
+		}
+
+		for (auto &m : nodesLines)
+		{
+			auto nodeName = m->shapeName.substr(2, m->shapeName.length() - 2);
+			if (nodeName == activeBone)
+			{
+				m->color.x = 0.7f;
+				m->color.y = 0.0f;
+				m->color.z = 0.0f;
+				m->overlayLayer = OverlayLayer::NodeSelection;
+			}
+			else
+			{
+				m->color.x = 0.0f;
+				m->color.y = 0.7f;
+				m->color.z = 0.0f;
+				m->overlayLayer = OverlayLayer::Default;
+			}
+		}
+
+		for (auto &m : bonesPoints)
+		{
+			auto nodeName = m->shapeName.substr(3, m->shapeName.length() - 3);
+			if (nodeName == activeBone)
+			{
+				m->color.x = 1.0f;
+				m->color.y = 0.0f;
+				m->color.z = 0.0f;
+				m->overlayLayer = OverlayLayer::NodeSelection;
+			}
+			else
+			{
+				m->color.x = 0.0f;
+				m->color.y = 1.0f;
+				m->color.z = 0.0f;
+				m->overlayLayer = OverlayLayer::Default;
+			}
+		}
+
+		for (auto &m : bonesLines)
+		{
+			auto nodeName = m->shapeName.substr(3, m->shapeName.length() - 3);
+			if (nodeName == activeBone)
+			{
+				m->color.x = 0.7f;
+				m->color.y = 0.0f;
+				m->color.z = 0.0f;
+				m->overlayLayer = OverlayLayer::NodeSelection;
+			}
+			else
+			{
+				m->color.x = 0.0f;
+				m->color.y = 0.7f;
+				m->color.z = 0.0f;
+				m->overlayLayer = OverlayLayer::Default;
+			}
+		}
+	}
+
+	void wxGLPanel::ShowFloor(bool show) {
+		floorMode = show;
+
+		for (auto &m : floorMeshes)
+			m->bVisible = show;
+
+		gls.RenderOneFrame();
+	}
+
+	void wxGLPanel::UpdateFloor() {
+		for (auto &m : floorMeshes)
+			gls.DeleteMesh(m);
+
+		floorMeshes.clear();
+
+		const float floorWidth = 100.0f;
+		const float floorWidthHalf = floorWidth / 2.0f;
+		const float floorGridStepBig = 5.0f;
+		const float floorGridStepSmall = 1.0f;
+		const int numLinesBig = (int)(floorWidth / floorGridStepBig) + 1;
+		const int numLinesSmall = (int)(floorWidth / floorGridStepSmall) + 1;
+
+		Matrix4 floorMat;
+		floorMat.Rotate(90.0f * DEG2RAD, 1.0f, 0.0f, 0.0f);
+
+		Vector3 floorColor(0.0f, 0.0f, 1.0f);
+		auto floorMesh = gls.AddVisPlane(floorMat, Vector2(floorWidth, floorWidth), 1.0f, 0.0f, "", &floorColor, true);
+		if (floorMesh)
+		{
+			floorMesh->prop.alpha = 0.05f;
+			floorMesh->bVisible = floorMode;
+			floorMeshes.push_back(floorMesh);
+		}
+
+		float nextLinePos = floorWidth - floorWidthHalf;
+
+		// Floor with width on X and Y axis (big grid)
+		for (int i = 0; i < numLinesBig; i++)
+		{
+			Vector3 startPos(floorWidthHalf, 0.0f, nextLinePos);
+			Vector3 endPos(-floorWidthHalf, 0.0f, nextLinePos);
+
+			auto lineMesh = gls.AddVisSeg(startPos, endPos, "", true);
+			if (lineMesh)
+			{
+				lineMesh->color.x = 0.0f;
+				lineMesh->color.y = 1.0f;
+				lineMesh->color.z = 0.0f;
+				lineMesh->bVisible = floorMode;
+				floorMeshes.push_back(lineMesh);
+			}
+
+			startPos = Vector3(nextLinePos, 0.0f, floorWidthHalf);
+			endPos = Vector3(nextLinePos, 0.0f, -floorWidthHalf);
+
+			lineMesh = gls.AddVisSeg(startPos, endPos, "", true);
+			if (lineMesh)
+			{
+				lineMesh->color.x = 0.0f;
+				lineMesh->color.y = 1.0f;
+				lineMesh->color.z = 0.0f;
+				lineMesh->bVisible = floorMode;
+				floorMeshes.push_back(lineMesh);
+			}
+
+			nextLinePos -= floorGridStepBig;
+		}
+
+		nextLinePos = floorWidth - floorWidthHalf;
+
+		// Floor with width on X and Y axis (small grid)
+		for (int i = 0; i < numLinesSmall; i++)
+		{
+			Vector3 startPos(floorWidthHalf, 0.0f, nextLinePos);
+			Vector3 endPos(-floorWidthHalf, 0.0f, nextLinePos);
+
+			auto lineMesh = gls.AddVisSeg(startPos, endPos, "", true);
+			if (lineMesh)
+			{
+				lineMesh->color.x = 0.0f;
+				lineMesh->color.y = 1.0f;
+				lineMesh->color.z = 0.0f;
+				lineMesh->prop.alpha = 0.7f;
+				lineMesh->bVisible = floorMode;
+				floorMeshes.push_back(lineMesh);
+			}
+
+			startPos = Vector3(nextLinePos, 0.0f, floorWidthHalf);
+			endPos = Vector3(nextLinePos, 0.0f, -floorWidthHalf);
+
+			lineMesh = gls.AddVisSeg(startPos, endPos, "", true);
+			if (lineMesh)
+			{
+				lineMesh->color.x = 0.0f;
+				lineMesh->color.y = 1.0f;
+				lineMesh->color.z = 0.0f;
+				lineMesh->prop.alpha = 0.7f;
+				lineMesh->bVisible = floorMode;
+				floorMeshes.push_back(lineMesh);
+			}
+
+			nextLinePos -= floorGridStepSmall;
+		}
+	}
+
+	void wxGLPanel::ShowVertexEdit(bool show) {
+		for (auto &m : gls.GetMeshes())
+			if (m)
+				m->bShowPoints = false;
+
+		if (show)
+		{
+			if (os->activeItem)
+			{
+				mesh* m = GetMesh(os->activeItem->GetShape()->name.get());
+				if (m)
+				{
+					m->bShowPoints = true;
+					m->QueueUpdate(mesh::UpdateType::VertexColors);
 				}
 			}
 		}
-
-		return anyBoneInSelection;
-	};
-
-	AnimBone* rb = AnimSkeleton::getInstance().GetRootBonePtr();
-	if (rb)
-		addChildBones(rb, rb->xformToParent.translation);
-
-	UpdateNodeColors();
-}
-
-void wxGLPanel::UpdateNodeColors() {
-	std::string activeBone = os->GetActiveBone();
-
-	for (auto &m : nodesPoints) {
-		auto nodeName = m->shapeName.substr(2, m->shapeName.length() - 2);
-		if (nodeName == activeBone) {
-			m->color.x = 1.0f;
-			m->color.y = 0.0f;
-			m->color.z = 0.0f;
-			m->overlayLayer = OverlayLayer::NodeSelection;
-		}
-		else {
-			m->color.x = 0.0f;
-			m->color.y = 1.0f;
-			m->color.z = 0.0f;
-			m->overlayLayer = OverlayLayer::Default;
-		}
 	}
 
-	for (auto &m : nodesLines) {
-		auto nodeName = m->shapeName.substr(2, m->shapeName.length() - 2);
-		if (nodeName == activeBone) {
-			m->color.x = 0.7f;
-			m->color.y = 0.0f;
-			m->color.z = 0.0f;
-			m->overlayLayer = OverlayLayer::NodeSelection;
-		}
-		else {
-			m->color.x = 0.0f;
-			m->color.y = 0.7f;
-			m->color.z = 0.0f;
-			m->overlayLayer = OverlayLayer::Default;
-		}
-	}
-
-	for (auto &m : bonesPoints) {
-		auto nodeName = m->shapeName.substr(3, m->shapeName.length() - 3);
-		if (nodeName == activeBone) {
-			m->color.x = 1.0f;
-			m->color.y = 0.0f;
-			m->color.z = 0.0f;
-			m->overlayLayer = OverlayLayer::NodeSelection;
-		}
-		else {
-			m->color.x = 0.0f;
-			m->color.y = 1.0f;
-			m->color.z = 0.0f;
-			m->overlayLayer = OverlayLayer::Default;
-		}
-	}
-
-	for (auto &m : bonesLines) {
-		auto nodeName = m->shapeName.substr(3, m->shapeName.length() - 3);
-		if (nodeName == activeBone) {
-			m->color.x = 0.7f;
-			m->color.y = 0.0f;
-			m->color.z = 0.0f;
-			m->overlayLayer = OverlayLayer::NodeSelection;
-		}
-		else {
-			m->color.x = 0.0f;
-			m->color.y = 0.7f;
-			m->color.z = 0.0f;
-			m->overlayLayer = OverlayLayer::Default;
-		}
-	}
-}
-
-void wxGLPanel::ShowFloor(bool show) {
-	floorMode = show;
-
-	for (auto &m : floorMeshes)
-		m->bVisible = show;
-
-	gls.RenderOneFrame();
-}
-
-void wxGLPanel::UpdateFloor() {
-	for (auto &m : floorMeshes)
-		gls.DeleteMesh(m);
-
-	floorMeshes.clear();
-
-	const float floorWidth = 100.0f;
-	const float floorWidthHalf = floorWidth / 2.0f;
-	const float floorGridStepBig = 5.0f;
-	const float floorGridStepSmall = 1.0f;
-	const int numLinesBig = (int)(floorWidth / floorGridStepBig) + 1;
-	const int numLinesSmall = (int)(floorWidth / floorGridStepSmall) + 1;
-
-	Matrix4 floorMat;
-	floorMat.Rotate(90.0f * DEG2RAD, 1.0f, 0.0f, 0.0f);
-
-	Vector3 floorColor(0.0f, 0.0f, 1.0f);
-	auto floorMesh = gls.AddVisPlane(floorMat, Vector2(floorWidth, floorWidth), 1.0f, 0.0f, "", &floorColor, true);
-	if (floorMesh) {
-		floorMesh->prop.alpha = 0.05f;
-		floorMesh->bVisible = floorMode;
-		floorMeshes.push_back(floorMesh);
-	}
-
-	float nextLinePos = floorWidth - floorWidthHalf;
-
-	// Floor with width on X and Y axis (big grid)
-	for (int i = 0; i < numLinesBig; i++) {
-		Vector3 startPos(floorWidthHalf, 0.0f, nextLinePos);
-		Vector3 endPos(-floorWidthHalf, 0.0f, nextLinePos);
-
-		auto lineMesh = gls.AddVisSeg(startPos, endPos, "", true);
-		if (lineMesh) {
-			lineMesh->color.x = 0.0f;
-			lineMesh->color.y = 1.0f;
-			lineMesh->color.z = 0.0f;
-			lineMesh->bVisible = floorMode;
-			floorMeshes.push_back(lineMesh);
-		}
-
-		startPos = Vector3(nextLinePos, 0.0f, floorWidthHalf);
-		endPos = Vector3(nextLinePos, 0.0f, -floorWidthHalf);
-
-		lineMesh = gls.AddVisSeg(startPos, endPos, "", true);
-		if (lineMesh) {
-			lineMesh->color.x = 0.0f;
-			lineMesh->color.y = 1.0f;
-			lineMesh->color.z = 0.0f;
-			lineMesh->bVisible = floorMode;
-			floorMeshes.push_back(lineMesh);
-		}
-
-		nextLinePos -= floorGridStepBig;
-	}
-
-	nextLinePos = floorWidth - floorWidthHalf;
-
-	// Floor with width on X and Y axis (small grid)
-	for (int i = 0; i < numLinesSmall; i++) {
-		Vector3 startPos(floorWidthHalf, 0.0f, nextLinePos);
-		Vector3 endPos(-floorWidthHalf, 0.0f, nextLinePos);
-
-		auto lineMesh = gls.AddVisSeg(startPos, endPos, "", true);
-		if (lineMesh) {
-			lineMesh->color.x = 0.0f;
-			lineMesh->color.y = 1.0f;
-			lineMesh->color.z = 0.0f;
-			lineMesh->prop.alpha = 0.7f;
-			lineMesh->bVisible = floorMode;
-			floorMeshes.push_back(lineMesh);
-		}
-
-		startPos = Vector3(nextLinePos, 0.0f, floorWidthHalf);
-		endPos = Vector3(nextLinePos, 0.0f, -floorWidthHalf);
-
-		lineMesh = gls.AddVisSeg(startPos, endPos, "", true);
-		if (lineMesh) {
-			lineMesh->color.x = 0.0f;
-			lineMesh->color.y = 1.0f;
-			lineMesh->color.z = 0.0f;
-			lineMesh->prop.alpha = 0.7f;
-			lineMesh->bVisible = floorMode;
-			floorMeshes.push_back(lineMesh);
-		}
-
-		nextLinePos -= floorGridStepSmall;
-	}
-}
-
-void wxGLPanel::ShowVertexEdit(bool show) {
-	for (auto &m : gls.GetMeshes())
-		if (m)
-			m->bShowPoints = false;
-
-	if (show) {
-		if (os->activeItem) {
-			mesh* m = GetMesh(os->activeItem->GetShape()->name.get());
-			if (m) {
-				m->bShowPoints = true;
-				m->QueueUpdate(mesh::UpdateType::VertexColors);
-			}
-		}
-	}
-}
-
-void wxGLPanel::OnIdle(wxIdleEvent& WXUNUSED(event)) {
-	if (wxGetKeyState(wxKeyCode::WXK_SHIFT) ||
-		wxGetKeyState(wxKeyCode::WXK_CONTROL) ||
-		wxGetKeyState(wxKeyCode::WXK_ALT) ||
-		lbuttonDown || rbuttonDown || mbuttonDown)
-		return;
-
-	for (auto &m : BVHUpdateQueue)
-		m->CreateBVH();
-
-	BVHUpdateQueue.clear();
-}
-
-void wxGLPanel::OnPaint(wxPaintEvent& event) {
-	// Initialize OpenGL the first time the window is painted.
-	// We unfortunately can't initialize it before the window is shown.
-	// We could register for the EVT_SHOW event, but unfortunately it
-	// appears to only be called after the first few EVT_PAINT events.
-	// It also isn't supported on all platforms.
-	if (firstPaint) {
-		firstPaint = false;
-		OnShown();
-	}
-
-	gls.RenderOneFrame();
-	event.Skip();
-}
-
-void wxGLPanel::OnSize(wxSizeEvent& event) {
-	wxSize sz = event.GetSize();
-	gls.SetSize(sz.GetX(), sz.GetY());
-	gls.RenderOneFrame();
-}
-
-void wxGLPanel::OnMouseWheel(wxMouseEvent& event) {
-	int delt = event.GetWheelRotation();
-
-	if (event.ControlDown()) {
-		std::string sliderName = os->lastActiveSlider;
-
-		if (sliderName.empty())
-			sliderName = os->project->GetSliderName(0);
-
-		if (sliderName.empty())
+	void wxGLPanel::OnIdle(wxIdleEvent& WXUNUSED(event)) {
+		if (wxGetKeyState(wxKeyCode::WXK_SHIFT) ||
+			wxGetKeyState(wxKeyCode::WXK_CONTROL) ||
+			wxGetKeyState(wxKeyCode::WXK_ALT) ||
+			lbuttonDown || rbuttonDown || mbuttonDown)
 			return;
 
-		if (!os->activeSlider.empty())
-			os->ExitSliderEdit();
+		for (auto &m : BVHUpdateQueue)
+			m->CreateBVH();
 
-		size_t sliderCount = os->project->SliderCount();
-		size_t sliderIndex = 0;
-		if (os->project->SliderIndexFromName(sliderName, sliderIndex)) {
-			if (delt < 0) {
-				++sliderIndex;
+		BVHUpdateQueue.clear();
+	}
 
-				if (sliderIndex == sliderCount)
-					sliderIndex = 0;
+	void wxGLPanel::OnPaint(wxPaintEvent& event) {
+		// Initialize OpenGL the first time the window is painted.
+		// We unfortunately can't initialize it before the window is shown.
+		// We could register for the EVT_SHOW event, but unfortunately it
+		// appears to only be called after the first few EVT_PAINT events.
+		// It also isn't supported on all platforms.
+		if (firstPaint)
+		{
+			firstPaint = false;
+			OnShown();
+		}
 
-				os->EnterSliderEdit(os->project->GetSliderName(sliderIndex));
-				os->ScrollToActiveSlider();
-			}
-			else {
-				if (sliderIndex == 0)
-					sliderIndex = sliderCount - 1;
+		gls.RenderOneFrame();
+		event.Skip();
+	}
+
+	void wxGLPanel::OnSize(wxSizeEvent& event) {
+		wxSize sz = event.GetSize();
+		gls.SetSize(sz.GetX(), sz.GetY());
+		gls.RenderOneFrame();
+	}
+
+	void wxGLPanel::OnMouseWheel(wxMouseEvent& event) {
+		int delt = event.GetWheelRotation();
+
+		if (event.ControlDown())
+		{
+			std::string sliderName = os->lastActiveSlider;
+
+			if (sliderName.empty())
+				sliderName = os->project->GetSliderName(0);
+
+			if (sliderName.empty())
+				return;
+
+			if (!os->activeSlider.empty())
+				os->ExitSliderEdit();
+
+			size_t sliderCount = os->project->SliderCount();
+			size_t sliderIndex = 0;
+			if (os->project->SliderIndexFromName(sliderName, sliderIndex))
+			{
+				if (delt < 0)
+				{
+					++sliderIndex;
+
+					if (sliderIndex == sliderCount)
+						sliderIndex = 0;
+
+					os->EnterSliderEdit(os->project->GetSliderName(sliderIndex));
+					os->ScrollToActiveSlider();
+				}
 				else
-					--sliderIndex;
+				{
+					if (sliderIndex == 0)
+						sliderIndex = sliderCount - 1;
+					else
+						--sliderIndex;
 
-				os->EnterSliderEdit(os->project->GetSliderName(sliderIndex));
-				os->ScrollToActiveSlider();
+					os->EnterSliderEdit(os->project->GetSliderName(sliderIndex));
+					os->ScrollToActiveSlider();
+				}
 			}
 		}
-	}
-	else if (wxGetKeyState(wxKeyCode('S')))  {
-		wxPoint p = event.GetPosition();
+		else if (wxGetKeyState(wxKeyCode('S')))
+		{
+			wxPoint p = event.GetPosition();
 
-		if (brushMode) {
-			// Adjust brush size
-			if (delt < 0)
-				DecBrush();
-			else
-				IncBrush();
+			if (brushMode)
+			{
+				// Adjust brush size
+				if (delt < 0)
+					DecBrush();
+				else
+					IncBrush();
 
-			os->CheckBrushBounds();
-			os->UpdateBrushSettings();
-			gls.UpdateCursor(p.x, p.y, bGlobalBrushCollision);
+				os->CheckBrushBounds();
+				os->UpdateBrushSettings();
+				gls.UpdateCursor(p.x, p.y, bGlobalBrushCollision);
+				gls.RenderOneFrame();
+			}
+		}
+		else
+		{
+			gls.DollyCamera(delt);
+			UpdateTransformTool();
+			UpdatePivot();
 			gls.RenderOneFrame();
 		}
 	}
-	else {
-		gls.DollyCamera(delt);
-		UpdateTransformTool();
-		UpdatePivot();
-		gls.RenderOneFrame();
-	}
-}
 
-void wxGLPanel::OnMouseMove(wxMouseEvent& event) {
-	if (os->IsActive())
-		SetFocus();
+	void wxGLPanel::OnMouseMove(wxMouseEvent& event) {
+		if (os->IsActive())
+			SetFocus();
 
-	bool cursorExists = false;
-	int x;
-	int y;
-	event.GetPosition(&x, &y);
-
-	ShowRotationCenter(false);
-
-	if (mbuttonDown) {
-		isMDragging = true;
-		if (wxGetKeyState(wxKeyCode::WXK_SHIFT))
-			gls.DollyCamera(y - lastY);
-		else
-			gls.PanCamera(x - lastX, y - lastY);
-
-		UpdateTransformTool();
-		UpdatePivot();
-		gls.RenderOneFrame();
-	}
-
-	if (rbuttonDown) {
-		isRDragging = true;
-		if (wxGetKeyState(WXK_SHIFT)) {
-			gls.PanCamera(x - lastX, y - lastY);
-		}
-		else {
-			gls.TurnTableCamera(x - lastX);
-			gls.PitchCamera(y - lastY);
-			ShowRotationCenter();
-		}
-
-		if (wxGetKeyState(WXK_ALT)) {
-			if (hoverPoint != -1) {
-				rotationCenterMode = RotationCenterMode::Picked;
-				gls.camRotOffset = hoverCoord;
-			}
-		}
-
-		UpdateTransformTool();
-		UpdatePivot();
-		gls.RenderOneFrame();
-	}
-
-	if (lbuttonDown) {
-		isLDragging = true;
-		if (isTransforming) {
-			UpdateTransform(event.GetPosition());
-		}
-		else if (isMovingPivot) {
-			UpdatePivotPosition(event.GetPosition());
-		}
-		else if (isPainting) {
-			UpdateBrushStroke(event.GetPosition());
-		}
-		else if (isSelecting) {
-			SelectVertex(event.GetPosition());
-		}
-		else if (isPickingVertex) {
-			UpdatePickVertex(event.GetPosition());
-		}
-		else if (isPickingEdge) {
-			UpdatePickEdge(event.GetPosition());
-		}
-		else {
-			if (Config.MatchValue("Input/LeftMousePan", "true")) {
-				gls.PanCamera(x - lastX, y - lastY);
-				UpdateTransformTool();
-				UpdatePivot();
-			}
-		}
-
-		gls.RenderOneFrame();
-	}
-
-	if (!rbuttonDown && !lbuttonDown) {
-		hoverMeshName.clear();
-		hoverPoint = -1;
-		hoverCoord.Zero();
-		hoverEdge.p1 = 0;
-		hoverEdge.p2 = 0;
-		Vector3 hoverColor;
-		float hoverAlpha = 1.0f;
-
-		if (editMode) {
-			cursorExists = gls.UpdateCursor(x, y, bGlobalBrushCollision, &hoverMeshName, &hoverPoint, &hoverColor, &hoverAlpha, &hoverEdge, &hoverCoord);
-		}
-		else {
-			cursorExists = false;
-			gls.ShowCursor(false);
-		}
-
-		if ((transformMode || pivotMode) && !isTransforming && !isMovingPivot) {
-			if (XMoveMesh) {
-				XMoveMesh->color = Vector3(1.0f, 0.0f, 0.0f);
-				YMoveMesh->color = Vector3(0.0f, 1.0f, 0.0f);
-				ZMoveMesh->color = Vector3(0.0f, 0.0f, 1.0f);
-				XRotateMesh->color = Vector3(1.0f, 0.0f, 0.0f);
-				YRotateMesh->color = Vector3(0.0f, 1.0f, 0.0f);
-				ZRotateMesh->color = Vector3(0.0f, 0.0f, 1.0f);
-				XScaleMesh->color = Vector3(1.0f, 0.0f, 0.0f);
-				YScaleMesh->color = Vector3(0.0f, 1.0f, 0.0f);
-				ZScaleMesh->color = Vector3(0.0f, 0.0f, 1.0f);
-				ScaleUniformMesh->color = Vector3(0.0f, 0.0f, 0.0f);
-			}
-
-			if (XPivotMesh) {
-				XPivotMesh->color = Vector3(1.0f, 0.0f, 0.0f);
-				YPivotMesh->color = Vector3(0.0f, 1.0f, 0.0f);
-				ZPivotMesh->color = Vector3(0.0f, 0.0f, 1.0f);
-				PivotCenterMesh->color = Vector3(0.0f, 0.0f, 0.0f);
-			}
-
-			Vector3 outOrigin, outNormal;
-			mesh* hitMesh = nullptr;
-			if (gls.CollideOverlay(x, y, outOrigin, outNormal, &hitMesh)) {
-				if (hitMesh && hitMesh != PivotCenterMesh) {
-					hitMesh->color = Vector3(1.0f, 1.0f, 0.0f);
-					gls.ShowCursor(false);
-				}
-			}
-		}
-
-		gls.RenderOneFrame();
-
-		if (os->statusBar) {
-			if (cursorExists) {
-				if (activeTool == ToolID::MaskBrush)
-					os->statusBar->SetStatusText(wxString::Format("Vertex: %d, Mask: %g", hoverPoint, hoverColor.x), 1);
-				else if (activeTool == ToolID::WeightBrush)
-					os->statusBar->SetStatusText(wxString::Format("Vertex: %d, Weight: %g", hoverPoint, hoverColor.y), 1);
-				else if (activeTool == ToolID::ColorBrush || activeTool == ToolID::AlphaBrush)
-					os->statusBar->SetStatusText(wxString::Format("Vertex: %d, Color: %g, %g, %g, Alpha: %g", hoverPoint, hoverColor.x, hoverColor.y, hoverColor.z, hoverAlpha), 1);
-				else {
-					Vector3 hoverCoordNif = mesh::VecToNifCoords(hoverCoord);
-					os->statusBar->SetStatusText(wxString::Format("Vertex: %d, X: %.5f Y: %.5f Z: %.5f", hoverPoint, hoverCoordNif.x, hoverCoordNif.y, hoverCoordNif.z), 1);
-				}
-			}
-			else {
-				os->statusBar->SetStatusText("", 1);
-			}
-		}
-	}
-
-	lastX = x;
-	lastY = y;
-}
-
-void wxGLPanel::OnLeftDown(wxMouseEvent& event) {
-	if (!HasCapture())
-		CaptureMouse();
-
-	lbuttonDown = true;
-
-	if (transformMode) {
-		bool meshHit = StartTransform(event.GetPosition());
-		if (meshHit) {
-			isTransforming = true;
-			return;
-		}
-	}
-
-	if (pivotMode) {
-		bool meshHit = StartPivotPosition(event.GetPosition());
-		if (meshHit) {
-			isMovingPivot = true;
-			return;
-		}
-	}
-
-	if (brushMode) {
-		bool meshHit = StartBrushStroke(event.GetPosition());
-		if (meshHit)
-			isPainting = true;
-	}
-	else if (activeTool == ToolID::CollapseVertex) {
-		bool meshHit = StartPickVertex();
-		if (meshHit)
-			isPickingVertex = true;
-	}
-	else if (activeTool == ToolID::FlipEdge || activeTool == ToolID::SplitEdge) {
-		bool meshHit = StartPickEdge();
-		if (meshHit)
-			isPickingEdge = true;
-	}
-	else if (vertexEdit) {
-		bool meshHit = SelectVertex(event.GetPosition());
-		if (meshHit)
-			isSelecting = true;
-	}
-}
-
-void wxGLPanel::OnMiddleDown(wxMouseEvent& WXUNUSED(event)) {
-	if (!HasCapture())
-		CaptureMouse();
-
-	mbuttonDown = true;
-}
-
-void wxGLPanel::OnMiddleUp(wxMouseEvent& WXUNUSED(event)) {
-	if (GetCapture() == this)
-		ReleaseMouse();
-
-	isMDragging = false;
-	mbuttonDown = false;
-}
-
-void wxGLPanel::OnLeftUp(wxMouseEvent& event) {
-	if (GetCapture() == this)
-		ReleaseMouse();
-
-	if (!isLDragging && !isPainting && activeTool == ToolID::Select) {
-		int x, y;
+		bool cursorExists = false;
+		int x;
+		int y;
 		event.GetPosition(&x, &y);
-		wxPoint p = event.GetPosition();
 
-		mesh* m = gls.PickMesh(x, y);
-		if (m)
-			os->SelectShape(m->shapeName);
-	}
+		ShowRotationCenter(false);
 
-	if (isPainting) {
-		EndBrushStroke();
-		isPainting = false;
-	}
+		if (mbuttonDown)
+		{
+			isMDragging = true;
+			if (wxGetKeyState(wxKeyCode::WXK_SHIFT))
+				gls.DollyCamera(y - lastY);
+			else
+				gls.PanCamera(x - lastX, y - lastY);
 
-	if (isPickingVertex) {
-		EndPickVertex();
-		isPickingVertex = false;
-	}
-
-	if (isPickingEdge) {
-		EndPickEdge();
-		isPickingEdge = false;
-	}
-
-	if (isTransforming) {
-		EndTransform();
-		isTransforming = false;
-	}
-
-	if (isMovingPivot) {
-		EndPivotPosition();
-		isMovingPivot = false;
-	}
-
-	if (isSelecting)
-		isSelecting = false;
-
-	isLDragging = false;
-	lbuttonDown = false;
-
-	gls.RenderOneFrame();
-}
-
-void wxGLPanel::OnCaptureLost(wxMouseCaptureLostEvent& WXUNUSED(event)) {
-	if (isPainting) {
-		EndBrushStroke();
-		isPainting = false;
-	}
-
-	if (isPickingVertex) {
-		EndPickVertex();
-		isPickingVertex = false;
-	}
-
-	if (isPickingEdge) {
-		EndPickEdge();
-		isPickingEdge = false;
-	}
-
-	if (isTransforming) {
-		EndTransform();
-		isTransforming = false;
-	}
-
-	if (isMovingPivot) {
-		EndPivotPosition();
-		isMovingPivot = false;
-	}
-
-	if (isSelecting)
-		isSelecting = false;
-
-	isLDragging = false;
-	lbuttonDown = false;
-
-	isMDragging = false;
-	mbuttonDown = false;
-
-	rbuttonDown = false;
-
-	gls.RenderOneFrame();
-}
-
-void wxGLPanel::OnRightDown(wxMouseEvent& WXUNUSED(event)) {
-	if (!HasCapture())
-		CaptureMouse();
-
-	rbuttonDown = true;
-}
-
-void wxGLPanel::OnRightUp(wxMouseEvent& WXUNUSED(event)) {
-	if (HasCapture())
-		ReleaseMouse();
-
-	rbuttonDown = false;
-}
-
-
-bool DnDFile::OnDropFiles(wxCoord, wxCoord, const wxArrayString& fileNames) {
-	if (owner) {
-		NiShape* mergeShape = nullptr;
-		if (owner->activeItem && fileNames.GetCount() == 1)
-			mergeShape = owner->activeItem->GetShape();
-
-		for (auto &inputFile : fileNames) {
-			wxString dataName = inputFile.AfterLast('/').AfterLast('\\');
-			dataName = dataName.BeforeLast('.');
-
-			if (inputFile.Lower().EndsWith(".nif")) {
-				owner->StartProgress(_("Adding NIF file..."));
-				owner->UpdateProgress(1, _("Adding NIF file..."));
-				owner->project->ImportNIF(inputFile.ToUTF8().data(), false);
-				owner->project->SetTextures();
-
-				owner->UpdateProgress(60, _("Refreshing GUI..."));
-				owner->RefreshGUIFromProj();
-
-				owner->UpdateProgress(100, _("Finished"));
-				owner->EndProgress();
-			}
-			else if (inputFile.Lower().EndsWith(".obj")) {
-				owner->StartProgress("Adding OBJ file...");
-				owner->UpdateProgress(1, _("Adding OBJ file..."));
-				owner->project->ImportOBJ(inputFile.ToUTF8().data(), dataName.ToUTF8().data(), mergeShape);
-				owner->project->SetTextures();
-
-				owner->UpdateProgress(60, _("Refreshing GUI..."));
-				owner->RefreshGUIFromProj();
-
-				owner->UpdateProgress(100, _("Finished"));
-				owner->EndProgress();
-			}
-			else if (inputFile.Lower().EndsWith(".fbx")) {
-				owner->StartProgress(_("Adding FBX file..."));
-				owner->UpdateProgress(1, _("Adding FBX file..."));
-				owner->project->ImportFBX(inputFile.ToUTF8().data(), dataName.ToUTF8().data(), mergeShape);
-				owner->project->SetTextures();
-
-				owner->UpdateProgress(60, _("Refreshing GUI..."));
-				owner->RefreshGUIFromProj();
-
-				owner->UpdateProgress(100, _("Finished"));
-				owner->EndProgress();
-			}
+			UpdateTransformTool();
+			UpdatePivot();
+			gls.RenderOneFrame();
 		}
-	}
-	else
-		return false;
 
-	return true;
-}
+		if (rbuttonDown)
+		{
+			isRDragging = true;
+			if (wxGetKeyState(WXK_SHIFT))
+			{
+				gls.PanCamera(x - lastX, y - lastY);
+			}
+			else
+			{
+				gls.TurnTableCamera(x - lastX);
+				gls.PitchCamera(y - lastY);
+				ShowRotationCenter();
+			}
 
-bool DnDSliderFile::OnDropFiles(wxCoord, wxCoord, const wxArrayString& fileNames) {
-	if (owner) {
-		bool isMultiple = (fileNames.GetCount() > 1);
-		for (size_t i = 0; i < fileNames.GetCount(); i++)	{
-			wxString inputFile;
-			inputFile = fileNames.Item(i);
+			if (wxGetKeyState(WXK_ALT))
+			{
+				if (hoverPoint != -1)
+				{
+					rotationCenterMode = RotationCenterMode::Picked;
+					gls.camRotOffset = hoverCoord;
+				}
+			}
 
-			wxString dataName = inputFile.AfterLast('/').AfterLast('\\');
-			dataName = dataName.BeforeLast('.');
+			UpdateTransformTool();
+			UpdatePivot();
+			gls.RenderOneFrame();
+		}
 
-			bool isBSD = inputFile.MakeLower().EndsWith(".bsd");
-			bool isOBJ = inputFile.MakeLower().EndsWith(".obj");
-			bool isFBX = inputFile.MakeLower().EndsWith(".fbx");
-			if (isBSD || isOBJ) {
-				if (!owner->activeItem) {
-					wxMessageBox(_("There is no shape selected!"), _("Error"));
-					return false;
+		if (lbuttonDown)
+		{
+			isLDragging = true;
+			if (isTransforming)
+			{
+				UpdateTransform(event.GetPosition());
+			}
+			else if (isMovingPivot)
+			{
+				UpdatePivotPosition(event.GetPosition());
+			}
+			else if (isPainting)
+			{
+				UpdateBrushStroke(event.GetPosition());
+			}
+			else if (isSelecting)
+			{
+				SelectVertex(event.GetPosition());
+			}
+			else if (isPickingVertex)
+			{
+				UpdatePickVertex(event.GetPosition());
+			}
+			else if (isPickingEdge)
+			{
+				UpdatePickEdge(event.GetPosition());
+			}
+			else
+			{
+				if (Config.MatchValue("Input/LeftMousePan", "true"))
+				{
+					gls.PanCamera(x - lastX, y - lastY);
+					UpdateTransformTool();
+					UpdatePivot();
+				}
+			}
+
+			gls.RenderOneFrame();
+		}
+
+		if (!rbuttonDown && !lbuttonDown)
+		{
+			hoverMeshName.clear();
+			hoverPoint = -1;
+			hoverCoord.Zero();
+			hoverEdge.p1 = 0;
+			hoverEdge.p2 = 0;
+			Vector3 hoverColor;
+			float hoverAlpha = 1.0f;
+
+			if (editMode)
+			{
+				cursorExists = gls.UpdateCursor(x, y, bGlobalBrushCollision, &hoverMeshName, &hoverPoint, &hoverColor, &hoverAlpha, &hoverEdge, &hoverCoord);
+			}
+			else
+			{
+				cursorExists = false;
+				gls.ShowCursor(false);
+			}
+
+			if ((transformMode || pivotMode) && !isTransforming && !isMovingPivot)
+			{
+				if (XMoveMesh)
+				{
+					XMoveMesh->color = Vector3(1.0f, 0.0f, 0.0f);
+					YMoveMesh->color = Vector3(0.0f, 1.0f, 0.0f);
+					ZMoveMesh->color = Vector3(0.0f, 0.0f, 1.0f);
+					XRotateMesh->color = Vector3(1.0f, 0.0f, 0.0f);
+					YRotateMesh->color = Vector3(0.0f, 1.0f, 0.0f);
+					ZRotateMesh->color = Vector3(0.0f, 0.0f, 1.0f);
+					XScaleMesh->color = Vector3(1.0f, 0.0f, 0.0f);
+					YScaleMesh->color = Vector3(0.0f, 1.0f, 0.0f);
+					ZScaleMesh->color = Vector3(0.0f, 0.0f, 1.0f);
+					ScaleUniformMesh->color = Vector3(0.0f, 0.0f, 0.0f);
 				}
 
-				if (lastResult == wxDragCopy) {
-					targetSlider = owner->NewSlider(dataName.ToUTF8().data(), isMultiple);
+				if (XPivotMesh)
+				{
+					XPivotMesh->color = Vector3(1.0f, 0.0f, 0.0f);
+					YPivotMesh->color = Vector3(0.0f, 1.0f, 0.0f);
+					ZPivotMesh->color = Vector3(0.0f, 0.0f, 1.0f);
+					PivotCenterMesh->color = Vector3(0.0f, 0.0f, 0.0f);
 				}
 
-				if (targetSlider.empty())
-					return false;
+				Vector3 outOrigin, outNormal;
+				mesh* hitMesh = nullptr;
+				if (gls.CollideOverlay(x, y, outOrigin, outNormal, &hitMesh))
+				{
+					if (hitMesh && hitMesh != PivotCenterMesh)
+					{
+						hitMesh->color = Vector3(1.0f, 1.0f, 0.0f);
+						gls.ShowCursor(false);
+					}
+				}
+			}
 
-				owner->StartProgress(_("Loading slider file..."));
-				owner->UpdateProgress(1, _("Loading slider file..."));
+			gls.RenderOneFrame();
 
-				if (isBSD)
-					owner->project->SetSliderFromBSD(targetSlider, owner->activeItem->GetShape(), inputFile.ToUTF8().data());
-				else if (isOBJ)
-					owner->project->SetSliderFromOBJ(targetSlider, owner->activeItem->GetShape(), inputFile.ToUTF8().data());
-				else if (isFBX)
-					owner->project->SetSliderFromFBX(targetSlider, owner->activeItem->GetShape(), inputFile.ToUTF8().data());
+			if (os->statusBar)
+			{
+				if (cursorExists)
+				{
+					if (activeTool == ToolID::MaskBrush)
+						os->statusBar->SetStatusText(wxString::Format("Vertex: %d, Mask: %g", hoverPoint, hoverColor.x), 1);
+					else if (activeTool == ToolID::WeightBrush)
+						os->statusBar->SetStatusText(wxString::Format("Vertex: %d, Weight: %g", hoverPoint, hoverColor.y), 1);
+					else if (activeTool == ToolID::ColorBrush || activeTool == ToolID::AlphaBrush)
+						os->statusBar->SetStatusText(wxString::Format("Vertex: %d, Color: %g, %g, %g, Alpha: %g", hoverPoint, hoverColor.x, hoverColor.y, hoverColor.z, hoverAlpha), 1);
+					else
+					{
+						Vector3 hoverCoordNif = mesh::VecToNifCoords(hoverCoord);
+						os->statusBar->SetStatusText(wxString::Format("Vertex: %d, X: %.5f Y: %.5f Z: %.5f", hoverPoint, hoverCoordNif.x, hoverCoordNif.y, hoverCoordNif.z), 1);
+					}
+				}
 				else
-					return false;
-
-
-				owner->UpdateProgress(100, _("Finished"));
-				owner->EndProgress();
+				{
+					os->statusBar->SetStatusText("", 1);
+				}
 			}
 		}
-		owner->EnterSliderEdit(targetSlider);
+
+		lastX = x;
+		lastY = y;
+	}
+
+	void wxGLPanel::OnLeftDown(wxMouseEvent& event) {
+		if (!HasCapture())
+			CaptureMouse();
+
+		lbuttonDown = true;
+
+		if (transformMode)
+		{
+			bool meshHit = StartTransform(event.GetPosition());
+			if (meshHit)
+			{
+				isTransforming = true;
+				return;
+			}
+		}
+
+		if (pivotMode)
+		{
+			bool meshHit = StartPivotPosition(event.GetPosition());
+			if (meshHit)
+			{
+				isMovingPivot = true;
+				return;
+			}
+		}
+
+		if (brushMode)
+		{
+			bool meshHit = StartBrushStroke(event.GetPosition());
+			if (meshHit)
+				isPainting = true;
+		}
+		else if (activeTool == ToolID::CollapseVertex)
+		{
+			bool meshHit = StartPickVertex();
+			if (meshHit)
+				isPickingVertex = true;
+		}
+		else if (activeTool == ToolID::FlipEdge || activeTool == ToolID::SplitEdge)
+		{
+			bool meshHit = StartPickEdge();
+			if (meshHit)
+				isPickingEdge = true;
+		}
+		else if (vertexEdit)
+		{
+			bool meshHit = SelectVertex(event.GetPosition());
+			if (meshHit)
+				isSelecting = true;
+		}
+	}
+
+	void wxGLPanel::OnMiddleDown(wxMouseEvent& WXUNUSED(event)) {
+		if (!HasCapture())
+			CaptureMouse();
+
+		mbuttonDown = true;
+	}
+
+	void wxGLPanel::OnMiddleUp(wxMouseEvent& WXUNUSED(event)) {
+		if (GetCapture() == this)
+			ReleaseMouse();
+
+		isMDragging = false;
+		mbuttonDown = false;
+	}
+
+	void wxGLPanel::OnLeftUp(wxMouseEvent& event) {
+		if (GetCapture() == this)
+			ReleaseMouse();
+
+		if (!isLDragging && !isPainting && activeTool == ToolID::Select)
+		{
+			int x, y;
+			event.GetPosition(&x, &y);
+			wxPoint p = event.GetPosition();
+
+			mesh* m = gls.PickMesh(x, y);
+			if (m)
+				os->SelectShape(m->shapeName);
+		}
+
+		if (isPainting)
+		{
+			EndBrushStroke();
+			isPainting = false;
+		}
+
+		if (isPickingVertex)
+		{
+			EndPickVertex();
+			isPickingVertex = false;
+		}
+
+		if (isPickingEdge)
+		{
+			EndPickEdge();
+			isPickingEdge = false;
+		}
+
+		if (isTransforming)
+		{
+			EndTransform();
+			isTransforming = false;
+		}
+
+		if (isMovingPivot)
+		{
+			EndPivotPosition();
+			isMovingPivot = false;
+		}
+
+		if (isSelecting)
+			isSelecting = false;
+
+		isLDragging = false;
+		lbuttonDown = false;
+
+		gls.RenderOneFrame();
+	}
+
+	void wxGLPanel::OnCaptureLost(wxMouseCaptureLostEvent& WXUNUSED(event)) {
+		if (isPainting)
+		{
+			EndBrushStroke();
+			isPainting = false;
+		}
+
+		if (isPickingVertex)
+		{
+			EndPickVertex();
+			isPickingVertex = false;
+		}
+
+		if (isPickingEdge)
+		{
+			EndPickEdge();
+			isPickingEdge = false;
+		}
+
+		if (isTransforming)
+		{
+			EndTransform();
+			isTransforming = false;
+		}
+
+		if (isMovingPivot)
+		{
+			EndPivotPosition();
+			isMovingPivot = false;
+		}
+
+		if (isSelecting)
+			isSelecting = false;
+
+		isLDragging = false;
+		lbuttonDown = false;
+
+		isMDragging = false;
+		mbuttonDown = false;
+
+		rbuttonDown = false;
+
+		gls.RenderOneFrame();
+	}
+
+	void wxGLPanel::OnRightDown(wxMouseEvent& WXUNUSED(event)) {
+		if (!HasCapture())
+			CaptureMouse();
+
+		rbuttonDown = true;
+	}
+
+	void wxGLPanel::OnRightUp(wxMouseEvent& WXUNUSED(event)) {
+		if (HasCapture())
+			ReleaseMouse();
+
+		rbuttonDown = false;
+	}
+
+
+	bool DnDFile::OnDropFiles(wxCoord, wxCoord, const wxArrayString& fileNames) {
+		if (owner)
+		{
+			NiShape* mergeShape = nullptr;
+			if (owner->activeItem && fileNames.GetCount() == 1)
+				mergeShape = owner->activeItem->GetShape();
+
+			for (auto &inputFile : fileNames)
+			{
+				wxString dataName = inputFile.AfterLast('/').AfterLast('\\');
+				dataName = dataName.BeforeLast('.');
+
+				if (inputFile.Lower().EndsWith(".nif"))
+				{
+					owner->StartProgress(_("Adding NIF file..."));
+					owner->UpdateProgress(1, _("Adding NIF file..."));
+					owner->project->ImportNIF(inputFile.ToUTF8().data(), false);
+					owner->project->SetTextures();
+
+					owner->UpdateProgress(60, _("Refreshing GUI..."));
+					owner->RefreshGUIFromProj();
+
+					owner->UpdateProgress(100, _("Finished"));
+					owner->EndProgress();
+				}
+				else if (inputFile.Lower().EndsWith(".obj"))
+				{
+					owner->StartProgress("Adding OBJ file...");
+					owner->UpdateProgress(1, _("Adding OBJ file..."));
+					owner->project->ImportOBJ(inputFile.ToUTF8().data(), dataName.ToUTF8().data(), mergeShape);
+					owner->project->SetTextures();
+
+					owner->UpdateProgress(60, _("Refreshing GUI..."));
+					owner->RefreshGUIFromProj();
+
+					owner->UpdateProgress(100, _("Finished"));
+					owner->EndProgress();
+				}
+				else if (inputFile.Lower().EndsWith(".fbx"))
+				{
+					owner->StartProgress(_("Adding FBX file..."));
+					owner->UpdateProgress(1, _("Adding FBX file..."));
+					owner->project->ImportFBX(inputFile.ToUTF8().data(), dataName.ToUTF8().data(), mergeShape);
+					owner->project->SetTextures();
+
+					owner->UpdateProgress(60, _("Refreshing GUI..."));
+					owner->RefreshGUIFromProj();
+
+					owner->UpdateProgress(100, _("Finished"));
+					owner->EndProgress();
+				}
+			}
+		}
+		else
+			return false;
+
+		return true;
+	}
+
+	bool DnDSliderFile::OnDropFiles(wxCoord, wxCoord, const wxArrayString& fileNames) {
+		if (owner)
+		{
+			bool isMultiple = (fileNames.GetCount() > 1);
+			for (size_t i = 0; i < fileNames.GetCount(); i++)
+			{
+				wxString inputFile;
+				inputFile = fileNames.Item(i);
+
+				wxString dataName = inputFile.AfterLast('/').AfterLast('\\');
+				dataName = dataName.BeforeLast('.');
+
+				bool isBSD = inputFile.MakeLower().EndsWith(".bsd");
+				bool isOBJ = inputFile.MakeLower().EndsWith(".obj");
+				bool isFBX = inputFile.MakeLower().EndsWith(".fbx");
+				if (isBSD || isOBJ)
+				{
+					if (!owner->activeItem)
+					{
+						wxMessageBox(_("There is no shape selected!"), _("Error"));
+						return false;
+					}
+
+					if (lastResult == wxDragCopy)
+					{
+						targetSlider = owner->NewSlider(dataName.ToUTF8().data(), isMultiple);
+					}
+
+					if (targetSlider.empty())
+						return false;
+
+					owner->StartProgress(_("Loading slider file..."));
+					owner->UpdateProgress(1, _("Loading slider file..."));
+
+					if (isBSD)
+						owner->project->SetSliderFromBSD(targetSlider, owner->activeItem->GetShape(), inputFile.ToUTF8().data());
+					else if (isOBJ)
+						owner->project->SetSliderFromOBJ(targetSlider, owner->activeItem->GetShape(), inputFile.ToUTF8().data());
+					else if (isFBX)
+						owner->project->SetSliderFromFBX(targetSlider, owner->activeItem->GetShape(), inputFile.ToUTF8().data());
+					else
+						return false;
+
+
+					owner->UpdateProgress(100, _("Finished"));
+					owner->EndProgress();
+				}
+			}
+			owner->EnterSliderEdit(targetSlider);
+			targetSlider.clear();
+		}
+		else
+			return false;
+
+		return true;
+	}
+
+	wxDragResult DnDSliderFile::OnDragOver(wxCoord x, wxCoord y, wxDragResult defResult) {
 		targetSlider.clear();
-	}
-	else
-		return false;
+		lastResult = defResult;
 
-	return true;
-}
+		if (defResult == wxDragCopy)
+			return lastResult;
 
-wxDragResult DnDSliderFile::OnDragOver(wxCoord x, wxCoord y, wxDragResult defResult) {
-	targetSlider.clear();
-	lastResult = defResult;
-
-	if (defResult == wxDragCopy)
-		return lastResult;
-
-	if (owner) {
-		for (auto &child : owner->sliderDisplays) {
-			if (child.second->sliderPane->GetRect().Contains(x, y)) {
-				targetSlider = child.first;
-				lastResult = wxDragMove;
-				break;
+		if (owner)
+		{
+			for (auto &child : owner->sliderDisplays)
+			{
+				if (child.second->sliderPane->GetRect().Contains(x, y))
+				{
+					targetSlider = child.first;
+					lastResult = wxDragMove;
+					break;
+				}
 			}
+
+			if (targetSlider.empty())
+				if (owner->sliderScroll->HitTest(x, y) == wxHT_WINDOW_INSIDE)
+					lastResult = wxDragCopy;
 		}
+		else
+			lastResult = wxDragCancel;
 
-		if (targetSlider.empty())
-			if (owner->sliderScroll->HitTest(x, y) == wxHT_WINDOW_INSIDE)
-				lastResult = wxDragCopy;
+		return lastResult;
 	}
-	else
-		lastResult = wxDragCancel;
-
-	return lastResult;
-}
 
 
-std::string JoinStrings(const std::vector<std::string>& elements, const char* const separator) {
-	switch (elements.size()) {
-	case 0:
-		return "";
-	case 1:
-		return elements[0];
-	default:
-		std::ostringstream os;
-		std::copy(elements.begin(), elements.end() - 1, std::ostream_iterator<std::string>(os, separator));
-		os << *elements.rbegin();
-		return os.str();
+	std::string JoinStrings(const std::vector<std::string>& elements, const char* const separator)
+	{
+		switch (elements.size())
+		{
+		case 0:
+			return "";
+		case 1:
+			return elements[0];
+		default:
+			std::ostringstream os;
+			std::copy(elements.begin(), elements.end() - 1, std::ostream_iterator<std::string>(os, separator));
+			os << *elements.rbegin();
+			return os.str();
+		}
 	}
-}

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -3463,6 +3463,7 @@ void OutfitStudioFrame::OnLoadReference(wxCommandEvent& WXUNUSED(event)) {
 
 	UpdateProgress(10, _("Loading reference set..."));
 	bool mergeSliders = (XRCCTRL(dlg, "chkClearSliders", wxCheckBox)->IsChecked());
+	bool keepZapSliders = (XRCCTRL(dlg, "chkKeepZapSliders", wxCheckBox)->IsChecked());
 
 	int error = 0;
 	if (XRCCTRL(dlg, "npRefIsTemplate", wxRadioButton)->GetValue() == true) {
@@ -3475,9 +3476,9 @@ void OutfitStudioFrame::OnLoadReference(wxCommandEvent& WXUNUSED(event)) {
 		auto tmpl = find_if(refTemplates.begin(), refTemplates.end(), [&tmplName](const RefTemplate& rt) { return rt.GetName() == tmplName; });
 		if (tmpl != refTemplates.end()) {
 			if (wxFileName(wxString::FromUTF8(tmpl->GetSource())).IsRelative())
-				error = project->LoadReferenceTemplate(GetProjectPath() + PathSepStr + tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), tmpl->GetLoadAll(), mergeSliders);
+				error = project->LoadReferenceTemplate(GetProjectPath() + PathSepStr + tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), tmpl->GetLoadAll(), mergeSliders, keepZapSliders);
 			else
-				error = project->LoadReferenceTemplate(tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), tmpl->GetLoadAll(), mergeSliders);
+				error = project->LoadReferenceTemplate(tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), tmpl->GetLoadAll(), mergeSliders, keepZapSliders);
 		}
 		else
 			error = 1;
@@ -3492,11 +3493,11 @@ void OutfitStudioFrame::OnLoadReference(wxCommandEvent& WXUNUSED(event)) {
 				refShape, sliderSetName, fileName);
 
 			error = project->LoadReference(fileName.ToUTF8().data(),
-				sliderSetName.ToUTF8().data(), mergeSliders, refShape.ToUTF8().data());
+				sliderSetName.ToUTF8().data(), mergeSliders, refShape.ToUTF8().data(), keepZapSliders);
 		}
 		else if (fileName.EndsWith(".nif")) {
 			wxLogMessage("Loading reference '%s' from '%s'...", refShape, fileName);
-			error = project->LoadReferenceNif(fileName.ToUTF8().data(), refShape.ToUTF8().data(), mergeSliders);
+			error = project->LoadReferenceNif(fileName.ToUTF8().data(), refShape.ToUTF8().data(), mergeSliders, keepZapSliders);
 		}
 	}
 	else

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -1233,14 +1233,13 @@ private:
 	void OnLoadOutfitFP_File(wxFileDirPickerEvent& event);
 	void OnLoadOutfitFP_Texture(wxFileDirPickerEvent& event);
 
+	
 	void OnSetBaseShape(wxCommandEvent &event);
 	void OnMakeConvRef(wxCommandEvent& event);
 
-	int BakeConversionReference() const;
 	void OnImportNIF(wxCommandEvent &event);
 	void OnExportNIF(wxCommandEvent &event);
 	void OnExportNIFWithRef(wxCommandEvent &event);
-	void OnBakeConversionReference(wxCommandEvent &event);
 	void OnExportShapeNIF(wxCommandEvent& event);
 
 	void OnImportOBJ(wxCommandEvent& event);
@@ -1263,6 +1262,7 @@ private:
 	void OnSSSGenWeightsFalse(wxCommandEvent& event);
 	void OnSaveSliderSet(wxCommandEvent &event);
 	void OnSaveSliderSetAs(wxCommandEvent &event);
+	void SetBaseShape();
 
 	void OnSlider(wxScrollEvent& event);
 	void OnClickSliderButton(wxCommandEvent &event);

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -1123,21 +1123,23 @@ public:
 	}
 
 	void StartSubProgress(int min, int max) {
-		int range = progressStack.back().second - progressStack.front().first;
+		int range = progressStack.back().second - progressStack.back().first;
 		float mindiv = min / 100.0f;
 		float maxdiv = max / 100.0f;
 		int minoff = mindiv * range + 1;
 		int maxoff = maxdiv * range + 1;
-		progressStack.emplace_back(progressStack.front().first + minoff, progressStack.front().first + maxoff);
+		progressStack.emplace_back(minoff + progressStack.back().first, maxoff + progressStack.back().first);
 	}
 
-	void EndProgress(const wxString& msg = "") {
+	void EndProgress(const wxString& msg = "", bool forceEmpty = false) {
 		if (progressStack.empty())
 			return;
 
-		progressBar->SetValue(progressStack.back().second);
-		progressStack.pop_back();
-
+		do {
+			progressBar->SetValue(progressStack.back().second);
+			progressStack.pop_back();
+		} while(forceEmpty && !progressStack.empty());
+		
 		if (progressStack.empty()) {
 			if (msg.IsEmpty())
 				statusBar->SetStatusText(_("Ready!"));

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -1067,6 +1067,7 @@ public:
 	void CloseBrushSettings();
 	void PopupBrushSettings(bool transient);
 	void UpdateBrushSettings();
+	void DeleteSliders(bool keepZaps = false);
 
 	void CheckBrushBounds() {
 		TweakBrush* brush = glView->GetActiveBrush();

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -1222,6 +1222,7 @@ private:
 	int LoadReferenceTemplate(const wxString& refTemplate, bool keepZapSliders);
 	void LoadDialogChoice(wxDialog& dlg, const char* dlgProperty) const;
 	void LoadDialogText(wxDialog& dlg, const char* dlgProperty) const;
+	void LoadDialogCheckBox(wxDialog& dlg, const char* dlgProperty) const;
 	bool AlertProgressError(int error, const wxString& title, const wxString& message);
 
 	void OnNewProject(wxCommandEvent& event);

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -1233,6 +1233,7 @@ private:
 	void OnImportNIF(wxCommandEvent &event);
 	void OnExportNIF(wxCommandEvent &event);
 	void OnExportNIFWithRef(wxCommandEvent &event);
+	void OnBakeNifInPlace(wxCommandEvent &event);
 	void OnExportShapeNIF(wxCommandEvent& event);
 
 	void OnImportOBJ(wxCommandEvent& event);

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -1342,8 +1342,8 @@ private:
 	void OnLoadPreset(wxCommandEvent& event);
 	void OnSavePreset(wxCommandEvent& event);
 	bool ShowConform(ConformOptions& options, bool silent = false);
-	int ConformShapes(std::vector<nifly::NiShape*> shapes, bool silent = false);
-	void ConformSliders(nifly::NiShape* shape, const ConformOptions& options, bool silent = false);
+	int ConformShapes(std::vector<nifly::NiShape*> shapes, bool silent = false, int minProgress = 0, int maxProgress = 100);
+	void ConformSliders(nifly::NiShape* shape, const ConformOptions& options, int minProgress = 0, int maxProgress = 100);
 	void OnSliderConform(wxCommandEvent& event);
 	void OnSliderConformAll(wxCommandEvent& event);
 	void OnSliderImportNIF(wxCommandEvent& event);
@@ -1404,7 +1404,7 @@ private:
 	void OnDeleteUnreferencedNodes(wxCommandEvent& event);
 	void OnRemoveSkinning(wxCommandEvent& event);
 	void OnShapeProperties(wxCommandEvent& event);
-	int CopyBoneWeightForShapes(std::vector<nifly::NiShape*> shapes, int addedRadius = 0, bool maskWeighted = false, bool silent = false);
+	int CopyBoneWeightForShapes(std::vector<nifly::NiShape*> shapes, bool silent = false, int minProgress = 0, int maxProgress = 100);
 	
 	void OnMaskLess(wxCommandEvent& event);
 	void OnMaskMore(wxCommandEvent& event);

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -1194,7 +1194,7 @@ private:
 
 	bool HasUnweightedCheck();
 	void CalcCopySkinTransOption(WeightCopyOptions &options);
-	bool ShowWeightCopy(WeightCopyOptions& options);
+	bool ShowWeightCopy(WeightCopyOptions& options, bool silent = false);
 	void ReselectBone();
 
 	void OnExit(wxCommandEvent& event);
@@ -1217,10 +1217,16 @@ private:
 	void AddProjectHistory(const std::string& fileName, const std::string& projectName);
 	void UpdateProjectHistory();
 
+	int LoadReferenceTemplate(const wxString& refTemplate, bool keepZapSliders);
+	void LoadDialogChoice(wxDialog& dlg, const char* dlgProperty) const;
+	void LoadDialogText(wxDialog& dlg, const char* dlgProperty) const;
+	bool AlertProgressError(int error, const wxString& title, const wxString& message);
+
 	void OnNewProject(wxCommandEvent& event);
 	void OnLoadProject(wxCommandEvent &event);
 	void OnAddProject(wxCommandEvent &event);
 	void OnLoadReference(wxCommandEvent &event);
+	void OnConvertBodyReference(wxCommandEvent &event);
 	void OnLoadOutfit(wxCommandEvent& event);
 	void OnUnloadProject(wxCommandEvent &event);
 
@@ -1230,10 +1236,11 @@ private:
 	void OnSetBaseShape(wxCommandEvent &event);
 	void OnMakeConvRef(wxCommandEvent& event);
 
+	int BakeConversionReference() const;
 	void OnImportNIF(wxCommandEvent &event);
 	void OnExportNIF(wxCommandEvent &event);
 	void OnExportNIFWithRef(wxCommandEvent &event);
-	void OnBakeNifInPlace(wxCommandEvent &event);
+	void OnBakeConversionReference(wxCommandEvent &event);
 	void OnExportShapeNIF(wxCommandEvent& event);
 
 	void OnImportOBJ(wxCommandEvent& event);
@@ -1334,8 +1341,9 @@ private:
 
 	void OnLoadPreset(wxCommandEvent& event);
 	void OnSavePreset(wxCommandEvent& event);
-	bool ShowConform(ConformOptions& options);
-	void ConformSliders(nifly::NiShape* shape, const ConformOptions& options);
+	bool ShowConform(ConformOptions& options, bool silent = false);
+	int ConformShapes(std::vector<nifly::NiShape*> shapes, bool silent = false);
+	void ConformSliders(nifly::NiShape* shape, const ConformOptions& options, bool silent = false);
 	void OnSliderConform(wxCommandEvent& event);
 	void OnSliderConformAll(wxCommandEvent& event);
 	void OnSliderImportNIF(wxCommandEvent& event);
@@ -1387,6 +1395,7 @@ private:
 	void GetBoneDlgData(wxDialog &dlg, nifly::MatTransform &xform, std::string &parentBone);
 	void OnEditBone(wxCommandEvent& event);
 	void OnCopyBoneWeight(wxCommandEvent& event);
+	void MaskWeightedOnShape(std::string& shapeName) const;
 	void OnCopySelectedWeight(wxCommandEvent& event);
 	void OnTransferSelectedWeight(wxCommandEvent& event);
 	void OnMaskWeighted(wxCommandEvent& event);
@@ -1395,7 +1404,8 @@ private:
 	void OnDeleteUnreferencedNodes(wxCommandEvent& event);
 	void OnRemoveSkinning(wxCommandEvent& event);
 	void OnShapeProperties(wxCommandEvent& event);
-
+	int CopyBoneWeightForShapes(std::vector<nifly::NiShape*> shapes, int addedRadius = 0, bool maskWeighted = false, bool silent = false);
+	
 	void OnMaskLess(wxCommandEvent& event);
 	void OnMaskMore(wxCommandEvent& event);
 

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -1342,8 +1342,8 @@ private:
 	void OnLoadPreset(wxCommandEvent& event);
 	void OnSavePreset(wxCommandEvent& event);
 	bool ShowConform(ConformOptions& options, bool silent = false);
-	int ConformShapes(std::vector<nifly::NiShape*> shapes, bool silent = false, int minProgress = 0, int maxProgress = 100);
-	void ConformSliders(nifly::NiShape* shape, const ConformOptions& options, int minProgress = 0, int maxProgress = 100);
+	int ConformShapes(std::vector<nifly::NiShape*> shapes, bool silent = false);
+	void ConformSliders(nifly::NiShape* shape, const ConformOptions& options);
 	void OnSliderConform(wxCommandEvent& event);
 	void OnSliderConformAll(wxCommandEvent& event);
 	void OnSliderImportNIF(wxCommandEvent& event);
@@ -1404,7 +1404,7 @@ private:
 	void OnDeleteUnreferencedNodes(wxCommandEvent& event);
 	void OnRemoveSkinning(wxCommandEvent& event);
 	void OnShapeProperties(wxCommandEvent& event);
-	int CopyBoneWeightForShapes(std::vector<nifly::NiShape*> shapes, bool silent = false, int minProgress = 0, int maxProgress = 100);
+	int CopyBoneWeightForShapes(std::vector<nifly::NiShape*> shapes, bool silent = false);
 	
 	void OnMaskLess(wxCommandEvent& event);
 	void OnMaskMore(wxCommandEvent& event);


### PR DESCRIPTION
* Added the ability to keep zap sliders when loading a reference body
* ~~Added 'Slider->Bake Conversion Ref' menu item
      - This menu item can be used wehn converting between body references in order to exclude the need to 'export to nif with reference'. Instead, this will simply bake the bodyslide used from the conversion reference into the mesh and you can simply continue using the mesh.~~
* Added 'File->Convert Body Reference' menu item
      - This will allow you to 1 click convert between body references (ie. CBBE to BHUNP)
      - All settings that are set on the wizard dialog are remembered between sessions - so you only need to enter them once for all of the outfits you wish to convert
      
      How to use:
         1) Open your outfit project
         2) Open the wizard ('File->Convert Body Reference')
         3) Select the conversion reference (ie. Convert: CBBE SE to BHUNP)
         4) Select the new body reference (ie. BHUNP 3BBB Advanced ver 2)
         5) Enter any text that you would like removing from outfit name, slider set file, shape data folder and shape data file - including spaces (ie. 'CBBE, Physics, p, P, SSE')
         6) Enter any text that you would like prepending to outfit name, slider set file, shape data folder and shape data file - including spaces (ie. 'BHUNP, Physics, p, P, SSE')
         7) Click OK, wait for the process to complete and you can then instantly save the project (which will use the updated project name values) or adjust weights and then save.