### PR TITLE
Adjusted scaling and defaults for brush strength for most brushes

### DIFF
--- a/src/components/TweakBrush.cpp
+++ b/src/components/TweakBrush.cpp
@@ -685,7 +685,7 @@ void TB_Smooth::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* p
 }
 
 TB_Undiff::TB_Undiff() {
-	strength = 0.1f;
+	strength = 0.01f;
 	brushName = "Undiff Brush";
 	brushType = TweakBrush::BrushType::Undiff;
 }

--- a/src/components/TweakBrush.cpp
+++ b/src/components/TweakBrush.cpp
@@ -327,7 +327,7 @@ TB_Mask::TB_Mask() {
 	bLiveBVH = false;
 	bLiveNormals = false;
 	brushName = "Mask Brush";
-	strength = 0.1f;
+	strength = 1.0f;
 }
 
 TB_Mask::~TB_Mask() {}
@@ -347,7 +347,7 @@ void TB_Mask::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* poi
 			startState[points[i]] = vc;
 
 		ve = vc;
-		if (strength < 0.1f)
+		if (strength < 1.0f)
 			ve.x += strength;
 		else
 			ve.x += 1.0f;
@@ -356,7 +356,7 @@ void TB_Mask::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* poi
 		float originToV = pickInfo.origin.DistanceTo(vs);
 		if (originToV > radius)
 			ve.Zero();
-		else if (strength < 0.1f)
+		else if (strength < 1.0f)
 			applyFalloff(ve, originToV);
 
 		vf = vc + ve;
@@ -375,7 +375,7 @@ TB_Unmask::TB_Unmask() {
 	bLiveBVH = false;
 	bLiveNormals = false;
 	brushName = "Unmask Brush";
-	strength = -0.1f;
+	strength = -1.0f;
 }
 
 TB_Unmask::~TB_Unmask() {}
@@ -395,7 +395,7 @@ void TB_Unmask::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* p
 			startState[points[i]] = vc;
 
 		ve = vc;
-		if (strength > -0.1f)
+		if (strength > -1.0f)
 			ve.x += strength;
 		else
 			ve.x -= 1.0f;
@@ -404,7 +404,7 @@ void TB_Unmask::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* p
 		float originToV = pickInfo.origin.DistanceTo(vs);
 		if (originToV > radius)
 			ve.Zero();
-		else if (strength > -0.1f)
+		else if (strength > -1.0f)
 			applyFalloff(ve, originToV);
 
 		vf = vc + ve;
@@ -522,27 +522,25 @@ void TB_SmoothMask::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const in
 		hclapFilter(refmesh, points, nPoints, wv, uss);
 
 	Vector3 delta;
