### PR TITLE
Add wizard to convert/replace references

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ set(OSsources
 	src/program/OutfitProject.cpp
 	src/program/OutfitStudio.cpp
 	src/program/ShapeProperties.cpp
+	src/program/ConvertBodyReferenceDialog.cpp
 	)
 set(BSsources
 	${commonsources}

--- a/OutfitStudio.vcxproj
+++ b/OutfitStudio.vcxproj
@@ -391,6 +391,7 @@
     <None Include="lib\gli\glm\gtx\wrap.inl" />
     <None Include="res\xrc\About.xrc" />
     <None Include="res\xrc\Actions.xrc" />
+    <None Include="res\xrc\ConvertBodyReference.xrc" />
     <None Include="res\xrc\OutfitStudio.xrc" />
     <None Include="res\xrc\Project.xrc" />
     <None Include="res\xrc\SavePreset.xrc" />
@@ -748,6 +749,7 @@
     <ClInclude Include="src\files\ObjFile.h" />
     <ClInclude Include="src\files\ResourceLoader.h" />
     <ClInclude Include="src\files\TriFile.h" />
+    <ClInclude Include="src\program\ConvertBodyReferenceDialog.h" />
     <ClInclude Include="src\program\EditUV.h" />
     <ClInclude Include="src\program\FBXImportDialog.h" />
     <ClInclude Include="src\program\FBXImportOptions.h" />
@@ -820,6 +822,7 @@
     <ClCompile Include="src\files\ObjFile.cpp" />
     <ClCompile Include="src\files\ResourceLoader.cpp" />
     <ClCompile Include="src\files\TriFile.cpp" />
+    <ClCompile Include="src\program\ConvertBodyReferenceDialog.cpp" />
     <ClCompile Include="src\program\EditUV.cpp" />
     <ClCompile Include="src\program\FBXImportDialog.cpp" />
     <ClCompile Include="src\program\GroupManager.cpp" />

--- a/OutfitStudio.vcxproj.filters
+++ b/OutfitStudio.vcxproj.filters
@@ -647,6 +647,9 @@
     <None Include="lib\gli\glm\gtx\color_space_YCoCg.inl">
       <Filter>Libraries\gli\glm\gtx</Filter>
     </None>
+    <None Include="res\xrc\ConvertBodyReference.xrc">
+      <Filter>Resources</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -1753,6 +1756,9 @@
     <ClInclude Include="src\ui\wxSliderPanel.h">
       <Filter>UI</Filter>
     </ClInclude>
+    <ClInclude Include="src\program\ConvertBodyReferenceDialog.h">
+      <Filter>Program</Filter>
+    </ClInclude>
     <ClInclude Include="src\utils\ConfigDialogUtil.h">
       <Filter>Utilities</Filter>
     </ClInclude>
@@ -1961,6 +1967,9 @@
     </ClCompile>
     <ClCompile Include="src\ui\wxSliderPanel.cpp">
       <Filter>UI</Filter>
+    </ClCompile>
+    <ClCompile Include="src\program\ConvertBodyReferenceDialog.cpp">
+      <Filter>Program</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/res/xrc/ConvertBodyReference.xrc
+++ b/res/xrc/ConvertBodyReference.xrc
@@ -2,7 +2,7 @@
 <resource xmlns="http://www.wxwidgets.org/wxxrc" version="2.5.3.0">
 	<object class="wxDialog" name="dlgConvertBodyRef">
 		<style>wxDEFAULT_DIALOG_STYLE</style>
-		<title>Convert Body Reference</title>
+		<title>Convert / Replace Body Reference</title>
 		<centered>1</centered>
 		<object class="wxBoxSizer">
 			<orient>wxVERTICAL</orient>

--- a/res/xrc/ConvertBodyReference.xrc
+++ b/res/xrc/ConvertBodyReference.xrc
@@ -1,381 +1,381 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <resource xmlns="http://www.wxwidgets.org/wxxrc" version="2.5.3.0">
-  <object class="wxDialog" name="dlgConvertBodyRef">
-    <style>wxDEFAULT_DIALOG_STYLE</style>
-    <title>Convert Body Reference</title>
-    <centered>1</centered>
-    <object class="wxBoxSizer">
-      <orient>wxVERTICAL</orient>
-      <object class="sizeritem">
-        <option>0</option>
-        <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
-        <border>10</border>
-        <object class="wxStaticText" name="lbLoadRef">
-          <label>This tool aids in the conversion or replacement process of body references.</label>
-        </object>
-      </object>
-      <object class="sizeritem">
-        <option>0</option>
-        <flag>wxALL|wxEXPAND</flag>
-        <border>10</border>
-        <object class="wxStaticBoxSizer">
-          <orient>wxVERTICAL</orient>
-          <label>Reference Bodies</label>
-          <object class="spacer">
-            <option>1</option>
-            <flag>wxEXPAND</flag>
-            <border>5</border>
-            <size>0,5</size>
-          </object>
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
-            <object class="wxStaticText" name="lbLoadRef">
-              <label>Select a conversion reference (or 'None' to skip converting):</label>
-              <wrap>380</wrap>
-            </object>
-          </object>
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxEXPAND</flag>
-            <border>5</border>
-            <object class="wxFlexGridSizer">
-              <rows>0</rows>
-              <cols>2</cols>
-              <vgap>0</vgap>
-              <hgap>0</hgap>
-              <growablecols>1</growablecols>
-              <growablerows></growablerows>
-              <object class="sizeritem">
-                <option>1</option>
-                <flag>wxALL|wxEXPAND</flag>
-                <border>5</border>
-                <minsize>170,25</minsize>
-                <object class="wxStaticText" name="npConvRef">
-                  <style>wxRB_GROUP</style>
-                  <label>Conversion Body Reference</label>
-                  <value translate="0">1</value>
-                </object>
-              </object>
-              <object class="sizeritem">
-                <option>1</option>
-                <flag>wxALL|wxEXPAND</flag>
-                <border>5</border>
-                <minsize>200,30</minsize>
-                <object class="wxChoice" name="npConvRefChoice">
-                  <selection>0</selection>
-                  <content />
-                </object>
-              </object>
-            </object>
-          </object>
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
-            <object class="wxStaticText" name="lbLoadRef">
-              <label>Select a body reference to convert to:</label>
-              <wrap>380</wrap>
-            </object>
-          </object>
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxEXPAND</flag>
-            <border>5</border>
-            <object class="wxFlexGridSizer">
-              <rows>0</rows>
-              <cols>2</cols>
-              <vgap>0</vgap>
-              <hgap>0</hgap>
-              <growablecols>1</growablecols>
-              <growablerows></growablerows>
-              <object class="sizeritem">
-                <option>1</option>
-                <flag>wxALL|wxEXPAND</flag>
-                <border>5</border>
-                <minsize>170,25</minsize>
-                <object class="wxStaticText" name="npNewRef">
-                  <style>wxRB_GROUP</style>
-                  <label>New Body Reference</label>
-                  <value translate="0">1</value>
-                </object>
-              </object>
-              <object class="sizeritem">
-                <option>1</option>
-                <flag>wxALL|wxEXPAND</flag>
-                <border>5</border>
-                <object class="wxChoice" name="npNewRefChoice">
-                  <style>wxCB_SORT</style>
-                  <selection>0</selection>
-                  <content />
-                </object>
-              </object>
-              <object class="spacer">
-                <option>1</option>
-                <flag>wxEXPAND</flag>
-                <border>5</border>
-                <size>0,0</size>
-              </object>
-            </object>
-          </object>
-        </object>
-      </object>
-      <object class="sizeritem">
-        <option>0</option>
-        <flag>wxALL|wxEXPAND</flag>
-        <border>10</border>
-        <object class="wxStaticBoxSizer">
-          <orient>wxVERTICAL</orient>
-          <label>Project Rename</label>
-          <object class="spacer">
-            <option>1</option>
-            <flag>wxEXPAND</flag>
-            <border>5</border>
-            <size>0,5</size>
-          </object>
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
-            <object class="wxStaticText" name="lbLoadRef">
-              <label>Specify text to be removed from the project output names (comma delimited):</label>
-            </object>
-          </object>
-	        <object class="sizeritem">
-            <option>0</option>
-            <flag>wxEXPAND</flag>
-            <border>5</border>
-            <object class="wxFlexGridSizer">
-              <rows>0</rows>
-              <cols>2</cols>
-              <vgap>0</vgap>
-              <hgap>0</hgap>
-              <growablecols>1</growablecols>
-              <growablerows></growablerows>
-              <object class="sizeritem">
-                <option>1</option>
-                <flag>wxALL|wxEXPAND</flag>
-                <border>5</border>
-                <minsize>170,20</minsize>
-                <object class="wxStaticText">
-                  <style>wxRB_GROUP</style>
-                  <label>Remove from project names</label>
-                  <value translate="0">1</value>
-                </object>
-              </object>
-              <object class="sizeritem">
-                <border>5</border>
-                <flag>wxALL|wxEXPAND</flag>
-                <object class="wxTextCtrl" name="npRemoveText"></object>
-              </object>
-            </object>
-          </object>
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
-            <object class="wxStaticText" name="lbLoadRef">
-              <label>Specify any text to be prepended to project names:</label>
-            </object>
-          </object>
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxEXPAND</flag>
-            <border>5</border>
-            <object class="wxFlexGridSizer">
-              <rows>0</rows>
-              <cols>2</cols>
-              <vgap>0</vgap>
-              <hgap>0</hgap>
-              <growablecols>1</growablecols>
-              <growablerows></growablerows>
-              <object class="sizeritem">
-                <option>1</option>
-                <flag>wxALL|wxEXPAND</flag>
-                <border>5</border>
-                <minsize>170,20</minsize>
-                <object class="wxStaticText">
-                  <style>wxRB_GROUP</style>
-                  <label>Prepend to project names</label>
-                  <value translate="0">1</value>
-                </object>
-              </object>
-              <object class="sizeritem">
-                <border>5</border>
-                <flag>wxALL|wxEXPAND</flag>
-                <object class="wxTextCtrl" name="npAppendText"></object>
-              </object>
-            </object>
-          </object>
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
-            <object class="wxStaticText" name="lbLoadRef">
-              <label>Note. Game file output path is unaffected by this</label>
-            </object>
-          </object>
-        </object>
-      </object>
-      <object class="sizeritem">
-        <option>0</option>
-        <flag>wxALL|wxEXPAND</flag>
-        <border>10</border>
-        <object class="wxStaticBoxSizer">
-          <orient>wxVERTICAL</orient>
-          <label>Additional</label>
-          <object class="spacer">
-            <option>1</option>
-            <flag>wxEXPAND</flag>
-            <border>5</border>
-            <size>0,5</size>
-          </object>
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
-            <object class="wxStaticText" name="lbLoadRef">
-              <label>Automatically remove the following shapes before conversion (comma delimited):</label>
-            </object>
-          </object>
+	<object class="wxDialog" name="dlgConvertBodyRef">
+		<style>wxDEFAULT_DIALOG_STYLE</style>
+		<title>Convert Body Reference</title>
+		<centered>1</centered>
+		<object class="wxBoxSizer">
+			<orient>wxVERTICAL</orient>
+			<object class="sizeritem">
+				<option>0</option>
+				<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+				<border>10</border>
+				<object class="wxStaticText" name="lbLoadRef">
+					<label>This tool aids in the conversion or replacement process of body references.</label>
+				</object>
+			</object>
+			<object class="sizeritem">
+				<option>0</option>
+				<flag>wxALL|wxEXPAND</flag>
+				<border>10</border>
+				<object class="wxStaticBoxSizer">
+					<orient>wxVERTICAL</orient>
+					<label>Reference Bodies</label>
+					<object class="spacer">
+						<option>1</option>
+						<flag>wxEXPAND</flag>
+						<border>5</border>
+						<size>0,5</size>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+						<object class="wxStaticText" name="lbLoadRef">
+							<label>Select a conversion reference (or 'None' to skip converting):</label>
+							<wrap>380</wrap>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxFlexGridSizer">
+							<rows>0</rows>
+							<cols>2</cols>
+							<vgap>0</vgap>
+							<hgap>0</hgap>
+							<growablecols>1</growablecols>
+							<growablerows></growablerows>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>5</border>
+								<minsize>170,25</minsize>
+								<object class="wxStaticText" name="npConvRef">
+									<style>wxRB_GROUP</style>
+									<label>Conversion Body Reference</label>
+									<value translate="0">1</value>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>5</border>
+								<minsize>200,30</minsize>
+								<object class="wxChoice" name="npConvRefChoice">
+									<selection>0</selection>
+									<content />
+								</object>
+							</object>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+						<object class="wxStaticText" name="lbLoadRef">
+							<label>Select a body reference to convert to:</label>
+							<wrap>380</wrap>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxFlexGridSizer">
+							<rows>0</rows>
+							<cols>2</cols>
+							<vgap>0</vgap>
+							<hgap>0</hgap>
+							<growablecols>1</growablecols>
+							<growablerows></growablerows>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>5</border>
+								<minsize>170,25</minsize>
+								<object class="wxStaticText" name="npNewRef">
+									<style>wxRB_GROUP</style>
+									<label>New Body Reference</label>
+									<value translate="0">1</value>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>5</border>
+								<object class="wxChoice" name="npNewRefChoice">
+									<style>wxCB_SORT</style>
+									<selection>0</selection>
+									<content />
+								</object>
+							</object>
+							<object class="spacer">
+								<option>1</option>
+								<flag>wxEXPAND</flag>
+								<border>5</border>
+								<size>0,0</size>
+							</object>
+						</object>
+					</object>
+				</object>
+			</object>
+			<object class="sizeritem">
+				<option>0</option>
+				<flag>wxALL|wxEXPAND</flag>
+				<border>10</border>
+				<object class="wxStaticBoxSizer">
+					<orient>wxVERTICAL</orient>
+					<label>Rename Project (optional)</label>
+					<object class="spacer">
+						<option>1</option>
+						<flag>wxEXPAND</flag>
+						<border>5</border>
+						<size>0,5</size>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+						<object class="wxStaticText" name="lbLoadRef">
+							<label>Specify text to be removed from the project name (comma-delimited):</label>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxFlexGridSizer">
+							<rows>0</rows>
+							<cols>2</cols>
+							<vgap>0</vgap>
+							<hgap>0</hgap>
+							<growablecols>1</growablecols>
+							<growablerows></growablerows>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>5</border>
+								<minsize>170,20</minsize>
+								<object class="wxStaticText">
+									<style>wxRB_GROUP</style>
+									<label>Remove from project name</label>
+									<value translate="0">1</value>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<border>5</border>
+								<flag>wxALL|wxEXPAND</flag>
+								<object class="wxTextCtrl" name="npRemoveText"></object>
+							</object>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+						<object class="wxStaticText" name="lbLoadRef">
+							<label>Specify any text to be prepended to project name:</label>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxFlexGridSizer">
+							<rows>0</rows>
+							<cols>2</cols>
+							<vgap>0</vgap>
+							<hgap>0</hgap>
+							<growablecols>1</growablecols>
+							<growablerows></growablerows>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>5</border>
+								<minsize>170,20</minsize>
+								<object class="wxStaticText">
+									<style>wxRB_GROUP</style>
+									<label>Prepend to project name</label>
+									<value translate="0">1</value>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<border>5</border>
+								<flag>wxALL|wxEXPAND</flag>
+								<object class="wxTextCtrl" name="npAppendText"></object>
+							</object>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+						<object class="wxStaticText" name="lbLoadRef">
+							<label>NOTE: Game file output path is unaffected by this</label>
+						</object>
+					</object>
+				</object>
+			</object>
+			<object class="sizeritem">
+				<option>0</option>
+				<flag>wxALL|wxEXPAND</flag>
+				<border>10</border>
+				<object class="wxStaticBoxSizer">
+					<orient>wxVERTICAL</orient>
+					<label>Extras (optional)</label>
+					<object class="spacer">
+						<option>1</option>
+						<flag>wxEXPAND</flag>
+						<border>5</border>
+						<size>0,5</size>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+						<object class="wxStaticText" name="lbLoadRef">
+							<label>Remove the following shapes before conversion (comma-delimited):</label>
+						</object>
+					</object>
 
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxEXPAND</flag>
-            <border>5</border>
-            <object class="wxFlexGridSizer">
-              <rows>0</rows>
-              <cols>2</cols>
-              <vgap>0</vgap>
-              <hgap>0</hgap>
-              <growablecols>1</growablecols>
-              <growablerows></growablerows>
-              <object class="sizeritem">
-                <option>1</option>
-                <flag>wxALL|wxEXPAND</flag>
-                <border>5</border>
-                <minsize>170,20</minsize>
-                <object class="wxStaticText">
-                  <style>wxRB_GROUP</style>
-                  <label>Shapes to Delete</label>
-                  <value translate="0">1</value>
-                </object>
-              </object>
-              <object class="sizeritem">
-                <border>5</border>
-                <flag>wxALL|wxEXPAND</flag>
-                <object class="wxTextCtrl" name="npDeleteShapesText"></object>
-              </object>
-            </object>
-          </object>
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
-            <object class="wxStaticText" name="lbLoadRef">
-              <label>Automatically add the following bones after conversion(comma delimited):</label>
-            </object>
-          </object>
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxEXPAND</flag>
-            <border>5</border>
-            <object class="wxFlexGridSizer">
-              <rows>0</rows>
-              <cols>2</cols>
-              <vgap>0</vgap>
-              <hgap>0</hgap>
-              <growablecols>1</growablecols>
-              <growablerows></growablerows>
-              <object class="sizeritem">
-                <option>1</option>
-                <flag>wxALL|wxEXPAND</flag>
-                <border>5</border>
-                <minsize>170,20</minsize>
-                <object class="wxStaticText">
-                  <style>wxRB_GROUP</style>
-                  <label>Bone Names to Add</label>
-                  <value translate="0">1</value>
-                </object>
-              </object>
-              <object class="sizeritem">
-                <border>5</border>
-                <flag>wxALL|wxEXPAND</flag>
-                <object class="wxTextCtrl" name="npAddBonesText"></object>
-              </object>
-            </object>
-          </object>
-        </object>
-      </object>
-      <object class="sizeritem">
-        <option>0</option>
-        <flag>wxALL|wxEXPAND</flag>
-        <border>10</border>
-        <object class="wxStaticBoxSizer">
-          <orient>wxVERTICAL</orient>
-          <label>Options</label>
-	        <object class="sizeritem">
-		        <option>0</option>
-		        <flag>wxALL</flag>
-		        <border>5</border>
-		        <object class="wxCheckBox" name="chkConvertMergeSliders">
-			        <label>Merge Sliders</label>
-			        <checked>1</checked>
-		        </object>
-	        </object>
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxALL</flag>
-            <border>5</border>
-            <object class="wxCheckBox" name="chkConvertMergeZaps">
-              <label>Merge Zaps</label>
-              <checked>1</checked>
-            </object>
-          </object>
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxALL</flag>
-            <border>5</border>
-            <object class="wxCheckBox" name="chkSkipConformPopup">
-              <label>Skip Conform Popup (Use Default Settings)</label>
-              <checked>0</checked>
-            </object>
-          </object>
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxALL</flag>
-            <border>5</border>
-            <object class="wxCheckBox" name="chkSkipCopyBonesPopup">
-              <label>Skip Copy Bones Popup (Use Default Settings)</label>
-              <checked>0</checked>
-            </object>
-          </object>
-          <object class="sizeritem">
-            <option>0</option>
-            <flag>wxALL</flag>
-            <border>5</border>
-            <object class="wxCheckBox" name="chkDeleteReferenceOnComplete">
-              <label>Delete Reference On Completed</label>
-              <checked>0</checked>
-            </object>
-          </object>
-        </object>
-      </object>
-      <object class="sizeritem">
-        <option>0</option>
-        <flag>wxEXPAND|wxALL</flag>
-        <border>10</border>
-        <object class="wxStdDialogButtonSizer">
-          <object class="button">
-            <flag>wxALIGN_CENTER_HORIZONTAL|wxALL</flag>
-            <border>5</border>
-            <object class="wxButton" name="wxID_OK">
-              <label>&amp;OK</label>
-            </object>
-          </object>
-          <object class="button">
-            <flag>wxALIGN_CENTER_HORIZONTAL|wxALL</flag>
-            <border>5</border>
-            <object class="wxButton" name="wxID_CANCEL">
-              <label>&amp;Cancel</label>
-            </object>
-          </object>
-        </object>
-      </object>
-    </object>
-  </object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxFlexGridSizer">
+							<rows>0</rows>
+							<cols>2</cols>
+							<vgap>0</vgap>
+							<hgap>0</hgap>
+							<growablecols>1</growablecols>
+							<growablerows></growablerows>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>5</border>
+								<minsize>170,20</minsize>
+								<object class="wxStaticText">
+									<style>wxRB_GROUP</style>
+									<label>Shapes to delete</label>
+									<value translate="0">1</value>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<border>5</border>
+								<flag>wxALL|wxEXPAND</flag>
+								<object class="wxTextCtrl" name="npDeleteShapesText"></object>
+							</object>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+						<object class="wxStaticText" name="lbLoadRef">
+							<label>Add the following bones after conversion (comma-delimited):</label>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxEXPAND</flag>
+						<border>5</border>
+						<object class="wxFlexGridSizer">
+							<rows>0</rows>
+							<cols>2</cols>
+							<vgap>0</vgap>
+							<hgap>0</hgap>
+							<growablecols>1</growablecols>
+							<growablerows></growablerows>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>5</border>
+								<minsize>170,20</minsize>
+								<object class="wxStaticText">
+									<style>wxRB_GROUP</style>
+									<label>Bones to add</label>
+									<value translate="0">1</value>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<border>5</border>
+								<flag>wxALL|wxEXPAND</flag>
+								<object class="wxTextCtrl" name="npAddBonesText"></object>
+							</object>
+						</object>
+					</object>
+				</object>
+			</object>
+			<object class="sizeritem">
+				<option>0</option>
+				<flag>wxALL|wxEXPAND</flag>
+				<border>10</border>
+				<object class="wxStaticBoxSizer">
+					<orient>wxVERTICAL</orient>
+					<label>Options</label>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxALL</flag>
+						<border>5</border>
+						<object class="wxCheckBox" name="chkConvertMergeSliders">
+							<label>Merge Sliders</label>
+							<checked>1</checked>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxALL</flag>
+						<border>5</border>
+						<object class="wxCheckBox" name="chkConvertMergeZaps">
+							<label>Merge Zaps</label>
+							<checked>1</checked>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxALL</flag>
+						<border>5</border>
+						<object class="wxCheckBox" name="chkSkipConformPopup">
+							<label>Skip conform popup (use default settings)</label>
+							<checked>0</checked>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxALL</flag>
+						<border>5</border>
+						<object class="wxCheckBox" name="chkSkipCopyBonesPopup">
+							<label>Skip bone weights popup (use default settings)</label>
+							<checked>0</checked>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxALL</flag>
+						<border>5</border>
+						<object class="wxCheckBox" name="chkDeleteReferenceOnComplete">
+							<label>Delete reference after completion</label>
+							<checked>0</checked>
+						</object>
+					</object>
+				</object>
+			</object>
+			<object class="sizeritem">
+				<option>0</option>
+				<flag>wxEXPAND|wxALL</flag>
+				<border>10</border>
+				<object class="wxStdDialogButtonSizer">
+					<object class="button">
+						<flag>wxALIGN_CENTER_HORIZONTAL|wxALL</flag>
+						<border>5</border>
+						<object class="wxButton" name="wxID_OK">
+							<label>&amp;OK</label>
+						</object>
+					</object>
+					<object class="button">
+						<flag>wxALIGN_CENTER_HORIZONTAL|wxALL</flag>
+						<border>5</border>
+						<object class="wxButton" name="wxID_CANCEL">
+							<label>&amp;Cancel</label>
+						</object>
+					</object>
+				</object>
+			</object>
+		</object>
+	</object>
 </resource>

--- a/res/xrc/ConvertBodyReference.xrc
+++ b/res/xrc/ConvertBodyReference.xrc
@@ -309,13 +309,22 @@
         <object class="wxStaticBoxSizer">
           <orient>wxVERTICAL</orient>
           <label>Options</label>
+	        <object class="sizeritem">
+		        <option>0</option>
+		        <flag>wxALL</flag>
+		        <border>5</border>
+		        <object class="wxCheckBox" name="chkConvertMergeSliders">
+			        <label>Merge Sliders</label>
+			        <checked>1</checked>
+		        </object>
+	        </object>
           <object class="sizeritem">
             <option>0</option>
             <flag>wxALL</flag>
             <border>5</border>
-            <object class="wxCheckBox" name="chkKeepZapSliders">
-              <label>Keep Zap Sliders</label>
-              <checked>0</checked>
+            <object class="wxCheckBox" name="chkConvertMergeZaps">
+              <label>Merge Zaps</label>
+              <checked>1</checked>
             </object>
           </object>
           <object class="sizeritem">

--- a/res/xrc/ConvertBodyReference.xrc
+++ b/res/xrc/ConvertBodyReference.xrc
@@ -1,377 +1,377 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <resource xmlns="http://www.wxwidgets.org/wxxrc" version="2.5.3.0">
-	<object class="wxDialog" name="dlgConvertBodyRef">
+	<object class="wxWizard" name="wizConvertBodyRef">
 		<style>wxDEFAULT_DIALOG_STYLE</style>
+		<pos>0,0</pos>
 		<title>Convert / Replace Body Reference</title>
 		<centered>1</centered>
-		<object class="wxBoxSizer">
-			<orient>wxVERTICAL</orient>
-			<object class="sizeritem">
-				<option>0</option>
-				<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
-				<border>10</border>
-				<object class="wxStaticText" name="lbLoadRef">
-					<label>This tool aids in the conversion or replacement process of body references.</label>
-				</object>
-			</object>
-			<object class="sizeritem">
-				<option>0</option>
-				<flag>wxALL|wxEXPAND</flag>
-				<border>10</border>
-				<object class="wxStaticBoxSizer">
-					<orient>wxVERTICAL</orient>
-					<label>Reference Bodies</label>
-					<object class="spacer">
-						<option>1</option>
-						<flag>wxEXPAND</flag>
-						<border>5</border>
-						<size>0,5</size>
-					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
-						<object class="wxStaticText" name="lbLoadRef">
-							<label>Select a conversion reference (or 'None' to skip converting):</label>
-							<wrap>380</wrap>
-						</object>
-					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxEXPAND</flag>
-						<border>5</border>
-						<object class="wxFlexGridSizer">
-							<rows>0</rows>
-							<cols>2</cols>
-							<vgap>0</vgap>
-							<hgap>0</hgap>
-							<growablecols>1</growablecols>
-							<growablerows></growablerows>
-							<object class="sizeritem">
-								<option>1</option>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-								<minsize>170,25</minsize>
-								<object class="wxStaticText" name="npConvRef">
-									<style>wxRB_GROUP</style>
-									<label>Conversion Body Reference</label>
-									<value translate="0">1</value>
-								</object>
-							</object>
-							<object class="sizeritem">
-								<option>1</option>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-								<minsize>200,30</minsize>
-								<object class="wxChoice" name="npConvRefChoice">
-									<selection>0</selection>
-									<content />
-								</object>
-							</object>
-						</object>
-					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
-						<object class="wxStaticText" name="lbLoadRef">
-							<label>Select a body reference to convert to:</label>
-							<wrap>380</wrap>
-						</object>
-					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxEXPAND</flag>
-						<border>5</border>
-						<object class="wxFlexGridSizer">
-							<rows>0</rows>
-							<cols>2</cols>
-							<vgap>0</vgap>
-							<hgap>0</hgap>
-							<growablecols>1</growablecols>
-							<growablerows></growablerows>
-							<object class="sizeritem">
-								<option>1</option>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-								<minsize>170,25</minsize>
-								<object class="wxStaticText" name="npNewRef">
-									<style>wxRB_GROUP</style>
-									<label>New Body Reference</label>
-									<value translate="0">1</value>
-								</object>
-							</object>
-							<object class="sizeritem">
-								<option>1</option>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-								<object class="wxChoice" name="npNewRefChoice">
-									<style>wxCB_SORT</style>
-									<selection>0</selection>
-									<content />
-								</object>
-							</object>
-							<object class="spacer">
-								<option>1</option>
-								<flag>wxEXPAND</flag>
-								<border>5</border>
-								<size>0,0</size>
-							</object>
-						</object>
+		<object class="wxWizardPageSimple" name="wizpgConvertBodyRef1">
+			<object class="wxBoxSizer">
+				<orient>wxVERTICAL</orient>
+				<object class="sizeritem">
+					<option>0</option>
+					<flag>wxALL|wxEXPAND</flag>
+					<border>5</border>
+					<object class="wxStaticText" name="lbLoadRef">
+						<label>This wizard aids in the conversion / replacement process of body references.</label>
 					</object>
 				</object>
-			</object>
-			<object class="sizeritem">
-				<option>0</option>
-				<flag>wxALL|wxEXPAND</flag>
-				<border>10</border>
-				<object class="wxStaticBoxSizer">
-					<orient>wxVERTICAL</orient>
-					<label>Rename Project (optional)</label>
-					<object class="spacer">
-						<option>1</option>
-						<flag>wxEXPAND</flag>
-						<border>5</border>
-						<size>0,5</size>
-					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
-						<object class="wxStaticText" name="lbLoadRef">
-							<label>Specify text to be removed from the project name (comma-delimited):</label>
+				<object class="sizeritem">
+					<option>0</option>
+					<flag>wxALL|wxEXPAND</flag>
+					<border>10</border>
+					<object class="wxStaticBoxSizer">
+						<orient>wxVERTICAL</orient>
+						<label>Reference Bodies</label>
+						<object class="spacer">
+							<option>0</option>
+							<flag>wxEXPAND</flag>
+							<border>5</border>
+							<size>0,5</size>
 						</object>
-					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxEXPAND</flag>
-						<border>5</border>
-						<object class="wxFlexGridSizer">
-							<rows>0</rows>
-							<cols>2</cols>
-							<vgap>0</vgap>
-							<hgap>0</hgap>
-							<growablecols>1</growablecols>
-							<growablerows></growablerows>
-							<object class="sizeritem">
-								<option>1</option>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-								<minsize>170,20</minsize>
-								<object class="wxStaticText">
-									<style>wxRB_GROUP</style>
-									<label>Remove from project name</label>
-									<value translate="0">1</value>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxALL|wxEXPAND</flag>
+							<object class="wxStaticText" name="lbLoadRef">
+								<label>Select a conversion reference (or 'None' to skip converting):</label>
+								<wrap>380</wrap>
+							</object>
+						</object>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxEXPAND</flag>
+							<border>5</border>
+							<object class="wxFlexGridSizer">
+								<rows>0</rows>
+								<cols>2</cols>
+								<vgap>0</vgap>
+								<hgap>0</hgap>
+								<growablecols>1</growablecols>
+								<growablerows></growablerows>
+								<object class="sizeritem">
+									<option>0</option>
+									<flag>wxALL|wxEXPAND</flag>
+									<border>5</border>
+									<minsize>170,25</minsize>
+									<object class="wxStaticText" name="npConvRef">
+										<style>wxRB_GROUP</style>
+										<label>Conversion Body Reference</label>
+										<value translate="0">1</value>
+									</object>
+								</object>
+								<object class="sizeritem">
+									<option>0</option>
+									<flag>wxALL|wxEXPAND</flag>
+									<border>5</border>
+									<minsize>300,25</minsize>
+									<object class="wxChoice" name="npConvRefChoice">
+										<selection>0</selection>
+										<content />
+									</object>
 								</object>
 							</object>
-							<object class="sizeritem">
-								<border>5</border>
-								<flag>wxALL|wxEXPAND</flag>
-								<object class="wxTextCtrl" name="npRemoveText"></object>
+						</object>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+							<object class="wxStaticText" name="lbLoadRef">
+								<label>Select a body reference to convert to:</label>
+								<wrap>380</wrap>
 							</object>
 						</object>
-					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
-						<object class="wxStaticText" name="lbLoadRef">
-							<label>Specify any text to be prepended to project name:</label>
-						</object>
-					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxEXPAND</flag>
-						<border>5</border>
-						<object class="wxFlexGridSizer">
-							<rows>0</rows>
-							<cols>2</cols>
-							<vgap>0</vgap>
-							<hgap>0</hgap>
-							<growablecols>1</growablecols>
-							<growablerows></growablerows>
-							<object class="sizeritem">
-								<option>1</option>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-								<minsize>170,20</minsize>
-								<object class="wxStaticText">
-									<style>wxRB_GROUP</style>
-									<label>Prepend to project name</label>
-									<value translate="0">1</value>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxEXPAND</flag>
+							<border>5</border>
+							<object class="wxFlexGridSizer">
+								<rows>0</rows>
+								<cols>2</cols>
+								<vgap>0</vgap>
+								<hgap>0</hgap>
+								<growablecols>1</growablecols>
+								<growablerows></growablerows>
+								<object class="sizeritem">
+									<option>0</option>
+									<flag>wxALL|wxEXPAND</flag>
+									<border>5</border>
+									<minsize>170,25</minsize>
+									<object class="wxStaticText" name="npNewRef">
+										<style>wxRB_GROUP</style>
+										<label>New Body Reference</label>
+										<value translate="0">1</value>
+									</object>
+								</object>
+								<object class="sizeritem">
+									<option>0</option>
+									<flag>wxALL|wxEXPAND</flag>
+									<border>5</border>
+									<minsize>300,25</minsize>
+									<object class="wxChoice" name="npNewRefChoice">
+										<selection>0</selection>
+										<content />
+									</object>
+								</object>
+								<object class="spacer">
+									<option>0</option>
+									<flag>wxEXPAND</flag>
+									<border>5</border>
+									<size>0,0</size>
 								</object>
 							</object>
-							<object class="sizeritem">
-								<border>5</border>
-								<flag>wxALL|wxEXPAND</flag>
-								<object class="wxTextCtrl" name="npAppendText"></object>
-							</object>
-						</object>
-					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
-						<object class="wxStaticText" name="lbLoadRef">
-							<label>NOTE: Game file output path is unaffected by this</label>
 						</object>
 					</object>
 				</object>
-			</object>
-			<object class="sizeritem">
-				<option>0</option>
-				<flag>wxALL|wxEXPAND</flag>
-				<border>10</border>
-				<object class="wxStaticBoxSizer">
-					<orient>wxVERTICAL</orient>
-					<label>Extras (optional)</label>
-					<object class="spacer">
-						<option>1</option>
-						<flag>wxEXPAND</flag>
-						<border>5</border>
-						<size>0,5</size>
-					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
-						<object class="wxStaticText" name="lbLoadRef">
-							<label>Remove the following shapes before conversion (comma-delimited):</label>
-						</object>
-					</object>
-
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxEXPAND</flag>
-						<border>5</border>
-						<object class="wxFlexGridSizer">
-							<rows>0</rows>
-							<cols>2</cols>
-							<vgap>0</vgap>
-							<hgap>0</hgap>
-							<growablecols>1</growablecols>
-							<growablerows></growablerows>
-							<object class="sizeritem">
-								<option>1</option>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-								<minsize>170,20</minsize>
-								<object class="wxStaticText">
-									<style>wxRB_GROUP</style>
-									<label>Shapes to delete</label>
-									<value translate="0">1</value>
-								</object>
-							</object>
-							<object class="sizeritem">
-								<border>5</border>
-								<flag>wxALL|wxEXPAND</flag>
-								<object class="wxTextCtrl" name="npDeleteShapesText"></object>
+				<object class="sizeritem">
+					<option>0</option>
+					<flag>wxALL|wxEXPAND</flag>
+					<border>10</border>
+					<object class="wxStaticBoxSizer">
+						<orient>wxVERTICAL</orient>
+						<label>Options</label>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxALL</flag>
+							<border>5</border>
+							<object class="wxCheckBox" name="chkConvertMergeSliders">
+								<label>Merge Sliders</label>
+								<checked>1</checked>
 							</object>
 						</object>
-					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
-						<object class="wxStaticText" name="lbLoadRef">
-							<label>Add the following bones after conversion (comma-delimited):</label>
-						</object>
-					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxEXPAND</flag>
-						<border>5</border>
-						<object class="wxFlexGridSizer">
-							<rows>0</rows>
-							<cols>2</cols>
-							<vgap>0</vgap>
-							<hgap>0</hgap>
-							<growablecols>1</growablecols>
-							<growablerows></growablerows>
-							<object class="sizeritem">
-								<option>1</option>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-								<minsize>170,20</minsize>
-								<object class="wxStaticText">
-									<style>wxRB_GROUP</style>
-									<label>Bones to add</label>
-									<value translate="0">1</value>
-								</object>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxALL</flag>
+							<border>5</border>
+							<object class="wxCheckBox" name="chkConvertMergeZaps">
+								<label>Merge Zaps</label>
+								<checked>1</checked>
 							</object>
-							<object class="sizeritem">
-								<border>5</border>
-								<flag>wxALL|wxEXPAND</flag>
-								<object class="wxTextCtrl" name="npAddBonesText"></object>
+						</object>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxALL</flag>
+							<border>5</border>
+							<object class="wxCheckBox" name="chkSkipConformPopup">
+								<label>Skip conform popup (use default settings)</label>
+								<checked>1</checked>
+							</object>
+						</object>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxALL</flag>
+							<border>5</border>
+							<object class="wxCheckBox" name="chkSkipCopyBonesPopup">
+								<label>Skip bone weights popup (use default settings)</label>
+								<checked>1</checked>
+							</object>
+						</object>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxALL</flag>
+							<border>5</border>
+							<object class="wxCheckBox" name="chkDeleteReferenceOnComplete">
+								<label>Delete reference after completion</label>
+								<checked>0</checked>
 							</object>
 						</object>
 					</object>
 				</object>
 			</object>
-			<object class="sizeritem">
-				<option>0</option>
-				<flag>wxALL|wxEXPAND</flag>
-				<border>10</border>
-				<object class="wxStaticBoxSizer">
-					<orient>wxVERTICAL</orient>
-					<label>Options</label>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxALL</flag>
-						<border>5</border>
-						<object class="wxCheckBox" name="chkConvertMergeSliders">
-							<label>Merge Sliders</label>
-							<checked>1</checked>
-						</object>
+		</object>
+		<object class="wxWizardPageSimple" name="wizpgConvertBodyRef2">
+			<object class="wxBoxSizer">
+				<orient>wxVERTICAL</orient>
+				<object class="sizeritem">
+					<option>0</option>
+					<flag>wxALL|wxEXPAND</flag>
+					<border>5</border>
+					<object class="wxStaticText" name="lbLoadRef">
+						<label>This wizard aids in the conversion / replacement process of body references.</label>
 					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxALL</flag>
-						<border>5</border>
-						<object class="wxCheckBox" name="chkConvertMergeZaps">
-							<label>Merge Zaps</label>
-							<checked>1</checked>
+				</object>
+				<object class="sizeritem">
+					<option>0</option>
+					<flag>wxALL|wxEXPAND</flag>
+					<border>10</border>
+					<object class="wxStaticBoxSizer">
+						<orient>wxVERTICAL</orient>
+						<label>Rename Project (optional)</label>
+						<object class="spacer">
+							<option>1</option>
+							<flag>wxEXPAND</flag>
+							<border>5</border>
+							<size>0,5</size>
 						</object>
-					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxALL</flag>
-						<border>5</border>
-						<object class="wxCheckBox" name="chkSkipConformPopup">
-							<label>Skip conform popup (use default settings)</label>
-							<checked>0</checked>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+							<object class="wxStaticText" name="lbLoadRef">
+								<label>Specify text to be removed from the project name (comma-delimited):</label>
+							</object>
 						</object>
-					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxALL</flag>
-						<border>5</border>
-						<object class="wxCheckBox" name="chkSkipCopyBonesPopup">
-							<label>Skip bone weights popup (use default settings)</label>
-							<checked>0</checked>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxEXPAND</flag>
+							<border>5</border>
+							<object class="wxFlexGridSizer">
+								<rows>0</rows>
+								<cols>2</cols>
+								<vgap>0</vgap>
+								<hgap>0</hgap>
+								<growablecols>1</growablecols>
+								<growablerows></growablerows>
+								<object class="sizeritem">
+									<option>1</option>
+									<flag>wxALL|wxEXPAND</flag>
+									<border>5</border>
+									<minsize>170,25</minsize>
+									<object class="wxStaticText">
+										<style>wxRB_GROUP</style>
+										<label>Remove from project name</label>
+										<value translate="0">1</value>
+									</object>
+								</object>
+								<object class="sizeritem">
+									<option>1</option>
+									<flag>wxALL|wxEXPAND</flag>
+									<border>5</border>
+									<minsize>200,25</minsize>
+									<object class="wxTextCtrl" name="npRemoveText"></object>
+								</object>
+							</object>
 						</object>
-					</object>
-					<object class="sizeritem">
-						<option>0</option>
-						<flag>wxALL</flag>
-						<border>5</border>
-						<object class="wxCheckBox" name="chkDeleteReferenceOnComplete">
-							<label>Delete reference after completion</label>
-							<checked>0</checked>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+							<object class="wxStaticText" name="lbLoadRef">
+								<label>Specify any text to be prepended to project name:</label>
+							</object>
+						</object>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxEXPAND</flag>
+							<border>5</border>
+							<object class="wxFlexGridSizer">
+								<rows>0</rows>
+								<cols>2</cols>
+								<vgap>0</vgap>
+								<hgap>0</hgap>
+								<growablecols>1</growablecols>
+								<growablerows></growablerows>
+								<object class="sizeritem">
+									<option>1</option>
+									<flag>wxALL|wxEXPAND</flag>
+									<border>5</border>
+									<minsize>170,25</minsize>
+									<object class="wxStaticText">
+										<style>wxRB_GROUP</style>
+										<label>Prepend to project name</label>
+										<value translate="0">1</value>
+									</object>
+								</object>
+								<object class="sizeritem">
+									<option>1</option>
+									<flag>wxALL|wxEXPAND</flag>
+									<border>5</border>
+									<minsize>200,25</minsize>
+									<object class="wxTextCtrl" name="npAppendText"></object>
+								</object>
+							</object>
+						</object>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+							<object class="wxStaticText" name="lbLoadRef">
+								<label>NOTE: Game file output path is unaffected by this</label>
+							</object>
 						</object>
 					</object>
 				</object>
-			</object>
-			<object class="sizeritem">
-				<option>0</option>
-				<flag>wxEXPAND|wxALL</flag>
-				<border>10</border>
-				<object class="wxStdDialogButtonSizer">
-					<object class="button">
-						<flag>wxALIGN_CENTER_HORIZONTAL|wxALL</flag>
-						<border>5</border>
-						<object class="wxButton" name="wxID_OK">
-							<label>&amp;OK</label>
+				<object class="sizeritem">
+					<option>0</option>
+					<flag>wxALL|wxEXPAND</flag>
+					<border>10</border>
+					<object class="wxStaticBoxSizer">
+						<orient>wxVERTICAL</orient>
+						<label>Extras (optional)</label>
+						<object class="spacer">
+							<option>1</option>
+							<flag>wxEXPAND</flag>
+							<border>5</border>
+							<size>0,5</size>
 						</object>
-					</object>
-					<object class="button">
-						<flag>wxALIGN_CENTER_HORIZONTAL|wxALL</flag>
-						<border>5</border>
-						<object class="wxButton" name="wxID_CANCEL">
-							<label>&amp;Cancel</label>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+							<object class="wxStaticText" name="lbLoadRef">
+								<label>Remove the following shapes before conversion (comma-delimited):</label>
+								<wrap>380</wrap>
+							</object>
+						</object>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxEXPAND</flag>
+							<border>5</border>
+							<object class="wxFlexGridSizer">
+								<rows>0</rows>
+								<cols>2</cols>
+								<vgap>0</vgap>
+								<hgap>0</hgap>
+								<growablecols>1</growablecols>
+								<growablerows></growablerows>
+								<object class="sizeritem">
+									<option>1</option>
+									<flag>wxALL|wxEXPAND</flag>
+									<border>5</border>
+									<minsize>170,20</minsize>
+									<object class="wxStaticText">
+										<style>wxRB_GROUP</style>
+										<label>Shapes to delete</label>
+										<value translate="0">1</value>
+									</object>
+								</object>
+								<object class="sizeritem">
+									<border>5</border>
+									<flag>wxALL|wxEXPAND</flag>
+									<minsize>200,-1</minsize>
+									<object class="wxTextCtrl" name="npDeleteShapesText"></object>
+								</object>
+							</object>
+						</object>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+							<object class="wxStaticText" name="lbLoadRef">
+								<label>Add the following bones after conversion (comma-delimited):</label>
+							</object>
+						</object>
+						<object class="sizeritem">
+							<option>0</option>
+							<flag>wxEXPAND</flag>
+							<border>5</border>
+							<object class="wxFlexGridSizer">
+								<rows>0</rows>
+								<cols>2</cols>
+								<vgap>0</vgap>
+								<hgap>0</hgap>
+								<growablecols>1</growablecols>
+								<growablerows></growablerows>
+								<object class="sizeritem">
+									<option>1</option>
+									<flag>wxALL|wxEXPAND</flag>
+									<border>5</border>
+									<minsize>170,20</minsize>
+									<object class="wxStaticText">
+										<style>wxRB_GROUP</style>
+										<label>Bones to add</label>
+										<value translate="0">1</value>
+									</object>
+								</object>
+								<object class="sizeritem">
+									<border>5</border>
+									<flag>wxALL|wxEXPAND</flag>
+									<object class="wxTextCtrl" name="npAddBonesText"></object>
+								</object>
+							</object>
 						</object>
 					</object>
 				</object>

--- a/res/xrc/ConvertBodyReference.xrc
+++ b/res/xrc/ConvertBodyReference.xrc
@@ -13,7 +13,7 @@
 					<flag>wxALL|wxEXPAND</flag>
 					<border>5</border>
 					<object class="wxStaticText" name="lbLoadRef">
-						<label>This wizard aids in the conversion / replacement process of body references.</label>
+						<label>This wizard aids in the conversion to another body/reference..</label>
 					</object>
 				</object>
 				<object class="sizeritem">
@@ -185,7 +185,7 @@
 					<flag>wxALL|wxEXPAND</flag>
 					<border>5</border>
 					<object class="wxStaticText" name="lbLoadRef">
-						<label>This wizard aids in the conversion / replacement process of body references.</label>
+						<label>This wizard aids in the conversion to another body/reference..</label>
 					</object>
 				</object>
 				<object class="sizeritem">

--- a/res/xrc/ConvertBodyReference.xrc
+++ b/res/xrc/ConvertBodyReference.xrc
@@ -1,0 +1,373 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<resource xmlns="http://www.wxwidgets.org/wxxrc" version="2.5.3.0">
+  <object class="wxDialog" name="dlgConvertBodyRef">
+    <style>wxDEFAULT_DIALOG_STYLE</style>
+    <title>Convert Body Reference</title>
+    <centered>1</centered>
+    <object class="wxBoxSizer">
+      <orient>wxVERTICAL</orient>
+      <object class="sizeritem">
+        <option>0</option>
+        <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+        <border>10</border>
+        <object class="wxStaticText" name="lbLoadRef">
+          <label>This tool aids in the conversion process between different body references (ie. CBBE to BHUNP).</label>
+        </object>
+      </object>
+      <object class="sizeritem">
+        <option>0</option>
+        <flag>wxALL|wxEXPAND</flag>
+        <border>10</border>
+        <object class="wxStaticBoxSizer">
+          <orient>wxVERTICAL</orient>
+          <label>Reference Bodies</label>
+          <object class="spacer">
+            <option>1</option>
+            <flag>wxEXPAND</flag>
+            <border>5</border>
+            <size>0,5</size>
+          </object>
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+            <object class="wxStaticText" name="lbLoadRef">
+              <label>1) Select a conversion reference (ie.'Convert: CBBE SE to BHUNP'):</label>
+              <wrap>380</wrap>
+            </object>
+          </object>
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxEXPAND</flag>
+            <border>5</border>
+            <object class="wxFlexGridSizer">
+              <rows>0</rows>
+              <cols>2</cols>
+              <vgap>0</vgap>
+              <hgap>0</hgap>
+              <growablecols>1</growablecols>
+              <growablerows></growablerows>
+              <object class="sizeritem">
+                <option>1</option>
+                <flag>wxALL|wxEXPAND</flag>
+                <border>5</border>
+                <minsize>170,25</minsize>
+                <object class="wxStaticText" name="npConvRef">
+                  <style>wxRB_GROUP</style>
+                  <label>Conversion Body Reference</label>
+                  <value translate="0">1</value>
+                </object>
+              </object>
+              <object class="sizeritem">
+                <option>1</option>
+                <flag>wxALL|wxEXPAND</flag>
+                <border>5</border>
+                <minsize>200,30</minsize>
+                <object class="wxChoice" name="npConvRefChoice">
+                  <selection>0</selection>
+                  <content />
+                </object>
+              </object>
+            </object>
+          </object>
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+            <object class="wxStaticText" name="lbLoadRef">
+              <label>2) Select a body reference to convert to (ie.'BHUNP 3BBB Advanced'):</label>
+              <wrap>380</wrap>
+            </object>
+          </object>
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxEXPAND</flag>
+            <border>5</border>
+            <object class="wxFlexGridSizer">
+              <rows>0</rows>
+              <cols>2</cols>
+              <vgap>0</vgap>
+              <hgap>0</hgap>
+              <growablecols>1</growablecols>
+              <growablerows></growablerows>
+              <object class="sizeritem">
+                <option>1</option>
+                <flag>wxALL|wxEXPAND</flag>
+                <border>5</border>
+                <minsize>170,25</minsize>
+                <object class="wxStaticText" name="npNewRef">
+                  <style>wxRB_GROUP</style>
+                  <label>New Body Reference</label>
+                  <value translate="0">1</value>
+                </object>
+              </object>
+              <object class="sizeritem">
+                <option>1</option>
+                <flag>wxALL|wxEXPAND</flag>
+                <border>5</border>
+                <object class="wxChoice" name="npNewRefChoice">
+                  <style>wxCB_SORT</style>
+                  <selection>0</selection>
+                  <content />
+                </object>
+              </object>
+              <object class="spacer">
+                <option>1</option>
+                <flag>wxEXPAND</flag>
+                <border>5</border>
+                <size>0,0</size>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object class="sizeritem">
+        <option>0</option>
+        <flag>wxALL|wxEXPAND</flag>
+        <border>10</border>
+        <object class="wxStaticBoxSizer">
+          <orient>wxVERTICAL</orient>
+          <label>Project Rename</label>
+          <object class="spacer">
+            <option>1</option>
+            <flag>wxEXPAND</flag>
+            <border>5</border>
+            <size>0,5</size>
+          </object>
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+            <object class="wxStaticText" name="lbLoadRef">
+              <label>3) Specify text to be removed from the project output names (comma delimited):</label>
+            </object>
+          </object>
+
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxEXPAND</flag>
+            <border>5</border>
+            <object class="wxFlexGridSizer">
+              <rows>0</rows>
+              <cols>2</cols>
+              <vgap>0</vgap>
+              <hgap>0</hgap>
+              <growablecols>1</growablecols>
+              <growablerows></growablerows>
+              <object class="sizeritem">
+                <option>1</option>
+                <flag>wxALL|wxEXPAND</flag>
+                <border>5</border>
+                <minsize>170,20</minsize>
+                <object class="wxStaticText">
+                  <style>wxRB_GROUP</style>
+                  <label>Remove from project names</label>
+                  <value translate="0">1</value>
+                </object>
+              </object>
+              <object class="sizeritem">
+                <border>5</border>
+                <flag>wxALL|wxEXPAND</flag>
+                <object class="wxTextCtrl" name="npRemoveText"></object>
+              </object>
+            </object>
+          </object>
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+            <object class="wxStaticText" name="lbLoadRef">
+              <label>4) Specify any text to be prepended to project names:</label>
+            </object>
+          </object>
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxEXPAND</flag>
+            <border>5</border>
+            <object class="wxFlexGridSizer">
+              <rows>0</rows>
+              <cols>2</cols>
+              <vgap>0</vgap>
+              <hgap>0</hgap>
+              <growablecols>1</growablecols>
+              <growablerows></growablerows>
+              <object class="sizeritem">
+                <option>1</option>
+                <flag>wxALL|wxEXPAND</flag>
+                <border>5</border>
+                <minsize>170,20</minsize>
+                <object class="wxStaticText">
+                  <style>wxRB_GROUP</style>
+                  <label>Prepend to project names</label>
+                  <value translate="0">1</value>
+                </object>
+              </object>
+              <object class="sizeritem">
+                <border>5</border>
+                <flag>wxALL|wxEXPAND</flag>
+                <object class="wxTextCtrl" name="npAppendText"></object>
+              </object>
+            </object>
+          </object>
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+            <object class="wxStaticText" name="lbLoadRef">
+              <label>Note. Game file output path is unaffected by this</label>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object class="sizeritem">
+        <option>0</option>
+        <flag>wxALL|wxEXPAND</flag>
+        <border>10</border>
+        <object class="wxStaticBoxSizer">
+          <orient>wxVERTICAL</orient>
+          <label>Additional</label>
+          <object class="spacer">
+            <option>1</option>
+            <flag>wxEXPAND</flag>
+            <border>5</border>
+            <size>0,5</size>
+          </object>
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+            <object class="wxStaticText" name="lbLoadRef">
+              <label>5) Automatically remove the following shapes before conversion (comma delimited):</label>
+            </object>
+          </object>
+
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxEXPAND</flag>
+            <border>5</border>
+            <object class="wxFlexGridSizer">
+              <rows>0</rows>
+              <cols>2</cols>
+              <vgap>0</vgap>
+              <hgap>0</hgap>
+              <growablecols>1</growablecols>
+              <growablerows></growablerows>
+              <object class="sizeritem">
+                <option>1</option>
+                <flag>wxALL|wxEXPAND</flag>
+                <border>5</border>
+                <minsize>170,20</minsize>
+                <object class="wxStaticText">
+                  <style>wxRB_GROUP</style>
+                  <label>Shapes to Delete</label>
+                  <value translate="0">1</value>
+                </object>
+              </object>
+              <object class="sizeritem">
+                <border>5</border>
+                <flag>wxALL|wxEXPAND</flag>
+                <object class="wxTextCtrl" name="npDeleteShapesText"></object>
+              </object>
+            </object>
+          </object>
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
+            <object class="wxStaticText" name="lbLoadRef">
+              <label>6) Automatically add the following bones after conversion(comma delimited):</label>
+            </object>
+          </object>
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxEXPAND</flag>
+            <border>5</border>
+            <object class="wxFlexGridSizer">
+              <rows>0</rows>
+              <cols>2</cols>
+              <vgap>0</vgap>
+              <hgap>0</hgap>
+              <growablecols>1</growablecols>
+              <growablerows></growablerows>
+              <object class="sizeritem">
+                <option>1</option>
+                <flag>wxALL|wxEXPAND</flag>
+                <border>5</border>
+                <minsize>170,20</minsize>
+                <object class="wxStaticText">
+                  <style>wxRB_GROUP</style>
+                  <label>Bone Names to Add</label>
+                  <value translate="0">1</value>
+                </object>
+              </object>
+              <object class="sizeritem">
+                <border>5</border>
+                <flag>wxALL|wxEXPAND</flag>
+                <object class="wxTextCtrl" name="npAddBonesText"></object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object class="sizeritem">
+        <option>0</option>
+        <flag>wxALL|wxEXPAND</flag>
+        <border>10</border>
+        <object class="wxStaticBoxSizer">
+          <orient>wxVERTICAL</orient>
+          <label>Options</label>
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxALL</flag>
+            <border>5</border>
+            <object class="wxCheckBox" name="chkKeepZapSliders">
+              <label>Keep Zap Sliders</label>
+              <checked>0</checked>
+            </object>
+          </object>
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxALL</flag>
+            <border>5</border>
+            <object class="wxCheckBox" name="chkSkipConformPopup">
+              <label>Skip Conform Popup (Use Default Settings)</label>
+              <checked>0</checked>
+            </object>
+          </object>
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxALL</flag>
+            <border>5</border>
+            <object class="wxCheckBox" name="chkSkipCopyBonesPopup">
+              <label>Skip Copy Bones Popup (Use Default Settings)</label>
+              <checked>0</checked>
+            </object>
+          </object>
+          <object class="sizeritem">
+            <option>0</option>
+            <flag>wxALL</flag>
+            <border>5</border>
+            <object class="wxCheckBox" name="chkDeleteReferenceOnComplete">
+              <label>Delete Reference On Completed</label>
+              <checked>0</checked>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object class="sizeritem">
+        <option>0</option>
+        <flag>wxEXPAND|wxALL</flag>
+        <border>10</border>
+        <object class="wxStdDialogButtonSizer">
+          <object class="button">
+            <flag>wxALIGN_CENTER_HORIZONTAL|wxALL</flag>
+            <border>5</border>
+            <object class="wxButton" name="wxID_OK">
+              <label>&amp;OK</label>
+            </object>
+          </object>
+          <object class="button">
+            <flag>wxALIGN_CENTER_HORIZONTAL|wxALL</flag>
+            <border>5</border>
+            <object class="wxButton" name="wxID_CANCEL">
+              <label>&amp;Cancel</label>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+</resource>

