### PR TITLE
View output conflicts and file paths in BodySlide

### DIFF
--- a/res/xrc/BodySlide.xrc
+++ b/res/xrc/BodySlide.xrc
@@ -185,7 +185,7 @@
 								<option>0</option>
 								<flag>wxLEFT|wxALIGN_CENTER_VERTICAL</flag>
 								<border>5</border>
-								<object class="wxCheckBox" name="cbDefaultOutfit">
+								<object class="wxCheckBox" name="cbIsOutfitChoice">
 									<fg>#c8c8c8</fg>
 									<tooltip>Default outfit choice in Batch Build</tooltip>
 									<label></label>

--- a/res/xrc/BodySlide.xrc
+++ b/res/xrc/BodySlide.xrc
@@ -13,7 +13,7 @@
 				<flag>wxEXPAND</flag>
 				<border>5</border>
 				<object class="wxFlexGridSizer">
-					<rows>2</rows>
+					<rows>3</rows>
 					<cols>5</cols>
 					<vgap>0</vgap>
 					<hgap>0</hgap>
@@ -164,6 +164,51 @@
 							<tooltip>Opens the group manager where you can edit existing or create new groups</tooltip>
 							<label>Group Manager</label>
 						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxALL|wxALIGN_CENTER</flag>
+						<border>5</border>
+						<object class="wxStaticText">
+							<fg>#c8c8c8</fg>
+							<label>Output Path</label>
+							<wrap>-1</wrap>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxBoxSizer">
+							<orient>wxHORIZONTAL</orient>
+							<object class="sizeritem">
+								<option>0</option>
+								<flag>wxLEFT|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<object class="wxCheckBox" name="cbDefaultOutfit">
+									<fg>#c8c8c8</fg>
+									<tooltip>Default outfit choice in Batch Build</tooltip>
+									<label></label>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxALIGN_LEFT</flag>
+								<border>5</border>
+								<object class="wxStaticText" name="conflictLabel">
+									<fg>#c8c8d8</fg>
+									<tooltip>Right click for conflicting outfit(s)</tooltip>
+									<label></label>
+									<wrap>-1</wrap>
+								</object>
+							</object>
+						</object>
+					</object>
+					<object class="sizeritem">
+					</object>
+					<object class="sizeritem">
+					</object>
+					<object class="sizeritem">
 					</object>
 				</object>
 			</object>
@@ -470,5 +515,7 @@
 		<object class="wxMenuItem" name="batchBuildInvert">
 			<label>Invert Selection</label>
 		</object>
+	</object>
+	<object class="wxMenu" name="menuFileCollision">
 	</object>
 </resource>

--- a/res/xrc/BodySlide.xrc
+++ b/res/xrc/BodySlide.xrc
@@ -13,7 +13,7 @@
 				<flag>wxEXPAND</flag>
 				<border>5</border>
 				<object class="wxFlexGridSizer">
-					<rows>3</rows>
+					<rows>2</rows>
 					<cols>5</cols>
 					<vgap>0</vgap>
 					<hgap>0</hgap>
@@ -165,51 +165,6 @@
 							<label>Group Manager</label>
 						</object>
 					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxALL|wxALIGN_CENTER</flag>
-						<border>5</border>
-						<object class="wxStaticText">
-							<fg>#c8c8c8</fg>
-							<label>Output Path</label>
-							<wrap>-1</wrap>
-						</object>
-					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxEXPAND</flag>
-						<border>5</border>
-						<object class="wxBoxSizer">
-							<orient>wxHORIZONTAL</orient>
-							<object class="sizeritem">
-								<option>0</option>
-								<flag>wxLEFT|wxALIGN_CENTER_VERTICAL</flag>
-								<border>5</border>
-								<object class="wxCheckBox" name="cbIsOutfitChoice">
-									<fg>#c8c8c8</fg>
-									<tooltip>Default outfit choice in Batch Build</tooltip>
-									<label></label>
-								</object>
-							</object>
-							<object class="sizeritem">
-								<option>1</option>
-								<flag>wxALL|wxALIGN_LEFT</flag>
-								<border>5</border>
-								<object class="wxStaticText" name="conflictLabel">
-									<fg>#c8c8d8</fg>
-									<tooltip>Right click for conflicting outfit(s)</tooltip>
-									<label></label>
-									<wrap>-1</wrap>
-								</object>
-							</object>
-						</object>
-					</object>
-					<object class="sizeritem">
-					</object>
-					<object class="sizeritem">
-					</object>
-					<object class="sizeritem">
-					</object>
 				</object>
 			</object>
 			<object class="sizeritem">
