### PR TITLE
Fixes for Skyrim and FO4 shaders

### DIFF
--- a/res/shaders/default.frag
+++ b/res/shaders/default.frag
@@ -207,45 +207,39 @@ void main(void)
 				vec3 outDiffuse = vec3(0.0);
 				vec3 outSpecular = vec3(0.0);
 
-				// Start off neutral
-				normal = normalize(vec3(0.0, 0.0, 0.5));
 				specFactor = 0.0;
 
-				if (bModelSpace)
+				if (bShowTexture && bNormalMap)
+				{
+					if (bModelSpace)
+					{
+						// Model Space Normal Map
+						normal = normalize(normalMap.rgb * 2.0 - 1.0);
+						normal.r = -normal.r;
+						normal = mv_normalMatrix * normal;
+						normal = normalize(normal);
+
+						if (bSpecular)
+						{
+							specFactor = specMap.r;
+						}
+					}
+					else
+					{
+						// Tangent Space Normal Map
+						normal = normalize(mv_tbn * (normalMap.rgb * 2.0 - 1.0));
+
+						if (bSpecular)
+						{
+							specFactor = normalMap.a;
+						}
+					}
+				}
+				else
 				{
 					// Vertex normal for shading with disabled maps
 					normal = mv_normalMatrix * n;
 					normal = normalize(normal);
-				}
-
-				if (bShowTexture)
-				{
-					if (bNormalMap)
-					{
-						if (bModelSpace)
-						{
-							// Model Space Normal Map
-							normal = normalize(normalMap.rgb * 2.0 - 1.0);
-							normal.r = -normal.r;
-							normal = mv_normalMatrix * normal;
-							normal = normalize(normal);
-
-							if (bSpecular)
-							{
-								specFactor = specMap.r;
-							}
-						}
-						else
-						{
-							// Tangent Space Normal Map
-							normal = normalize(mv_tbn * (normalMap.rgb * 2.0 - 1.0));
-
-							if (bSpecular)
-							{
-								specFactor = normalMap.a;
-							}
-						}
-					}
 				}
 
 				directionalLight(frontal, lightFrontal, outDiffuse, outSpecular);

--- a/res/shaders/fo4_default.frag
+++ b/res/shaders/fo4_default.frag
@@ -369,11 +369,13 @@ void main(void)
 						}
 						else
 						{
-							// Tangent space map
-							normal = normalize(mv_tbn * (normalMap.rgb * 2.0 - 1.0));
+							normal = (normalMap.rgb * 2.0 - 1.0);
 
 							// Calculate missing blue channel
 							normal.b = sqrt(1.0 - dot(normal.rg, normal.rg));
+
+							// Tangent space map
+							normal = normalize(mv_tbn * normal);
 						}
 					}
 


### PR DESCRIPTION
Problems:
- For Skyrim models without textures and _with_ tangent space normals, vertex normals were not applied.
- FO4 meshes shading was incorrect.

Solutions:
- Adjust if-block to also initiate normal to vertex normal when using a tangent space mesh without textures (and not just when using model space normals). - done by Ousnius.
- Reconstitute the missing blue channel for the normal map _before_ converting the normal from tangent space to view space.