--- a/res/xrc/ConvertBodyReference.xrc
+++ b/res/xrc/ConvertBodyReference.xrc
@@ -11,7 +11,7 @@
         <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
         <border>10</border>
         <object class="wxStaticText" name="lbLoadRef">
-          <label>This tool aids in the conversion process between different body references (ie. CBBE to BHUNP).</label>
+          <label>This tool aids in the conversion or replacement process of body references.</label>
         </object>
       </object>
       <object class="sizeritem">
@@ -31,7 +31,7 @@
             <option>0</option>
             <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
             <object class="wxStaticText" name="lbLoadRef">
-              <label>1) Select a conversion reference (ie.'Convert: CBBE SE to BHUNP'):</label>
+              <label>Select a conversion reference (or 'None' to skip converting):</label>
               <wrap>380</wrap>
             </object>
           </object>
@@ -73,7 +73,7 @@
             <option>0</option>
             <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
             <object class="wxStaticText" name="lbLoadRef">
-              <label>2) Select a body reference to convert to (ie.'BHUNP 3BBB Advanced'):</label>
+              <label>Select a body reference to convert to:</label>
               <wrap>380</wrap>
             </object>
           </object>
@@ -136,11 +136,10 @@
             <option>0</option>
             <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
             <object class="wxStaticText" name="lbLoadRef">
