### PR TITLE
Update conflictLabel tooltip to be informative

### DIFF
--- a/res/xrc/BodySlide.xrc
+++ b/res/xrc/BodySlide.xrc
@@ -299,7 +299,7 @@
 								<border>5</border>
 								<object class="wxStaticText" name="conflictLabel">
 									<fg>#c8c8d8</fg>
-									<tooltip>Right-click to view conflicts</tooltip>
+									<tooltip>Output Path (which the game would use for this outfit)</tooltip>
 									<label></label>
 									<wrap>-1</wrap>
 									<hidden>1</hidden>

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -758,7 +758,12 @@ void BodySlideApp::UpdateConflictManager() {
 
 	conflictLabel->SetForegroundColour(wxTheColourDatabase->Find(textColourName));
 	conflictLabel->Show();
-	conflictInfo->Show();
+	if (1 < col.size()) {
+		conflictInfo->Show();
+	}
+	else {
+		conflictInfo->Hide();
+	}
 }
 
 void BodySlideApp::SetDefaultBuildSelection() {


### PR DESCRIPTION
Since the "Output Path" label has been removed, and the previous text of this tooltip is now redundant.

Also, only show info message about conflicts when conflicts exist.