@@ -301,77 +256,107 @@
 			</object>
 			<object class="sizeritem">
 				<option>0</option>
-				<flag>wxEXPAND</flag>
-				<border>5</border>
-				<object class="wxBoxSizer">
-					<orient>wxHORIZONTAL</orient>
+				<flag>wxALL|wxEXPAND</flag>
+				<object class="wxGridBagSizer">
+					<cols>3</cols>
+					<hgap>5</hgap>
+					<vgap>5</vgap>
+					<growablecols>0,1,2</growablecols>
+					<growablerows></growablerows>
 					<object class="sizeritem">
-						<option>1</option>
-						<flag>wxEXPAND</flag>
+						<cellpos>0,0</cellpos>
+						<cellspan>1,1</cellspan>
+						<flag>wxALIGN_CENTER|wxALL</flag>
+						<border>5</border>
+						<object class="wxButton" name="btnLowToHigh">
+							<size>26,-1</size>
+							<fg>wxSYS_COLOUR_BTNTEXT</fg>
+							<tooltip>Copy the low weight slider values to the high weight section.</tooltip>
+							<label translate="0">&#8594;</label>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<cellpos>1,0</cellpos>
+						<cellspan>1,3</cellspan>
 						<border>5</border>
 						<object class="wxBoxSizer">
-							<orient>wxVERTICAL</orient>
+							<orient>wxHORIZONTAL</orient>
+							<object class="sizeritem">
+								<option>0</option>
+								<flag>wxALL|wxALIGN_CENTER</flag>
+								<border>5</border>
+								<object class="wxStaticText">
+									<fg>#c8c8c8</fg>
+									<label>Output Path</label>
+									<wrap>-1</wrap>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>0</option>
+								<flag>wxLEFT|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<object class="wxCheckBox" name="cbIsOutfitChoice">
+									<fg>#c8c8c8</fg>
+									<tooltip>Default outfit choice in Batch Build</tooltip>
+									<label></label>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxALIGN_LEFT</flag>
+								<border>5</border>
+								<object class="wxStaticText" name="conflictLabel">
+									<fg>#c8c8d8</fg>
+									<tooltip>Right click for conflicting outfit(s)</tooltip>
+									<label></label>
+									<wrap>-1</wrap>
+								</object>
+							</object>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<cellpos>2,0</cellpos>
+						<cellspan>1,1</cellspan>
+						<flag>wxALL</flag>
+						<border>5</border>
+						<object class="wxBoxSizer">
+							<orient>wxHORIZONTAL</orient>
 							<object class="sizeritem">
 								<option>0</option>
 								<flag>wxALIGN_CENTER|wxALL</flag>
 								<border>5</border>
-								<object class="wxButton" name="btnLowToHigh">
-									<size>26,-1</size>
+								<object class="wxButton" name="btnBuildBatch">
 									<fg>wxSYS_COLOUR_BTNTEXT</fg>
-									<tooltip>Copy the low weight slider values to the high weight section.</tooltip>
-									<label translate="0">&#8594;</label>
+									<tooltip>Build multiple outfits using the currently active slider values.\n\nHold CTRL = Build to custom directory\nHold ALT = Delete from output directory</tooltip>
+									<label>Batch Build...</label>
 								</object>
-							</object>
-							<object class="spacer">
-								<option>1</option>
-								<flag>wxEXPAND</flag>
-								<border>5</border>
-								<size>0,15</size>
 							</object>
 							<object class="sizeritem">
 								<option>0</option>
-								<flag>wxALL</flag>
+								<flag>wxALIGN_CENTER|wxALL</flag>
 								<border>5</border>
 								<object class="wxBoxSizer">
-									<orient>wxHORIZONTAL</orient>
+									<orient>wxVERTICAL</orient>
 									<object class="sizeritem">
 										<option>0</option>