-              <label>3) Specify text to be removed from the project output names (comma delimited):</label>
+              <label>Specify text to be removed from the project output names (comma delimited):</label>
             </object>
           </object>
-
-          <object class="sizeritem">
+	        <object class="sizeritem">
             <option>0</option>
             <flag>wxEXPAND</flag>
             <border>5</border>
@@ -173,7 +172,7 @@
             <option>0</option>
             <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
             <object class="wxStaticText" name="lbLoadRef">
-              <label>4) Specify any text to be prepended to project names:</label>
+              <label>Specify any text to be prepended to project names:</label>
             </object>
           </object>
           <object class="sizeritem">
@@ -231,7 +230,7 @@
             <option>0</option>
             <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
             <object class="wxStaticText" name="lbLoadRef">
-              <label>5) Automatically remove the following shapes before conversion (comma delimited):</label>
+              <label>Automatically remove the following shapes before conversion (comma delimited):</label>
             </object>
           </object>
 
@@ -268,7 +267,7 @@
             <option>0</option>
             <flag>wxLEFT|wxRIGHT|wxTOP|wxEXPAND</flag>
             <object class="wxStaticText" name="lbLoadRef">
-              <label>6) Automatically add the following bones after conversion(comma delimited):</label>
+              <label>Automatically add the following bones after conversion(comma delimited):</label>
             </object>
           </object>
           <object class="sizeritem">

