### PR TITLE
Cleaned up mesh coordinate transforms

### DIFF
--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -330,7 +330,7 @@ bool AnimInfo::CalcShapeSkinBounds(const std::string& shapeName, const int& bone
 	const MatTransform& xformSkinToBone = shapeSkinning[shapeName].boneWeights[boneIndex].xformSkinToBone;
 
 	bounds.center = xformSkinToBone.ApplyTransform(bounds.center);
-	bounds.radius *= xformSkinToBone.scale;
+	bounds.radius = xformSkinToBone.ApplyTransformToDist(bounds.radius);
 	shapeSkinning[shapeName].boneWeights[boneIndex].bounds = bounds;
 	return true;
 }

--- a/src/components/Automorph.cpp
+++ b/src/components/Automorph.cpp
@@ -451,7 +451,7 @@ void Automorph::GenerateResultDiff(
 			continue;
 
 		if (!solidMode) {
-			(*resultDiffSet)[i] = totalMove;
+			(*resultDiffSet)[i] = m->DiffModelToMesh(morphRef->DiffMeshToModel(totalMove));
 		}
 		else {
 			totalMoveList.reserve(m->nVerts);
@@ -503,7 +503,7 @@ void Automorph::GenerateResultDiff(
 			if (totalMove.IsZero(true))
 				continue;
 
-			(*resultDiffSet)[i] = totalMove;
+			(*resultDiffSet)[i] = m->DiffModelToMesh(morphRef->DiffMeshToModel(totalMove));
 		}
 	}
 }