-										<flag>wxALIGN_CENTER|wxALL</flag>
-										<border>5</border>
-										<object class="wxButton" name="btnBuildBatch">
-											<fg>wxSYS_COLOUR_BTNTEXT</fg>
-											<tooltip>Build multiple outfits using the currently active slider values.\n\nHold CTRL = Build to custom directory\nHold ALT = Delete from output directory</tooltip>
-											<label>Batch Build...</label>
+										<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
+										<border>0</border>
+										<object class="wxCheckBox" name="cbMorphs">
+											<fg>#c8c8c8</fg>
+											<label>Build Morphs</label>
+											<tooltip>Builds a morphs (.tri) file alongside the meshes for accessing the sliders in-game. Requires other mods to make use of the morph data.</tooltip>
+											<hidden>1</hidden>
 										</object>
 									</object>
 									<object class="sizeritem">
 										<option>0</option>
-										<flag>wxALIGN_CENTER|wxALL</flag>
-										<border>5</border>
-										<object class="wxBoxSizer">
-											<orient>wxVERTICAL</orient>
-											<object class="sizeritem">
-												<option>0</option>
-												<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
-												<border>0</border>
-												<object class="wxCheckBox" name="cbMorphs">
-													<fg>#c8c8c8</fg>
-													<label>Build Morphs</label>
-													<tooltip>Builds a morphs (.tri) file alongside the meshes for accessing the sliders in-game. Requires other mods to make use of the morph data.</tooltip>
-													<hidden>1</hidden>
-												</object>
-											</object>
-											<object class="sizeritem">
-												<option>0</option>
-												<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
-												<border>0</border>
-												<object class="wxCheckBox" name="cbForceBodyNormals">
-													<fg>#c8c8c8</fg>
-													<label>Force Body Normals</label>
-													<tooltip>Adds normal and tangent data to the body meshes (including bodies within outfits) for Skyrim. Use this only if you have a tangent space body mod.</tooltip>
-													<hidden>1</hidden>
-												</object>
-											</object>
+										<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
+										<border>0</border>
+										<object class="wxCheckBox" name="cbForceBodyNormals">
+											<fg>#c8c8c8</fg>
+											<label>Force Body Normals</label>
+											<tooltip>Adds normal and tangent data to the body meshes (including bodies within outfits) for Skyrim. Use this only if you have a tangent space body mod.</tooltip>
+											<hidden>1</hidden>
 										</object>
 									</object>
 								</object>
@@ -379,102 +364,84 @@
 						</object>
 					</object>
 					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxEXPAND</flag>
+						<cellpos>0,1</cellpos>
+						<cellspan>1,1</cellspan>
+						<flag>wxALIGN_CENTER|wxALL</flag>
 						<border>5</border>
-						<object class="wxBoxSizer">
-							<orient>wxVERTICAL</orient>
-							<object class="sizeritem">
-								<option>0</option>
-								<flag>wxALIGN_CENTER|wxALL</flag>
-								<border>5</border>
-								<object class="wxButton" name="btnPreview">
-									<size>128,-1</size>
-									<fg>wxSYS_COLOUR_BTNTEXT</fg>
-									<tooltip>Show a preview window for this outfit.</tooltip>
-									<label>Preview</label>
-								</object>
-							</object>
-							<object class="sizeritem">
-								<option>0</option>
-								<flag>wxALIGN_CENTER|wxALL</flag>
-								<border>5</border>
-								<object class="wxButton" name="btnBuild">
-									<size>128,45</size>
-									<font>
-										<size>12</size>
-										<style>normal</style>
-										<weight>normal</weight>
-										<underlined>0</underlined>
-										<face>Andalus</face>
-									</font>
-									<fg>wxSYS_COLOUR_BTNTEXT</fg>
-									<tooltip>Creates the currently selected outfit/body.\n\nHold CTRL = Build to working directory\nHold ALT = Delete from output directory</tooltip>
-									<label>Build</label>
-									<default>0</default>
-								</object>
-							</object>
+						<object class="wxButton" name="btnPreview">
+							<size>128,-1</size>
+							<fg>wxSYS_COLOUR_BTNTEXT</fg>
+							<tooltip>Show a preview window for this outfit.</tooltip>
+							<label>Preview</label>
 						</object>
 					</object>
 					<object class="sizeritem">