--- a/res/xrc/OutfitStudio.xrc
+++ b/res/xrc/OutfitStudio.xrc
@@ -1569,6 +1569,11 @@
 				<help>Load a NIF file as the working outfit, replacing any current outfit objects.</help>
 			</object>
 			<object class="separator" />
+			<object class="wxMenuItem" name="fileConvBodyRef">
+				<label>Convert Body Reference...\tCtrl+Shift+R</label>
+				<help>Convert an outfits body reference to use a different reference</help>
+			</object>
+			<object class="separator" />
 			<object class="wxMenuItem" name="fileSave">
 				<label>Save Project\tCtrl+S</label>
 				<help>Save the project.</help>

--- a/res/xrc/OutfitStudio.xrc
+++ b/res/xrc/OutfitStudio.xrc
@@ -1625,8 +1625,8 @@
 			</object>
 			<object class="separator" />
 			<object class="wxMenuItem" name="fileConvBodyRef">
-				<label>Convert / Replace Body Reference\tCtrl+Shift+R</label>
-				<help>Convert or replace an outfits body reference</help>
+				<label>Convert / Replace Reference...\tCtrl+Shift+R</label>
+				<help>Convert to or replace an outfit's body/reference</help>
 			</object>
 			<object class="separator" />
 			<object class="wxMenuItem" name="fileSave">

