### PR TITLE
Progress bar interpolation changes

### DIFF
--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -1119,10 +1119,17 @@ public:
 		if (progressStack.empty())
 			return;
 
-		do {
+		progressBar->SetValue(progressStack.back().second);
+		progressStack.pop_back();
+
+		if(forceEmpty) {
+			progressBar->SetValue(progressStack.front().second);
+			progressStack.clear();
+		}
+		else {
 			progressBar->SetValue(progressStack.back().second);
 			progressStack.pop_back();
-		} while(forceEmpty && !progressStack.empty());
+		}
 		
 		if (progressStack.empty()) {
 			if (msg.IsEmpty())

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -1107,21 +1107,23 @@ public:
 	}
 
 	void StartSubProgress(int min, int max) {
-		int range = progressStack.back().second - progressStack.front().first;
+		int range = progressStack.back().second - progressStack.back().first;
 		float mindiv = min / 100.0f;
 		float maxdiv = max / 100.0f;
 		int minoff = mindiv * range + 1;
 		int maxoff = maxdiv * range + 1;
-		progressStack.emplace_back(progressStack.front().first + minoff, progressStack.front().first + maxoff);
+		progressStack.emplace_back(minoff + progressStack.back().first, maxoff + progressStack.back().first);
 	}
 
-	void EndProgress(const wxString& msg = "") {
+	void EndProgress(const wxString& msg = "", bool forceEmpty = false) {
 		if (progressStack.empty())
 			return;
 
-		progressBar->SetValue(progressStack.back().second);
-		progressStack.pop_back();
-
+		do {
+			progressBar->SetValue(progressStack.back().second);
+			progressStack.pop_back();
+		} while(forceEmpty && !progressStack.empty());
+		
 		if (progressStack.empty()) {
 			if (msg.IsEmpty())
 				statusBar->SetStatusText(_("Ready!"));

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -1119,9 +1119,6 @@ public:
 		if (progressStack.empty())
 			return;
 
-		progressBar->SetValue(progressStack.back().second);
-		progressStack.pop_back();
-
 		if(forceEmpty) {
 			progressBar->SetValue(progressStack.front().second);
 			progressStack.clear();


### PR DESCRIPTION
```
ProgressStack
{0, 10000}
```

Add first subprogress (same result for new and old formula)
StartSubProgress(10,20):

```
ProgressStack:
{0, 10000}
{1001, 2001} (range = 10000 - 0 = 10000, push(0 + 1001, 0 + 2001)
```

Add another subprogress:
StartSubProgress(10,15):

Old Formula:
```
ProgressStack:
{0, 10000}
{1001, 2001}
{100, 151} (range = 1001 - 0 = 1001, push(0 + 101, 0 + 151)
```
^^ this will give us a progress which is less than the previous progress (when displaying on the progress bar)

New Formula
```
ProgressStack
{0, 10000}
{1001, 2001}
{1101, 1151} (range = 2001 - 1001 = 1000, push(1000 + 101, 1000 + 151)
```
^^ this will give us a progress display that is always using the previous value as the minimum and interpolates the percentage in the same way, no matter how many sub progresses are on the stack

Currently I don't believe there are any methods that push onto the stack more than a single sub progress at a time, so the issue isn't visible. But I have future changes that would use this

The other change just allows for the progress stack to empty completely, for example - if an error occurs mid progress