### PR TITLE
Slider merge issue when shapeattribute already exists but targetshape differs

### DIFF
--- a/src/components/SliderSet.cpp
+++ b/src/components/SliderSet.cpp
@@ -273,8 +273,7 @@ void SliderSet::Merge(SliderSet& mergeSet, DiffDataSets& inDataStorage, DiffData
 
 	for (auto &s : mergeSet.shapeAttributes) {
 		// Copy new shapes to the set
-		auto it = shapeAttributes.find(s.first);
-		if (it == shapeAttributes.end()) {
+		if (shapeAttributes.find(s.first) == shapeAttributes.end()) {
 			if (newDataLocal)
 				s.second.dataFolder.clear();
 

--- a/src/components/SliderSet.cpp
+++ b/src/components/SliderSet.cpp
@@ -36,6 +36,10 @@ void SliderSet::DeleteSlider(const std::string& setName) {
 	}
 }
 
+void SliderSet::DeleteShapeAttribute(const std::string& shapeName) {
+	shapeAttributes.erase(shapeName);
+}
+
 size_t SliderSet::CreateSlider(const std::string& setName) {
 	sliders.emplace_back(setName);
 	return sliders.size() - 1;
@@ -269,7 +273,8 @@ void SliderSet::Merge(SliderSet& mergeSet, DiffDataSets& inDataStorage, DiffData
 
 	for (auto &s : mergeSet.shapeAttributes) {
 		// Copy new shapes to the set
-		if (shapeAttributes.find(s.first) == shapeAttributes.end()) {
+		auto it = shapeAttributes.find(s.first);
+		if (it == shapeAttributes.end()) {
 			if (newDataLocal)
 				s.second.dataFolder.clear();
 

--- a/src/components/SliderSet.h
+++ b/src/components/SliderSet.h
@@ -84,6 +84,7 @@ public:
 	void WriteSliderSet(XMLElement* sliderSetElement);
 
 	void DeleteSlider(const std::string& setName);
+	void DeleteShapeAttribute(const std::string& shapeName);
 
 	std::string GetName() {
 		return name;

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -3310,6 +3310,7 @@ void OutfitProject::DeleteShape(NiShape* shape) {
 	owner->glView->DeleteMesh(shapeName);
 	shapeTextures.erase(shapeName);
 	shapeMaterialFiles.erase(shapeName);
+	activeSet.DeleteShapeAttribute(shapeName);
 
 	if (IsBaseShape(shape)) {
 		morpher.UnlinkRefDiffData();


### PR DESCRIPTION
When importing the sliderset and a shapeattribute already exists, it doesnt update the existing shape attribute, even though the targetshape (within a shapeattribute) may be different

At an initial glance, theres a few ways this could be fixed:
in SliderSet::Merge
   -always update the shape attribute (even if it already exists)
   -check if the shapetarget is different and update it
Or
   -clear the shape attribute from the slider set when the shape is deleted

This PR currently uses the last method as it seems to make sense to clear the old shape attribute when the old shape is deleted, though, I'm not sure if this would cover all scenarios - so it may be better to just already update a shape attribute if it exists. Also, I'm not sure if there is a reason that I didn't consider in which you might want to keep a shape attribute if the shape no longer exists

Test scenario (prior to PR)
1. Load CBBE Underwear
2. Delete all sliders
3. Delete CBBE
4. Load reference Template CBBE Body SMP (3BBB)

Note how the sliders don't affect the 'CBBE' shape. The issue is resolved with the PR