-						<option>1</option>
-						<flag>wxEXPAND</flag>
+						<cellpos>2,1</cellpos>
+						<cellspan>1,1</cellspan>
+						<flag>wxALIGN_CENTER|wxALL</flag>
+						<border>5</border>
+						<object class="wxButton" name="btnBuild">
+							<size>128,45</size>
+							<font>
+								<size>12</size>
+								<style>normal</style>
+								<weight>normal</weight>
+								<underlined>0</underlined>
+								<face>Andalus</face>
+							</font>
+							<fg>wxSYS_COLOUR_BTNTEXT</fg>
+							<tooltip>Creates the currently selected outfit/body.\n\nHold CTRL = Build to working directory\nHold ALT = Delete from output directory</tooltip>
+							<label>Build</label>
+							<default>0</default>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<cellpos>0,2</cellpos>
+						<cellspan>1,1</cellspan>
+						<flag>wxALIGN_CENTER|wxALL</flag>
+						<border>5</border>
+						<object class="wxButton" name="btnHighToLow">
+							<size>26,-1</size>
+							<fg>wxSYS_COLOUR_BTNTEXT</fg>
+							<tooltip>Copy the high weight slider values to the low weight section.</tooltip>
+							<label translate="0">&#8592;</label>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<cellpos>2,2</cellpos>
+						<cellspan>1,1</cellspan>
+						<flag>wxALIGN_RIGHT|wxALL</flag>
 						<border>5</border>
 						<object class="wxBoxSizer">
-							<orient>wxVERTICAL</orient>
+							<orient>wxHORIZONTAL</orient>
 							<object class="sizeritem">
 								<option>0</option>
 								<flag>wxALIGN_CENTER|wxALL</flag>
 								<border>5</border>
-								<object class="wxButton" name="btnHighToLow">
-									<size>26,-1</size>
-									<fg>wxSYS_COLOUR_BTNTEXT</fg>
-									<tooltip>Copy the high weight slider values to the low weight section.</tooltip>
-									<label translate="0">&#8592;</label>
+								<object class="wxButton" name="btnAbout">
+									<size>24,24</size>
+									<bitmap stock_id="wxART_INFORMATION"/>
+									<tooltip>About</tooltip>
 								</object>
-							</object>
-							<object class="spacer">
-								<option>1</option>
-								<flag>wxEXPAND</flag>
-								<border>5</border>
-								<size>0,15</size>
 							</object>
 							<object class="sizeritem">
 								<option>0</option>
-								<flag>wxALIGN_RIGHT|wxALL</flag>
+								<flag>wxALIGN_CENTER|wxALL</flag>
 								<border>5</border>
-								<object class="wxBoxSizer">
-									<orient>wxHORIZONTAL</orient>
-									<object class="sizeritem">
-										<option>0</option>
-										<flag>wxALIGN_CENTER|wxALL</flag>
-										<border>5</border>
-										<object class="wxButton" name="btnAbout">
-											<size>24,24</size>
-											<bitmap stock_id="wxART_INFORMATION"/>
-											<tooltip>About</tooltip>
-										</object>
-									</object>
-									<object class="sizeritem">
-										<option>0</option>
-										<flag>wxALIGN_CENTER|wxALL</flag>
-										<border>5</border>
-										<object class="wxButton" name="btnSettings">
-											<fg>wxSYS_COLOUR_BTNTEXT</fg>
-											<tooltip>Open settings dialog.</tooltip>
-											<label>Settings</label>
-										</object>
-									</object>
-									<object class="sizeritem">
-										<option>0</option>
-										<flag>wxALIGN_CENTER|wxALL</flag>
-										<border>5</border>
-										<object class="wxButton" name="btnOutfitStudio">
-											<fg>wxSYS_COLOUR_BTNTEXT</fg>
-											<tooltip>Open Outfit Studio, a full-featured tool for creating and converting outfits.</tooltip>
-											<label>Outfit Studio</label>
-										</object>
-									</object>
+								<object class="wxButton" name="btnSettings">
+									<fg>wxSYS_COLOUR_BTNTEXT</fg>
+									<tooltip>Open settings dialog.</tooltip>
+									<label>Settings</label>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>0</option>
+								<flag>wxALIGN_CENTER|wxALL</flag>
+								<border>5</border>
+								<object class="wxButton" name="btnOutfitStudio">
+									<fg>wxSYS_COLOUR_BTNTEXT</fg>
+									<tooltip>Open Outfit Studio, a full-featured tool for creating and converting outfits.</tooltip>
+									<label>Outfit Studio</label>
 								</object>
 							</object>
 						</object>