-	if (strength != 1.0f) {
-		for (int p = 0; p < nPoints; p++) {
-			int i = points[p];
-			vs = refmesh->verts[i];
-			vm = refmesh->mask[i];
-			delta.x = wv[i].x - vm;
-			delta.x *= strength;
+	for (int p = 0; p < nPoints; p++) {
+		int i = points[p];
+		vs = refmesh->verts[i];
+		vm = refmesh->mask[i];
+		delta.x = wv[i].x - vm;
+		delta.x *= strength;
 
-			applyFalloff(delta, pickInfo.origin.DistanceTo(vs));
+		applyFalloff(delta, pickInfo.origin.DistanceTo(vs));
 
-			vm += delta.x;
+		vm += delta.x;
 
-			if (vm < EPSILON)
-				vm = 0.0f;
-			if (vm > 1.0f)
-				vm = 1.0f;
-			endState[i].x = refmesh->mask[i] = vm;
-		}
-
-		refmesh->QueueUpdate(mesh::UpdateType::Mask);
+		if (vm < EPSILON)
+			vm = 0.0f;
+		if (vm > 1.0f)
+			vm = 1.0f;
+		endState[i].x = refmesh->mask[i] = vm;
 	}
+
+	refmesh->QueueUpdate(mesh::UpdateType::Mask);
 }
 
 TB_Deflate::TB_Deflate() {
@@ -562,7 +560,7 @@ float TB_Deflate::getStrength() {
 
 TB_Smooth::TB_Smooth() {
 	method = 1;
-	strength = 0.01f;
+	strength = 0.1f;
 	hcAlpha = 0.2f;
 	hcBeta = 0.5f;
 	brushName = "Smooth Brush";
@@ -657,39 +655,37 @@ void TB_Smooth::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* p
 		hclapFilter(refmesh, points, nPoints, wv, uss);
 
 	Vector3 delta;
-	if (strength != 1.0f) {
-		for (int p = 0; p < nPoints; p++) {
-			int i = points[p];
-			vs = refmesh->verts[i];
-			delta = wv[i] - refmesh->verts[i];
-			delta *= strength;
-			applyFalloff(delta, pickInfo.origin.DistanceTo(vs));
+	for (int p = 0; p < nPoints; p++) {
+		int i = points[p];
+		vs = refmesh->verts[i];
+		delta = wv[i] - refmesh->verts[i];
+		delta *= strength;
+		applyFalloff(delta, pickInfo.origin.DistanceTo(vs));
 
-			delta = delta * (1.0f - refmesh->mask[i]);
-			Vector3 ve = refmesh->verts[i] + delta;
+		delta = delta * (1.0f - refmesh->mask[i]);
+		Vector3 ve = refmesh->verts[i] + delta;
 
-			if (restrictNormal) {
-				const Vector3& n = cache[refmesh].startNorms[i];
-				ve = startState[i] + n * (ve - startState[i]).dot(n);
-			}
-
-			if (restrictPlane) {
-				const Vector3& n = cache[refmesh].startNorms[i];
-				ve -= startState[i];
-				ve -= n * ve.dot(n);
-				ve += startState[i];
-			}
-
-			refmesh->verts[i] = ve;
-			endState[i] = ve;
+		if (restrictNormal) {
+			const Vector3& n = cache[refmesh].startNorms[i];
+			ve = startState[i] + n * (ve - startState[i]).dot(n);
 		}
 
-		refmesh->QueueUpdate(mesh::UpdateType::Position);
+		if (restrictPlane) {
+			const Vector3& n = cache[refmesh].startNorms[i];
+			ve -= startState[i];
+			ve -= n * ve.dot(n);
+			ve += startState[i];
+		}
+
+		refmesh->verts[i] = ve;
+		endState[i] = ve;
 	}
+
+	refmesh->QueueUpdate(mesh::UpdateType::Position);
 }
 
 TB_Undiff::TB_Undiff() {
-	strength = 0.01f;
+	strength = 0.1f;
 	brushName = "Undiff Brush";
 	brushType = TweakBrush::BrushType::Undiff;
 }
@@ -751,7 +747,7 @@ TB_Move::TB_Move() {
 	brushName = "Move Brush";
 	bLiveBVH = false;
 	focus = 0.5f;
-	strength = 0.1f;
+	strength = 1.0f;
 }
 
 TB_Move::~TB_Move() {}
@@ -1038,7 +1034,7 @@ static inline void ClampWeight(float& w) {
 
 TB_Weight::TB_Weight() {
 	brushType = TweakBrush::BrushType::Weight;
-	strength = 0.0015f;
+	strength = 0.015f;
 	bMirror = false;
 	bLiveBVH = false;
 	bLiveNormals = false;
@@ -1071,7 +1067,7 @@ void TB_Weight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* p
 		adjFlag[0] = b0falloff > 0.0;
 
 		float sw = uss.boneWeights[0].weights[i].endVal;
-		float str = bFixedWeight ? strength * 10.0f - sw : strength;
+		float str = bFixedWeight ? strength - sw : strength;
 		float maskF = 1.0f - refmesh->mask[i];
 
 		uss.boneWeights[0].weights[i].endVal += str * maskF * b0falloff;
@@ -1086,7 +1082,7 @@ void TB_Weight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* p
 
 			adjFlag[1] = b1falloff > 0.0;
 			sw = uss.boneWeights[1].weights[i].endVal;
-			str = bFixedWeight ? strength * 10.0f - sw : strength;
+			str = bFixedWeight ? strength - sw : strength;
 			uss.boneWeights[1].weights[i].endVal += str * maskF * b1falloff;
 
 			if (!bNormalizeWeights)
@@ -1104,7 +1100,7 @@ void TB_Weight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* p
 
 TB_Unweight::TB_Unweight() {
 	brushType = TweakBrush::BrushType::Weight;
-	strength = -0.0015f;
+	strength = -0.015f;
 	bMirror = false;
 	bLiveBVH = false;
 	bLiveNormals = false;
@@ -1165,7 +1161,7 @@ void TB_Unweight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int*
 
 TB_SmoothWeight::TB_SmoothWeight() {
 	brushType = TweakBrush::BrushType::Weight;
-	strength = 0.015f;
+	strength = 0.15f;
 	method = 1;
 	hcAlpha = 0.2f;
 	hcBeta = 0.5f;
@@ -1343,7 +1339,7 @@ void TB_SmoothWeight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const 
 
 TB_Color::TB_Color() {
 	brushType = TweakBrush::BrushType::Color;
-	strength = 0.003f;
+	strength = 0.03f;
 	bMirror = false;
 	bLiveBVH = false;
 	bLiveNormals = false;
@@ -1366,7 +1362,7 @@ void TB_Color::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* po
 
 		float originToV = pickInfo.origin.DistanceTo(vs);
 		if (originToV <= radius) {
-			Vector3 falloff(strength * 10.0f, strength * 10.0f, strength * 10.0f);
+			Vector3 falloff(strength, strength, strength);
 			applyFalloff(falloff, originToV);
 
 			vc.x = color.x * falloff.x + vc.x * (1.0f - falloff.x);
@@ -1397,7 +1393,7 @@ void TB_Color::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* po
 
 TB_Uncolor::TB_Uncolor() {
 	brushType = TweakBrush::BrushType::Color;
-	strength = -0.003f;
+	strength = -0.03f;
 	bMirror = false;
 	bLiveBVH = false;
 	bLiveNormals = false;
@@ -1420,7 +1416,7 @@ void TB_Uncolor::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* 
 
 		float originToV = pickInfo.origin.DistanceTo(vs);
 		if (originToV <= radius) {
-			Vector3 falloff(-strength * 10.0f, -strength * 10.0f, -strength * 10.0f);
+			Vector3 falloff(-strength, -strength, -strength);
 			applyFalloff(falloff, originToV);
 
 			vc.x = falloff.x + vc.x * (1.0f - falloff.x);
@@ -1455,7 +1451,7 @@ TB_Alpha::TB_Alpha() {
 	bLiveBVH = false;
 	bLiveNormals = false;
 	brushName = "Alpha Brush";
-	strength = 0.003f;
+	strength = 0.03f;
 }
 
 TB_Alpha::~TB_Alpha() {}
@@ -1475,7 +1471,7 @@ void TB_Alpha::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* po
 			startState[points[i]].x = vc;
 
 		ve = vc;
-		if (strength < 0.1f)
+		if (strength < 1.0f)
 			ve -= strength;
 		else
 			ve -= 1.0f;
@@ -1485,7 +1481,7 @@ void TB_Alpha::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* po
 		float originToV = pickInfo.origin.DistanceTo(vs);
 		if (originToV > radius)
 			vev.Zero();
-		else if (strength < 0.1f)
+		else if (strength < 1.0f)
 			applyFalloff(vev, originToV);
 
 		vf = vc + vev.x;
@@ -1504,7 +1500,7 @@ TB_Unalpha::TB_Unalpha() {
 	bLiveBVH = false;
 	bLiveNormals = false;
 	brushName = "Unalpha Brush";
-	strength = -0.003f;
+	strength = -0.03f;
 }
 
 TB_Unalpha::~TB_Unalpha() {}
@@ -1524,7 +1520,7 @@ void TB_Unalpha::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* 
 			startState[points[i]].x = vc;
 
 		ve = vc;
-		if (strength > -0.1f)
+		if (strength > -1.0f)
 			ve -= strength;
 		else
 			ve += 1.0f;
@@ -1534,7 +1530,7 @@ void TB_Unalpha::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* 
 		float originToV = pickInfo.origin.DistanceTo(vs);
 		if (originToV > radius)
 			vev.Zero();
-		else if (strength > -0.1f)
+		else if (strength > -1.0f)
 			applyFalloff(vev, originToV);
 
 		vf = vc + vev.x;

--- a/src/components/TweakBrush.h
+++ b/src/components/TweakBrush.h
@@ -119,12 +119,12 @@ public:
 	TweakBrushMeshCache* getCache(mesh* m) { return &cache[m]; }
 
 	virtual float getRadius() { return radius; }
-	virtual float getStrength() { return strength * 10.0f; }
+	virtual float getStrength() { return strength; }
 	virtual float getFocus() { return focus; }
 	virtual float getSpacing() { return spacing; }
 	virtual void setRadius(float newRadius) { radius = newRadius; }
 	virtual void setFocus(float newFocus) { focus = newFocus; }
-	virtual void setStrength(float newStr) { strength = newStr / 10.0f; }
+	virtual void setStrength(float newStr) { strength = newStr; }
 	virtual void setSpacing(float newSpacing) { spacing = newSpacing; }
 
 	virtual int CachedPointIndex(mesh*, int) { return 0; }
@@ -172,6 +172,9 @@ class TB_Inflate : public TweakBrush {
 public:
 	TB_Inflate();
 	virtual ~TB_Inflate();
+
+	virtual float getStrength() { return strength * 10.0f; }
+	virtual void setStrength(float newStr) { strength = newStr / 10.0f; }
 
 	virtual void brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss);
 };

--- a/src/components/TweakBrush.h
+++ b/src/components/TweakBrush.h
@@ -257,6 +257,9 @@ public:
 	virtual void strokeInit(const std::vector<mesh*>&, TweakPickInfo&, UndoStateProject&, std::vector<std::vector<nifly::Vector3>>&);
 	virtual void brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss);
 	virtual bool checkSpacing(nifly::Vector3&, nifly::Vector3&) { return true; }
+
+	virtual float getStrength() { return strength * 10.0f; }
+	virtual void setStrength(float newStr) { strength = newStr / 10.0f; }
 };
 
 // Move brush behavior is significantly different from other brush types.

--- a/src/components/TweakBrush.h
+++ b/src/components/TweakBrush.h
@@ -82,12 +82,13 @@ public:
 	std::unordered_set<AABBTree::AABBTreeNode*> cachedNodes;
 	std::unordered_set<AABBTree::AABBTreeNode*> cachedNodesM;
 	std::vector<nifly::Vector3> positionData;
+	std::unique_ptr<nifly::Vector3[]> startNorms;
 };
 
 
 class TweakBrush {
 public:
-	enum class BrushType { Standard = 1, Move, Mask, Weight, Color, Alpha, Transform, Undiff };
+	enum class BrushType { Inflate = 1, Move, Mask, Weight, Color, Alpha, Transform, Undiff };
 
 protected:
 	BrushType brushType;
@@ -101,6 +102,8 @@ protected:
 	bool bLiveBVH;	   // Update BVH at each update instead of at stroke completion.
 	bool bLiveNormals; // Update mesh normals at each update instead of at stroke completion.
 	bool bConnected;   // Operate on connected vertices only.
+	bool restrictPlane = false;
+	bool restrictNormal = false;
 
 	std::unordered_map<mesh*, TweakBrushMeshCache> cache;
 
@@ -131,13 +134,15 @@ public:
 
 	virtual bool isConnected() { return bConnected; }
 	virtual void setConnected(bool wantConnected = true) { bConnected = wantConnected; }
+	virtual void setRestrictPlane(bool on) { restrictPlane = on; }
+	virtual void setRestrictNormal(bool on) { restrictNormal = on; }
 	virtual bool LiveBVH() { return bLiveBVH; }
 	virtual bool LiveNormals() { return bLiveNormals; }
 
 	virtual bool NeedMirrorMergedQuery() { return false; }
 
 	// Stroke initialization interface, allows a brush to set up initial conditions.
-	virtual void strokeInit(const std::vector<mesh*>&, TweakPickInfo&, UndoStateProject&) {}
+	virtual void strokeInit(const std::vector<mesh*>&, TweakPickInfo&, UndoStateProject&);
 	virtual void strokeInit(const std::vector<mesh*>&, TweakPickInfo&, UndoStateProject&, std::vector<std::vector<nifly::Vector3>>&) {}
 
 	// Using the start and end points, determine if enough distance has been covered to satisfy the spacing setting.
@@ -155,12 +160,20 @@ public:
 		mesh* refmesh, TweakPickInfo& pickInfo, TweakPickInfo& mirrorPick, int* resultPoints, int& outResultCount, std::unordered_set<AABBTree::AABBTreeNode*>& affectedNodes);
 
 	// Apply the brush effect to the mesh
-	virtual void brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss);
+	virtual void brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) = 0;
 };
 
 class ClampBrush {
 public:
 	float clampMaxValue = 0.0f;
+};
+
+class TB_Inflate : public TweakBrush {
+public:
+	TB_Inflate();
+	virtual ~TB_Inflate();
+
+	virtual void brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss);
 };
 
 class TB_Mask : public TweakBrush {
@@ -199,7 +212,7 @@ public:
 	virtual void brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss);
 };
 
-class TB_Deflate : public TweakBrush {
+class TB_Deflate : public TB_Inflate {
 public:
 	TB_Deflate();
 	virtual ~TB_Deflate();

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -758,7 +758,7 @@ private:
 
 	TweakBrush* activeBrush = nullptr;
 	TweakBrush* savedBrush;
-	TweakBrush standardBrush;
+	TB_Inflate standardBrush;
 	TB_Deflate deflateBrush;
 	TB_Move moveBrush;
 	TB_Smooth smoothBrush;


### PR DESCRIPTION
I changed the brush strength scaling so that now only inflate/deflate have a factor-of-10 scaling instead of all brushes.  I also increased the default value of brush strength by a factor of ten for smooth, move, undiff, weight, color, and alpha.  I also fixed some bugs that would make high strength values do nothing.