### PR TITLE
Implemented Copy Segments or Partitions

### DIFF
--- a/res/xrc/OutfitStudio.xrc
+++ b/res/xrc/OutfitStudio.xrc
@@ -1947,8 +1947,8 @@
 			</object>
 			<object class="separator" />
 			<object class="wxMenuItem" name="copySegPart">
-				<label>Copy Segments or Partitions...</label>
-				<help>Copies segments or partitions and all triangle segment/partition memberships from the reference shape to the current shape.</help>
+				<label>Copy Partitions/Segments...</label>
+				<help>Copies partitions/segments and all triangle assignments from the reference shape to the current shape.</help>
 			</object>
 			<object class="separator" />
 			<object class="wxMenuItem" name="deleteShape">
@@ -2388,8 +2388,8 @@
 		</object>
 		<object class="separator" />
 		<object class="wxMenuItem" name="copySegPart">
-			<label>Copy Segments or Partitions...</label>
-			<help>Copies segments or partitions and all triangle segment/partition memberships from the reference shape to the current shape.</help>
+			<label>Copy Partitions/Segments...</label>
+			<help>Copies partitions/segments and all triangle assignments from the reference shape to the current shape.</help>
 		</object>
 		<object class="separator" />
 		<object class="wxMenuItem" name="deleteShape">

--- a/res/xrc/OutfitStudio.xrc
+++ b/res/xrc/OutfitStudio.xrc
@@ -1946,6 +1946,11 @@
 				<help>Masks vertices with bone weights, so you can manually assign weights to unweighted vertices.</help>
 			</object>
 			<object class="separator" />
+			<object class="wxMenuItem" name="copySegPart">
+				<label>Copy Segments or Partitions...</label>
+				<help>Copies segments or partitions and all triangle segment/partition memberships from the reference shape to the current shape.</help>
+			</object>
+			<object class="separator" />
 			<object class="wxMenuItem" name="deleteShape">
 				<label>Delete\tDel</label>
 				<help>Removes the currently selected shape from the outfit.</help>
@@ -2380,6 +2385,11 @@
 		<object class="wxMenuItem" name="maskWeightedVerts">
 			<label>Mask Weighted Vertices</label>
 			<help>Masks vertices with bone weights, so you can manually assign weights to unweighted vertices.</help>
+		</object>
+		<object class="separator" />
+		<object class="wxMenuItem" name="copySegPart">
+			<label>Copy Segments or Partitions...</label>
+			<help>Copies segments or partitions and all triangle segment/partition memberships from the reference shape to the current shape.</help>
 		</object>
 		<object class="separator" />
 		<object class="wxMenuItem" name="deleteShape">

