### PR TITLE
Changed lighting calculations from being in tangent space to being in…

### DIFF
--- a/res/shaders/default.frag
+++ b/res/shaders/default.frag
@@ -34,7 +34,9 @@ uniform bool bRimlight;
 uniform bool bSoftlight;
 uniform bool bGlowmap;
 
-uniform mat4 matModelView;
+uniform mat4 matModel;
+uniform mat4 matModelViewInverse;
+uniform mat3 mv_normalMatrix;
 
 struct Properties
 {
@@ -212,7 +214,7 @@ void main(void)
 				if (bModelSpace)
 				{
 					// Vertex normal for shading with disabled maps
-					normal = mat3(matModelView) * n;
+					normal = mv_normalMatrix * n;
 					normal = normalize(normal);
 				}
 
@@ -225,7 +227,7 @@ void main(void)
 							// Model Space Normal Map
 							normal = normalize(normalMap.rgb * 2.0 - 1.0);
 							normal.r = -normal.r;
-							normal = mat3(matModelView) * normal;
+							normal = mv_normalMatrix * normal;
 							normal = normalize(normal);
 
 							if (bSpecular)
@@ -254,8 +256,7 @@ void main(void)
 				if (bCubemap && bShowTexture)
 				{
 					vec3 reflected = reflect(-viewDir, normal);
-					vec3 reflectedWS = mat3(matModelView) * reflected;
-					reflectedWS = normalize(reflectedWS);
+					vec3 reflectedWS = vec3(matModel * (matModelViewInverse * vec4(reflected, 0.0)));
 
 					vec4 cubeMap = texture(texCubemap, reflectedWS);
 					cubeMap.rgb *= prop.envReflection;

--- a/res/shaders/default.frag
+++ b/res/shaders/default.frag
@@ -72,9 +72,8 @@ in vec3 lightDirectional1;
 in vec3 lightDirectional2;
 
 in vec3 viewDir;
-in vec3 t;
-in vec3 b;
 in vec3 n;
+in mat3 mv_tbn;
 
 in float maskFactor;
 in vec3 weightColor;
@@ -237,7 +236,7 @@ void main(void)
 						else
 						{
 							// Tangent Space Normal Map
-							normal = normalize(normalMap.rgb * 2.0 - 1.0);
+							normal = normalize(mv_tbn * (normalMap.rgb * 2.0 - 1.0));
 
 							if (bSpecular)
 							{
@@ -255,8 +254,7 @@ void main(void)
 				if (bCubemap && bShowTexture)
 				{
 					vec3 reflected = reflect(-viewDir, normal);
-					vec3 reflectedVS = b * reflected.x + t * reflected.y + n * reflected.z;
-					vec3 reflectedWS = mat3(matModelView) * reflectedVS;
+					vec3 reflectedWS = mat3(matModelView) * reflected;
 					reflectedWS = normalize(reflectedWS);
 
 					vec4 cubeMap = texture(texCubemap, reflectedWS);

--- a/res/shaders/default.vert
+++ b/res/shaders/default.vert
@@ -49,9 +49,8 @@ out vec3 lightDirectional1;
 out vec3 lightDirectional2;
 
 out vec3 viewDir;
-out vec3 t;
-out vec3 b;
 out vec3 n;
+out mat3 mv_tbn;
 
 out float maskFactor;
 out vec3 weightColor;
@@ -119,44 +118,24 @@ void main(void)
 	vec3 vPos = vec3(matModelView * vec4(vertexPosition, 1.0));
 	gl_Position = matProjection * vec4(vPos, 1.0);
 
-	t = vertexTangent;
-	b = vertexBitangent;
 	n = vertexNormal;
 
 	if (!bModelSpace)
 	{
 		mat3 mv_normalMatrix = transpose(inverse(mat3(matModelView)));
-		vec3 mv_normal = normalize(mv_normalMatrix * n);
-		vec3 mv_tangent = normalize(mv_normalMatrix * t);
-		vec3 mv_bitangent = normalize(mv_normalMatrix * b);
+		vec3 mv_normal = mv_normalMatrix * n;
+		vec3 mv_tangent = mv_normalMatrix * vertexTangent;
+		vec3 mv_bitangent = mv_normalMatrix * vertexBitangent;
 
-		mat3 mv_tbn = mat3(mv_bitangent.x, mv_tangent.x, mv_normal.x,
-                           mv_bitangent.y, mv_tangent.y, mv_normal.y,
-                           mv_bitangent.z, mv_tangent.z, mv_normal.z);
-
-		mat3 m_normalMatrix = transpose(inverse(mat3(matModel)));
-		vec3 m_normal = normalize(m_normalMatrix * n);
-		vec3 m_tangent = normalize(m_normalMatrix * t);
-		vec3 m_bitangent = normalize(m_normalMatrix * b);
-
-		mat3 m_tbn = mat3(m_bitangent.x, m_tangent.x, m_normal.x,
-                          m_bitangent.y, m_tangent.y, m_normal.y,
-                          m_bitangent.z, m_tangent.z, m_normal.z);
-
-		viewDir = normalize(mv_tbn * -vPos);
-		lightFrontal = normalize(mv_tbn * frontal.direction);
-		lightDirectional0 = normalize(m_tbn * directional0.direction);
-		lightDirectional1 = normalize(m_tbn * directional1.direction);
-		lightDirectional2 = normalize(m_tbn * directional2.direction);
+		mv_tbn = mat3(mv_bitangent.x, mv_bitangent.y, mv_bitangent.z,
+                           mv_tangent.x, mv_tangent.y, mv_tangent.z,
+                           mv_normal.x, mv_normal.y, mv_normal.z);
 	}
-	else
-	{
-		viewDir = normalize(-vPos);
-		lightFrontal = normalize(frontal.direction);
-		lightDirectional0 = normalize(mat3(matView) * directional0.direction);
-		lightDirectional1 = normalize(mat3(matView) * directional1.direction);
-		lightDirectional2 = normalize(mat3(matView) * directional2.direction);
-	}
+	viewDir = normalize(-vPos);
+	lightFrontal = normalize(frontal.direction);
+	lightDirectional0 = normalize(mat3(matView) * directional0.direction);
+	lightDirectional1 = normalize(mat3(matView) * directional1.direction);
+	lightDirectional2 = normalize(mat3(matView) * directional2.direction);
 
 	if (!bPoints)
 	{

--- a/res/shaders/default.vert
+++ b/res/shaders/default.vert
@@ -9,8 +9,8 @@
 
 uniform mat4 matProjection;
 uniform mat4 matView;
-uniform mat4 matModel;
 uniform mat4 matModelView;
+uniform mat3 mv_normalMatrix;
 uniform vec3 color;
 uniform vec3 subColor;
 
@@ -122,7 +122,6 @@ void main(void)
 
 	if (!bModelSpace)
 	{
-		mat3 mv_normalMatrix = transpose(inverse(mat3(matModelView)));
 		vec3 mv_normal = mv_normalMatrix * n;
 		vec3 mv_tangent = mv_normalMatrix * vertexTangent;
 		vec3 mv_bitangent = mv_normalMatrix * vertexBitangent;

--- a/res/shaders/fo4_default.vert
+++ b/res/shaders/fo4_default.vert
@@ -11,6 +11,7 @@ uniform mat4 matProjection;
 uniform mat4 matView;
 uniform mat4 matModel;
 uniform mat4 matModelView;
+uniform mat3 mv_normalMatrix;
 uniform vec3 color;
 uniform vec3 subColor;
 
@@ -48,9 +49,7 @@ out vec3 lightDirectional1;
 out vec3 lightDirectional2;
 
 out vec3 viewDir;
-out vec3 t;
-out vec3 b;
-out vec3 n;
+out mat3 mv_tbn;
 
 out float maskFactor;
 out vec3 weightColor;
@@ -118,33 +117,19 @@ void main(void)
 	vec3 vPos = vec3(matModelView * vec4(vertexPosition, 1.0));
 	gl_Position = matProjection * vec4(vPos, 1.0);
 
-	t = vertexTangent;
-	b = vertexBitangent;
-	n = vertexNormal;
+	vec3 mv_normal = mv_normalMatrix * vertexNormal;
+	vec3 mv_tangent = mv_normalMatrix * vertexTangent;
+	vec3 mv_bitangent = mv_normalMatrix * vertexBitangent;
 
-	mat3 mv_normalMatrix = transpose(inverse(mat3(matModelView)));
-	vec3 mv_normal = normalize(mv_normalMatrix * n);
-	vec3 mv_tangent = normalize(mv_normalMatrix * t);
-	vec3 mv_bitangent = normalize(mv_normalMatrix * b);
+	mv_tbn = mat3(mv_bitangent.x, mv_bitangent.y, mv_bitangent.z,
+				  mv_tangent.x, mv_tangent.y, mv_tangent.z,
+				  mv_normal.x, mv_normal.y, mv_normal.z);
 
-	mat3 mv_tbn = mat3(mv_bitangent.x, mv_tangent.x, mv_normal.x,
-                       mv_bitangent.y, mv_tangent.y, mv_normal.y,
-                       mv_bitangent.z, mv_tangent.z, mv_normal.z);
-
-	mat3 m_normalMatrix = transpose(inverse(mat3(matModel)));
-	vec3 m_normal = normalize(m_normalMatrix * n);
-	vec3 m_tangent = normalize(m_normalMatrix * t);
-	vec3 m_bitangent = normalize(m_normalMatrix * b);
-
-	mat3 m_tbn = mat3(m_bitangent.x, m_tangent.x, m_normal.x,
-                      m_bitangent.y, m_tangent.y, m_normal.y,
-                      m_bitangent.z, m_tangent.z, m_normal.z);
-
-	viewDir = normalize(mv_tbn * -vPos);
-	lightFrontal = normalize(mv_tbn * frontal.direction);
-	lightDirectional0 = normalize(m_tbn * directional0.direction);
-	lightDirectional1 = normalize(m_tbn * directional1.direction);
-	lightDirectional2 = normalize(m_tbn * directional2.direction);
+	viewDir = normalize(-vPos);
+	lightFrontal = normalize(frontal.direction);
+	lightDirectional0 = normalize(mat3(matView) * directional0.direction);
+	lightDirectional1 = normalize(mat3(matView) * directional1.direction);
+	lightDirectional2 = normalize(mat3(matView) * directional2.direction);
 
 	if (!bPoints)
 	{

--- a/res/shaders/ob_default.frag
+++ b/res/shaders/ob_default.frag
@@ -57,9 +57,7 @@ in vec3 lightDirectional1;
 in vec3 lightDirectional2;
 
 in vec3 viewDir;
-in vec3 t;
-in vec3 b;
-in vec3 n;
+in mat3 mv_tbn;
 
 in float maskFactor;
 in vec3 weightColor;
@@ -129,7 +127,7 @@ void main(void)
 				vec3 outSpecular = vec3(0.0);
 
 				// Start off neutral
-				normal = normalize(vec3(0.0, 0.0, 0.5));
+				normal = normalize(mv_tbn * vec3(0.0, 0.0, 0.5));
 				specFactor = 0.0;
 
 				directionalLight(frontal, lightFrontal, outDiffuse, outSpecular);

--- a/res/shaders/ob_default.vert
+++ b/res/shaders/ob_default.vert
@@ -11,6 +11,7 @@ uniform mat4 matProjection;
 uniform mat4 matView;
 uniform mat4 matModel;
 uniform mat4 matModelView;
+uniform mat3 mv_normalMatrix;
 uniform vec3 color;
 uniform vec3 subColor;
 
@@ -48,9 +49,7 @@ out vec3 lightDirectional1;
 out vec3 lightDirectional2;
 
 out vec3 viewDir;
-out vec3 t;
-out vec3 b;
-out vec3 n;
+out mat3 mv_tbn;
 
 out float maskFactor;
 out vec3 weightColor;
@@ -118,33 +117,19 @@ void main(void)
 	vec3 vPos = vec3(matModelView * vec4(vertexPosition, 1.0));
 	gl_Position = matProjection * vec4(vPos, 1.0);
 
-	t = vertexTangent;
-	b = vertexBitangent;
-	n = vertexNormal;
+	vec3 mv_normal = mv_normalMatrix * vertexNormal;
+	vec3 mv_tangent = mv_normalMatrix * vertexTangent;
+	vec3 mv_bitangent = mv_normalMatrix * vertexBitangent;
 
-	mat3 mv_normalMatrix = transpose(inverse(mat3(matModelView)));
-	vec3 mv_normal = normalize(mv_normalMatrix * n);
-	vec3 mv_tangent = normalize(mv_normalMatrix * t);
-	vec3 mv_bitangent = normalize(mv_normalMatrix * b);
+	mv_tbn = mat3(mv_bitangent.x, mv_bitangent.y, mv_bitangent.z,
+				  mv_tangent.x, mv_tangent.y, mv_tangent.z,
+				  mv_normal.x, mv_normal.y, mv_normal.z);
 
-	mat3 mv_tbn = mat3(mv_bitangent.x, mv_tangent.x, mv_normal.x,
-					   mv_bitangent.y, mv_tangent.y, mv_normal.y,
-					   mv_bitangent.z, mv_tangent.z, mv_normal.z);
-
-	mat3 m_normalMatrix = transpose(inverse(mat3(matModel)));
-	vec3 m_normal = normalize(m_normalMatrix * n);
-	vec3 m_tangent = normalize(m_normalMatrix * t);
-	vec3 m_bitangent = normalize(m_normalMatrix * b);
-
-	mat3 m_tbn = mat3(m_bitangent.x, m_tangent.x, m_normal.x,
-					  m_bitangent.y, m_tangent.y, m_normal.y,
-					  m_bitangent.z, m_tangent.z, m_normal.z);
-
-	viewDir = normalize(mv_tbn * -vPos);
-	lightFrontal = normalize(mv_tbn * frontal.direction);
-	lightDirectional0 = normalize(m_tbn * directional0.direction);
-	lightDirectional1 = normalize(m_tbn * directional1.direction);
-	lightDirectional2 = normalize(m_tbn * directional2.direction);
+	viewDir = normalize(-vPos);
+	lightFrontal = normalize(frontal.direction);
+	lightDirectional0 = normalize(mat3(matView) * directional0.direction);
+	lightDirectional1 = normalize(mat3(matView) * directional1.direction);
+	lightDirectional2 = normalize(mat3(matView) * directional2.direction);
 
 	if (!bPoints)
 	{

--- a/src/render/GLExtensions.cpp
+++ b/src/render/GLExtensions.cpp
@@ -47,6 +47,7 @@ PFNGLUNIFORM1FPROC glUniform1f = nullptr;
 PFNGLUNIFORM1IPROC glUniform1i = nullptr;
 PFNGLUNIFORM2FPROC glUniform2f = nullptr;
 PFNGLUNIFORM3FPROC glUniform3f = nullptr;
+PFNGLUNIFORMMATRIX3FVPROC glUniformMatrix3fv = nullptr;
 PFNGLUNIFORMMATRIX4FVPROC glUniformMatrix4fv = nullptr;
 
 PFNGLGETSHADERIVPROC glGetShaderiv = nullptr;
@@ -128,6 +129,7 @@ void InitExtensions() {
 		glUniform1i = (PFNGLUNIFORM1IPROC)wglGetProcAddress("glUniform1i");
 		glUniform2f = (PFNGLUNIFORM2FPROC)wglGetProcAddress("glUniform2f");
 		glUniform3f = (PFNGLUNIFORM3FPROC)wglGetProcAddress("glUniform3f");
+		glUniformMatrix3fv = (PFNGLUNIFORMMATRIX3FVPROC)wglGetProcAddress("glUniformMatrix3fv");
 		glUniformMatrix4fv = (PFNGLUNIFORMMATRIX4FVPROC)wglGetProcAddress("glUniformMatrix4fv");
 
 		glActiveTexture = (PFNGLACTIVETEXTUREPROC)wglGetProcAddress("glActiveTexture");

--- a/src/render/GLExtensions.h
+++ b/src/render/GLExtensions.h
@@ -61,6 +61,7 @@ extern PFNGLUNIFORM1FPROC glUniform1f;
 extern PFNGLUNIFORM1IPROC glUniform1i;
 extern PFNGLUNIFORM2FPROC glUniform2f;
 extern PFNGLUNIFORM3FPROC glUniform3f;
+extern PFNGLUNIFORMMATRIX3FVPROC glUniformMatrix3fv;
 extern PFNGLUNIFORMMATRIX4FVPROC glUniformMatrix4fv;
 
 extern PFNGLGETSHADERIVPROC glGetShaderiv;

--- a/src/render/GLShader.cpp
+++ b/src/render/GLShader.cpp
@@ -139,6 +139,16 @@ void GLShader::SetMatrixModelView(const glm::mat4x4& matView, const glm::mat4x4&
 	if (loc >= 0) {
 		glm::mat4x4 matModelView = matView * matModel;
 		glUniformMatrix4fv(loc, 1, GL_FALSE, (GLfloat*)&matModelView);
+		loc = glGetUniformLocation(progID, "matModelViewInverse");
+		if (loc >= 0) {
+			glm::mat4x4 matModelViewInverse = glm::inverse(matModelView);
+			glUniformMatrix4fv(loc, 1, GL_FALSE, (GLfloat*)&matModelViewInverse);
+		}
+		loc = glGetUniformLocation(progID, "mv_normalMatrix");
+		if (loc >= 0) {
+			glm::mat3x3 mv_normalMatrix = glm::transpose(glm::inverse(glm::mat3(matModelView)));
+			glUniformMatrix3fv(loc, 1, GL_FALSE, (GLfloat*)&mv_normalMatrix);
+		}
 	}
 }
 


### PR DESCRIPTION
… view space to reduce problems with interpolation.

This caused shading issues to show up on meshes that didn't show them in-game or in the Creation Kit.

![image](https://user-images.githubusercontent.com/45334438/141657452-d430e14f-f36e-4e47-bafd-dc66e23132bc.png)

![image](https://user-images.githubusercontent.com/45334438/141657450-6b0a15dd-d5c4-42c8-8b46-c0ccb3fcb8f3.png)

Test mesh:
[DetailCloset.zip](https://github.com/ousnius/BodySlide-and-Outfit-Studio/files/7532659/DetailCloset.zip)
[TestCubeMap.zip](https://github.com/ousnius/BodySlide-and-Outfit-Studio/files/7534482/TestCubeMap.zip)

Additional changes:
- The cube map intersection vector is now properly brought into world space by first bringing it from view space into model space (inverted of matModelView), and then into world space by multiplication with matModel. It is also no longer normalized (not necessary for that use, and it's not used for anything else).
- Calculation of mv_normalMatrix happens globally, rather than in the vertex shader, since it was calculated only from a uniform matrix.
- World space normals are multiplied with mv_normalMatrix instead of matModelView, since they do the same rotation, but mv_normalMatrix does scale adjustment appropriate for normals (only really noticeable with non-uniform scale, not sure how often that happens in OS, but since the matrix is available anyways I thought it best practice).

As a note, I also noticed that normalization of ViewDir and the light directions happens in the vertex shader instead of in the fragment shader. In principle, this should happen in the fragment shader to prevent some warping on interpolation, but that of course only matters if that lightdir is different between different vertices, so I'm not sure how high priority that is.
https://forum.unity.com/threads/why-cant-i-normalize-view-direction-in-vertex-shader.636205/