--- a/res/xrc/OutfitStudio.xrc
+++ b/res/xrc/OutfitStudio.xrc
@@ -1625,8 +1625,8 @@
 			</object>
 			<object class="separator" />
 			<object class="wxMenuItem" name="fileConvBodyRef">
-				<label>Convert Body Reference...\tCtrl+Shift+R</label>
-				<help>Convert an outfits body reference to use a different reference</help>
+				<label>Convert / Replace Body Reference\tCtrl+Shift+R</label>
+				<help>Convert or replace an outfits body reference</help>
 			</object>
 			<object class="separator" />
 			<object class="wxMenuItem" name="fileSave">

--- a/src/program/ConvertBodyReferenceDialog.cpp
+++ b/src/program/ConvertBodyReferenceDialog.cpp
@@ -31,8 +31,12 @@ ConvertBodyReferenceDialog::ConvertBodyReferenceDialog(OutfitStudioFrame* outfit
 	wxChoice* choice = XRCCTRL((*this), "npConvRefChoice", wxChoice);
 	choice->Append("None");
 
-	ConfigDialogUtil::LoadDialogChoices(config, (*this), "npConvRefChoice", refTemplates);
-	ConfigDialogUtil::LoadDialogChoices(config, (*this), "npNewRefChoice", refTemplates);
+	std::vector<RefTemplate> converters;
+	std::vector<RefTemplate> bodies;
+	std::copy_if(refTemplates.begin(), refTemplates.end(), std::back_inserter(converters), [](const RefTemplate& refTemplate) {return strstr(refTemplate.GetName().c_str(), "Convert");});
+	std::copy_if(refTemplates.begin(), refTemplates.end(), std::back_inserter(bodies), [](const RefTemplate& refTemplate) {return !strstr(refTemplate.GetName().c_str(), "Convert") && !strstr(refTemplate.GetName().c_str(), "Sliders");});
+	ConfigDialogUtil::LoadDialogChoices(config, (*this), "npConvRefChoice", converters);
+	ConfigDialogUtil::LoadDialogChoices(config, (*this), "npNewRefChoice", bodies);
 	ConfigDialogUtil::LoadDialogText(config, (*this), "npRemoveText");
 	ConfigDialogUtil::LoadDialogText(config, (*this), "npAppendText");
 	ConfigDialogUtil::LoadDialogText(config, (*this), "npDeleteShapesText");

--- a/src/program/ConvertBodyReferenceDialog.cpp
+++ b/src/program/ConvertBodyReferenceDialog.cpp
@@ -22,6 +22,8 @@ wxBEGIN_EVENT_TABLE(ConvertBodyReferenceDialog, wxDialog)
 
 wxEND_EVENT_TABLE()
 
+const char* CONVERT_SLIDER_PREFIX = "Convert";
+const char* SLIDER_SET_PREFIX = "Sliders";
 ConvertBodyReferenceDialog::ConvertBodyReferenceDialog(OutfitStudioFrame* outfitStudio, OutfitProject* project, ConfigurationManager& config, const std::vector<RefTemplate>& refTemplates)
 	: outfitStudio(outfitStudio), project(project), config(config), refTemplates(refTemplates) {
 
@@ -39,13 +41,14 @@ ConvertBodyReferenceDialog::ConvertBodyReferenceDialog(OutfitStudioFrame* outfit
 	{
 		const bool firstHasPriorityName = std::any_of(prioritizeNames.begin(), prioritizeNames.end(), [first](const string& name) { return strstr(first.GetName().c_str(), name.c_str());});
 		const bool secondHasPriorityName = std::any_of(prioritizeNames.begin(), prioritizeNames.end(), [second](const string& name) { return strstr(second.GetName().c_str(), name.c_str());});
-		if (firstHasPriorityName && secondHasPriorityName || !firstHasPriorityName && !secondHasPriorityName)
-			return (first.GetName().compare(second.GetName()) > 0) ^ ascendingPriority;
-		return (!firstHasPriorityName && secondHasPriorityName) ^ ascendingPriority;
+		if (firstHasPriorityName == secondHasPriorityName)
+			return first.GetName().compare(second.GetName()) <= 0;
+		return static_cast<bool>((!firstHasPriorityName && secondHasPriorityName) ^ ascendingPriority);
 	};
 
-	std::sort(converters.begin(), converters.end(), [&](const RefTemplate& first, const RefTemplate& second) {return sortTemplates(first, second, { "Convert" }, true);});
-	std::sort(bodies.begin(), bodies.end(), [&](const RefTemplate& first, const RefTemplate& second) {return sortTemplates(first, second, { "Convert", "Sliders"}, false);});
+
+	std::sort(converters.begin(), converters.end(), [&](const RefTemplate& first, const RefTemplate& second) {return sortTemplates(first, second, { CONVERT_SLIDER_PREFIX }, true);});
+	std::sort(bodies.begin(), bodies.end(), [&](const RefTemplate& first, const RefTemplate& second) {return sortTemplates(first, second, { CONVERT_SLIDER_PREFIX, SLIDER_SET_PREFIX }, false);});
 
 	ConfigDialogUtil::LoadDialogChoices(config, (*this), "npConvRefChoice", converters);
 	ConfigDialogUtil::LoadDialogChoices(config, (*this), "npNewRefChoice", bodies);

--- a/src/program/ConvertBodyReferenceDialog.cpp
+++ b/src/program/ConvertBodyReferenceDialog.cpp
@@ -18,19 +18,23 @@ using namespace std;
 class RefTemplate;
 extern ConfigurationManager Config;
 
-wxBEGIN_EVENT_TABLE(ConvertBodyReferenceDialog, wxDialog)
+wxBEGIN_EVENT_TABLE(ConvertBodyReferenceDialog, wxWizard)
 
 wxEND_EVENT_TABLE()
 
 const char* CONVERT_SLIDER_PREFIX = "Convert";
 const char* SLIDER_SET_PREFIX = "Sliders";
+
+
 ConvertBodyReferenceDialog::ConvertBodyReferenceDialog(OutfitStudioFrame* outfitStudio, OutfitProject* project, ConfigurationManager& config, const std::vector<RefTemplate>& refTemplates)
-	: outfitStudio(outfitStudio), project(project), config(config), refTemplates(refTemplates) {
+	: outfitStudio(outfitStudio), project(project), config(config), refTemplates(refTemplates), pg1(nullptr), pg2(nullptr){
 
 	wxXmlResource* xrc = wxXmlResource::Get();
 	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/ConvertBodyReference.xrc");
-	xrc->LoadDialog(this, outfitStudio, "dlgConvertBodyRef");
+	xrc->LoadObject(this, outfitStudio, "wizConvertBodyRef", "wxWizard");
 
+	pg1 = (wxWizardPage*)XRCCTRL(*this, "wizpgConvertBodyRef1", wxWizardPageSimple);
+	pg2 = (wxWizardPage*)XRCCTRL(*this, "wizpgConvertBodyRef2", wxWizardPageSimple);
 	wxChoice* choice = XRCCTRL((*this), "npConvRefChoice", wxChoice);
 	choice->Append("None");
 
@@ -68,6 +72,11 @@ ConvertBodyReferenceDialog::ConvertBodyReferenceDialog(OutfitStudioFrame* outfit
 	
 ConvertBodyReferenceDialog::~ConvertBodyReferenceDialog() {
 	wxXmlResource::Get()->Unload(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/ConvertBodyReferenceDialog.xrc");
+}
+
+bool ConvertBodyReferenceDialog::Load() {
+	FitToPage(pg1);
+	return RunWizard(pg1);
 }
 
 void ConvertBodyReferenceDialog::ConvertBodyReference() const

--- a/src/program/ConvertBodyReferenceDialog.cpp
+++ b/src/program/ConvertBodyReferenceDialog.cpp
@@ -1,0 +1,262 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#include "ConvertBodyReferenceDialog.h"
+
+#include <NifUtil.hpp>
+
+#include "../utils/ConfigurationManager.h"
+#include "../utils/ConfigDialogUtil.h"
+
+#include <regex>
+
+#include "OutfitStudio.h"
+
+class RefTemplate;
+extern ConfigurationManager Config;
+
+wxBEGIN_EVENT_TABLE(ConvertBodyReferenceDialog, wxDialog)
+
+wxEND_EVENT_TABLE()
+
+ConvertBodyReferenceDialog::ConvertBodyReferenceDialog(OutfitStudioFrame* outfitStudio, OutfitProject* project, ConfigurationManager& config, const std::vector<RefTemplate>& refTemplates)
+	: outfitStudio(outfitStudio), project(project), config(config), refTemplates(refTemplates) {
+
+	wxXmlResource* xrc = wxXmlResource::Get();
+	xrc->Load(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/ConvertBodyReference.xrc");
+	xrc->LoadDialog(this, outfitStudio, "dlgConvertBodyRef");
+
+	wxChoice* choice = XRCCTRL((*this), "npConvRefChoice", wxChoice);
+	choice->Append("None");
+
+	ConfigDialogUtil::LoadDialogChoices(config, (*this), "npConvRefChoice", refTemplates);
+	ConfigDialogUtil::LoadDialogChoices(config, (*this), "npNewRefChoice", refTemplates);
+	ConfigDialogUtil::LoadDialogText(config, (*this), "npRemoveText");
+	ConfigDialogUtil::LoadDialogText(config, (*this), "npAppendText");
+	ConfigDialogUtil::LoadDialogText(config, (*this), "npDeleteShapesText");
+	ConfigDialogUtil::LoadDialogText(config, (*this), "npAddBonesText");
+	ConfigDialogUtil::LoadDialogCheckBox(config, (*this), "chkKeepZapSliders");
+	ConfigDialogUtil::LoadDialogCheckBox(config, (*this), "chkSkipConformPopup");
+	ConfigDialogUtil::LoadDialogCheckBox(config, (*this), "chkSkipCopyBonesPopup");
+	ConfigDialogUtil::LoadDialogCheckBox(config, (*this), "chkDeleteReferenceOnComplete");
+
+	SetDoubleBuffered(true);
+	CenterOnParent();
+}
+	
+ConvertBodyReferenceDialog::~ConvertBodyReferenceDialog() {
+	wxXmlResource::Get()->Unload(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/ConvertBodyReferenceDialog.xrc");
+}
+
+void ConvertBodyReferenceDialog::ConvertBodyReference() const
+{
+	outfitStudio->StartProgress(_("Start Conversion.."));
+
+	bool keepZapSliders = ConfigDialogUtil::SetBoolFromDialogCheckbox(config, (*this), "chkKeepZapSliders");
+	bool skipConformPopup = ConfigDialogUtil::SetBoolFromDialogCheckbox(config, (*this), "chkSkipConformPopup");
+	bool skipCopyBonesPopup = ConfigDialogUtil::SetBoolFromDialogCheckbox(config, (*this), "chkSkipCopyBonesPopup");
+	bool deleteReferenceOnCompleted = ConfigDialogUtil::SetBoolFromDialogCheckbox(config, (*this), "chkDeleteReferenceOnComplete");
+	auto conversionRefTemplate = ConfigDialogUtil::SetStringFromDialogChoice(config, (*this), "npConvRefChoice");
+	auto newRefTemplate = ConfigDialogUtil::SetStringFromDialogChoice(config, (*this), "npNewRefChoice");
+	auto removeFromProjectText = ConfigDialogUtil::SetStringFromDialogTextControl(config, (*this), "npRemoveText");
+	auto appendToProjectText = ConfigDialogUtil::SetStringFromDialogTextControl(config, (*this), "npAppendText");
+	auto deleteShapesText = ConfigDialogUtil::SetStringFromDialogTextControl(config, (*this), "npDeleteShapesText");
+	auto addBonesText = ConfigDialogUtil::SetStringFromDialogTextControl(config, (*this), "npAddBonesText");
+
+	Config.SaveConfig(Config["AppDir"] + "/Config.xml");
+
+	outfitStudio->UpdateProgress(1, _("Updating Project Output Settings"));
+
+	if (!removeFromProjectText.IsEmpty())
+	{
+		wxStringTokenizer tkz(removeFromProjectText, wxT(","));
+		bool modifiedName = false;
+		while (tkz.HasMoreTokens()) {
+			wxString token = tkz.GetNextToken();
+			if (!modifiedName && !appendToProjectText.IsEmpty() && project->mFileName.Contains(token)) {
+				project->mFileName.Replace(token, appendToProjectText);
+				modifiedName = true;
+			}
+			else {
+				project->mFileName.Replace(token, "");
+			}
+			project->mOutfitName.Replace(token, "");
+			project->mDataDir.Replace(token, "");
+			project->mBaseFile.Replace(token, "");
+		}
+	}
+	if (!appendToProjectText.IsEmpty()) {
+		if (project->mOutfitName[0] != ' ')
+			project->mOutfitName.Prepend(' ');
+		if (project->mDataDir[0] != ' ')
+			project->mDataDir.Prepend(' ');
+		if (project->mBaseFile[0] != ' ')
+			project->mBaseFile.Prepend(' ');
+		project->mOutfitName.Prepend(appendToProjectText);
+		project->mDataDir.Prepend(appendToProjectText);
+		project->mBaseFile.Prepend(appendToProjectText);
+
+		project->outfitName = project->mOutfitName.ToStdString();
+		outfitStudio->UpdateTitle();
+	}
+
+	outfitStudio->DeleteSliders(false, true); // we need to do this first so we can clear any broken sliders
+	project->ResetTransforms();
+
+	auto originalShapes = project->GetWorkNif()->GetShapes(); // get outfit shapes
+	if (!deleteShapesText.IsEmpty())
+	{
+		outfitStudio->UpdateProgress(5, _("Deleting Shapes..."));
+		wxStringTokenizer tkz(deleteShapesText, wxT(","));
+
+		while (tkz.HasMoreTokens()) {
+			wxString token = tkz.GetNextToken();
+			for (auto& shape : originalShapes) {
+				if (shape == nullptr)
+					continue;
+				auto shapeName = wxString(shape->name.get().c_str());
+				if (shapeName.Contains(token)) {
+					project->DeleteShape(shape);
+					shape = nullptr;
+				}
+			}
+		}
+	}
+
+	project->DeleteShape(project->GetBaseShape());
+	auto remainingOutfitShapes = project->GetWorkNif()->GetShapes(); // get outfit shapes
+
+	if (conversionRefTemplate != "None")
+	{
+		outfitStudio->UpdateProgress(5, _("Loading conversion reference..."));
+		outfitStudio->StartSubProgress(5, 10);
+		if (AlertProgressError(LoadReferenceTemplate(conversionRefTemplate, keepZapSliders), "Load Error", "Failed to load conversion reference"))
+			return;
+		outfitStudio->EndProgress();
+
+		outfitStudio->StartSubProgress(10, 20);
+		outfitStudio->CreateSetSliders();
+		outfitStudio->RefreshGUIFromProj();
+
+		outfitStudio->UpdateProgress(20, _("Conforming outfit parts..."));
+		outfitStudio->StartSubProgress(20, 35);
+
+		// We shouldn't ever need to skip using default for this case as a correct conversion reference should always conform accurately
+		if (AlertProgressError(outfitStudio->ConformShapes(remainingOutfitShapes, true), "Conform Error", "Failed to conform shapes"))
+			return;
+
+		outfitStudio->UpdateProgress(35, _("Updating conversion Slider..."));
+		outfitStudio->SetSliderValue(project->activeSet.size() - 1, 100);
+		outfitStudio->ApplySliders();
+
+		outfitStudio->UpdateProgress(40, _("Setting the base shape and removing the conversion reference"));
+		outfitStudio->SetBaseShape();
+		project->DeleteShape(project->GetBaseShape());
+		outfitStudio->DeleteSliders(false, keepZapSliders);
+		project->GetWorkAnim()->Clear();
+	}
+	else {
+		outfitStudio->UpdateProgress(5, _("Skipping conversion reference..."));
+	}
+
+	outfitStudio->RefreshGUIFromProj();
+
+	outfitStudio->UpdateProgress(50, _("Loading new reference..."));
+	outfitStudio->StartSubProgress(50, 55);
+	if (AlertProgressError(LoadReferenceTemplate(newRefTemplate, keepZapSliders), "Load Error", "Failed to load new reference"))
+		return;
+	outfitStudio->EndProgress();
+
+	outfitStudio->StartSubProgress(55, 65);
+	outfitStudio->CreateSetSliders();
+	outfitStudio->RefreshGUIFromProj();
+
+	if (AlertProgressError(project->GetBaseShape() == nullptr, "Missing Base Shape", "The loaded reference does not contain a base shape"))
+		return;
+
+	outfitStudio->UpdateProgress(65, _("Copying bones..."));
+	outfitStudio->StartSubProgress(65, 85);
+	if (AlertProgressError(outfitStudio->CopyBoneWeightForShapes(remainingOutfitShapes, skipCopyBonesPopup), "Copy Bone Weights Error", "Failed to copy bone weights"))
+		return;
+
+	outfitStudio->UpdateProgress(85, _("Conforming outfit parts..."));
+	outfitStudio->StartSubProgress(85, 100);
+	if (AlertProgressError(outfitStudio->ConformShapes(remainingOutfitShapes, skipConformPopup), "Conform Error", "Failed to conform shapes"))
+		return;
+
+	if (!addBonesText.IsEmpty())
+	{
+		outfitStudio->UpdateProgress(100, _("Adding Bones..."));
+		wxStringTokenizer tkz(addBonesText, wxT(","));
+		while (tkz.HasMoreTokens()) {
+			wxString token = tkz.GetNextToken();
+			project->AddBoneRef(token.ToStdString());
+		}
+	}
+
+	if (deleteReferenceOnCompleted) {
+		auto allShapes = project->GetWorkNif()->GetShapes();
+		for (auto& s : allShapes) {
+			if (std::find(remainingOutfitShapes.begin(), remainingOutfitShapes.end(), s) == remainingOutfitShapes.end())
+				project->DeleteShape(s);
+		}
+	}
+
+	int deletionCount = 0;
+	auto workNif = project->GetWorkNif();
+	if (workNif)
+		workNif->DeleteUnreferencedNodes(&deletionCount);
+
+	auto allShapes = project->GetWorkNif()->GetShapes();
+	for (auto& s : allShapes)
+		outfitStudio->glView->RecalcNormals(s->name.get());
+
+	outfitStudio->RefreshGUIFromProj();
+	outfitStudio->ApplySliders();
+
+	wxLogMessage("Finished conversion.");
+	outfitStudio->UpdateProgress(100, _("Finished"));
+	outfitStudio->EndProgress();
+}
+
+int ConvertBodyReferenceDialog::LoadReferenceTemplate(const wxString& refTemplate, bool keepZapSliders) const
+{
+	nifly::NiShape* baseShape = project->GetBaseShape();
+	if (baseShape)
+		outfitStudio->glView->DeleteMesh(baseShape->name.get());
+
+	int error;
+	wxLogMessage("Loading reference template '%s'...", refTemplate);
+	std::string tmplName{ refTemplate.ToUTF8() };
+	auto tmpl = find_if(refTemplates.begin(), refTemplates.end(), [&tmplName](const RefTemplate& rt) { return rt.GetName() == tmplName; });
+	if (tmpl != refTemplates.end()) {
+		if (wxFileName(wxString::FromUTF8(tmpl->GetSource())).IsRelative())
+			error = project->LoadReferenceTemplate(GetProjectPath() + PathSepStr + tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), tmpl->GetLoadAll(), false, keepZapSliders);
+		else
+			error = project->LoadReferenceTemplate(tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), tmpl->GetLoadAll(), false, keepZapSliders);
+	}
+	else
+		error = 1;
+
+	if (!error) {
+		// since some reference files have multiple shapes, just update all textures
+		for (auto& s : project->GetWorkNif()->GetShapes())
+			project->SetTextures(s);
+	}
+
+	return error;
+}
+
+bool ConvertBodyReferenceDialog::AlertProgressError(int error, const wxString& title, const wxString& message) const
+{
+	if (error == 0)
+		return false;
+
+	wxLogError(message);
+	wxMessageBox(message, _(title), wxICON_ERROR);
+	outfitStudio->EndProgress("", true);
+	outfitStudio->RefreshGUIFromProj();
+	return true;
+}

--- a/src/program/ConvertBodyReferenceDialog.h
+++ b/src/program/ConvertBodyReferenceDialog.h
@@ -14,19 +14,23 @@ class OutfitStudioFrame;
 class ConfigurationManager;
 class RefTemplate;
 
-class ConvertBodyReferenceDialog : public wxDialog {
+class ConvertBodyReferenceDialog : public wxWizard {
 public:
 	ConvertBodyReferenceDialog(OutfitStudioFrame* outfitStudio, OutfitProject* project, ConfigurationManager& config, const std::vector<RefTemplate>& refTemplates);
 	~ConvertBodyReferenceDialog() override;
 
+	bool Load();
 	void ConvertBodyReference() const;
-	wxDECLARE_EVENT_TABLE();
 private:
 	OutfitStudioFrame* outfitStudio;
 	OutfitProject* project;
 	ConfigurationManager& config;
 	const std::vector<RefTemplate>& refTemplates;
+	wxWizardPage* pg1;
+	wxWizardPage* pg2;
 
 	int LoadReferenceTemplate(const wxString& refTemplate, bool mergeSliders, bool mergeZaps) const;
 	bool AlertProgressError(int error, const wxString& title, const wxString& message) const;
+
+	wxDECLARE_EVENT_TABLE();
 };

--- a/src/program/ConvertBodyReferenceDialog.h
+++ b/src/program/ConvertBodyReferenceDialog.h
@@ -1,0 +1,32 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#pragma once
+
+#include <wx/wx.h>
+#include <wx/xrc/xmlres.h>
+
+#include "OutfitProject.h"
+
+class OutfitStudioFrame;
+class ConfigurationManager;
+class RefTemplate;
+
+class ConvertBodyReferenceDialog : public wxDialog {
+public:
+	ConvertBodyReferenceDialog(OutfitStudioFrame* outfitStudio, OutfitProject* project, ConfigurationManager& config, const std::vector<RefTemplate>& refTemplates);
+	~ConvertBodyReferenceDialog() override;
+
+	void ConvertBodyReference() const;
+	wxDECLARE_EVENT_TABLE();
+private:
+	OutfitStudioFrame* outfitStudio;
+	OutfitProject* project;
+	ConfigurationManager& config;
+	const std::vector<RefTemplate>& refTemplates;
+
+	int LoadReferenceTemplate(const wxString& refTemplate, bool keepZapSliders) const;
+	bool AlertProgressError(int error, const wxString& title, const wxString& message) const;
+};

--- a/src/program/ConvertBodyReferenceDialog.h
+++ b/src/program/ConvertBodyReferenceDialog.h
@@ -27,6 +27,6 @@ private:
 	ConfigurationManager& config;
 	const std::vector<RefTemplate>& refTemplates;
 
-	int LoadReferenceTemplate(const wxString& refTemplate, bool keepZapSliders) const;
+	int LoadReferenceTemplate(const wxString& refTemplate, bool mergeSliders, bool mergeZaps) const;
 	bool AlertProgressError(int error, const wxString& title, const wxString& message) const;
 };

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -3511,7 +3511,14 @@ void OutfitStudioFrame::OnConvertBodyReference(wxCommandEvent& WXUNUSED(event)) 
 		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
 		return;
 	}
-	
+
+	auto shapes = project->GetWorkNif()->GetShapes();
+	auto baseShape = project->GetBaseShape();
+	if (baseShape && shapes.size() == 1) {
+		wxMessageBox(_("There is no outfit loaded!"), _("Error"));
+		return;
+	}
+
 	if (bEditSlider) {
 		wxMessageBox(_("You're currently editing slider data, please exit the slider's edit mode (pencil button) and try again."));
 		return;

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -3514,8 +3514,8 @@ void OutfitStudioFrame::OnConvertBodyReference(wxCommandEvent& WXUNUSED(event)) 
 
 	auto shapes = project->GetWorkNif()->GetShapes();
 	auto baseShape = project->GetBaseShape();
-	if (baseShape && shapes.size() == 1) {
-		wxMessageBox(_("There is no outfit loaded!"), _("Error"));
+	if (shapes.size() == 0 || baseShape && shapes.size() == 1) {
+		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
 		return;
 	}
 

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -32,6 +32,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <wx/zipstrm.h>
 #include <sstream>
 
+#include "ConvertBodyReferenceDialog.h"
+
 using namespace nifly;
 
 // ----------------------------------------------------------------------------
@@ -49,6 +51,7 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_MENU(XRCID("btnLoadProject"), OutfitStudioFrame::OnLoadProject)
 	EVT_MENU(XRCID("btnAddProject"), OutfitStudioFrame::OnAddProject)
 	EVT_MENU(XRCID("fileLoadRef"), OutfitStudioFrame::OnLoadReference)
+	EVT_MENU(XRCID("fileConvBodyRef"), OutfitStudioFrame::OnConvertBodyReference)
 	EVT_MENU(XRCID("fileLoadOutfit"), OutfitStudioFrame::OnLoadOutfit)
 	EVT_MENU(XRCID("fileSave"), OutfitStudioFrame::OnSaveSliderSet)
 	EVT_MENU(XRCID("fileSaveAs"), OutfitStudioFrame::OnSaveSliderSetAs)
@@ -3487,6 +3490,29 @@ void OutfitStudioFrame::OnLoadReference(wxCommandEvent& WXUNUSED(event)) {
 	EndProgress();
 }
 
+void OutfitStudioFrame::OnConvertBodyReference(wxCommandEvent& WXUNUSED(event)) {
+	
+	if (!project->GetWorkNif()->IsValid()) {
+		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
+		return;
+	}
+	
+	if (bEditSlider) {
+		wxMessageBox(_("You're currently editing slider data, please exit the slider's edit mode (pencil button) and try again."));
+		return;
+	}
+
+	UpdateReferenceTemplates();
+
+	ConvertBodyReferenceDialog dlg(this, project, OutfitStudioConfig, refTemplates);
+	int result = dlg.ShowModal();
+	if (result == wxID_CANCEL)
+		return;
+
+	dlg.ConvertBodyReference();
+}
+
+
 void OutfitStudioFrame::OnLoadOutfit(wxCommandEvent& WXUNUSED(event)) {
 	wxDialog dlg;
 	int result = wxID_CANCEL;
@@ -4008,6 +4034,10 @@ void OutfitStudioFrame::OnSaveSliderSetAs(wxCommandEvent& WXUNUSED(event)) {
 
 void OutfitStudioFrame::OnSetBaseShape(wxCommandEvent& WXUNUSED(event)) {
 	wxLogMessage("Setting new base shape.");
+	SetBaseShape();
+}
+
+void OutfitStudioFrame::SetBaseShape() {
 	project->ClearBoneScale();
 
 	for (auto &s : project->GetWorkNif()->GetShapes())
@@ -7696,43 +7726,29 @@ void OutfitStudioFrame::OnSliderConform(wxCommandEvent& WXUNUSED(event)) {
 	if (!project->GetBaseShape())
 		return;
 
-	ConformOptions options;
-	if (ShowConform(options)) {
-		wxLogMessage("Conforming...");
-		ZeroSliders();
-
-		StartProgress(_("Initializing data..."));
-		project->InitConform();
-
-		for (auto &i : selectedItems)
-			ConformSliders(i->GetShape(), options);
-
-		project->morpher.ClearProximityCache();
-		project->morpher.UnlinkRefDiffData();
-
-		if (statusBar)
-			statusBar->SetStatusText(_("Shape(s) conformed."));
-
-		SetPendingChanges();
-
-		wxLogMessage("%zu shape(s) conformed.", selectedItems.size());
-		UpdateProgress(100, _("Finished"));
-		EndProgress();
-	}
+	std::vector<NiShape*> shapes;
+	for (auto &i : selectedItems)
+		shapes.push_back(i->GetShape());
+	
+	ConformShapes(shapes);
 }
 
 void OutfitStudioFrame::OnSliderConformAll(wxCommandEvent& WXUNUSED(event)) {
 	if (!project->GetBaseShape())
 		return;
+	
+	auto shapes = project->GetWorkNif()->GetShapes();
+	ConformShapes(shapes);
+}
 
+int OutfitStudioFrame::ConformShapes(std::vector<NiShape*> shapes, bool silent) {
+	
 	ConformOptions options;
-	if (ShowConform(options)) {
-		wxLogMessage("Conforming all shapes...");
+	if (ShowConform(options, silent)) {
+		wxLogMessage("Conforming shapes...");
 		ZeroSliders();
 
-		auto shapes = project->GetWorkNif()->GetShapes();
-
-		StartProgress(_("Conforming all shapes..."));
+		StartProgress(_("Conforming shapes..."));
 		project->InitConform();
 
 		int inc = 100 / shapes.size() - 1;
@@ -7757,10 +7773,13 @@ void OutfitStudioFrame::OnSliderConformAll(wxCommandEvent& WXUNUSED(event)) {
 		wxLogMessage("All shapes conformed.");
 		UpdateProgress(100, _("Finished"));
 		EndProgress();
+		
+		return 0;
 	}
+	return 1;
 }
 
-bool OutfitStudioFrame::ShowConform(ConformOptions& options) {
+bool OutfitStudioFrame::ShowConform(ConformOptions& options, bool silent) {
 	CloseBrushSettings();
 
 	wxDialog dlg;
@@ -7825,7 +7844,7 @@ bool OutfitStudioFrame::ShowConform(ConformOptions& options) {
 
 		dlg.Bind(wxEVT_CHAR_HOOK, &OutfitStudioFrame::OnEnterClose, this);
 
-		if (dlg.ShowModal() == wxID_OK) {
+		if (silent || dlg.ShowModal() == wxID_OK) {
 			options.proximityRadius = atof(XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->GetValue().c_str());
 
 			bool noTargetLimit = XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->IsChecked();
@@ -9003,7 +9022,7 @@ bool OutfitStudioFrame::HasUnweightedCheck() {
 	return false;
 }
 
-bool OutfitStudioFrame::ShowWeightCopy(WeightCopyOptions& options) {
+bool OutfitStudioFrame::ShowWeightCopy(WeightCopyOptions& options, bool silent) {
 	CloseBrushSettings();
 
 	wxDialog dlg;
@@ -9048,7 +9067,7 @@ bool OutfitStudioFrame::ShowWeightCopy(WeightCopyOptions& options) {
 
 		dlg.SetSize(dlg.GetBestSize());
 		
-		if (dlg.ShowModal() == wxID_OK) {
+		if (silent || dlg.ShowModal() == wxID_OK) {
 			options.proximityRadius = atof(XRCCTRL(dlg, "proximityRadiusText", wxTextCtrl)->GetValue().c_str());
 
 			bool noTargetLimit = XRCCTRL(dlg, "noTargetLimit", wxCheckBox)->IsChecked();
@@ -9174,11 +9193,23 @@ void OutfitStudioFrame::OnCopyBoneWeight(wxCommandEvent& WXUNUSED(event)) {
 		return;
 	}
 
+	std::vector<NiShape*> selectedShapes;
+	for(auto &s : selectedItems) {
+		if (auto shape = s->GetShape(); !project->IsBaseShape(shape))
+			selectedShapes.push_back(s->GetShape());
+		else
+			wxMessageBox(_("Sorry, you can't copy weights from the reference shape to itself. Skipping this shape."), _("Can't copy weights"), wxICON_WARNING);
+	}
+	CopyBoneWeightForShapes(selectedShapes);
+}
+
+int OutfitStudioFrame::CopyBoneWeightForShapes(std::vector<NiShape*> shapes, bool silent) {
+
 	WeightCopyOptions options;
 	CalcCopySkinTransOption(options);
 	AnimInfo &workAnim = *project->GetWorkAnim();
 
-	if (ShowWeightCopy(options)) {
+	if (ShowWeightCopy(options, silent)) {
 		StartProgress(_("Copying bone weights..."));
 
 		UndoStateProject *usp = glView->GetUndoHistory()->PushState();
@@ -9187,40 +9218,42 @@ void OutfitStudioFrame::OnCopyBoneWeight(wxCommandEvent& WXUNUSED(event)) {
 		std::vector<std::string> baseBones = workAnim.shapeBones[project->GetBaseShape()->name.get()];
 		std::sort(baseBones.begin(), baseBones.end());
 		std::unordered_map<uint16_t, float> mask;
-		for (size_t i = 0; i < selectedItems.size(); i++) {
-			NiShape *shape = selectedItems[i]->GetShape();
-			if (!project->IsBaseShape(shape)) {
-				wxLogMessage("Copying bone weights to '%s'...", shape->name.get());
 
-				if (options.doSkinTransCopy) {
-					const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->name.get()].xformGlobalToSkin;
-					const MatTransform &oldXformGlobalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
+		const int inc = 100 / shapes.size() - 1;
+		
+		for (size_t i = 0; i < shapes.size(); i++) {
+			NiShape *shape = shapes[i];
+			wxLogMessage("Copying bone weights to '%s'...", shape->name.get());
+			StartSubProgress(i * inc, i * inc + inc);
+			
+			if (options.doSkinTransCopy) {
+				const MatTransform &baseXformGlobalToSkin = workAnim.shapeSkinning[project->GetBaseShape()->name.get()].xformGlobalToSkin;
+				const MatTransform &oldXformGlobalToSkin = workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin;
 
-					if (options.doTransformGeo && !baseXformGlobalToSkin.IsNearlyEqualTo(oldXformGlobalToSkin))
-						project->ApplyTransformToShapeGeometry(shape, baseXformGlobalToSkin.ComposeTransforms(oldXformGlobalToSkin.InverseTransform()));
+				if (options.doTransformGeo && !baseXformGlobalToSkin.IsNearlyEqualTo(oldXformGlobalToSkin))
+					project->ApplyTransformToShapeGeometry(shape, baseXformGlobalToSkin.ComposeTransforms(oldXformGlobalToSkin.InverseTransform()));
 
-					workAnim.ChangeGlobalToSkinTransform(shape->name.get(), baseXformGlobalToSkin);
-					project->GetWorkNif()->SetShapeTransformGlobalToSkin(shape, baseXformGlobalToSkin);
-				}
-
-				usp->usss.resize(usp->usss.size() + 1);
-				usp->usss.back().shapeName = shape->name.get();
-
-				mask.clear();
-				glView->GetShapeMask(mask, shape->name.get());
-
-				std::vector<std::string> bones = workAnim.shapeBones[shape->name.get()];
-				std::vector<std::string> mergedBones = baseBones;
-
-				for (auto b : bones)
-					if (!std::binary_search(baseBones.begin(), baseBones.end(), b))
-						mergedBones.push_back(b);
-
-				std::vector<std::string> lockedBones;
-				project->CopyBoneWeights(shape, options.proximityRadius, options.maxResults, mask, mergedBones, baseBones.size(), lockedBones, usp->usss.back(), false);
+				workAnim.ChangeGlobalToSkinTransform(shape->name.get(), baseXformGlobalToSkin);
+				project->GetWorkNif()->SetShapeTransformGlobalToSkin(shape, baseXformGlobalToSkin);
 			}
-			else
-				wxMessageBox(_("Sorry, you can't copy weights from the reference shape to itself. Skipping this shape."), _("Can't copy weights"), wxICON_WARNING);
+
+			usp->usss.resize(usp->usss.size() + 1);
+			usp->usss.back().shapeName = shape->name.get();
+
+			mask.clear();
+			glView->GetShapeMask(mask, shape->name.get());
+
+			std::vector<std::string> bones = workAnim.shapeBones[shape->name.get()];
+			std::vector<std::string> mergedBones = baseBones;
+
+			for (auto b : bones)
+				if (!std::binary_search(baseBones.begin(), baseBones.end(), b))
+					mergedBones.push_back(b);
+
+			std::vector<std::string> lockedBones;
+
+			project->CopyBoneWeights(shape, options.proximityRadius, options.maxResults, mask, mergedBones, baseBones.size(), lockedBones, usp->usss.back(), false);
+			EndProgress();
 		}
 
 		if (options.doSkinTransCopy || options.doTransformGeo)
@@ -9237,6 +9270,7 @@ void OutfitStudioFrame::OnCopyBoneWeight(wxCommandEvent& WXUNUSED(event)) {
 
 	workAnim.CleanupBones();
 	UpdateAnimationGUI();
+	return 0;
 }
 
 void OutfitStudioFrame::OnCopySelectedWeight(wxCommandEvent& WXUNUSED(event)) {

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -3520,8 +3520,7 @@ void OutfitStudioFrame::OnConvertBodyReference(wxCommandEvent& WXUNUSED(event)) 
 	UpdateReferenceTemplates();
 
 	ConvertBodyReferenceDialog dlg(this, project, OutfitStudioConfig, refTemplates);
-	int result = dlg.ShowModal();
-	if (result == wxID_CANCEL)
+	if (!dlg.Load())
 		return;
 
 	dlg.ConvertBodyReference();

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -3514,7 +3514,7 @@ void OutfitStudioFrame::OnConvertBodyReference(wxCommandEvent& WXUNUSED(event)) 
 
 	auto shapes = project->GetWorkNif()->GetShapes();
 	auto baseShape = project->GetBaseShape();
-	if (shapes.size() == 0 || baseShape && shapes.size() == 1) {
+	if (shapes.size() == 0 || (baseShape && shapes.size() == 1)) {
 		wxMessageBox(_("There are no valid shapes loaded!"), _("Error"));
 		return;
 	}

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -1052,6 +1052,10 @@ public:
 	void PopupBrushSettings(wxWindow* popupAt = nullptr);
 	void UpdateBrushSettings();
 	void DeleteSliders(bool keepSliders = false, bool keepZaps = false);
+	int CopyBoneWeightForShapes(std::vector<nifly::NiShape*> shapes, bool silent = false);
+	int ConformShapes(std::vector<nifly::NiShape*> shapes, bool silent = false);
+	void SetBaseShape();
+	void UpdateTitle();
 
 	void CheckBrushBounds() {
 		TweakBrush* brush = glView->GetActiveBrush();
@@ -1187,7 +1191,7 @@ private:
 
 	bool HasUnweightedCheck();
 	void CalcCopySkinTransOption(WeightCopyOptions &options);
-	bool ShowWeightCopy(WeightCopyOptions& options);
+	bool ShowWeightCopy(WeightCopyOptions& options, bool silent = false);
 	void ReselectBone();
 
 	void OnExit(wxCommandEvent& event);
@@ -1206,8 +1210,6 @@ private:
 	void OnMoveWindowEnd(wxMoveEvent& event);
 	void OnSetSize(wxSizeEvent& event);
 
-	void UpdateTitle();
-
 	void AddProjectHistory(const std::string& fileName, const std::string& projectName);
 	void UpdateProjectHistory();
 
@@ -1215,6 +1217,7 @@ private:
 	void OnLoadProject(wxCommandEvent &event);
 	void OnAddProject(wxCommandEvent &event);
 	void OnLoadReference(wxCommandEvent &event);
+	void OnConvertBodyReference(wxCommandEvent &event);
 	void OnLoadOutfit(wxCommandEvent& event);
 	void OnUnloadProject(wxCommandEvent &event);
 
@@ -1329,7 +1332,7 @@ private:
 
 	void OnLoadPreset(wxCommandEvent& event);
 	void OnSavePreset(wxCommandEvent& event);
-	bool ShowConform(ConformOptions& options);
+	bool ShowConform(ConformOptions& options, bool silent = false);
 	void ConformSliders(nifly::NiShape* shape, const ConformOptions& options);
 	void OnSliderConform(wxCommandEvent& event);
 	void OnSliderConformAll(wxCommandEvent& event);
@@ -1382,6 +1385,7 @@ private:
 	void GetBoneDlgData(wxDialog &dlg, nifly::MatTransform &xform, std::string &parentBone);
 	void OnEditBone(wxCommandEvent& event);
 	void OnCopyBoneWeight(wxCommandEvent& event);
+	void MaskWeightedOnShape(std::string& shapeName) const;
 	void OnCopySelectedWeight(wxCommandEvent& event);
 	void OnTransferSelectedWeight(wxCommandEvent& event);
 	void OnMaskWeighted(wxCommandEvent& event);

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -1385,7 +1385,6 @@ private:
 	void GetBoneDlgData(wxDialog &dlg, nifly::MatTransform &xform, std::string &parentBone);
 	void OnEditBone(wxCommandEvent& event);
 	void OnCopyBoneWeight(wxCommandEvent& event);
-	void MaskWeightedOnShape(std::string& shapeName) const;
 	void OnCopySelectedWeight(wxCommandEvent& event);
 	void OnTransferSelectedWeight(wxCommandEvent& event);
 	void OnMaskWeighted(wxCommandEvent& event);

--- a/src/utils/ConfigDialogUtil.h
+++ b/src/utils/ConfigDialogUtil.h
@@ -31,7 +31,7 @@ namespace ConfigDialogUtil {
 
 	inline void LoadDialogCheckBox(ConfigurationManager& configManager, const wxDialog& dlg, const char* dlgProperty) {
 		wxCheckBox* tmplChoice = XRCCTRL(dlg, dlgProperty, wxCheckBox);
-		bool lastValue = configManager.GetBoolValue(dlgProperty);
+		bool lastValue = configManager.GetBoolValue(dlgProperty, tmplChoice->GetValue());
 		tmplChoice->SetValue(lastValue);
 	}
 


### PR DESCRIPTION
Has the ability to 1 click convert a reference body in an outfit project (ie. CBBE to BHUNP) or replace an existing body (select 'None' for the conversion). Though, you may wish to do additional weight painting after the conversion is complete (depending on the outfit)

Includes an automated way to rename the project (which can be tedious when doing many outfits) and various other settings that may be useful

Tried my best to separate the dialog from the main code, though as it calls existing methods to automate the process, some methods required minor refactoring