--- a/src/components/Automorph.cpp
+++ b/src/components/Automorph.cpp
@@ -97,7 +97,7 @@ void Automorph::SetRef(NifFile& ref, NiShape* refShape, const AnimInfo* workAnim
 	morphRef = std::make_unique<mesh>();
 	MeshFromNifShape(morphRef.get(), ref, refShape, workAnim);
 
-	refTree = std::make_unique<kd_tree>(morphRef->verts.get(), static_cast<uint16_t>(morphRef->nVerts));
+	refTree = std::make_unique<kd_tree<uint16_t>>(morphRef->verts.get(), static_cast<uint16_t>(morphRef->nVerts));
 }
 
 void Automorph::LinkRefDiffData(DiffDataSets* diffData) {
@@ -232,7 +232,7 @@ void Automorph::BuildProximityCache(const std::string& shapeName, float proximit
 		if (resultCount > maxCount)
 			maxCount = resultCount;
 
-		std::vector<kd_query_result> indexResults;
+		std::vector<kd_query_result<uint16_t>> indexResults;
 		for (uint16_t id = 0; id < resultCount; id++) {
 			auto& result = refTree->queryResult[id];
 
@@ -390,7 +390,7 @@ void Automorph::GenerateResultDiff(
 	std::vector<Vector3> effectVector;
 
 	for (int i = 0; i < m->nVerts; i++) {
-		std::vector<kd_query_result>* vertProx = &prox_cache[i];
+		std::vector<kd_query_result<uint16_t>>* vertProx = &prox_cache[i];
 		int nValues = vertProx->size();
 		if (nValues > maxResults)
 			nValues = maxResults;

--- a/src/components/Automorph.h
+++ b/src/components/Automorph.h
@@ -13,10 +13,10 @@ See the included LICENSE file
 class AnimInfo;
 
 class Automorph {
-	std::unique_ptr<nifly::kd_tree> refTree;
+	std::unique_ptr<nifly::kd_tree<uint16_t>> refTree;
 	std::map<std::string, mesh*> sourceShapes;
 	// Class - to prevent AutoMorph from deleting it. Golly, smart pointers would be nice.
-	std::map<int, std::vector<nifly::kd_query_result>> prox_cache;
+	std::map<int, std::vector<nifly::kd_query_result<uint16_t>>> prox_cache;
 	DiffDataSets __srcDiffData;			 // Unternally loaded and stored diff data.diffs loaded from existing reference .bsd files.
 	DiffDataSets* srcDiffData = nullptr; // Either __srcDiffData or an external linked data set.
 	DiffDataSets resultDiffData;		 // Diffs calculated by AutoMorph.

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -1853,7 +1853,7 @@ int OutfitProject::CopySegPart(NiShape* shape) {
 
 	// Build proximity cache for triangle centers of baseShape.
 	// Note that kd_tree keeps pointers into tricenters.
-	kd_tree refTree(&tricenters[0], tricenters.size());
+	kd_tree<uint32_t> refTree(&tricenters[0], tricenters.size());
 
 	// Get baseShape's segment/partition data
 	std::vector<int> bstriParts;

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -1819,6 +1819,98 @@ void OutfitProject::ModifyCustomBone(AnimBone* bPtr, const std::string& parentBo
 		workAnim.RecursiveRecalcXFormSkinToBone(s, bPtr);
 }
 
+MatTransform OutfitProject::GetTransformShapeToGlobal(NiShape* shape) {
+	if (shape->IsSkinned()) {
+		return workAnim.shapeSkinning[shape->name.get()].xformGlobalToSkin.InverseTransform();
+	}
+	else {	// Unskinned mesh
+		MatTransform ttg = shape->GetTransformToParent();
+		NiNode* parent = workNif.GetParentNode(shape);
+		while (parent) {
+			ttg = parent->GetTransformToParent().ComposeTransforms(ttg);
+			parent = workNif.GetParentNode(parent);
+		}
+		return ttg;
+	}
+}
+
+int OutfitProject::CopySegPart(NiShape* shape) {
+	// Gather baseShape's triangles and vertices
+	std::vector<Triangle> tris;
+	baseShape->GetTriangles(tris);
+	std::vector<Vector3> verts;
+	workNif.GetVertsForShape(baseShape, verts);
+
+	// Transform baseShape vertices to nif global coordinates
+	MatTransform xformToGlobal = GetTransformShapeToGlobal(baseShape);
+	for (Vector3& v : verts)
+		v = xformToGlobal.ApplyTransform(v);
+
+	// Calculate center of each triangle (times 3)
+	std::vector<Vector3> tricenters(tris.size());
+	for (size_t ti = 0; ti < tris.size(); ++ti)
+		tricenters[ti] = verts[tris[ti].p1] + verts[tris[ti].p2] + verts[tris[ti].p3];
+
+	// Build proximity cache for triangle centers of baseShape.
+	// Note that kd_tree keeps pointers into tricenters.
+	kd_tree refTree(&tricenters[0], tricenters.size());
+
+	// Get baseShape's segment/partition data
+	std::vector<int> bstriParts;
+	NifSegmentationInfo inf;
+	bool gotsegs = workNif.GetShapeSegments(baseShape, inf, bstriParts);
+	NiVector<BSDismemberSkinInstance::PartitionInfo> partitionInfo;
+	bool gotparts = false;
+	if (!gotsegs)
+		gotparts = workNif.GetShapePartitions(baseShape, partitionInfo, bstriParts);
+
+	// Gather shape's triangles and vertices
+	shape->GetTriangles(tris);
+	workNif.GetVertsForShape(shape, verts);
+
+	// Transform shape's vertices to nif global coordinates
+	xformToGlobal = GetTransformShapeToGlobal(shape);
+	for (Vector3& v : verts)
+		v = xformToGlobal.ApplyTransform(v);
+
+	// Calculate new partition/segment for each triangle
+	std::vector<int> triParts(tris.size());
+	int failcount = 0;
+	for (size_t ti = 0; ti < tris.size(); ++ti) {
+		// Calculate center of triangle (times 3)
+		Vector3 tricenter = verts[tris[ti].p1] + verts[tris[ti].p2] + verts[tris[ti].p3];
+
+		// Find closest triangle center in proximity cache.
+		uint32_t resultcount = refTree.kd_nn(&tricenter, 0);
+		if (resultcount < 1) {
+			++failcount;
+			triParts[ti] = -1;
+			continue;
+		}
+
+		// Look up closest triangle and copy its partition/segment ID.
+		size_t bti = refTree.queryResult[0].vertex_index;
+		triParts[ti] = bstriParts[bti];
+		if (triParts[ti] == -1)
+			++failcount;
+	}
+
+	// Refuse to continue if we have any triangles without segments/partitions.
+	if (failcount)
+		return failcount;
+
+	// Store new information in NIF.
+	if (gotsegs)
+		workNif.SetShapeSegments(shape, inf, triParts);
+
+	if (gotparts) {
+		workNif.SetShapePartitions(shape, partitionInfo, triParts);
+		workNif.RemoveEmptyPartitions(shape);
+	}
+
+	return 0;
+}
+
 void OutfitProject::ClearWorkSliders() {
 	morpher.ClearResultDiff();
 }

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -215,6 +215,10 @@ public:
 	void AddCustomBoneRef(const std::string& boneName, const std::string& parentBone, const nifly::MatTransform& xformToParent);
 	void ModifyCustomBone(AnimBone* bPtr, const std::string& parentBone, const nifly::MatTransform& xformToParent);
 
+	nifly::MatTransform GetTransformShapeToGlobal(nifly::NiShape* shape);
+	// CopySegPart returns the number of failed triangles, or 0 for success.
+	int CopySegPart(nifly::NiShape* shape);
+
 	void ClearWorkSliders();
 	void ClearReference();
 	void ClearOutfit();

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -227,6 +227,7 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_MENU(XRCID("transferSelectedWeight"), OutfitStudioFrame::OnTransferSelectedWeight)
 	EVT_MENU(XRCID("maskWeightedVerts"), OutfitStudioFrame::OnMaskWeighted)
 	EVT_MENU(XRCID("maskBoneWeightedVerts"), OutfitStudioFrame::OnMaskBoneWeighted)
+	EVT_MENU(XRCID("copySegPart"), OutfitStudioFrame::OnCopySegPart)
 	EVT_MENU(XRCID("resetTransforms"), OutfitStudioFrame::OnResetTransforms)
 	EVT_MENU(XRCID("deleteUnreferencedNodes"), OutfitStudioFrame::OnDeleteUnreferencedNodes)
 	EVT_MENU(XRCID("removeSkinning"), OutfitStudioFrame::OnRemoveSkinning)
@@ -9799,6 +9800,72 @@ void OutfitStudioFrame::OnMaskBoneWeighted(wxCommandEvent& WXUNUSED(event)) {
 	}
 
 	glView->Refresh();
+}
+
+void OutfitStudioFrame::OnCopySegPart(wxCommandEvent& WXUNUSED(event)) {
+	if (!activeItem) {
+		wxMessageBox(_("There is no shape selected!"), _("Error"));
+		return;
+	}
+
+	if (!project->GetBaseShape()) {
+		wxMessageBox(_("There is no reference shape!"), _("Error"));
+		return;
+	}
+
+	std::vector<NiShape*> selectedShapes;
+	for (auto& s : selectedItems) {
+		if (auto shape = s->GetShape(); !project->IsBaseShape(shape))
+			selectedShapes.push_back(s->GetShape());
+		else
+			wxMessageBox(_("Sorry, you can't copy segments/partitions from the reference shape to itself. Skipping this shape."), _("Can't copy segments/partitions"), wxICON_WARNING);
+	}
+	if (selectedShapes.empty())
+		return;
+
+	if (wxMessageBox(_("The segment or partition list will be copied from the reference shape to the target shape, wiping out any existing segments or partitions.  Each triangle of the target shape will be assigned to a segment or partition by finding the nearest triangle of the reference within the given radius.  This action can not be undone."), _("Copy Segments Or Partitions"), wxOK | wxCANCEL | wxICON_INFORMATION | wxOK_DEFAULT) != wxOK)
+		return;
+
+	CopySegPartForShapes(selectedShapes);
+}
+
+int OutfitStudioFrame::CopySegPartForShapes(std::vector<NiShape*> shapes, bool silent) {
+	int failshapes = 0;
+
+	StartProgress(_("Copying segments/partitions..."));
+
+	const int inc = 100 / shapes.size() - 1;
+
+	for (size_t i = 0; i < shapes.size(); i++) {
+		NiShape* shape = shapes[i];
+		wxLogMessage("Copying segments/partitions to '%s'...", shape->name.get());
+		StartSubProgress(i * inc, i * inc + inc);
+
+		int failcount = project->CopySegPart(shape);
+		if (failcount && !silent)
+			wxMessageBox(wxString::Format(_("The segments/partitions could not be copied for '%s' because %d triangles could not be matched."), shape->name.get(), failcount), _("Error"));
+		if (failcount)
+			++failshapes;
+
+		if (!failcount) {
+			MeshFromProj(shape);
+
+			if (shape == activeItem->GetShape()) {
+				CreateSegmentTree(shape);
+				CreatePartitionTree(shape);
+			}
+		}
+
+		EndProgress();
+	}
+
+	SetPendingChanges();
+	UpdateUndoTools();
+
+	UpdateProgress(100, _("Finished"));
+	EndProgress();
+
+	return failshapes;
 }
 
 void OutfitStudioFrame::OnResetTransforms(wxCommandEvent& WXUNUSED(event)) {

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -9818,12 +9818,12 @@ void OutfitStudioFrame::OnCopySegPart(wxCommandEvent& WXUNUSED(event)) {
 		if (auto shape = s->GetShape(); !project->IsBaseShape(shape))
 			selectedShapes.push_back(s->GetShape());
 		else
-			wxMessageBox(_("Sorry, you can't copy segments/partitions from the reference shape to itself. Skipping this shape."), _("Can't copy segments/partitions"), wxICON_WARNING);
+			wxMessageBox(_("Sorry, you can't copy partitions/segments from the reference shape to itself. Skipping this shape."), _("Can't copy segments/partitions"), wxICON_WARNING);
 	}
 	if (selectedShapes.empty())
 		return;
 
-	if (wxMessageBox(_("The segment or partition list will be copied from the reference shape to the target shape, wiping out any existing segments or partitions.  Each triangle of the target shape will be assigned to a segment or partition by finding the nearest triangle of the reference within the given radius.  This action can not be undone."), _("Copy Segments Or Partitions"), wxOK | wxCANCEL | wxICON_INFORMATION | wxOK_DEFAULT) != wxOK)
+	if (wxMessageBox(_("Triangles will be assigned to the partition/segment of the nearest triangle in the reference.  Existing partitions/segments are cleared.  This action can't be undone."), _("Copy Partitions/Segments"), wxOK | wxCANCEL | wxICON_INFORMATION | wxOK_DEFAULT) != wxOK)
 		return;
 
 	CopySegPartForShapes(selectedShapes);
@@ -9843,7 +9843,7 @@ int OutfitStudioFrame::CopySegPartForShapes(std::vector<NiShape*> shapes, bool s
 
 		int failcount = project->CopySegPart(shape);
 		if (failcount && !silent)
-			wxMessageBox(wxString::Format(_("The segments/partitions could not be copied for '%s' because %d triangles could not be matched."), shape->name.get(), failcount), _("Error"));
+			wxMessageBox(wxString::Format(_("The partitions/segments could not be copied for '%s' because %d triangles could not be matched."), shape->name.get(), failcount), _("Error"));
 		if (failcount)
 			++failshapes;
 

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -1172,6 +1172,8 @@ private:
 	bool ShowWeightCopy(WeightCopyOptions& options, bool silent = false);
 	void ReselectBone();
 
+	int CopySegPartForShapes(std::vector<nifly::NiShape*> shapes, bool silent = false);
+
 	void OnExit(wxCommandEvent& event);
 	void OnClose(wxCloseEvent& event);
 
@@ -1370,6 +1372,7 @@ private:
 	void OnTransferSelectedWeight(wxCommandEvent& event);
 	void OnMaskWeighted(wxCommandEvent& event);
 	void OnMaskBoneWeighted(wxCommandEvent& event);
+	void OnCopySegPart(wxCommandEvent& event);
 	void OnResetTransforms(wxCommandEvent& event);
 	void OnDeleteUnreferencedNodes(wxCommandEvent& event);
 	void OnRemoveSkinning(wxCommandEvent& event);


### PR DESCRIPTION
This is a bare-bones implementation of copying segments or partitions.  It ignores the current mask.  All segment/partition data in the target is wiped out.