--- a/src/components/Automorph.cpp
+++ b/src/components/Automorph.cpp
@@ -201,7 +201,7 @@ void Automorph::MeshFromNifShape(mesh* m, NifFile& ref, NiShape* shape, const An
 
 	// Load verts. No CS transformation is done (in contrast to the very similar code in GLSurface).
 	for (int i = 0; i < m->nVerts; i++)
-		m->verts[i] = m->PosMeshToModel(nifVerts[i]);
+		m->verts[i] = m->TransformPosMeshToModel(nifVerts[i]);
 }
 
 void Automorph::DeleteVerts(const std::string& shapeName, const std::vector<uint16_t>& indices) {
@@ -322,7 +322,7 @@ void Automorph::UpdateResultDiff(const std::string& shapeName, const std::string
 		resultDiffData.AddEmptySet(setName, shapeName);
 
 	for (auto& i : diff) {
-		Vector3 diffscale = mesh::DiffMeshToNif(i.second);
+		Vector3 diffscale = mesh::TransformDiffMeshToNif(i.second);
 		resultDiffData.SumDiff(setName, shapeName, i.first, diffscale);
 	}
 }
@@ -334,7 +334,7 @@ void Automorph::UpdateRefDiff(const std::string& shapeName, const std::string& s
 		srcDiffData->AddEmptySet(setName, shapeName);
 
 	for (auto& i : diff) {
-		Vector3 diffscale = mesh::DiffMeshToNif(i.second);
+		Vector3 diffscale = mesh::TransformDiffMeshToNif(i.second);
 		srcDiffData->SumDiff(setName, shapeName, i.first, diffscale);
 	}
 }
@@ -451,7 +451,7 @@ void Automorph::GenerateResultDiff(
 			continue;
 
 		if (!solidMode) {
-			(*resultDiffSet)[i] = m->DiffModelToMesh(morphRef->DiffMeshToModel(totalMove));
+			(*resultDiffSet)[i] = m->TransformDiffModelToMesh(morphRef->TransformDiffMeshToModel(totalMove));
 		}
 		else {
 			totalMoveList.reserve(m->nVerts);
@@ -503,7 +503,7 @@ void Automorph::GenerateResultDiff(
 			if (totalMove.IsZero(true))
 				continue;
 
-			(*resultDiffSet)[i] = m->DiffModelToMesh(morphRef->DiffMeshToModel(totalMove));
+			(*resultDiffSet)[i] = m->TransformDiffModelToMesh(morphRef->TransformDiffMeshToModel(totalMove));
 		}
 	}
 }

--- a/src/components/Automorph.h
+++ b/src/components/Automorph.h
@@ -70,6 +70,7 @@ public:
 	void GenerateResultDiff(const std::string& shapeName,
 							const std::string& sliderName,
 							const std::string& refDataName,
+							bool transformResults,
 							int maxResults = 10,
 							bool noSqueeze = false,
 							bool solidMode = false,

--- a/src/components/Mesh.h
+++ b/src/components/Mesh.h
@@ -48,7 +48,10 @@ public:
 		float paletteScale = 0.0f;
 	};
 
+	// Use SetXformMeshToModel or SetXformModelToMesh to set matModel,
+	// xformMeshToModel, and xformModelToMesh.
 	glm::mat4x4 matModel = glm::identity<glm::mat4x4>();
+	nifly::MatTransform xformMeshToModel, xformModelToMesh;
 
 	int nVerts = 0;
 	std::unique_ptr<nifly::Vector3[]> verts;
@@ -196,43 +199,113 @@ public:
 
 	void ColorChannelFill(int channel, float value);
 
-	static nifly::Vector3 VecToMeshCoords(const nifly::Vector3& vec) {
-		nifly::Vector3 vecNew = vec;
-		vecNew.x /= -10.0f;
-		vecNew.y /= 10.0f;
-		vecNew.z /= 10.0f;
-		std::swap(vecNew.y, vecNew.z);
-		return vecNew;
+	static constexpr nifly::MatTransform xformNifToMesh{nifly::Vector3(),nifly::Matrix3(-1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f),0.1f};
+	static constexpr nifly::MatTransform xformMeshToNif{nifly::Vector3(),nifly::Matrix3(-1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f),10.0f};
+
+	static constexpr nifly::Vector3 VecToMeshCoords(const nifly::Vector3& vec) {
+		// This function efficiently calculates xformNifToMesh.ApplyTransform(vec)
+		return nifly::Vector3(
+			vec.x / -10.0f,
+			vec.z / 10.0f,
+			vec.y / 10.0f);
 	}
 
-	static nifly::Vector3 VecToNifCoords(const nifly::Vector3& vec) {
-		nifly::Vector3 vecNew = vec;
-		vecNew.x *= -10.0f;
-		vecNew.y *= 10.0f;
-		vecNew.z *= 10.0f;
-		std::swap(vecNew.y, vecNew.z);
-		return vecNew;
+	static constexpr nifly::Vector3 VecToNifCoords(const nifly::Vector3& vec) {
+		// This function efficiently calculates xformMeshToNif.ApplyTransform(vec)
+		return nifly::Vector3(
+			vec.x * -10.0f,
+			vec.z * 10.0f,
+			vec.y * 10.0f);
 	}
 
-	static glm::mat4x4 TransformToMatrix4(const nifly::MatTransform& xform) {
-		auto mat44 = glm::identity<glm::mat4x4>();
+	static constexpr nifly::Vector3 DiffNifToMesh(const nifly::Vector3& diff) {
+		// This function efficiently calculates xformNifToMesh::ApplyTransformToDiff(diff)
+		return nifly::Vector3(
+			diff.x / -10.0f,
+			diff.z / 10.0f,
+			diff.y / 10.0f);
+	}
 
-		float y, p, r;
-		xform.rotation.ToEulerAngles(y, p, r);
+	static constexpr nifly::Vector3 DiffMeshToNif(const nifly::Vector3& diff) {
+		// This function efficiently calculates xformMeshToNif::ApplyTransformToDiff(diff)
+		return nifly::Vector3(
+			diff.x * -10.0f,
+			diff.z * 10.0f,
+			diff.y * 10.0f);
+	}
 
-		mat44 = glm::translate(mat44, glm::vec3(xform.translation.x, xform.translation.y, xform.translation.z));
-		mat44 *= glm::eulerAngleXZY(y, p, r);
-		mat44 = glm::scale(mat44, glm::vec3(xform.scale, xform.scale, xform.scale));
-		return mat44;
+	static constexpr nifly::Vector3 DirNifToMesh(const nifly::Vector3& dir) {
+		// This function efficiently calculates xformNifToMesh::ApplyTransformToDir(dir)
+		return nifly::Vector3(
+			-dir.x,
+			dir.z,
+			dir.y);
+	}
+
+	static constexpr nifly::Vector3 DirMeshToNif(const nifly::Vector3& dir) {
+		// This function efficiently calculates xformMeshToNif::ApplyTransformToDir(dir)
+		return nifly::Vector3(
+			-dir.x,
+			dir.z,
+			dir.y);
+	}
+
+	static constexpr float DistNifToMesh(float d) {
+		// This function calculates xformMeshToNif::ApplyTransformToDist(d)
+		return d / 10.0f;
+	}
+
+	static constexpr float DistMeshToNif(float d) {
+		// This function calculates xformMeshToNif::ApplyTransformToDist(d)
+		return d * 10.0f;
+	}
+
+	void SetXformMeshToModel(const nifly::MatTransform& tMeshToModel) {
+		xformMeshToModel = tMeshToModel;
+		xformModelToMesh = tMeshToModel.InverseTransform();
+		matModel = xformMeshToModel.ToGLMMatrix<glm::mat4x4>();
+	}
+
+	void SetXformModelToMesh(const nifly::MatTransform& tModelToMesh) {
+		xformModelToMesh = tModelToMesh;
+		xformMeshToModel = tModelToMesh.InverseTransform();
+		matModel = xformMeshToModel.ToGLMMatrix<glm::mat4x4>();
+	}
+
+	nifly::Vector3 PosMeshToModel(const nifly::Vector3 &pos) {
+		return xformMeshToModel.ApplyTransform(pos);
+	}
+
+	nifly::Vector3 PosModelToMesh(const nifly::Vector3 &pos) {
+		return xformModelToMesh.ApplyTransform(pos);
+	}
+
+	nifly::Vector3 DirMeshToModel(const nifly::Vector3 &dir) {
+		return xformMeshToModel.ApplyTransformToDir(dir);
+	}
+
+	nifly::Vector3 DirModelToMesh(const nifly::Vector3 &dir) {
+		return xformModelToMesh.ApplyTransformToDir(dir);
+	}
+
+	nifly::Vector3 DiffMeshToModel(const nifly::Vector3 &diff) {
+		return xformMeshToModel.ApplyTransformToDiff(diff);
+	}
+
+	nifly::Vector3 DiffModelToMesh(const nifly::Vector3 &diff) {
+		return xformModelToMesh.ApplyTransformToDiff(diff);
+	}
+
+	float DistMeshToModel(float dist) {
+		return xformMeshToModel.ApplyTransformToDist(dist);
+	}
+
+	float DistModelToMesh(float dist) {
+		return xformModelToMesh.ApplyTransformToDist(dist);
 	}
 
 	static nifly::Vector3 ApplyMatrix4(const glm::mat4x4& mat, const nifly::Vector3& p) {
 		glm::vec3 gp(mat * glm::vec4(p.x, p.y, p.z, 1.0f));
-		return nifly::Vector3(gp.x, gp.y, gp.z);
-	}
-
-	static nifly::Vector3 ApplyMatrix4ToDir(const glm::mat4x4& mat, const nifly::Vector3& p) {
-		glm::vec3 gp(mat * glm::vec4(p.x, p.y, p.z, 0.0f));
 		return nifly::Vector3(gp.x, gp.y, gp.z);
 	}
 };

--- a/src/components/Mesh.h
+++ b/src/components/Mesh.h
@@ -202,7 +202,7 @@ public:
 	static constexpr nifly::MatTransform xformNifToMesh{nifly::Vector3(),nifly::Matrix3(-1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f),0.1f};
 	static constexpr nifly::MatTransform xformMeshToNif{nifly::Vector3(),nifly::Matrix3(-1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f),10.0f};
 
-	static constexpr nifly::Vector3 VecToMeshCoords(const nifly::Vector3& vec) {
+	static constexpr nifly::Vector3 TransformPosNifToMesh(const nifly::Vector3& vec) {
 		// This function efficiently calculates xformNifToMesh.ApplyTransform(vec)
 		return nifly::Vector3(
 			vec.x / -10.0f,
@@ -210,7 +210,7 @@ public:
 			vec.y / 10.0f);
 	}
 
-	static constexpr nifly::Vector3 VecToNifCoords(const nifly::Vector3& vec) {
+	static constexpr nifly::Vector3 TransformPosMeshToNif(const nifly::Vector3& vec) {
 		// This function efficiently calculates xformMeshToNif.ApplyTransform(vec)
 		return nifly::Vector3(
 			vec.x * -10.0f,
@@ -218,7 +218,7 @@ public:
 			vec.y * 10.0f);
 	}
 
-	static constexpr nifly::Vector3 DiffNifToMesh(const nifly::Vector3& diff) {
+	static constexpr nifly::Vector3 TransformDiffNifToMesh(const nifly::Vector3& diff) {
 		// This function efficiently calculates xformNifToMesh::ApplyTransformToDiff(diff)
 		return nifly::Vector3(
 			diff.x / -10.0f,
@@ -226,7 +226,7 @@ public:
 			diff.y / 10.0f);
 	}
 
-	static constexpr nifly::Vector3 DiffMeshToNif(const nifly::Vector3& diff) {
+	static constexpr nifly::Vector3 TransformDiffMeshToNif(const nifly::Vector3& diff) {
 		// This function efficiently calculates xformMeshToNif::ApplyTransformToDiff(diff)
 		return nifly::Vector3(
 			diff.x * -10.0f,
@@ -234,7 +234,7 @@ public:
 			diff.y * 10.0f);
 	}
 
-	static constexpr nifly::Vector3 DirNifToMesh(const nifly::Vector3& dir) {
+	static constexpr nifly::Vector3 TransformDirNifToMesh(const nifly::Vector3& dir) {
 		// This function efficiently calculates xformNifToMesh::ApplyTransformToDir(dir)
 		return nifly::Vector3(
 			-dir.x,
@@ -242,7 +242,7 @@ public:
 			dir.y);
 	}
 
-	static constexpr nifly::Vector3 DirMeshToNif(const nifly::Vector3& dir) {
+	static constexpr nifly::Vector3 TransformDirMeshToNif(const nifly::Vector3& dir) {
 		// This function efficiently calculates xformMeshToNif::ApplyTransformToDir(dir)
 		return nifly::Vector3(
 			-dir.x,
@@ -250,12 +250,12 @@ public:
 			dir.y);
 	}
 
-	static constexpr float DistNifToMesh(float d) {
+	static constexpr float TransformDistNifToMesh(float d) {
 		// This function calculates xformMeshToNif::ApplyTransformToDist(d)
 		return d / 10.0f;
 	}
 
-	static constexpr float DistMeshToNif(float d) {
+	static constexpr float TransformDistMeshToNif(float d) {
 		// This function calculates xformMeshToNif::ApplyTransformToDist(d)
 		return d * 10.0f;
 	}
@@ -272,35 +272,35 @@ public:
 		matModel = xformMeshToModel.ToGLMMatrix<glm::mat4x4>();
 	}
 
-	nifly::Vector3 PosMeshToModel(const nifly::Vector3 &pos) {
+	nifly::Vector3 TransformPosMeshToModel(const nifly::Vector3 &pos) {
 		return xformMeshToModel.ApplyTransform(pos);
 	}
 
-	nifly::Vector3 PosModelToMesh(const nifly::Vector3 &pos) {
+	nifly::Vector3 TransformPosModelToMesh(const nifly::Vector3 &pos) {
 		return xformModelToMesh.ApplyTransform(pos);
 	}
 
-	nifly::Vector3 DirMeshToModel(const nifly::Vector3 &dir) {
+	nifly::Vector3 TransformDirMeshToModel(const nifly::Vector3 &dir) {
 		return xformMeshToModel.ApplyTransformToDir(dir);
 	}
 
-	nifly::Vector3 DirModelToMesh(const nifly::Vector3 &dir) {
+	nifly::Vector3 TransformDirModelToMesh(const nifly::Vector3 &dir) {
 		return xformModelToMesh.ApplyTransformToDir(dir);
 	}
 
-	nifly::Vector3 DiffMeshToModel(const nifly::Vector3 &diff) {
+	nifly::Vector3 TransformDiffMeshToModel(const nifly::Vector3 &diff) {
 		return xformMeshToModel.ApplyTransformToDiff(diff);
 	}
 
-	nifly::Vector3 DiffModelToMesh(const nifly::Vector3 &diff) {
+	nifly::Vector3 TransformDiffModelToMesh(const nifly::Vector3 &diff) {
 		return xformModelToMesh.ApplyTransformToDiff(diff);
 	}
 
-	float DistMeshToModel(float dist) {
+	float TransformDistMeshToModel(float dist) {
 		return xformMeshToModel.ApplyTransformToDist(dist);
 	}
 
-	float DistModelToMesh(float dist) {
+	float TransformDistModelToMesh(float dist) {
 		return xformModelToMesh.ApplyTransformToDist(dist);
 	}
 

--- a/src/components/TweakBrush.cpp
+++ b/src/components/TweakBrush.cpp
@@ -284,7 +284,7 @@ TB_Inflate::~TB_Inflate() {}
 void TB_Inflate::brushAction(mesh* m, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
 	Matrix4 xform;
 	float meshstrength = m->TransformDistModelToMesh(strength);
-	xform.Translate(pickInfo.normal * meshstrength);
+	xform.Translate(m->TransformDirModelToMesh(pickInfo.normal) * meshstrength);
 	Vector3 vs;
 	Vector3 ve;
 	Vector3 vf;

--- a/src/components/TweakBrush.cpp
+++ b/src/components/TweakBrush.cpp
@@ -67,7 +67,7 @@ void TweakStroke::updateStroke(TweakPickInfo& pickInfo) {
 
 			// Get rid of model space from collision again
 			if (brushType == TweakBrush::BrushType::Move)
-				pickInfo.origin = mesh::ApplyMatrix4(glm::inverse(m->matModel), originSave);
+				pickInfo.origin = m->PosModelToMesh(originSave);
 
 			if (!refBrush->queryPoints(m, pickInfo, mirrorPick, nullptr, nPts1, affectedNodes[m]))
 				continue;
@@ -908,7 +908,7 @@ void TB_XForm::brushAction(mesh* m, TweakPickInfo& pickInfo, const int*, int, Un
 	dv.y *= pick.view.y;
 	dv.z *= pick.view.z;
 
-	Vector3 center = mesh::ApplyMatrix4(glm::inverse(m->matModel), pick.center);
+	Vector3 center = m->PosModelToMesh(pick.center);
 
 	Matrix4 xform;
 	if (xformType == 0) {
@@ -945,8 +945,8 @@ void TB_XForm::brushAction(mesh* m, TweakPickInfo& pickInfo, const int*, int, Un
 	else if (xformType == 3) {
 		xform.PushTranslate(center);
 
-		Vector3 a = mesh::ApplyMatrix4(glm::inverse(m->matModel), pick.origin) - center;
-		Vector3 b = mesh::ApplyMatrix4(glm::inverse(m->matModel), pickInfo.origin) - center;
+		Vector3 a = m->PosModelToMesh(pick.origin) - center;
+		Vector3 b = m->PosModelToMesh(pickInfo.origin) - center;
 		Vector3 dist = a + b;
 
 		float scale = (dist.x + dist.y) / 2.0f;

--- a/src/components/TweakBrush.cpp
+++ b/src/components/TweakBrush.cpp
@@ -67,7 +67,7 @@ void TweakStroke::updateStroke(TweakPickInfo& pickInfo) {
 
 			// Get rid of model space from collision again
 			if (brushType == TweakBrush::BrushType::Move)
-				pickInfo.origin = m->PosModelToMesh(originSave);
+				pickInfo.origin = m->TransformPosModelToMesh(originSave);
 
 			if (!refBrush->queryPoints(m, pickInfo, mirrorPick, nullptr, nPts1, affectedNodes[m]))
 				continue;
@@ -908,7 +908,7 @@ void TB_XForm::brushAction(mesh* m, TweakPickInfo& pickInfo, const int*, int, Un
 	dv.y *= pick.view.y;
 	dv.z *= pick.view.z;
 
-	Vector3 center = m->PosModelToMesh(pick.center);
+	Vector3 center = m->TransformPosModelToMesh(pick.center);
 
 	Matrix4 xform;
 	if (xformType == 0) {
@@ -945,8 +945,8 @@ void TB_XForm::brushAction(mesh* m, TweakPickInfo& pickInfo, const int*, int, Un
 	else if (xformType == 3) {
 		xform.PushTranslate(center);
 
-		Vector3 a = m->PosModelToMesh(pick.origin) - center;
-		Vector3 b = m->PosModelToMesh(pickInfo.origin) - center;
+		Vector3 a = m->TransformPosModelToMesh(pick.origin) - center;
+		Vector3 b = m->TransformPosModelToMesh(pickInfo.origin) - center;
 		Vector3 dist = a + b;
 
 		float scale = (dist.x + dist.y) / 2.0f;

--- a/src/components/TweakBrush.cpp
+++ b/src/components/TweakBrush.cpp
@@ -37,7 +37,6 @@ void TweakStroke::updateStroke(TweakPickInfo& pickInfo) {
 	TweakPickInfo mirrorPick = pickInfo;
 	mirrorPick.origin.x *= -1.0f;
 	mirrorPick.normal.x *= -1.0f;
-	mirrorPick.facet = pickInfo.facetM;
 
 	if (!newStroke) {
 		if (!refBrush->checkSpacing(lastPoint, pickInfo.origin))
@@ -58,16 +57,10 @@ void TweakStroke::updateStroke(TweakPickInfo& pickInfo) {
 	// Move/transform handles most operations differently than other brushes.
 	// Mirroring is done internally, most of the pick info values are ignored.
 	if (brushType == TweakBrush::BrushType::Move || brushType == TweakBrush::BrushType::Transform) {
-		Vector3 originSave = pickInfo.origin;
-		Vector3 centerSave = pickInfo.center;
 		for (int mi = 0; mi < nMesh; ++mi) {
 			mesh* m = refMeshes[mi];
 			UndoStateShape& uss = usp.usss[mi];
 			int nPts1 = 0;
-
-			// Get rid of model space from collision again
-			if (brushType == TweakBrush::BrushType::Move)
-				pickInfo.origin = m->TransformPosModelToMesh(originSave);
 
 			if (!refBrush->queryPoints(m, pickInfo, mirrorPick, nullptr, nPts1, affectedNodes[m]))
 				continue;
@@ -79,8 +72,6 @@ void TweakStroke::updateStroke(TweakPickInfo& pickInfo) {
 				normalUpdates.push_back(std::move(pending));
 			}
 		}
-		pickInfo.origin = originSave;
-		pickInfo.center = centerSave;
 	}
 	else {
 		for (int mi = 0; mi < nMesh; ++mi) {
@@ -168,7 +159,6 @@ void TweakStroke::endStroke() {
 TweakBrush::TweakBrush()
 	: radius(0.45f)
 	, focus(0.50f)
-	, inset(0.00f)
 	, strength(0.0015f)
 	, spacing(0.015f) {
 	bMirror = true;
@@ -199,9 +189,9 @@ bool TweakBrush::checkSpacing(Vector3& start, Vector3& end) {
 		return false;
 }
 
-float TweakBrush::getFalloff(float dist) {
+float TweakBrush::getFalloff(float dist, float meshradius) {
 	// Beyond the radius, no strength
-	if (dist > radius)
+	if (dist > meshradius)
 		return 0.0;
 
 	// No distance, keep strength
@@ -209,26 +199,29 @@ float TweakBrush::getFalloff(float dist) {
 		return 1.0;
 
 	float p = std::pow(6.0f, focus * 2.0f - 1.0f);
-	float x = std::pow(dist / radius, p);
+	float x = std::pow(dist / meshradius, p);
 	return (2 * x - 3) * x * x + 1;
 }
 
-void TweakBrush::applyFalloff(Vector3& deltaVec, float dist) {
-	deltaVec *= getFalloff(dist);
+void TweakBrush::applyFalloff(Vector3& deltaVec, float dist, float meshradius) {
+	deltaVec *= getFalloff(dist, meshradius);
 }
 
 bool TweakBrush::queryPoints(
-	mesh* refmesh, TweakPickInfo& pickInfo, TweakPickInfo& mirrorPick, int* resultPoints, int& outResultCount, std::unordered_set<AABBTree::AABBTreeNode*>& affectedNodes) {
+	mesh* m, TweakPickInfo& pickInfo, TweakPickInfo& mirrorPick, int* resultPoints, int& outResultCount, std::unordered_set<AABBTree::AABBTreeNode*>& affectedNodes) {
 	std::vector<IntersectResult> IResults;
+	float meshradius = m->TransformDistModelToMesh(radius);
+	Vector3 meshorigin = m->TransformPosModelToMesh(pickInfo.origin);
+	Vector3 meshmirrororigin = m->TransformPosModelToMesh(mirrorPick.origin);
 
-	if (!refmesh->bvh || !refmesh->bvh->IntersectSphere(pickInfo.origin, radius, &IResults))
+	if (!m->bvh || !m->bvh->IntersectSphere(meshorigin, meshradius, &IResults))
 		return false;
 	unsigned int mirrorStartInd = IResults.size();
 	bool mergeMirror = NeedMirrorMergedQuery();
 	if (mergeMirror)
-		refmesh->bvh->IntersectSphere(mirrorPick.origin, radius, &IResults);
+		m->bvh->IntersectSphere(meshmirrororigin, meshradius, &IResults);
 
-	std::unique_ptr<bool[]> pointVisit = std::make_unique<bool[]>(refmesh->nVerts);
+	std::unique_ptr<bool[]> pointVisit = std::make_unique<bool[]>(m->nVerts);
 
 	if (bConnected && !IResults.empty()) {
 		int pickFacet = IResults[0].HitFacet;
@@ -242,7 +235,7 @@ bool TweakBrush::queryPoints(
 		}
 
 		std::vector<int> resultFacets;
-		refmesh->ConnectedPointsInSphere(pickInfo.origin, radius * radius, pickFacet, nullptr, pointVisit.get(), resultPoints, outResultCount, resultFacets);
+		m->ConnectedPointsInSphere(meshorigin, meshradius * meshradius, pickFacet, nullptr, pointVisit.get(), resultPoints, outResultCount, resultFacets);
 		if (mergeMirror && mirrorStartInd < IResults.size()) {
 			pickFacet = IResults[mirrorStartInd].HitFacet;
 			minDist = IResults[mirrorStartInd].HitDistance;
@@ -253,7 +246,7 @@ bool TweakBrush::queryPoints(
 					pickFacet = r.HitFacet;
 				}
 			}
-			refmesh->ConnectedPointsInSphere(mirrorPick.origin, radius * radius, pickFacet, nullptr, pointVisit.get(), resultPoints, outResultCount, resultFacets);
+			m->ConnectedPointsInSphere(meshmirrororigin, meshradius * meshradius, pickFacet, nullptr, pointVisit.get(), resultPoints, outResultCount, resultFacets);
 		}
 	}
 	else
@@ -261,7 +254,7 @@ bool TweakBrush::queryPoints(
 
 	for (unsigned int i = 0; i < IResults.size(); i++) {
 		if (!bConnected) {
-			const Triangle& t = refmesh->tris[IResults[i].HitFacet];
+			const Triangle& t = m->tris[IResults[i].HitFacet];
 			if (!pointVisit[t.p1]) {
 				resultPoints[outResultCount++] = t.p1;
 				pointVisit[t.p1] = true;
@@ -288,38 +281,41 @@ TB_Inflate::TB_Inflate() {
 
 TB_Inflate::~TB_Inflate() {}
 
-void TB_Inflate::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
+void TB_Inflate::brushAction(mesh* m, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
 	Matrix4 xform;
-	xform.Translate(pickInfo.normal * strength);
+	float meshstrength = m->TransformDistModelToMesh(strength);
+	xform.Translate(pickInfo.normal * meshstrength);
 	Vector3 vs;
 	Vector3 ve;
 	Vector3 vf;
 	auto& startState = uss.pointStartState;
 	auto& endState = uss.pointEndState;
+	float meshradius = m->TransformDistModelToMesh(radius);
+	Vector3 meshorigin = m->TransformPosModelToMesh(pickInfo.origin);
 
 	for (int i = 0; i < nPoints; i++) {
-		vs = refmesh->verts[points[i]];
+		vs = m->verts[points[i]];
 		if (startState.find(points[i]) == startState.end())
 			startState[points[i]] = vs;
 		if (restrictNormal) {
-			const Vector3& n = cache[refmesh].startNorms[points[i]];
-			ve = n * strength;
+			const Vector3& n = cache[m].startNorms[points[i]];
+			ve = n * meshstrength;
 		}
 		else {
 			ve = xform * vs;
 			ve -= vs;
 		}
 
-		applyFalloff(ve, pickInfo.origin.DistanceTo(vs));
+		applyFalloff(ve, meshorigin.DistanceTo(vs), meshradius);
 
-		ve = ve * (1.0f - refmesh->mask[points[i]]);
+		ve = ve * (1.0f - m->mask[points[i]]);
 
 		vf = vs + ve;
 
-		endState[points[i]] = refmesh->verts[points[i]] = (vf);
+		endState[points[i]] = m->verts[points[i]] = (vf);
 	}
 
-	refmesh->QueueUpdate(mesh::UpdateType::Position);
+	m->QueueUpdate(mesh::UpdateType::Position);
 }
 
 TB_Mask::TB_Mask() {
@@ -332,17 +328,19 @@ TB_Mask::TB_Mask() {
 
 TB_Mask::~TB_Mask() {}
 
-void TB_Mask::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
+void TB_Mask::brushAction(mesh* m, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
 	Vector3 vs;
 	Vector3 vc;
 	Vector3 ve;
 	Vector3 vf;
 	auto& startState = uss.pointStartState;
 	auto& endState = uss.pointEndState;
+	float meshradius = m->TransformDistModelToMesh(radius);
+	Vector3 meshorigin = m->TransformPosModelToMesh(pickInfo.origin);
 
 	for (int i = 0; i < nPoints; i++) {
-		vs = refmesh->verts[points[i]];
-		vc = Vector3(refmesh->mask[points[i]], 0.0f, 0.0f);
+		vs = m->verts[points[i]];
+		vc = Vector3(m->mask[points[i]], 0.0f, 0.0f);
 		if (startState.find(points[i]) == startState.end())
 			startState[points[i]] = vc;
 
@@ -353,21 +351,21 @@ void TB_Mask::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* poi
 			ve.x += 1.0f;
 		ve -= vc;
 
-		float originToV = pickInfo.origin.DistanceTo(vs);
-		if (originToV > radius)
+		float originToV = meshorigin.DistanceTo(vs);
+		if (originToV > meshradius)
 			ve.Zero();
 		else if (strength < 1.0f)
-			applyFalloff(ve, originToV);
+			applyFalloff(ve, originToV, meshradius);
 
 		vf = vc + ve;
 		if (vf.x > 1.0f)
 			vf.x = 1.0f;
 
-		refmesh->mask[points[i]] = vf.x;
+		m->mask[points[i]] = vf.x;
 		endState[points[i]] = vf;
 	}
 
-	refmesh->QueueUpdate(mesh::UpdateType::Mask);
+	m->QueueUpdate(mesh::UpdateType::Mask);
 }
 
 TB_Unmask::TB_Unmask() {
@@ -380,17 +378,19 @@ TB_Unmask::TB_Unmask() {
 
 TB_Unmask::~TB_Unmask() {}
 
-void TB_Unmask::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
+void TB_Unmask::brushAction(mesh* m, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
 	Vector3 vs;
 	Vector3 vc;
 	Vector3 ve;
 	Vector3 vf;
 	auto& startState = uss.pointStartState;
 	auto& endState = uss.pointEndState;
+	float meshradius = m->TransformDistModelToMesh(radius);
+	Vector3 meshorigin = m->TransformPosModelToMesh(pickInfo.origin);
 
 	for (int i = 0; i < nPoints; i++) {
-		vs = refmesh->verts[points[i]];
-		vc = Vector3(refmesh->mask[points[i]], 0.0f, 0.0f);
+		vs = m->verts[points[i]];
+		vc = Vector3(m->mask[points[i]], 0.0f, 0.0f);
 		if (startState.find(points[i]) == startState.end())
 			startState[points[i]] = vc;
 
@@ -401,21 +401,21 @@ void TB_Unmask::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* p
 			ve.x -= 1.0f;
 		ve -= vc;
 
-		float originToV = pickInfo.origin.DistanceTo(vs);
-		if (originToV > radius)
+		float originToV = meshorigin.DistanceTo(vs);
+		if (originToV > meshradius)
 			ve.Zero();
 		else if (strength > -1.0f)
-			applyFalloff(ve, originToV);
+			applyFalloff(ve, originToV, meshradius);
 
 		vf = vc + ve;
 		if (vf.x < 0.0f)
 			vf.x = 0.0f;
 
-		refmesh->mask[points[i]] = vf.x;
+		m->mask[points[i]] = vf.x;
 		endState[points[i]] = vf;
 	}
 
-	refmesh->QueueUpdate(mesh::UpdateType::Mask);
+	m->QueueUpdate(mesh::UpdateType::Mask);
 }
 
 TB_SmoothMask::TB_SmoothMask() {
@@ -431,58 +431,58 @@ TB_SmoothMask::TB_SmoothMask() {
 
 TB_SmoothMask::~TB_SmoothMask() {}
 
-void TB_SmoothMask::lapFilter(mesh* refmesh, const int* points, int nPoints, std::unordered_map<int, Vector3>& wv) {
+void TB_SmoothMask::lapFilter(mesh* m, const int* points, int nPoints, std::unordered_map<int, Vector3>& wv) {
 	int adjPoints[1000];
 
 	for (int i = 0; i < nPoints; i++) {
-		int c = refmesh->GetAdjacentPoints(points[i], adjPoints, 1000);
+		int c = m->GetAdjacentPoints(points[i], adjPoints, 1000);
 		if (c == 0)
 			continue;
 		// average adjacent points positions, using values from last iteration.
 		Vector3 d;
 		for (int n = 0; n < c; n++)
-			d += Vector3(refmesh->mask[adjPoints[n]], 0.0f, 0.0f);
+			d += Vector3(m->mask[adjPoints[n]], 0.0f, 0.0f);
 		wv[points[i]] = d / (float)c;
 
-		if (refmesh->weldVerts.find(points[i]) != refmesh->weldVerts.end()) {
-			for (unsigned int v = 0; v < refmesh->weldVerts[points[i]].size(); v++) {
-				wv[refmesh->weldVerts[points[i]][v]] = wv[points[i]];
+		if (m->weldVerts.find(points[i]) != m->weldVerts.end()) {
+			for (unsigned int v = 0; v < m->weldVerts[points[i]].size(); v++) {
+				wv[m->weldVerts[points[i]][v]] = wv[points[i]];
 			}
 		}
 	}
 }
 
-void TB_SmoothMask::hclapFilter(mesh* refmesh, const int* points, int nPoints, std::unordered_map<int, Vector3>& wv, UndoStateShape& uss) {
-	std::vector<Vector3> b(refmesh->nVerts);
+void TB_SmoothMask::hclapFilter(mesh* m, const int* points, int nPoints, std::unordered_map<int, Vector3>& wv, UndoStateShape& uss) {
+	std::vector<Vector3> b(m->nVerts);
 
 	int adjPoints[1000];
 	// First step is to calculate the laplacian
 	for (int p = 0; p < nPoints; p++) {
 		int i = points[p];
-		int c = refmesh->GetAdjacentPoints(i, adjPoints, 1000);
+		int c = m->GetAdjacentPoints(i, adjPoints, 1000);
 		if (c == 0)
 			continue;
 		// average adjacent points positions, using values from last iteration.
 		Vector3 d;
 		for (int n = 0; n < c; n++)
-			d += Vector3(refmesh->mask[adjPoints[n]], 0.0f, 0.0f);
+			d += Vector3(m->mask[adjPoints[n]], 0.0f, 0.0f);
 		wv[i] = d / (float)c;
 		// Calculate the difference between the new position and a blend of the original and previous positions
-		b[i] = wv[i] - ((uss.pointStartState[i] * hcAlpha) + (Vector3(refmesh->mask[i], 0.0f, 0.0f) * (1.0f - hcAlpha)));
+		b[i] = wv[i] - ((uss.pointStartState[i] * hcAlpha) + (Vector3(m->mask[i], 0.0f, 0.0f) * (1.0f - hcAlpha)));
 	}
 
 	for (int p = 0; p < nPoints; p++) {
 		int i = points[p];
 		// Check if it's a welded vertex; only do welded vertices once.
 		bool skip = false;
-		if (refmesh->weldVerts.find(i) != refmesh->weldVerts.end())
-			for (unsigned int v = 0; v < refmesh->weldVerts[i].size(); v++)
-				if (refmesh->weldVerts[i][v] < i)
+		if (m->weldVerts.find(i) != m->weldVerts.end())
+			for (unsigned int v = 0; v < m->weldVerts[i].size(); v++)
+				if (m->weldVerts[i][v] < i)
 					skip = true;
 		if (skip)
 			continue;
 		// Average 'b' for adjacent points
-		int c = refmesh->GetAdjacentPoints(i, adjPoints, 1000);
+		int c = m->GetAdjacentPoints(i, adjPoints, 1000);
 		if (c == 0)
 			continue;
 		Vector3 d;
@@ -493,43 +493,45 @@ void TB_SmoothMask::hclapFilter(mesh* refmesh, const int* points, int nPoints, s
 		float avgB = (1 - hcBeta) / (float)c;
 		wv[i] -= ((b[i] * hcBeta) + (d * avgB));
 
-		if (refmesh->weldVerts.find(i) != refmesh->weldVerts.end()) {
-			for (unsigned int v = 0; v < refmesh->weldVerts[i].size(); v++) {
-				wv[refmesh->weldVerts[i][v]] = wv[i];
+		if (m->weldVerts.find(i) != m->weldVerts.end()) {
+			for (unsigned int v = 0; v < m->weldVerts[i].size(); v++) {
+				wv[m->weldVerts[i][v]] = wv[i];
 			}
 		}
 	}
 }
 
-void TB_SmoothMask::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
+void TB_SmoothMask::brushAction(mesh* m, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
 	std::unordered_map<int, Vector3> wv;
 	Vector3 vs;
 	Vector3 vc;
 	float vm;
 	auto& startState = uss.pointStartState;
 	auto& endState = uss.pointEndState;
+	float meshradius = m->TransformDistModelToMesh(radius);
+	Vector3 meshorigin = m->TransformPosModelToMesh(pickInfo.origin);
 
 	for (int i = 0; i < nPoints; i++) {
-		vc = Vector3(refmesh->mask[points[i]], 0.0f, 0.0f);
+		vc = Vector3(m->mask[points[i]], 0.0f, 0.0f);
 		if (startState.find(points[i]) == startState.end())
 			startState[points[i]] = vc;
 		wv[points[i]] = vc;
 	}
 
 	if (method == 0) // laplacian smooth
-		lapFilter(refmesh, points, nPoints, wv);
+		lapFilter(m, points, nPoints, wv);
 	else // HC-laplacian smooth
-		hclapFilter(refmesh, points, nPoints, wv, uss);
+		hclapFilter(m, points, nPoints, wv, uss);
 
 	Vector3 delta;
 	for (int p = 0; p < nPoints; p++) {
 		int i = points[p];
-		vs = refmesh->verts[i];
-		vm = refmesh->mask[i];
+		vs = m->verts[i];
+		vm = m->mask[i];
 		delta.x = wv[i].x - vm;
 		delta.x *= strength;
 
-		applyFalloff(delta, pickInfo.origin.DistanceTo(vs));
+		applyFalloff(delta, meshorigin.DistanceTo(vs), meshradius);
 
 		vm += delta.x;
 
@@ -537,10 +539,10 @@ void TB_SmoothMask::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const in
 			vm = 0.0f;
 		if (vm > 1.0f)
 			vm = 1.0f;
-		endState[i].x = refmesh->mask[i] = vm;
+		endState[i].x = m->mask[i] = vm;
 	}
 
-	refmesh->QueueUpdate(mesh::UpdateType::Mask);
+	m->QueueUpdate(mesh::UpdateType::Mask);
 }
 
 TB_Deflate::TB_Deflate() {
@@ -568,58 +570,58 @@ TB_Smooth::TB_Smooth() {
 
 TB_Smooth::~TB_Smooth() {}
 
-void TB_Smooth::lapFilter(mesh* refmesh, const int* points, int nPoints, std::unordered_map<int, Vector3>& wv) {
+void TB_Smooth::lapFilter(mesh* m, const int* points, int nPoints, std::unordered_map<int, Vector3>& wv) {
 	int adjPoints[1000];
 
 	for (int i = 0; i < nPoints; i++) {
-		int c = refmesh->GetAdjacentPoints(points[i], adjPoints, 1000);
+		int c = m->GetAdjacentPoints(points[i], adjPoints, 1000);
 		if (c == 0)
 			continue;
 		// average adjacent points positions, using values from last iteration.
 		Vector3 d;
 		for (int n = 0; n < c; n++)
-			d += refmesh->verts[adjPoints[n]];
+			d += m->verts[adjPoints[n]];
 		wv[points[i]] = d / (float)c;
 
-		if (refmesh->weldVerts.find(points[i]) != refmesh->weldVerts.end()) {
-			for (unsigned int v = 0; v < refmesh->weldVerts[points[i]].size(); v++) {
-				wv[refmesh->weldVerts[points[i]][v]] = wv[points[i]];
+		if (m->weldVerts.find(points[i]) != m->weldVerts.end()) {
+			for (unsigned int v = 0; v < m->weldVerts[points[i]].size(); v++) {
+				wv[m->weldVerts[points[i]][v]] = wv[points[i]];
 			}
 		}
 	}
 }
 
-void TB_Smooth::hclapFilter(mesh* refmesh, const int* points, int nPoints, std::unordered_map<int, Vector3>& wv, UndoStateShape& uss) {
-	std::vector<Vector3> b(refmesh->nVerts);
+void TB_Smooth::hclapFilter(mesh* m, const int* points, int nPoints, std::unordered_map<int, Vector3>& wv, UndoStateShape& uss) {
+	std::vector<Vector3> b(m->nVerts);
 
 	int adjPoints[1000];
 	// First step is to calculate the laplacian
 	for (int p = 0; p < nPoints; p++) {
 		int i = points[p];
-		int c = refmesh->GetAdjacentPoints(i, adjPoints, 1000);
+		int c = m->GetAdjacentPoints(i, adjPoints, 1000);
 		if (c == 0)
 			continue;
 		// average adjacent points positions, using values from last iteration.
 		Vector3 d;
 		for (int n = 0; n < c; n++)
-			d += refmesh->verts[adjPoints[n]];
+			d += m->verts[adjPoints[n]];
 		wv[i] = d / (float)c;
 		// Calculate the difference between the new position and a blend of the original and previous positions
-		b[i] = wv[i] - ((uss.pointStartState[i] * hcAlpha) + (refmesh->verts[i] * (1.0f - hcAlpha)));
+		b[i] = wv[i] - ((uss.pointStartState[i] * hcAlpha) + (m->verts[i] * (1.0f - hcAlpha)));
 	}
 
 	for (int p = 0; p < nPoints; p++) {
 		int i = points[p];
 		// Check if it's a welded vertex; only do welded vertices once.
 		bool skip = false;
-		if (refmesh->weldVerts.find(i) != refmesh->weldVerts.end())
-			for (unsigned int v = 0; v < refmesh->weldVerts[i].size(); v++)
-				if (refmesh->weldVerts[i][v] < i)
+		if (m->weldVerts.find(i) != m->weldVerts.end())
+			for (unsigned int v = 0; v < m->weldVerts[i].size(); v++)
+				if (m->weldVerts[i][v] < i)
 					skip = true;
 		if (skip)
 			continue;
 		// Average 'b' for adjacent points
-		int c = refmesh->GetAdjacentPoints(i, adjPoints, 1000);
+		int c = m->GetAdjacentPoints(i, adjPoints, 1000);
 		if (c == 0)
 			continue;
 		Vector3 d;
@@ -630,58 +632,60 @@ void TB_Smooth::hclapFilter(mesh* refmesh, const int* points, int nPoints, std::
 		float avgB = (1 - hcBeta) / (float)c;
 		wv[i] -= ((b[i] * hcBeta) + (d * avgB));
 
-		if (refmesh->weldVerts.find(i) != refmesh->weldVerts.end())
-			for (unsigned int v = 0; v < refmesh->weldVerts[i].size(); v++)
-				wv[refmesh->weldVerts[i][v]] = wv[i];
+		if (m->weldVerts.find(i) != m->weldVerts.end())
+			for (unsigned int v = 0; v < m->weldVerts[i].size(); v++)
+				wv[m->weldVerts[i][v]] = wv[i];
 	}
 }
 
-void TB_Smooth::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
+void TB_Smooth::brushAction(mesh* m, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
 	std::unordered_map<int, Vector3> wv;
 	Vector3 vs;
 	auto& startState = uss.pointStartState;
 	auto& endState = uss.pointEndState;
+	float meshradius = m->TransformDistModelToMesh(radius);
+	Vector3 meshorigin = m->TransformPosModelToMesh(pickInfo.origin);
 
 	for (int i = 0; i < nPoints; i++) {
-		vs = refmesh->verts[points[i]];
+		vs = m->verts[points[i]];
 		if (startState.find(points[i]) == startState.end())
 			startState[points[i]] = vs;
 		wv[points[i]] = vs;
 	}
 
 	if (method == 0) // laplacian smooth
-		lapFilter(refmesh, points, nPoints, wv);
+		lapFilter(m, points, nPoints, wv);
 	else // HC-laplacian smooth
-		hclapFilter(refmesh, points, nPoints, wv, uss);
+		hclapFilter(m, points, nPoints, wv, uss);
 
 	Vector3 delta;
 	for (int p = 0; p < nPoints; p++) {
 		int i = points[p];
-		vs = refmesh->verts[i];
-		delta = wv[i] - refmesh->verts[i];
+		vs = m->verts[i];
+		delta = wv[i] - m->verts[i];
 		delta *= strength;
-		applyFalloff(delta, pickInfo.origin.DistanceTo(vs));
+		applyFalloff(delta, meshorigin.DistanceTo(vs), meshradius);
 
-		delta = delta * (1.0f - refmesh->mask[i]);
-		Vector3 ve = refmesh->verts[i] + delta;
+		delta = delta * (1.0f - m->mask[i]);
+		Vector3 ve = m->verts[i] + delta;
 
 		if (restrictNormal) {
-			const Vector3& n = cache[refmesh].startNorms[i];
+			const Vector3& n = cache[m].startNorms[i];
 			ve = startState[i] + n * (ve - startState[i]).dot(n);
 		}
 
 		if (restrictPlane) {
-			const Vector3& n = cache[refmesh].startNorms[i];
+			const Vector3& n = cache[m].startNorms[i];
 			ve -= startState[i];
 			ve -= n * ve.dot(n);
 			ve += startState[i];
 		}
 
-		refmesh->verts[i] = ve;
+		m->verts[i] = ve;
 		endState[i] = ve;
 	}
 
-	refmesh->QueueUpdate(mesh::UpdateType::Position);
+	m->QueueUpdate(mesh::UpdateType::Position);
 }
 
 TB_Undiff::TB_Undiff() {
@@ -706,6 +710,8 @@ void TB_Undiff::strokeInit(const std::vector<mesh*>& refMeshes, TweakPickInfo& p
 void TB_Undiff::brushAction(mesh* m, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
 	TweakBrushMeshCache* meshCache = &cache[m];
 	std::vector<Vector3>& basePosition = meshCache->positionData;
+	float meshradius = m->TransformDistModelToMesh(radius);
+	Vector3 meshorigin = m->TransformPosModelToMesh(pickInfo.origin);
 
 	int p;
 	Vector3 vs;
@@ -730,7 +736,7 @@ void TB_Undiff::brushAction(mesh* m, TweakPickInfo& pickInfo, const int* points,
 			dv = bp - vs;
 			ve = dv * strength;
 
-			applyFalloff(ve, pickInfo.origin.DistanceTo(vs));
+			applyFalloff(ve, meshorigin.DistanceTo(vs), meshradius);
 
 			ve = ve * (1.0f - m->mask[p]);
 			vf = vs + ve;
@@ -757,7 +763,6 @@ void TB_Move::strokeInit(const std::vector<mesh*>& refMeshes, TweakPickInfo& pic
 	mpick = pickInfo;
 	mpick.origin.x = -mpick.origin.x;
 	mpick.view.x = -mpick.view.x;
-	mpick.facet = pickInfo.facetM;
 	d = pick.origin.dot(pick.view);
 	md = mpick.origin.dot(mpick.view);
 
@@ -811,17 +816,11 @@ bool TB_Move::queryPoints(mesh* m, TweakPickInfo&, TweakPickInfo&, int* resultPo
 }
 
 void TB_Move::brushAction(mesh* m, TweakPickInfo& pickInfo, const int*, int, UndoStateShape& uss) {
-	float dist = pickInfo.origin.dot(pick.view) - d;
-	Vector3 v = pickInfo.origin - pick.view * dist;
-	Vector3 dv = v - pick.origin;
-
-	Matrix4 xform;
-	xform.Translate(dv * strength);
-	Vector3 vs;
-	Vector3 ve;
-	Vector3 vf;
 	auto& startState = uss.pointStartState;
 	auto& endState = uss.pointEndState;
+	float meshradius = m->TransformDistModelToMesh(radius);
+	Vector3 start = m->TransformPosModelToMesh(pick.origin);
+	Vector3 mirrorstart = m->TransformPosModelToMesh(mpick.origin);
 
 	TweakBrushMeshCache* meshCache = &cache[m];
 	if (bMirror) {
@@ -829,20 +828,18 @@ void TB_Move::brushAction(mesh* m, TweakPickInfo& pickInfo, const int*, int, Und
 		lmo.x = -pickInfo.origin.x;
 		lmo.y = pickInfo.origin.y;
 		lmo.z = pickInfo.origin.z;
-		dist = lmo.dot(mpick.view) - md;
-		v = lmo - mpick.view * dist;
-		dv = v - mpick.origin;
-		Matrix4 xformMirror;
-		xformMirror.Translate(dv * strength);
+		float dist = lmo.dot(mpick.view) - md;
+		Vector3 v = lmo - mpick.view * dist;
+		Vector3 dv = (v - mpick.origin) * strength;
+		Vector3 meshdv = m->TransformDiffModelToMesh(dv);
 
 		for (int p = 0; p < meshCache->nCachedPointsM; p++) {
 			int i = meshCache->cachedPointsM[p];
-			vs = startState[i];
-			if (mpick.origin.DistanceTo(vs) > pick.origin.DistanceTo(vs))
+			Vector3 vs = startState[i];
+			if (mirrorstart.DistanceTo(vs) > start.DistanceTo(vs))
 				continue;
-			ve = xformMirror * vs;
-			ve -= vs;
-			applyFalloff(ve, mpick.origin.DistanceTo(vs));
+			Vector3 ve = meshdv;
+			applyFalloff(ve, mirrorstart.DistanceTo(vs), meshradius);
 
 			if (m->mask)
 				ve = ve * (1.0f - m->mask[i]);
@@ -857,20 +854,24 @@ void TB_Move::brushAction(mesh* m, TweakPickInfo& pickInfo, const int*, int, Und
 				ve -= n * ve.dot(n);
 			}
 
-			vf = vs + ve;
+			Vector3 vf = vs + ve;
 
 			endState[i] = m->verts[i] = (vf);
 		}
 	}
 
+	float dist = pickInfo.origin.dot(pick.view) - d;
+	Vector3 v = pickInfo.origin - pick.view * dist;
+	Vector3 dv = (v - pick.origin) * strength;
+	Vector3 meshdv = m->TransformDiffModelToMesh(dv);
+
 	for (int p = 0; p < meshCache->nCachedPoints; p++) {
 		int i = meshCache->cachedPoints[p];
-		vs = startState[i];
-		if (bMirror && pick.origin.DistanceTo(vs) > mpick.origin.DistanceTo(vs))
+		Vector3 vs = startState[i];
+		if (bMirror && start.DistanceTo(vs) > mirrorstart.DistanceTo(vs))
 			continue;
-		ve = xform * vs;
-		ve -= vs;
-		applyFalloff(ve, pick.origin.DistanceTo(vs));
+		Vector3 ve = meshdv;
+		applyFalloff(ve, start.DistanceTo(vs), meshradius);
 
 		if (m->mask)
 			ve = ve * (1.0f - m->mask[i]);
@@ -885,7 +886,7 @@ void TB_Move::brushAction(mesh* m, TweakPickInfo& pickInfo, const int*, int, Und
 			ve -= n * ve.dot(n);
 		}
 
-		vf = vs + ve;
+		Vector3 vf = vs + ve;
 
 		endState[i] = m->verts[i] = (vf);
 	}
@@ -951,6 +952,7 @@ void TB_XForm::brushAction(mesh* m, TweakPickInfo& pickInfo, const int*, int, Un
 	auto& startState = uss.pointStartState;
 	auto& endState = uss.pointEndState;
 
+	// Project dv onto movement axis (which is stored in pick.view)
 	dv.x *= pick.view.x;
 	dv.y *= pick.view.y;
 	dv.z *= pick.view.z;
@@ -959,7 +961,7 @@ void TB_XForm::brushAction(mesh* m, TweakPickInfo& pickInfo, const int*, int, Un
 
 	Matrix4 xform;
 	if (xformType == 0) {
-		xform.Translate(dv * strength);
+		xform.Translate(m->TransformDiffModelToMesh(dv) * strength);
 	}
 	else if (xformType == 1) {
 		xform.PushTranslate(center);
@@ -1044,21 +1046,25 @@ TB_Weight::TB_Weight() {
 
 TB_Weight::~TB_Weight() {}
 
-void TB_Weight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
+void TB_Weight::brushAction(mesh* m, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
 	BoneWeightAutoNormalizer nzer;
-	nzer.SetUp(&uss, animInfo, refmesh->shapeName, boneNames, lockedBoneNames, bXMirrorBone ? 2 : 1, bSpreadWeight);
+	nzer.SetUp(&uss, animInfo, m->shapeName, boneNames, lockedBoneNames, bXMirrorBone ? 2 : 1, bSpreadWeight);
 	nzer.GrabStartingWeights(points, nPoints);
+
+	float meshradius = m->TransformDistModelToMesh(radius);
+	Vector3 meshorigin = m->TransformPosModelToMesh(pickInfo.origin);
 
 	Vector3 mOrigin = pickInfo.origin;
 	mOrigin.x = -mOrigin.x;
+	mOrigin = m->TransformPosModelToMesh(mOrigin);
 
 	for (int pi = 0; pi < nPoints; pi++) {
 		int i = points[pi];
 		bool adjFlag[2] = {true, false};
-		float orDist = pickInfo.origin.DistanceTo(refmesh->verts[i]);
-		float morDist = mOrigin.DistanceTo(refmesh->verts[i]);
-		float falloff = getFalloff(orDist);
-		float mFalloff = getFalloff(morDist);
+		float orDist = meshorigin.DistanceTo(m->verts[i]);
+		float morDist = mOrigin.DistanceTo(m->verts[i]);
+		float falloff = getFalloff(orDist, meshradius);
+		float mFalloff = getFalloff(morDist, meshradius);
 		float b0falloff = falloff;
 
 		if (bMirror && morDist < orDist)
@@ -1068,7 +1074,7 @@ void TB_Weight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* p
 
 		float sw = uss.boneWeights[0].weights[i].endVal;
 		float str = bFixedWeight ? strength - sw : strength;
-		float maskF = 1.0f - refmesh->mask[i];
+		float maskF = 1.0f - m->mask[i];
 
 		uss.boneWeights[0].weights[i].endVal += str * maskF * b0falloff;
 
@@ -1092,10 +1098,10 @@ void TB_Weight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* p
 		if (bNormalizeWeights)
 			nzer.AdjustWeights(i, adjFlag);
 
-		refmesh->weight[i] = uss.boneWeights[0].weights[i].endVal;
+		m->weight[i] = uss.boneWeights[0].weights[i].endVal;
 	}
 
-	refmesh->QueueUpdate(mesh::UpdateType::Weight);
+	m->QueueUpdate(mesh::UpdateType::Weight);
 }
 
 TB_Unweight::TB_Unweight() {
@@ -1109,21 +1115,25 @@ TB_Unweight::TB_Unweight() {
 
 TB_Unweight::~TB_Unweight() {}
 
-void TB_Unweight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
+void TB_Unweight::brushAction(mesh* m, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
 	BoneWeightAutoNormalizer nzer;
-	nzer.SetUp(&uss, animInfo, refmesh->shapeName, boneNames, lockedBoneNames, bXMirrorBone ? 2 : 1, bSpreadWeight);
+	nzer.SetUp(&uss, animInfo, m->shapeName, boneNames, lockedBoneNames, bXMirrorBone ? 2 : 1, bSpreadWeight);
 	nzer.GrabStartingWeights(points, nPoints);
+
+	float meshradius = m->TransformDistModelToMesh(radius);
+	Vector3 meshorigin = m->TransformPosModelToMesh(pickInfo.origin);
 
 	Vector3 mOrigin = pickInfo.origin;
 	mOrigin.x = -mOrigin.x;
+	mOrigin = m->TransformPosModelToMesh(mOrigin);
 
 	for (int pi = 0; pi < nPoints; pi++) {
 		int i = points[pi];
 		bool adjFlag[2] = {true, false};
-		float orDist = pickInfo.origin.DistanceTo(refmesh->verts[i]);
-		float morDist = mOrigin.DistanceTo(refmesh->verts[i]);
-		float falloff = getFalloff(orDist);
-		float mFalloff = getFalloff(morDist);
+		float orDist = meshorigin.DistanceTo(m->verts[i]);
+		float morDist = mOrigin.DistanceTo(m->verts[i]);
+		float falloff = getFalloff(orDist, meshradius);
+		float mFalloff = getFalloff(morDist, meshradius);
 		float b0falloff = falloff;
 
 		if (bMirror && morDist < orDist)
@@ -1131,7 +1141,7 @@ void TB_Unweight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int*
 
 		adjFlag[0] = b0falloff > 0.0;
 
-		float maskF = 1.0f - refmesh->mask[i];
+		float maskF = 1.0f - m->mask[i];
 
 		uss.boneWeights[0].weights[i].endVal += strength * maskF * b0falloff;
 
@@ -1153,10 +1163,10 @@ void TB_Unweight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int*
 		if (bNormalizeWeights)
 			nzer.AdjustWeights(i, adjFlag);
 
-		refmesh->weight[i] = uss.boneWeights[0].weights[i].endVal;
+		m->weight[i] = uss.boneWeights[0].weights[i].endVal;
 	}
 
-	refmesh->QueueUpdate(mesh::UpdateType::Weight);
+	m->QueueUpdate(mesh::UpdateType::Weight);
 }
 
 TB_SmoothWeight::TB_SmoothWeight() {
@@ -1173,40 +1183,40 @@ TB_SmoothWeight::TB_SmoothWeight() {
 
 TB_SmoothWeight::~TB_SmoothWeight() {}
 
-void TB_SmoothWeight::lapFilter(mesh* refmesh, const int* points, int nPoints, std::unordered_map<int, float>& wv) {
+void TB_SmoothWeight::lapFilter(mesh* m, const int* points, int nPoints, std::unordered_map<int, float>& wv) {
 	int adjPoints[1000];
 
 	for (int i = 0; i < nPoints; i++) {
-		int c = refmesh->GetAdjacentPoints(points[i], adjPoints, 1000);
+		int c = m->GetAdjacentPoints(points[i], adjPoints, 1000);
 		if (c == 0)
 			continue;
 
 		// average adjacent points values, using values from last iteration.
 		float d = 0.0;
 		for (int n = 0; n < c; n++)
-			d += refmesh->weight[adjPoints[n]];
+			d += m->weight[adjPoints[n]];
 
 		wv[points[i]] = d / (float)c;
 
-		if (refmesh->weldVerts.find(points[i]) != refmesh->weldVerts.end()) {
-			for (unsigned int v = 0; v < refmesh->weldVerts[points[i]].size(); v++) {
-				wv[refmesh->weldVerts[points[i]][v]] = wv[points[i]];
+		if (m->weldVerts.find(points[i]) != m->weldVerts.end()) {
+			for (unsigned int v = 0; v < m->weldVerts[points[i]].size(); v++) {
+				wv[m->weldVerts[points[i]][v]] = wv[points[i]];
 			}
 		}
 	}
 }
 
 void TB_SmoothWeight::hclapFilter(
-	mesh* refmesh, const int* points, int nPoints, std::unordered_map<int, float>& wv, UndoStateShape& uss, const int boneInd, const std::unordered_map<uint16_t, float>* wPtr) {
+	mesh* m, const int* points, int nPoints, std::unordered_map<int, float>& wv, UndoStateShape& uss, const int boneInd, const std::unordered_map<uint16_t, float>* wPtr) {
 	auto& ubw = uss.boneWeights[boneInd].weights;
-	std::vector<float> b(refmesh->nVerts);
+	std::vector<float> b(m->nVerts);
 
 	int adjPoints[1000];
 
 	// First step is to calculate the laplacian
 	for (int p = 0; p < nPoints; p++) {
 		int i = points[p];
-		int c = refmesh->GetAdjacentPoints(i, adjPoints, 1000);
+		int c = m->GetAdjacentPoints(i, adjPoints, 1000);
 		if (c == 0)
 			continue;
 
@@ -1232,16 +1242,16 @@ void TB_SmoothWeight::hclapFilter(
 
 		// Check if it's a welded vertex; only do welded vertices once.
 		bool skip = false;
-		if (refmesh->weldVerts.find(i) != refmesh->weldVerts.end())
-			for (unsigned int v = 0; v < refmesh->weldVerts[i].size(); v++)
-				if (refmesh->weldVerts[i][v] < i)
+		if (m->weldVerts.find(i) != m->weldVerts.end())
+			for (unsigned int v = 0; v < m->weldVerts[i].size(); v++)
+				if (m->weldVerts[i][v] < i)
 					skip = true;
 
 		if (skip)
 			continue;
 
 		// Average 'b' for adjacent points
-		int c = refmesh->GetAdjacentPoints(i, adjPoints, 1000);
+		int c = m->GetAdjacentPoints(i, adjPoints, 1000);
 		if (c == 0)
 			continue;
 
@@ -1254,21 +1264,25 @@ void TB_SmoothWeight::hclapFilter(
 		float avgB = (1 - hcBeta) / (float)c;
 		wv[i] -= ((b[i] * hcBeta) + (d * avgB));
 
-		if (refmesh->weldVerts.find(i) != refmesh->weldVerts.end()) {
-			for (unsigned int v = 0; v < refmesh->weldVerts[i].size(); v++) {
-				wv[refmesh->weldVerts[i][v]] = wv[i];
+		if (m->weldVerts.find(i) != m->weldVerts.end()) {
+			for (unsigned int v = 0; v < m->weldVerts[i].size(); v++) {
+				wv[m->weldVerts[i][v]] = wv[i];
 			}
 		}
 	}
 }
 
-void TB_SmoothWeight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
+void TB_SmoothWeight::brushAction(mesh* m, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
 	BoneWeightAutoNormalizer nzer;
-	nzer.SetUp(&uss, animInfo, refmesh->shapeName, boneNames, lockedBoneNames, bXMirrorBone ? 2 : 1, bSpreadWeight);
+	nzer.SetUp(&uss, animInfo, m->shapeName, boneNames, lockedBoneNames, bXMirrorBone ? 2 : 1, bSpreadWeight);
 	nzer.GrabStartingWeights(points, nPoints);
+
+	float meshradius = m->TransformDistModelToMesh(radius);
+	Vector3 meshorigin = m->TransformPosModelToMesh(pickInfo.origin);
 
 	Vector3 mOrigin = pickInfo.origin;
 	mOrigin.x = -mOrigin.x;
+	mOrigin = m->TransformPosModelToMesh(mOrigin);
 
 	// Copy previous iteration's results into wv
 	std::unordered_map<int, float> wv, mwv;
@@ -1281,24 +1295,24 @@ void TB_SmoothWeight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const 
 	}
 
 	if (method == 0) // laplacian smooth
-		lapFilter(refmesh, points, nPoints, wv);
+		lapFilter(m, points, nPoints, wv);
 	else // HC-laplacian smooth
-		hclapFilter(refmesh, points, nPoints, wv, uss, 0, animInfo->GetWeightsPtr(refmesh->shapeName, boneNames[0]));
+		hclapFilter(m, points, nPoints, wv, uss, 0, animInfo->GetWeightsPtr(m->shapeName, boneNames[0]));
 
 	if (bXMirrorBone) {
 		if (method == 0) // laplacian smooth
-			lapFilter(refmesh, points, nPoints, mwv);
+			lapFilter(m, points, nPoints, mwv);
 		else // HC-laplacian smooth
-			hclapFilter(refmesh, points, nPoints, mwv, uss, 1, animInfo->GetWeightsPtr(refmesh->shapeName, boneNames[1]));
+			hclapFilter(m, points, nPoints, mwv, uss, 1, animInfo->GetWeightsPtr(m->shapeName, boneNames[1]));
 	}
 
 	for (int pi = 0; pi < nPoints; pi++) {
 		int i = points[pi];
 		bool adjFlag[2] = {true, false};
-		float orDist = pickInfo.origin.DistanceTo(refmesh->verts[i]);
-		float morDist = mOrigin.DistanceTo(refmesh->verts[i]);
-		float falloff = getFalloff(orDist);
-		float mFalloff = getFalloff(morDist);
+		float orDist = meshorigin.DistanceTo(m->verts[i]);
+		float morDist = mOrigin.DistanceTo(m->verts[i]);
+		float falloff = getFalloff(orDist, meshradius);
+		float mFalloff = getFalloff(morDist, meshradius);
 		float b0falloff = falloff;
 
 		if (bMirror && morDist < orDist)
@@ -1307,7 +1321,7 @@ void TB_SmoothWeight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const 
 		adjFlag[0] = b0falloff > 0.0;
 
 		float str = wv[i] - uss.boneWeights[0].weights[i].endVal;
-		float maskF = 1.0f - refmesh->mask[i];
+		float maskF = 1.0f - m->mask[i];
 
 		uss.boneWeights[0].weights[i].endVal += str * maskF * b0falloff;
 
@@ -1331,10 +1345,10 @@ void TB_SmoothWeight::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const 
 		if (bNormalizeWeights)
 			nzer.AdjustWeights(i, adjFlag);
 
-		refmesh->weight[i] = uss.boneWeights[0].weights[i].endVal;
+		m->weight[i] = uss.boneWeights[0].weights[i].endVal;
 	}
 
-	refmesh->QueueUpdate(mesh::UpdateType::Weight);
+	m->QueueUpdate(mesh::UpdateType::Weight);
 }
 
 TB_Color::TB_Color() {
@@ -1348,22 +1362,24 @@ TB_Color::TB_Color() {
 
 TB_Color::~TB_Color() {}
 
-void TB_Color::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
+void TB_Color::brushAction(mesh* m, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
 	Vector3 vs;
 	Vector3 vc;
 	auto& startState = uss.pointStartState;
 	auto& endState = uss.pointEndState;
+	float meshradius = m->TransformDistModelToMesh(radius);
+	Vector3 meshorigin = m->TransformPosModelToMesh(pickInfo.origin);
 
 	for (int i = 0; i < nPoints; i++) {
-		vs = refmesh->verts[points[i]];
-		vc = refmesh->vcolors[points[i]];
+		vs = m->verts[points[i]];
+		vc = m->vcolors[points[i]];
 		if (startState.find(points[i]) == startState.end())
 			startState[points[i]] = vc;
 
-		float originToV = pickInfo.origin.DistanceTo(vs);
-		if (originToV <= radius) {
+		float originToV = meshorigin.DistanceTo(vs);
+		if (originToV <= meshradius) {
 			Vector3 falloff(strength, strength, strength);
-			applyFalloff(falloff, originToV);
+			applyFalloff(falloff, originToV, meshradius);
 
 			vc.x = color.x * falloff.x + vc.x * (1.0f - falloff.x);
 			vc.y = color.y * falloff.y + vc.y * (1.0f - falloff.y);
@@ -1385,10 +1401,10 @@ void TB_Color::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* po
 		else if (vc.z < 0.0f)
 			vc.z = 0.0f;
 
-		endState[points[i]] = refmesh->vcolors[points[i]] = vc;
+		endState[points[i]] = m->vcolors[points[i]] = vc;
 	}
 
-	refmesh->QueueUpdate(mesh::UpdateType::VertexColors);
+	m->QueueUpdate(mesh::UpdateType::VertexColors);
 }
 
 TB_Uncolor::TB_Uncolor() {
@@ -1402,22 +1418,24 @@ TB_Uncolor::TB_Uncolor() {
 
 TB_Uncolor::~TB_Uncolor() {}
 
-void TB_Uncolor::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
+void TB_Uncolor::brushAction(mesh* m, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
 	Vector3 vs;
 	Vector3 vc;
 	auto& startState = uss.pointStartState;
 	auto& endState = uss.pointEndState;
+	float meshradius = m->TransformDistModelToMesh(radius);
+	Vector3 meshorigin = m->TransformPosModelToMesh(pickInfo.origin);
 
 	for (int i = 0; i < nPoints; i++) {
-		vs = refmesh->verts[points[i]];
-		vc = refmesh->vcolors[points[i]];
+		vs = m->verts[points[i]];
+		vc = m->vcolors[points[i]];
 		if (startState.find(points[i]) == startState.end())
 			startState[points[i]] = vc;
 
-		float originToV = pickInfo.origin.DistanceTo(vs);
-		if (originToV <= radius) {
+		float originToV = meshorigin.DistanceTo(vs);
+		if (originToV <= meshradius) {
 			Vector3 falloff(-strength, -strength, -strength);
-			applyFalloff(falloff, originToV);
+			applyFalloff(falloff, originToV, meshradius);
 
 			vc.x = falloff.x + vc.x * (1.0f - falloff.x);
 			vc.y = falloff.y + vc.y * (1.0f - falloff.y);
@@ -1439,10 +1457,10 @@ void TB_Uncolor::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* 
 		else if (vc.z < 0.0f)
 			vc.z = 0.0f;
 
-		endState[points[i]] = refmesh->vcolors[points[i]] = vc;
+		endState[points[i]] = m->vcolors[points[i]] = vc;
 	}
 
-	refmesh->QueueUpdate(mesh::UpdateType::VertexColors);
+	m->QueueUpdate(mesh::UpdateType::VertexColors);
 }
 
 TB_Alpha::TB_Alpha() {
@@ -1456,17 +1474,19 @@ TB_Alpha::TB_Alpha() {
 
 TB_Alpha::~TB_Alpha() {}
 
-void TB_Alpha::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
+void TB_Alpha::brushAction(mesh* m, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
 	Vector3 vs;
 	float vc;
 	float ve;
 	float vf;
 	auto& startState = uss.pointStartState;
 	auto& endState = uss.pointEndState;
+	float meshradius = m->TransformDistModelToMesh(radius);
+	Vector3 meshorigin = m->TransformPosModelToMesh(pickInfo.origin);
 
 	for (int i = 0; i < nPoints; i++) {
-		vs = refmesh->verts[points[i]];
-		vc = refmesh->valpha[points[i]];
+		vs = m->verts[points[i]];
+		vc = m->valpha[points[i]];
 		if (startState.find(points[i]) == startState.end())
 			startState[points[i]].x = vc;
 
@@ -1478,20 +1498,20 @@ void TB_Alpha::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* po
 		ve -= vc;
 
 		Vector3 vev(ve, ve, ve);
-		float originToV = pickInfo.origin.DistanceTo(vs);
-		if (originToV > radius)
+		float originToV = meshorigin.DistanceTo(vs);
+		if (originToV > meshradius)
 			vev.Zero();
 		else if (strength < 1.0f)
-			applyFalloff(vev, originToV);
+			applyFalloff(vev, originToV, meshradius);
 
 		vf = vc + vev.x;
 		if (vf < clampMaxValue)
 			vf = clampMaxValue;
 
-		endState[points[i]].x = refmesh->valpha[points[i]] = vf;
+		endState[points[i]].x = m->valpha[points[i]] = vf;
 	}
 
-	refmesh->QueueUpdate(mesh::UpdateType::VertexAlpha);
+	m->QueueUpdate(mesh::UpdateType::VertexAlpha);
 }
 
 TB_Unalpha::TB_Unalpha() {
@@ -1505,17 +1525,19 @@ TB_Unalpha::TB_Unalpha() {
 
 TB_Unalpha::~TB_Unalpha() {}
 
-void TB_Unalpha::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
+void TB_Unalpha::brushAction(mesh* m, TweakPickInfo& pickInfo, const int* points, int nPoints, UndoStateShape& uss) {
 	Vector3 vs;
 	float vc;
 	float ve;
 	float vf;
 	auto& startState = uss.pointStartState;
 	auto& endState = uss.pointEndState;
+	float meshradius = m->TransformDistModelToMesh(radius);
+	Vector3 meshorigin = m->TransformPosModelToMesh(pickInfo.origin);
 
 	for (int i = 0; i < nPoints; i++) {
-		vs = refmesh->verts[points[i]];
-		vc = refmesh->valpha[points[i]];
+		vs = m->verts[points[i]];
+		vc = m->valpha[points[i]];
 		if (startState.find(points[i]) == startState.end())
 			startState[points[i]].x = vc;
 
@@ -1527,18 +1549,18 @@ void TB_Unalpha::brushAction(mesh* refmesh, TweakPickInfo& pickInfo, const int* 
 		ve -= vc;
 
 		Vector3 vev(ve, ve, ve);
-		float originToV = pickInfo.origin.DistanceTo(vs);
-		if (originToV > radius)
+		float originToV = meshorigin.DistanceTo(vs);
+		if (originToV > meshradius)
 			vev.Zero();
 		else if (strength > -1.0f)
-			applyFalloff(vev, originToV);
+			applyFalloff(vev, originToV, meshradius);
 
 		vf = vc + vev.x;
 		if (vf > 1.0f)
 			vf = 1.0f;
 
-		endState[points[i]].x = refmesh->valpha[points[i]] = vf;
+		endState[points[i]].x = m->valpha[points[i]] = vf;
 	}
 
-	refmesh->QueueUpdate(mesh::UpdateType::VertexAlpha);
+	m->QueueUpdate(mesh::UpdateType::VertexAlpha);
 }

--- a/src/components/TweakBrush.h
+++ b/src/components/TweakBrush.h
@@ -65,12 +65,11 @@ See the included LICENSE file
 // Collecton of information that identifies the position and attributes where a brush stroke is taking place.
 class TweakPickInfo {
 public:
+	// All vectors are in model space, not mesh
 	nifly::Vector3 origin; // Point on the surface of the mesh that was touched.
 	nifly::Vector3 normal; // Surface normal at the point of impact.
 	nifly::Vector3 view;   // View vector.
 	nifly::Vector3 center; // Center point for a transform.
-	int facet = 0;		   // Facet index touched.
-	int facetM = 0;		   // Mirrored facet index touched (X-axis mirror).
 };
 
 class TweakBrushMeshCache {
@@ -96,7 +95,6 @@ protected:
 	float radius;
 	float focus; // Focus between 0 and 1.
 	float strength;
-	float inset;	   // Normally 0. Values between 0 and 1 increase displacement, values below 0 reduce displacement.
 	float spacing;	   // Distance between points; movements less than this distance don't update the stroke.
 	bool bMirror;	   // X-axis mirror enabled
 	bool bLiveBVH;	   // Update BVH at each update instead of at stroke completion.
@@ -148,8 +146,8 @@ public:
 	// Using the start and end points, determine if enough distance has been covered to satisfy the spacing setting.
 	virtual bool checkSpacing(nifly::Vector3& start, nifly::Vector3& end);
 
-	virtual float getFalloff(float dist);
-	virtual void applyFalloff(nifly::Vector3& deltaVec, float dist);
+	virtual float getFalloff(float dist, float meshradius);
+	virtual void applyFalloff(nifly::Vector3& deltaVec, float dist, float meshradius);
 
 	// Get the list of points, facets and BVH nodes within the brush sphere of influence.
 	// Normally, the origin point is used for sphere center and assumed to be an arbitrary point on the surface.

--- a/src/components/UndoState.h
+++ b/src/components/UndoState.h
@@ -38,8 +38,8 @@ struct UndoStateVertex {
 	nifly::Vector3 pos; // position in skin coordinates
 	nifly::Vector2 uv;
 	nifly::Color4 color;
-	// normal, tangent, and bitangent are in skin CS tangent space (so
-	// only the rotation part of transforms affects them).
+	// normal, tangent, and bitangent are directions in skin coordinates
+	// (so use ApplyTransformToDir instead of ApplyTransform).
 	nifly::Vector3 normal, tangent, bitangent;
 	float eyeData = 0.0f;
 	std::vector<UndoStateVertexBoneWeight> weights;

--- a/src/files/FBXWrangler.cpp
+++ b/src/files/FBXWrangler.cpp
@@ -328,7 +328,7 @@ void FBXWrangler::AddNif(NifFile* nif, AnimInfo* anim, bool transToGlobal, NiSha
 					if (norms) {
 						gNorms.resize(norms->size());
 						for (size_t i = 0; i < gNorms.size(); ++i)
-							gNorms[i] = toGlobal.rotation * (*norms)[i];
+							gNorms[i] = toGlobal.ApplyTransformToDir((*norms)[i]);
 
 						norms = &gNorms;
 					}

--- a/src/program/EditUV.cpp
+++ b/src/program/EditUV.cpp
@@ -969,7 +969,7 @@ void EditUVCanvas::UpdateCursor(int ScreenX, int ScreenY, const std::string& mes
 
 			hoverPoint = pointid;
 
-			Vector3 visPoint = m->PosMeshToModel(hilitepoint);
+			Vector3 visPoint = m->TransformPosMeshToModel(hilitepoint);
 			auto visPointMesh = uvSurface.AddVisPoint(visPoint, "pointhilite");
 			if (visPointMesh)
 				visPointMesh->color = Vector3(1.0f, 0.0f, 0.0f);

--- a/src/program/EditUV.cpp
+++ b/src/program/EditUV.cpp
@@ -969,7 +969,7 @@ void EditUVCanvas::UpdateCursor(int ScreenX, int ScreenY, const std::string& mes
 
 			hoverPoint = pointid;
 
-			Vector3 visPoint = mesh::ApplyMatrix4(m->matModel, hilitepoint);
+			Vector3 visPoint = m->PosMeshToModel(hilitepoint);
 			auto visPointMesh = uvSurface.AddVisPoint(visPoint, "pointhilite");
 			if (visPointMesh)
 				visPointMesh->color = Vector3(1.0f, 0.0f, 0.0f);

--- a/src/program/EditUV.cpp
+++ b/src/program/EditUV.cpp
@@ -516,7 +516,7 @@ void EditUVCanvas::OnMouseMove(wxMouseEvent& event) {
 				for (auto& s : startState) {
 					if (uvGridMesh->vcolors[s.first] == Vector3(1.0f, 1.0f, 0.0f)) {
 						Vector3 startPos(s.second.u, s.second.v, 0.0f);
-						uvGridMesh->verts[s.first] = (startPos - currentCenter) * scale + currentCenter;
+						uvGridMesh->verts[s.first] = (startPos - currentCenter).ComponentMultiply(scale) + currentCenter;
 
 						m->texcoord[s.first].u = uvGridMesh->verts[s.first].x;
 						m->texcoord[s.first].v = uvGridMesh->verts[s.first].y * -1.0f;

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -1417,7 +1417,7 @@ void OutfitProject::UpdateShapeFromMesh(NiShape* shape, const mesh* m) {
 	std::vector<Vector3> liveVerts(m->nVerts);
 
 	for (int i = 0; i < m->nVerts; i++)
-		liveVerts[i] = mesh::VecToNifCoords(m->verts[i]);
+		liveVerts[i] = mesh::TransformPosMeshToNif(m->verts[i]);
 
 	workNif.SetVertsForShape(shape, liveVerts);
 }
@@ -1437,7 +1437,7 @@ void OutfitProject::UpdateMorphResult(NiShape* shape, const std::string& sliderN
 
 	if (IsBaseShape(shape)) {
 		for (auto& i : vertUpdates) {
-			Vector3 diffscale = mesh::DiffMeshToNif(i.second);
+			Vector3 diffscale = mesh::TransformDiffMeshToNif(i.second);
 			baseDiffData.SumDiff(dataName, target, i.first, diffscale);
 		}
 	}
@@ -1733,7 +1733,7 @@ void OutfitProject::ApplyBoneScale(const std::string& bone, int sliderPos, bool 
 				boneScaleVerts.emplace(s, std::vector<Vector3>(m->nVerts));
 				it = boneScaleVerts.find(s);
 				for (int i = 0; i < m->nVerts; i++)
-					it->second[i] = mesh::VecToNifCoords(m->verts[i]);
+					it->second[i] = mesh::TransformPosMeshToNif(m->verts[i]);
 			}
 		}
 
@@ -3845,8 +3845,8 @@ int OutfitProject::ExportNIF(const std::string& fileName, const std::vector<mesh
 			liveNorms.clear();
 
 			for (int i = 0; i < m->nVerts; i++) {
-				liveVerts.emplace_back(mesh::VecToNifCoords(m->verts[i]));
-				liveNorms.emplace_back(mesh::DirMeshToNif(m->norms[i]));
+				liveVerts.emplace_back(mesh::TransformPosMeshToNif(m->verts[i]));
+				liveNorms.emplace_back(mesh::TransformDirMeshToNif(m->norms[i]));
 			}
 
 			clone.SetVertsForShape(shape, liveVerts);

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -1589,7 +1589,7 @@ void OutfitProject::CopyBoneWeights(NiShape* shape,
 
 		// Calculate new values for bone's weights
 		std::string wtSet = boneName + "_WT_";
-		morpher.GenerateResultDiff(shapeName, wtSet, wtSet, maxResults);
+		morpher.GenerateResultDiff(shapeName, wtSet, wtSet, false, maxResults);
 
 		std::unordered_map<uint16_t, Vector3> diffResult;
 		morpher.GetRawResultDiff(shapeName, wtSet, diffResult);
@@ -2269,6 +2269,7 @@ void OutfitProject::ConformShape(NiShape* shape, const ConformOptions& options) 
 			morpher.GenerateResultDiff(shape->name.get(),
 									   activeSet[i].name,
 									   activeSet[i].TargetDataName(refTarget),
+									   true,
 									   options.maxResults,
 									   options.noSqueeze,
 									   options.solidMode,

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -231,6 +231,8 @@ public:
 	int LoadFromSliderSet(const std::string& fileName, const std::string& setName, std::vector<std::string>* origShapeOrder = nullptr);
 	int AddFromSliderSet(const std::string& fileName, const std::string& setName, const bool newDataLocal = true);
 
+	std::unordered_map<uint16_t, nifly::Vector3>* GetDiffSet(SliderData& silderData, nifly::NiShape* shape);
+
 	void CollectVertexData(nifly::NiShape* shape, UndoStateShape& uss, const std::vector<uint16_t>& indices);
 	void CollectTriangleData(nifly::NiShape* shape, UndoStateShape& uss, const std::vector<uint32_t>& indices);
 	bool PrepareDeleteVerts(nifly::NiShape* shape, const std::unordered_map<uint16_t, float>& mask, UndoStateShape& uss);

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -8277,8 +8277,8 @@ void OutfitStudioFrame::OnMoveShape(wxCommandEvent& WXUNUSED(event)) {
 						diff.z = -diff.z;
 
 					Vector3 newPos = vertPos + diff;
-					uss.pointStartState[i] = mesh::VecToMeshCoords(vertPos);
-					uss.pointEndState[i] = mesh::VecToMeshCoords(newPos);
+					uss.pointStartState[i] = mesh::TransformPosNifToMesh(vertPos);
+					uss.pointEndState[i] = mesh::TransformPosNifToMesh(newPos);
 				}
 
 				usp->usss.push_back(std::move(uss));
@@ -8395,7 +8395,7 @@ void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
 			if (originSelection == 1) {
 				// Center of selected shape(s), respecting mask
 				origin = glView->gls.GetActiveCenter();
-				origin = mesh::VecToNifCoords(origin);
+				origin = mesh::TransformPosMeshToNif(origin);
 			}
 
 			UndoStateProject* usp = glView->GetUndoHistory()->PushState();
@@ -8431,8 +8431,8 @@ void OutfitStudioFrame::OnScaleShape(wxCommandEvent& WXUNUSED(event)) {
 						continue;
 
 					Vector3 newPos = vertPos + diff;
-					uss.pointStartState[i] = mesh::VecToMeshCoords(vertPos);
-					uss.pointEndState[i] = mesh::VecToMeshCoords(newPos);
+					uss.pointStartState[i] = mesh::TransformPosNifToMesh(vertPos);
+					uss.pointEndState[i] = mesh::TransformPosNifToMesh(newPos);
 				}
 
 				usp->usss.push_back(std::move(uss));
@@ -8584,7 +8584,7 @@ void OutfitStudioFrame::OnRotateShape(wxCommandEvent& WXUNUSED(event)) {
 			if (originSelection == 1) {
 				// Center of selected shape(s), respecting mask
 				origin = glView->gls.GetActiveCenter();
-				origin = mesh::VecToNifCoords(origin);
+				origin = mesh::TransformPosMeshToNif(origin);
 			}
 
 			UndoStateProject* usp = glView->GetUndoHistory()->PushState();
@@ -8622,8 +8622,8 @@ void OutfitStudioFrame::OnRotateShape(wxCommandEvent& WXUNUSED(event)) {
 						continue;
 
 					Vector3 newPos = vertPos + diff;
-					uss.pointStartState[i] = mesh::VecToMeshCoords(vertPos);
-					uss.pointEndState[i] = mesh::VecToMeshCoords(newPos);
+					uss.pointStartState[i] = mesh::TransformPosNifToMesh(vertPos);
+					uss.pointEndState[i] = mesh::TransformPosNifToMesh(newPos);
 				}
 
 				usp->usss.push_back(std::move(uss));
@@ -10651,8 +10651,8 @@ void wxGLPanel::OnKeys(wxKeyEvent& event) {
 						os->project->MoveVertex(shape, newPos, vertIndex);
 
 					// To mesh coordinates
-					oldPos = mesh::VecToMeshCoords(oldPos);
-					newPos = mesh::VecToMeshCoords(newPos);
+					oldPos = mesh::TransformPosNifToMesh(oldPos);
+					newPos = mesh::TransformPosNifToMesh(newPos);
 
 					UndoStateShape uss;
 					uss.shapeName = shape->name.get();
@@ -10911,7 +10911,7 @@ bool wxGLPanel::StartBrushStroke(const wxPoint& screenPos) {
 				workNif->GetVertsForShape(shape, basePosition);
 
 			for (auto& p : basePosition)
-				p = mesh::VecToMeshCoords(p);
+				p = mesh::TransformPosNifToMesh(p);
 
 			positionData[i] = std::move(basePosition);
 		}
@@ -11346,7 +11346,7 @@ bool wxGLPanel::StartMoveVertex(const wxPoint& screenPos) {
 	mouseDownMeshName = lastHitResult.hitMeshName;
 	mouseDownPoint = lastHitResult.hoverPoint;
 	mouseHasMovedSinceStart = false;
-	mouseDownPointNormal = m->DirMeshToModel(m->GetOneVertexNormal(mouseDownPoint));
+	mouseDownPointNormal = m->TransformDirMeshToModel(m->GetOneVertexNormal(mouseDownPoint));
 	moveVertexOperation = MoveVertexOperation::None;
 
 	Vector3 viewOrigin;
@@ -11355,9 +11355,9 @@ bool wxGLPanel::StartMoveVertex(const wxPoint& screenPos) {
 
 	// snapDistance: shortest edge length of triangle under pointer
 	const Triangle& tri = m->tris[lastHitResult.hoverTri];
-	Vector3 gtp1 = m->PosMeshToModel(m->verts[tri.p1]);
-	Vector3 gtp2 = m->PosMeshToModel(m->verts[tri.p2]);
-	Vector3 gtp3 = m->PosMeshToModel(m->verts[tri.p3]);
+	Vector3 gtp1 = m->TransformPosMeshToModel(m->verts[tri.p1]);
+	Vector3 gtp2 = m->TransformPosMeshToModel(m->verts[tri.p2]);
+	Vector3 gtp3 = m->TransformPosMeshToModel(m->verts[tri.p3]);
 	snapDistance = gtp1.DistanceTo(gtp2);
 	float elen = gtp2.DistanceTo(gtp3);
 	if (snapDistance > elen)
@@ -11413,7 +11413,7 @@ void wxGLPanel::UpdateMoveVertex(const wxPoint& screenPos) {
 	m->verts[mouseDownPoint] = mesholdpos;
 	if (mouseDownMirrorPoint != -1)
 		m->verts[mouseDownMirrorPoint] = uss.pointStartState[mouseDownMirrorPoint];
-	Vector3 oldpos = m->PosMeshToModel(mesholdpos);
+	Vector3 oldpos = m->TransformPosMeshToModel(mesholdpos);
 
 	// Since the pointer can be offset from screenPos, calculate a point
 	// to display at screenPos.  We do this by intersecting the
@@ -11434,7 +11434,7 @@ void wxGLPanel::UpdateMoveVertex(const wxPoint& screenPos) {
 			moveVertexOperation = MoveVertexOperation::None;
 		}
 		else
-			newpos = hitmesh->PosMeshToModel(hitpt);
+			newpos = hitmesh->TransformPosMeshToModel(hitpt);
 	}
 	else if (toolOptionRestrictPlane) {
 		gls.CollidePlane(screenPos.x, screenPos.y, newpos, mouseDownPointNormal, mouseDownPointNormal.dot(oldpos));
@@ -11467,8 +11467,8 @@ void wxGLPanel::UpdateMoveVertex(const wxPoint& screenPos) {
 			Vector3 viewDir, viewOrigin;
 			gls.GetPickRay(screenPos.x, screenPos.y, tm, viewDir, viewOrigin);
 
-			Vector3 tmnewpos = tm->PosModelToMesh(newpos);
-			float tmSnapDistance = tm->DistModelToMesh(snapDistance);
+			Vector3 tmnewpos = tm->TransformPosModelToMesh(newpos);
+			float tmSnapDistance = tm->TransformDistModelToMesh(snapDistance);
 
 			std::vector<IntersectResult> iresults;
 			if (tm->bvh && tm->bvh->IntersectSphere(tmnewpos, tmSnapDistance, &iresults)) {
@@ -11484,7 +11484,7 @@ void wxGLPanel::UpdateMoveVertex(const wxPoint& screenPos) {
 						// Calculate distance in plane perpendicular to view
 						Vector3 diff = tm->verts[tp] - tmnewpos;
 						diff -= viewDir * viewDir.dot(diff);
-						float d = tm->DistMeshToModel(diff.length());
+						float d = tm->TransformDistMeshToModel(diff.length());
 						if (d >= closestDist)
 							continue;
 
@@ -11502,7 +11502,7 @@ void wxGLPanel::UpdateMoveVertex(const wxPoint& screenPos) {
 			bool canWeld = toolOptionWeld && s1 && s2 && os->project->PointsHaveDifferingWeightsOrDiffs(s1, mouseDownPoint, s2, closestPoint);
 			bool canMerge = toolOptionMerge && m == closestMesh;
 			if (canWeld || canMerge) {
-				newpos = closestMesh->PosMeshToModel(closestMesh->verts[closestPoint]);
+				newpos = closestMesh->TransformPosMeshToModel(closestMesh->verts[closestPoint]);
 				if (canWeld)
 					moveVertexOperation = MoveVertexOperation::Weld;
 				else if (canMerge)
@@ -11513,7 +11513,7 @@ void wxGLPanel::UpdateMoveVertex(const wxPoint& screenPos) {
 		}
 	}
 
-	Vector3 meshnewpos = m->PosModelToMesh(newpos);
+	Vector3 meshnewpos = m->TransformPosModelToMesh(newpos);
 	uss.pointEndState[mouseDownPoint] = meshnewpos;
 	m->verts[mouseDownPoint] = meshnewpos;
 	gls.SetPointCursor(newpos);
@@ -12114,7 +12114,7 @@ void wxGLPanel::UpdateNodes() {
 
 			std::string nodeName = node->name.get();
 			if (!nodeName.empty()) {
-				Vector3 renderPosition = mesh::VecToMeshCoords(position);
+				Vector3 renderPosition = mesh::TransformPosNifToMesh(position);
 
 				auto pointMesh = gls.AddVisPoint(renderPosition, "P_" + nodeName);
 				if (pointMesh) {
@@ -12123,7 +12123,7 @@ void wxGLPanel::UpdateNodes() {
 				}
 
 				if (parent) {
-					Vector3 renderParentPosition = mesh::VecToMeshCoords(parentPosition);
+					Vector3 renderParentPosition = mesh::TransformPosNifToMesh(parentPosition);
 
 					auto lineMesh = gls.AddVisSeg(renderParentPosition, renderPosition, "L_" + nodeName);
 					if (lineMesh) {
@@ -12191,7 +12191,7 @@ void wxGLPanel::UpdateBones() {
 					Vector3 parentPosition = parent->xformToGlobal.ApplyTransform(rootPosition);
 					bool matchesParent = position.IsNearlyEqualTo(parentPosition);
 
-					Vector3 renderPosition = mesh::VecToMeshCoords(position);
+					Vector3 renderPosition = mesh::TransformPosNifToMesh(position);
 
 					auto pointMesh = gls.AddVisPoint(renderPosition, "BP_" + cb->boneName);
 					if (pointMesh) {
@@ -12199,7 +12199,7 @@ void wxGLPanel::UpdateBones() {
 						bonesPoints.push_back(pointMesh);
 					}
 
-					Vector3 renderParentPosition = mesh::VecToMeshCoords(parentPosition);
+					Vector3 renderParentPosition = mesh::TransformPosNifToMesh(parentPosition);
 
 					if (!matchesParent) {
 						auto lineMesh = gls.AddVisSeg(renderParentPosition, renderPosition, "BL_" + cb->boneName);
@@ -12661,7 +12661,7 @@ void wxGLPanel::OnMouseMove(wxMouseEvent& event) {
 																  hitResult.hoverAlpha),
 												 1);
 				else {
-					Vector3 hoverCoordNif = mesh::VecToNifCoords(hitResult.hoverMeshCoord);
+					Vector3 hoverCoordNif = mesh::TransformPosMeshToNif(hitResult.hoverMeshCoord);
 					os->statusBar->SetStatusText(wxString::Format("Vertex: %d, X: %.5f Y: %.5f Z: %.5f", hitResult.hoverPoint, hoverCoordNif.x, hoverCoordNif.y, hoverCoordNif.z),
 												 1);
 				}

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -11355,9 +11355,9 @@ bool wxGLPanel::StartMoveVertex(const wxPoint& screenPos) {
 
 	// snapDistance: shortest edge length of triangle under pointer
 	const Triangle& tri = m->tris[lastHitResult.hoverTri];
-	Vector3 gtp1 = m->PosMeshToModel( m->verts[tri.p1]);
-	Vector3 gtp2 = m->PosMeshToModel( m->verts[tri.p2]);
-	Vector3 gtp3 = m->PosMeshToModel( m->verts[tri.p3]);
+	Vector3 gtp1 = m->PosMeshToModel(m->verts[tri.p1]);
+	Vector3 gtp2 = m->PosMeshToModel(m->verts[tri.p2]);
+	Vector3 gtp3 = m->PosMeshToModel(m->verts[tri.p3]);
 	snapDistance = gtp1.DistanceTo(gtp2);
 	float elen = gtp2.DistanceTo(gtp3);
 	if (snapDistance > elen)
@@ -11413,7 +11413,7 @@ void wxGLPanel::UpdateMoveVertex(const wxPoint& screenPos) {
 	m->verts[mouseDownPoint] = mesholdpos;
 	if (mouseDownMirrorPoint != -1)
 		m->verts[mouseDownMirrorPoint] = uss.pointStartState[mouseDownMirrorPoint];
-	Vector3 oldpos = m->PosMeshToModel( mesholdpos);
+	Vector3 oldpos = m->PosMeshToModel(mesholdpos);
 
 	// Since the pointer can be offset from screenPos, calculate a point
 	// to display at screenPos.  We do this by intersecting the
@@ -11434,7 +11434,7 @@ void wxGLPanel::UpdateMoveVertex(const wxPoint& screenPos) {
 			moveVertexOperation = MoveVertexOperation::None;
 		}
 		else
-			newpos = hitmesh->PosMeshToModel( hitpt);
+			newpos = hitmesh->PosMeshToModel(hitpt);
 	}
 	else if (toolOptionRestrictPlane) {
 		gls.CollidePlane(screenPos.x, screenPos.y, newpos, mouseDownPointNormal, mouseDownPointNormal.dot(oldpos));

--- a/src/program/ShapeProperties.cpp
+++ b/src/program/ShapeProperties.cpp
@@ -1033,7 +1033,7 @@ void ShapeProperties::ApplyChanges() {
 			if (shape->IsSkinned())
 				os->project->ApplyTransformToShapeGeometry(shape, newTransform.ComposeTransforms(oldTransform.InverseTransform()));
 			else
-				os->project->ApplyTransformToShapeGeometry(shape, newTransform.ComposeTransforms(oldTransform));
+				os->project->ApplyTransformToShapeGeometry(shape, newTransform.InverseTransform().ComposeTransforms(oldTransform));
 		}
 
 		if (shape->IsSkinned()) {

--- a/src/render/GLSurface.cpp
+++ b/src/render/GLSurface.cpp
@@ -366,11 +366,13 @@ bool GLSurface::CollideMeshes(int ScreenX, int ScreenY, Vector3& outOrigin, Vect
 		Vector3 d;
 		Vector3 o;
 
-		GetPickRay(ScreenX, ScreenY, m, d, o);
+		GetPickRay(ScreenX, ScreenY, nullptr, d, o);
 		if (mirrored) {
 			d.x *= -1.0f;
 			o.x *= -1.0f;
 		}
+		o = m->TransformPosModelToMesh(o);
+		d = m->TransformDirModelToMesh(d);
 
 		std::vector<IntersectResult> results;
 		if (m->bvh->IntersectRay(o, d, &results)) {
@@ -560,6 +562,7 @@ bool GLSurface::UpdateCursor(int ScreenX, int ScreenY, bool allMeshes, CursorHit
 
 					Vector3 norm;
 					m->tris[results[min_i].HitFacet].trinormal(m->verts.get(), &norm);
+					norm = m->TransformDirMeshToModel(norm);
 
 					AddVisCircle(morigin, norm, cursorSize, "cursormesh");
 

--- a/src/render/GLSurface.cpp
+++ b/src/render/GLSurface.cpp
@@ -556,19 +556,19 @@ bool GLSurface::UpdateCursor(int ScreenX, int ScreenY, bool allMeshes, CursorHit
 					const int dec = 5;
 					Edge closestEdge = t.ClosestEdge(m->verts.get(), origin);
 
-					Vector3 morigin = m->PosMeshToModel(origin);
+					Vector3 morigin = m->TransformPosMeshToModel(origin);
 
 					Vector3 norm;
 					m->tris[results[min_i].HitFacet].trinormal(m->verts.get(), &norm);
 
 					AddVisCircle(morigin, norm, cursorSize, "cursormesh");
 
-					Vector3 mhilitepoint = m->PosMeshToModel(hilitepoint);
+					Vector3 mhilitepoint = m->TransformPosMeshToModel(hilitepoint);
 					AddVisPoint(mhilitepoint, "pointhilite");
 					AddVisPoint(morigin, "cursorcenter")->color = Vector3(1.0f, 0.0f, 0.0f);
 
-					Vector3 mep1 = m->PosMeshToModel(m->verts[closestEdge.p1]);
-					Vector3 mep2 = m->PosMeshToModel(m->verts[closestEdge.p2]);
+					Vector3 mep1 = m->TransformPosMeshToModel(m->verts[closestEdge.p1]);
+					Vector3 mep2 = m->TransformPosMeshToModel(m->verts[closestEdge.p2]);
 					AddVisSeg(mep1, mep2, "seghilite");
 
 					if (hitResult) {
@@ -673,17 +673,17 @@ void GLSurface::HideSegCursor() {
 }
 
 void GLSurface::SetPointCursor(const Vector3 &p, mesh* m) {
-	Vector3 gp = m ? m->PosMeshToModel(p) : p;
+	Vector3 gp = m ? m->TransformPosMeshToModel(p) : p;
 	AddVisPoint(gp, "pointhilite");
 }
 
 void GLSurface::SetCenterCursor(const Vector3 &p, mesh* m) {
-	Vector3 gp = m ? m->PosMeshToModel(p) : p;
+	Vector3 gp = m ? m->TransformPosMeshToModel(p) : p;
 	AddVisPoint(gp, "cursorcenter")->color = Vector3(1.0f, 0.0f, 0.0f);
 }
 
 void GLSurface::ShowMirrorPointCursor(const Vector3 &p, mesh* m) {
-	Vector3 gp = m ? m->PosMeshToModel(p) : p;
+	Vector3 gp = m ? m->TransformPosMeshToModel(p) : p;
 	AddVisPoint(gp, "mirrorpoint")->color = Vector3(0.3f, 0.7f, 0.7f);;
 	SetOverlayVisibility("mirrorpoint", true);
 }
@@ -1232,7 +1232,7 @@ mesh* GLSurface::AddMeshFromNif(NifFile* nif, const std::string& shapeName, Vect
 	// Scale down by 10 and rotate on x axis by flipping y and z components. To face the camera, this also mirrors
 	// on X and Y (180 degree y axis rotation.)
 	for (int i = 0; i < m->nVerts; i++)
-		m->verts[i] = mesh::VecToMeshCoords(nifVerts[i]);
+		m->verts[i] = mesh::TransformPosNifToMesh(nifVerts[i]);
 
 	if (nifUvs && !nifUvs->empty()) {
 		for (int i = 0; i < m->nVerts; i++) {
@@ -1254,7 +1254,7 @@ mesh* GLSurface::AddMeshFromNif(NifFile* nif, const std::string& shapeName, Vect
 		// Already have normals, just copy the data over.
 		// Copy normals. Note, normals are transformed the same way the vertices are.
 		for (int i = 0; i < m->nVerts; i++)
-			m->norms[i] = mesh::DirNifToMesh((*nifNorms)[i]);
+			m->norms[i] = mesh::TransformDirNifToMesh((*nifNorms)[i]);
 
 		for (auto& extraDataRef : shape->extraDataRefs) {
 			auto integersExtraData = nif->GetHeader().GetBlock<NiIntegersExtraData>(extraDataRef);
@@ -1938,7 +1938,7 @@ void GLSurface::Update(mesh* m, std::vector<Vector3>* vertices, std::vector<Vect
 		if (changed)
 			old = m->verts[i];
 
-		m->verts[i] = mesh::VecToMeshCoords((*vertices)[i]);
+		m->verts[i] = mesh::TransformPosNifToMesh((*vertices)[i]);
 
 		if (uvSize > i)
 			m->texcoord[i] = (*uvs)[i];

--- a/src/render/GLSurface.h
+++ b/src/render/GLSurface.h
@@ -158,7 +158,7 @@ public:
 		for (auto& m : activeMeshes) {
 			for (int i = 0; i < m->nVerts; i++) {
 				if (!useMask || m->mask[i] == 0.0f) {
-					total += m->PosMeshToModel(m->verts[i]);
+					total += m->TransformPosMeshToModel(m->verts[i]);
 					count++;
 				}
 			}

--- a/src/render/GLSurface.h
+++ b/src/render/GLSurface.h
@@ -278,8 +278,7 @@ public:
 	void ShowMirrorPointCursor(const nifly::Vector3 &p, mesh*m = nullptr);
 
 	// Ray/mesh collision detection. From a screen point, calculates a ray and finds the nearest collision point and surface normal on
-	// the active mesh. Optionally, the ray and ray origin can be provided, which skips the internal call to GetPickRay.
-	// Screen x/y are ignored if the ray is provided.
+	// the active mesh.  The outOrigin and outNormal results are in mesh coordinates.
 	bool CollideMeshes(int ScreenX,
 					   int ScreenY,
 					   nifly::Vector3& outOrigin,

--- a/src/render/GLSurface.h
+++ b/src/render/GLSurface.h
@@ -158,7 +158,7 @@ public:
 		for (auto& m : activeMeshes) {
 			for (int i = 0; i < m->nVerts; i++) {
 				if (!useMask || m->mask[i] == 0.0f) {
-					total += mesh::ApplyMatrix4(m->matModel, m->verts[i]);
+					total += m->PosMeshToModel(m->verts[i]);
 					count++;
 				}
 			}


### PR DESCRIPTION
This commit is mostly cosmetic changes to improve clarity.  But it also fixes bugs in computing mesh::matModel.  matModel is computed in five different places, and each had at least one bug.  In fixing these bugs, I deleted the function mesh::TransformToMatrix4, which definitely had a rotation bug, and possibly a translation bug depending on how it was called.  Different callers actually needed different functionality.  So I implemented correct functionality in the five callers rather than have them call a common function that needed to be different for each of them.

I added static variables xformNifToMesh and xformMeshToNif to mesh.  These encode, as a MatTransform, the transformation that multiplies or divides by 10, negates x, and swaps y and z.

I added member variables xformMeshToModel and xformModelToMesh to mesh.  These keep the MatTransforms corresponding to matModel and its inverse so they can be used directly instead of having to convert nifly::Vector3 to glm::vec4 and back.  I added setup functions for these three member variables.

I added static functions to mesh that do the same thing as VecToMeshCoords and VecToNifCoords, but for direction vectors, difference vectors, and distances in addition to position vectors.

I added member functions to mesh that apply xformMeshToModel and xformModelToMesh to positions, directions, differences, and distances.

I tried my best to use these new mesh functions wherever appropriate.  I searched for all instances of '10.0f', '* 10', and '/ 10' in src to try to catch places where VecToMeshCoords and VecToNifCoords should have been called but weren't.

mesh::ApplyMatrix4 is no longer used anywhere, but I left it in in case someone has a use for it someday.