--- a/res/xrc/BodySlide.xrc
+++ b/res/xrc/BodySlide.xrc
@@ -278,19 +278,10 @@
 					<object class="sizeritem">
 						<cellpos>1,0</cellpos>
 						<cellspan>1,3</cellspan>
+						<flag>wxLEFT</flag>
 						<border>5</border>
 						<object class="wxBoxSizer">
 							<orient>wxHORIZONTAL</orient>
-							<object class="sizeritem">
-								<option>0</option>
-								<flag>wxALL|wxALIGN_CENTER</flag>
-								<border>5</border>
-								<object class="wxStaticText">
-									<fg>#c8c8c8</fg>
-									<label>Output Path</label>
-									<wrap>-1</wrap>
-								</object>
-							</object>
 							<object class="sizeritem">
 								<option>0</option>
 								<flag>wxLEFT|wxALIGN_CENTER_VERTICAL</flag>
@@ -299,17 +290,30 @@
 									<fg>#c8c8c8</fg>
 									<tooltip>Default outfit choice in Batch Build</tooltip>
 									<label></label>
+									<hidden>1</hidden>
 								</object>
 							</object>
 							<object class="sizeritem">
 								<option>1</option>
-								<flag>wxALL|wxALIGN_LEFT</flag>
+								<flag>wxLEFT|wxALIGN_LEFT</flag>
 								<border>5</border>
 								<object class="wxStaticText" name="conflictLabel">
 									<fg>#c8c8d8</fg>
-									<tooltip>Right click for conflicting outfit(s)</tooltip>
+									<tooltip>Right-click to view conflicts</tooltip>
 									<label></label>
 									<wrap>-1</wrap>
+									<hidden>1</hidden>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>0</option>
+								<flag>wxLEFT|wxALIGN_LEFT</flag>
+								<border>5</border>
+								<object class="wxStaticText" name="conflictInfo">
+									<fg>#c8c8d8</fg>
+									<label>(right-click to view conflicts)</label>
+									<wrap>-1</wrap>
+									<hidden>1</hidden>
 								</object>
 							</object>
 						</object>

