### PR TITLE
Fix shape attributes

### DIFF
--- a/src/components/SliderSet.cpp
+++ b/src/components/SliderSet.cpp
@@ -32,10 +32,6 @@ void SliderSet::DeleteSlider(const std::string& setName) {
 	}
 }
 
-void SliderSet::DeleteShapeAttribute(const std::string& shapeName) {
-	shapeAttributes.erase(shapeName);
-}
-
 size_t SliderSet::CreateSlider(const std::string& setName) {
 	sliders.emplace_back(setName);
 	return sliders.size() - 1;

--- a/src/components/SliderSet.cpp
+++ b/src/components/SliderSet.cpp
@@ -263,12 +263,10 @@ void SliderSet::Merge(SliderSet& mergeSet, DiffDataSets& inDataStorage, DiffData
 
 	for (auto& s : mergeSet.shapeAttributes) {
 		// Copy new shapes to the set
-		if (shapeAttributes.find(s.first) == shapeAttributes.end()) {
-			if (newDataLocal)
-				s.second.dataFolder.clear();
+		if (newDataLocal)
+			s.second.dataFolder.clear();
 
-			shapeAttributes[s.first] = s.second;
-		}
+		shapeAttributes[s.first] = s.second;
 	}
 
 	// Load from cached data locations at once

--- a/src/components/SliderSet.h
+++ b/src/components/SliderSet.h
@@ -69,7 +69,6 @@ public:
 	void WriteSliderSet(XMLElement* sliderSetElement);
 
 	void DeleteSlider(const std::string& setName);
-	void DeleteShapeAttribute(const std::string& shapeName);
 
 	std::string GetName() { return name; }
 

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -3311,7 +3311,6 @@ void OutfitProject::DeleteShape(NiShape* shape) {
 	owner->glView->DeleteMesh(shapeName);
 	shapeTextures.erase(shapeName);
 	shapeMaterialFiles.erase(shapeName);
-	activeSet.DeleteShapeAttribute(shapeName);
 
 	if (IsBaseShape(shape)) {
 		morpher.UnlinkRefDiffData();


### PR DESCRIPTION
Reference issue: https://github.com/ousnius/BodySlide-and-Outfit-Studio/issues/412

DeleteShape is being called from LoadProject when clearing the project and at this point, the sliderset with valid shapeattributes has already been loaded and baseshape has been set. So when DeleteShape is called, it clears the required shape attribute.

The addition of [DeleteShapeAttribute to DeleteShape](https://github.com/ousnius/BodySlide-and-Outfit-Studio/pull/407) was a little too dangerous to fix the shape attribute issue as it caused the above regression, so I've swapped it for a less risky fix of simply updating the existing shape attribute data when merging the slider set. At this point, it's likely that any old shape would have either been deleted or renamed and have little use for the prior target shape that may be on the old shapeAttribute.