--- a/src/components/BuildSelection.cpp
+++ b/src/components/BuildSelection.cpp
@@ -197,14 +197,12 @@ int BuildSelectionFile::Update(BuildSelection& inBuildSel) {
 
 // Removes a single choice from BuildSelection 
 void BuildSelectionFile::Remove(std::string& path) {
-	BuildSelection bsFile = root;
 	XMLElement* elem = root->FirstChildElement("OutputChoice");
 	while (elem) {
 		if (0 == path.compare(elem->Attribute("path"))) {
 			root->DeleteChild(elem);
-				return;
+			return;
 		}
 		elem = elem->NextSiblingElement("OutputChoice");
 	}
 }
-

--- a/src/components/BuildSelection.cpp
+++ b/src/components/BuildSelection.cpp
@@ -56,6 +56,10 @@ void BuildSelection::SetOutputChoice(const std::string& outputPath, const std::s
 	outputChoice[outputPath] = choice;
 }
 
+void BuildSelection::RemoveOutputChoice(const std::string& outputPath) {
+	outputChoice.erase(outputPath);
+}
+
 BuildSelectionFile::BuildSelectionFile(const std::string& srcFileName) {
 	root = nullptr;
 	error = 0;
@@ -190,3 +194,17 @@ int BuildSelectionFile::Update(BuildSelection& inBuildSel) {
 
 	return 0;
 }
+
+// Removes a single choice from BuildSelection 
+void BuildSelectionFile::Remove(std::string& path) {
+	BuildSelection bsFile = root;
+	XMLElement* elem = root->FirstChildElement("OutputChoice");
+	while (elem) {
+		if (0 == path.compare(elem->Attribute("path"))) {
+			root->DeleteChild(elem);
+				return;
+		}
+		elem = elem->NextSiblingElement("OutputChoice");
+	}
+}
+

--- a/src/components/BuildSelection.h
+++ b/src/components/BuildSelection.h
@@ -30,6 +30,7 @@ public:
 	std::unordered_map<std::string, std::string> GetOutputChoices();
 	std::string GetOutputChoice(const std::string& outputPath);
 	void SetOutputChoice(const std::string& outputPath, const std::string& choice);
+	void RemoveOutputChoice(const std::string& outputPath);
 
 	int LoadBuildSelection(XMLElement* srcElement);
 };
@@ -75,4 +76,7 @@ public:
 
 	// Updates or adds a build selection in the XML document
 	int Update(BuildSelection& inBuildSel);
+
+	// Removes a single element from the XML document
+	void Remove(std::string& path);
 };

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -2703,8 +2703,13 @@ BodySlideFrame::BodySlideFrame(BodySlideApp* a, const wxSize &size) : delayLoad(
 	outfitsearch->SetToolTip(_("Filter by outfit"));
 	outfitsearch->SetMenu(outfitsrchMenu);
 
-	auto conflictLabel = (wxStaticText*)this->FindWindowByName("conflictLabel");
-	conflictLabel->Bind(wxEVT_RIGHT_DOWN, &BodySlideFrame::OnConflictPopup, this);
+	auto conflictLabel = (wxStaticText*)FindWindowByName("conflictLabel");
+	if (conflictLabel)
+		conflictLabel->Bind(wxEVT_RIGHT_DOWN, &BodySlideFrame::OnConflictPopup, this);
+
+	auto conflictInfo = (wxStaticText*)FindWindowByName("conflictInfo");
+	if (conflictInfo)
+		conflictInfo->Bind(wxEVT_RIGHT_DOWN, &BodySlideFrame::OnConflictPopup, this);
 
 	xrc->AttachUnknownControl("searchHolder", search, this);
 	xrc->AttachUnknownControl("outfitsearchHolder", outfitsearch, this);

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -62,7 +62,7 @@ wxBEGIN_EVENT_TABLE(BodySlideFrame, wxFrame)
 
 	EVT_BUTTON(XRCID("btnDeleteProject"), BodySlideFrame::OnDeleteProject)
 	EVT_BUTTON(XRCID("btnDeletePreset"), BodySlideFrame::OnDeletePreset)
-	EVT_CHECKBOX(XRCID("cbDefaultOutfit"), BodySlideFrame::OnDefaultSelect)
+	EVT_CHECKBOX(XRCID("cbIsOutfitChoice"), BodySlideFrame::OnOutfitChoiceSelect)
 
 	EVT_BUTTON(XRCID("btnPreview"), BodySlideFrame::OnPreview)
 	EVT_BUTTON(XRCID("btnHighToLow"), BodySlideFrame::OnHighToLow)
@@ -719,10 +719,10 @@ void BodySlideApp::DisplayActiveSet() {
 
 void BodySlideApp::UpdateConflictManager(bool setActive) {
 	// Populate Conflict UI
-	auto conflictCheckBox = (wxCheckBox*)wxWindowBase::FindWindowByName("cbDefaultOutfit");
+	auto conflictCheckBox = (wxCheckBox*)wxWindowBase::FindWindowByName("cbIsOutfitChoice");
 	auto conflictLabel = (wxStaticText*)wxWindowBase::FindWindowByName("conflictLabel");
 	auto outputFilePath = activeSet.GetOutputFilePath();
-	bool isDefault = true;
+	bool isOutputChoice3 = true;
 	conflictLabel->SetLabel(outputFilePath);
 	auto& col = outFileCount[outputFilePath];
 	std::string textColourName = "WHITE";
@@ -735,11 +735,11 @@ void BodySlideApp::UpdateConflictManager(bool setActive) {
 			BuildSelection buildSelection;
 			buildSelFile.Get(buildSelection);
 			std::string outputChoice = buildSelection.GetOutputChoice(outputFilePath);
-			isDefault = outputChoice == activeSet.GetName();
+			isOutputChoice3 = outputChoice == activeSet.GetName();
 		}
-		textColourName = isDefault ? "CYAN" : "RED";
+		textColourName = isOutputChoice3 ? "CYAN" : "RED";
 	}
-	conflictCheckBox->SetValue(isDefault);
+	conflictCheckBox->SetValue(isOutputChoice3);
 	conflictLabel->SetForegroundColour(wxTheColourDatabase->Find(textColourName));
 }
 
@@ -3353,7 +3353,7 @@ void BodySlideFrame::OnConflictPopup(wxMouseEvent& WXUNUSED(event)) {
 	if (selectedOutfitName != currentOutfitName) app->ActivateOutfit(selectedOutfitName);
 }
 
-void BodySlideFrame::OnDefaultSelect(wxCommandEvent& WXUNUSED(event)) {
+void BodySlideFrame::OnOutfitChoiceSelect(wxCommandEvent& WXUNUSED(event)) {
 	app->SetDefaultBuildSelection();
 }
 

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -720,43 +720,58 @@ void BodySlideApp::DisplayActiveSet() {
 
 void BodySlideApp::UpdateConflictManager() {
 	// Populate Conflict UI
-	auto conflictCheckBox = (wxCheckBox*)wxWindowBase::FindWindowByName("cbIsOutfitChoice");
-	auto conflictLabel = (wxStaticText*)wxWindowBase::FindWindowByName("conflictLabel");
+	auto conflictCheckBox = (wxCheckBox*)sliderView->FindWindowByName("cbIsOutfitChoice");
+	auto conflictLabel = (wxStaticText*)sliderView->FindWindowByName("conflictLabel");
+	auto conflictInfo = (wxStaticText*)sliderView->FindWindowByName("conflictInfo");
+
 	auto outputFilePath = activeSet.GetOutputFilePath();
-	bool isOutputChoice = true;
 	auto& col = outFileCount[outputFilePath];
+
+	bool isOutputChoice = true;
 	std::string textColourName = "WHITE";
+
 	if (1 < col.size()) {
 		std::string buildSelFileName = Config["AppDir"] + PathSepStr + "BuildSelection.xml";
+
 		BuildSelectionFile buildSelFile(buildSelFileName);
 		if (buildSelFile.GetError())
 			buildSelFile.New(buildSelFileName);
+
 		BuildSelection buildSelection;
 		buildSelFile.Get(buildSelection);
+
 		std::string outputChoice = buildSelection.GetOutputChoice(outputFilePath);
 		isOutputChoice = outputChoice == activeSet.GetName();
 		textColourName = isOutputChoice ? "CYAN" : "RED";
 	}
+
 	conflictCheckBox->SetValue(isOutputChoice);
+	conflictCheckBox->Show();
+
 	if (activeSet.GenWeights()) {
 		std::regex prefix(".*[/\\\\]");
 		std::string filePart = std::regex_replace(outputFilePath, prefix, "");
-		conflictLabel->SetLabel(outputFilePath + "_0.nif  and  " + filePart + "_1.nif");
+		conflictLabel->SetLabel(outputFilePath + "_0.nif (and _1.nif)");
 	}
-	else {
+	else
 		conflictLabel->SetLabel(outputFilePath + ".nif");
-	}
+
 	conflictLabel->SetForegroundColour(wxTheColourDatabase->Find(textColourName));
+	conflictLabel->Show();
+	conflictInfo->Show();
 }
 
 void BodySlideApp::SetDefaultBuildSelection() {
 	auto outputFilePath = activeSet.GetOutputFilePath();
 	std::string buildSelFileName = Config["AppDir"] + PathSepStr + "BuildSelection.xml";
+
 	BuildSelectionFile buildSelFile(buildSelFileName);
 	if (buildSelFile.GetError())
 		buildSelFile.New(buildSelFileName);
+
 	BuildSelection buildSelection;
 	buildSelFile.Get(buildSelection);
+
 	std::string choiceName = activeSet.GetName();
 	bool willSet = 0 != choiceName.compare(buildSelection.GetOutputChoice(outputFilePath));
 	if (willSet) {
@@ -767,7 +782,9 @@ void BodySlideApp::SetDefaultBuildSelection() {
 		buildSelection.SetOutputChoice(outputFilePath, "");
 		buildSelFile.Remove(outputFilePath);
 	}
+
 	buildSelFile.Save();
+
 	UpdateConflictManager();
 	sliderView->Refresh();
 }
@@ -2686,7 +2703,7 @@ BodySlideFrame::BodySlideFrame(BodySlideApp* a, const wxSize &size) : delayLoad(
 	outfitsearch->SetToolTip(_("Filter by outfit"));
 	outfitsearch->SetMenu(outfitsrchMenu);
 
-	auto conflictLabel= (wxStaticText*)this->FindWindowByName("conflictLabel");
+	auto conflictLabel = (wxStaticText*)this->FindWindowByName("conflictLabel");
 	conflictLabel->Bind(wxEVT_RIGHT_DOWN, &BodySlideFrame::OnConflictPopup, this);
 
 	xrc->AttachUnknownControl("searchHolder", search, this);

--- a/src/program/BodySlideApp.h
+++ b/src/program/BodySlideApp.h
@@ -175,6 +175,8 @@ public:
 	void PopulatePresetList(const std::string& select);
 	void PopulateOutfitList(const std::string& select);
 	void DisplayActiveSet();
+	void UpdateConflictManager(bool setActive);
+	void SetDefaultBuildSelection();
 
 	int LoadSliderSets();
 	void RefreshOutfitList();
@@ -183,6 +185,10 @@ public:
 
 	void ActivateOutfit(const std::string& outfitName);
 	void ActivatePreset(const std::string& presetName, const bool updatePreview = true);
+
+	std::vector<std::string> GetConflictingOutfits() {
+		return outFileCount.find(activeSet.GetOutputFilePath())->second;
+	}
 
 	void DeleteOutfit(const std::string& outfitName);
 	void DeletePreset(const std::string& presetName);
@@ -265,6 +271,7 @@ public:
 	wxSearchCtrl* search = nullptr;
 	wxSearchCtrl* outfitsearch = nullptr;
 	wxCheckListBox* batchBuildList = nullptr;
+	wxMenu* fileCollisionMenu = nullptr;
 
 	BodySlideFrame(BodySlideApp* app, const wxSize& size);
 	~BodySlideFrame() {
@@ -331,6 +338,8 @@ private:
 	void OnSavePreset(wxCommandEvent& event);
 	void OnSavePresetAs(wxCommandEvent& event);
 	void OnGroupManager(wxCommandEvent& event);
+	void OnConflictPopup(wxMouseEvent& event);
+	void OnDefaultSelect(wxCommandEvent& event);
 
 	void OnPreview(wxCommandEvent& event);
 	void OnHighToLow(wxCommandEvent& event);

--- a/src/program/BodySlideApp.h
+++ b/src/program/BodySlideApp.h
@@ -175,7 +175,7 @@ public:
 	void PopulatePresetList(const std::string& select);
 	void PopulateOutfitList(const std::string& select);
 	void DisplayActiveSet();
-	void UpdateConflictManager(bool setActive);
+	void UpdateConflictManager();
 	void SetDefaultBuildSelection();
 
 	int LoadSliderSets();

--- a/src/program/BodySlideApp.h
+++ b/src/program/BodySlideApp.h
@@ -339,7 +339,7 @@ private:
 	void OnSavePresetAs(wxCommandEvent& event);
 	void OnGroupManager(wxCommandEvent& event);
 	void OnConflictPopup(wxMouseEvent& event);
-	void OnDefaultSelect(wxCommandEvent& event);
+	void OnOutfitChoiceSelect(wxCommandEvent& event);
 
 	void OnPreview(wxCommandEvent& event);
 	void OnHighToLow(wxCommandEvent& event);


### PR DESCRIPTION
Exposes the bodyslide conflict management logic used in batch builds in the base UI.

Supports quick navigation between conflicting alternatives.

Implements Issue #386

This is a first draft -- if you do not like something about the code, please let me know and I will fix it.

(Note also that I have only tested this under VS2022 so there may be issues under VS2019)