### PR TITLE
Fixed g++-10 -Wall warnings

### DIFF
--- a/Readme-linux.txt
+++ b/Readme-linux.txt
@@ -20,7 +20,7 @@ Make sure GLEW is installed.
 Then go to your BodySlide-and-Outfit-Studio directory and do:
 mkdir Release
 cd Release
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall" ..
 make
 
 The possible values for CMAKE_BUILD_TYPE:

--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -337,7 +337,7 @@ bool AnimInfo::CalcShapeSkinBounds(const std::string& shapeName, const int& bone
 
 void AnimInfo::SetWeights(const std::string& shape, const std::string& boneName, std::unordered_map<uint16_t, float>& inVertWeights) {
 	int bid = GetShapeBoneIndex(shape, boneName);
-	if (bid == 0xFFFFFFFF)
+	if (bid == -1)
 		return;
 
 	shapeSkinning[shape].boneWeights[bid].weights = inVertWeights;
@@ -524,7 +524,7 @@ void AnimInfo::RenameShape(const std::string& shapeName, const std::string& newS
 	}
 }
 
-AnimBone& AnimBone::LoadFromNif(NifFile* skeletonNif, int srcBlock, AnimBone* inParent) {
+AnimBone& AnimBone::LoadFromNif(NifFile* skeletonNif, uint32_t srcBlock, AnimBone* inParent) {
 	parent = inParent;
 	isStandardBone = false;
 	auto node = skeletonNif->GetHeader().GetBlock<NiNode>(srcBlock);
@@ -580,7 +580,7 @@ int AnimSkeleton::LoadFromNif(const std::string& fileName) {
 	}
 
 	rootBone = Config["Anim/SkeletonRootName"];
-	int nodeID = refSkeletonNif.GetBlockID(refSkeletonNif.FindBlockByName<NiNode>(rootBone));
+	uint32_t nodeID = refSkeletonNif.GetBlockID(refSkeletonNif.FindBlockByName<NiNode>(rootBone));
 	if (nodeID == 0xFFFFFFFF) {
 		wxLogError("Root '%s' not found in skeleton '%s'!", rootBone, fileName);
 		wxMessageBox(wxString::Format(_("Root '%s' not found in skeleton '%s'!"), rootBone, fileName));

--- a/src/components/Anim.h
+++ b/src/components/Anim.h
@@ -48,7 +48,7 @@ public:
 
 	int refCount = 0; // reference count of this bone
 
-	AnimBone& LoadFromNif(nifly::NifFile* skeletonNif, int srcBlock, AnimBone* parent = nullptr);
+	AnimBone& LoadFromNif(nifly::NifFile* skeletonNif, uint32_t srcBlock, AnimBone* parent = nullptr);
 	// AddToNif adds this bone to the given nif, as well as its parent
 	// if missing, recursively.  The new bone's NiNode is returned.
 	nifly::NiNode* AddToNif(nifly::NifFile* nif) const;

--- a/src/components/BuildSelection.h
+++ b/src/components/BuildSelection.h
@@ -36,14 +36,12 @@ public:
 
 class BuildSelectionFile {
 	XMLDocument doc;
-	XMLElement* root;
-	int error;
+	XMLElement* root = nullptr;
+	int error = 0;
 
 public:
 	std::string fileName;
-	BuildSelectionFile()
-		: error(0)
-		, root(nullptr) {}
+	BuildSelectionFile() {}
 	BuildSelectionFile(const std::string& srcFileName);
 	~BuildSelectionFile(){};
 

--- a/src/components/DiffData.cpp
+++ b/src/components/DiffData.cpp
@@ -21,7 +21,7 @@ See the included LICENSE file
 using namespace nifly;
 
 OSDataFile::OSDataFile() {
-	header = 'OSD\0';
+	header = "OSD\0"_mci;
 	version = 1;
 	dataCount = 0;
 }
@@ -43,7 +43,7 @@ bool OSDataFile::Read(const std::string& fileName) {
 		return false;
 
 	file.read((char*)&header, 4);
-	if (header != 'OSD\0')
+	if (header != "OSD\0"_mci)
 		return false;
 
 	file.read((char*)&version, 4);

--- a/src/components/Mesh.h
+++ b/src/components/Mesh.h
@@ -9,14 +9,8 @@ See the included LICENSE file
 #include "../render/GLExtensions.h"
 #include "../utils/AABBTree.h"
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
 #include "../gli/glm/gtc/matrix_transform.hpp"
 #include "../gli/glm/gtx/euler_angles.hpp"
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include <array>
 #include <memory>

--- a/src/components/Mesh.h
+++ b/src/components/Mesh.h
@@ -9,10 +9,14 @@ See the included LICENSE file
 #include "../render/GLExtensions.h"
 #include "../utils/AABBTree.h"
 
+#ifdef _MSC_VER
 #pragma warning(push, 0)
+#endif
 #include "../gli/glm/gtc/matrix_transform.hpp"
 #include "../gli/glm/gtx/euler_angles.hpp"
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
 #include <array>
 #include <memory>

--- a/src/components/RefTemplates.h
+++ b/src/components/RefTemplates.h
@@ -63,15 +63,13 @@ public:
 
 class RefTemplateFile {
 	XMLDocument doc;
-	XMLElement* root;
+	XMLElement* root = nullptr;
 	std::vector<std::pair<std::string, XMLElement*>> refTemplatesInFile;
-	int error;
+	int error = 0;
 
 public:
 	std::string fileName;
-	RefTemplateFile()
-		: error(0)
-		, root(nullptr) {}
+	RefTemplateFile() {}
 	RefTemplateFile(const std::string& srcFileName);
 	~RefTemplateFile(){};
 

--- a/src/components/SliderCategories.h
+++ b/src/components/SliderCategories.h
@@ -68,15 +68,13 @@ public:
 
 class SliderCategoryFile {
 	XMLDocument doc;
-	XMLElement* root;
+	XMLElement* root = nullptr;
 	std::unordered_map<std::string, XMLElement*> categoriesInFile;
-	int error;
+	int error = 0;
 
 public:
 	std::string fileName;
-	SliderCategoryFile()
-		: error(0)
-		, root(nullptr) {}
+	SliderCategoryFile() {}
 	SliderCategoryFile(const std::string& srcFileName);
 	~SliderCategoryFile(){};
 

--- a/src/components/SliderGroup.h
+++ b/src/components/SliderGroup.h
@@ -57,15 +57,13 @@ public:
 
 class SliderSetGroupFile {
 	XMLDocument doc;
-	XMLElement* root;
+	XMLElement* root = nullptr;
 	std::map<std::string, XMLElement*> groupsInFile;
-	int error;
+	int error = 0;
 
 public:
 	std::string fileName;
-	SliderSetGroupFile()
-		: error(0)
-		, root(nullptr) {}
+	SliderSetGroupFile() {}
 	SliderSetGroupFile(const std::string& srcFileName);
 	~SliderSetGroupFile() {}
 

--- a/src/components/UndoHistory.cpp
+++ b/src/components/UndoHistory.cpp
@@ -8,14 +8,14 @@ See the included LICENSE file
 
 void UndoHistory::ClearHistory() {
 	states.clear();
-	curIndex = UH_NONE;
+	curIndex = -1;
 }
 
 bool UndoHistory::PopState() {
 	if (states.empty())
 		return false;
 
-	if (curIndex + 1 == states.size())
+	if (curIndex + 1 == static_cast<int>(states.size()))
 		curIndex--;
 
 	states.pop_back();
@@ -23,18 +23,18 @@ bool UndoHistory::PopState() {
 }
 
 UndoStateProject* UndoHistory::PushState(std::unique_ptr<UndoStateProject> uspp) {
-	size_t nStrokes = states.size();
+	int nStrokes = states.size();
 	if (curIndex + 1 < nStrokes)
 		states.resize(curIndex + 1);
 	else if (nStrokes == UH_MAX_UNDO)
 		states.erase(states.begin());
 	states.push_back(std::move(uspp));
-	curIndex = static_cast<uint32_t>(states.size() - 1);
+	curIndex = static_cast<int>(states.size()) - 1;
 	return states.back().get();
 }
 
 bool UndoHistory::BackStepHistory() {
-	if (curIndex != UH_NONE) {
+	if (curIndex != -1) {
 		curIndex--;
 		return true;
 	}
@@ -45,8 +45,8 @@ bool UndoHistory::ForwardStepHistory() {
 	if (states.empty())
 		return false;
 
-	size_t nStrokes = states.size();
-	if (curIndex == UH_NONE || curIndex < nStrokes - 1) {
+	int nStrokes = states.size();
+	if (curIndex == -1 || curIndex < nStrokes - 1) {
 		++curIndex;
 		return true;
 	}

--- a/src/components/UndoHistory.cpp
+++ b/src/components/UndoHistory.cpp
@@ -8,14 +8,14 @@ See the included LICENSE file
 
 void UndoHistory::ClearHistory() {
 	states.clear();
-	curIndex = -1;
+	curIndex = UH_NONE;
 }
 
 bool UndoHistory::PopState() {
 	if (states.empty())
 		return false;
 
-	if (curIndex + 1 == static_cast<int>(states.size()))
+	if (curIndex + 1 == states.size())
 		curIndex--;
 
 	states.pop_back();
@@ -23,18 +23,18 @@ bool UndoHistory::PopState() {
 }
 
 UndoStateProject* UndoHistory::PushState(std::unique_ptr<UndoStateProject> uspp) {
-	int nStrokes = states.size();
+	size_t nStrokes = states.size();
 	if (curIndex + 1 < nStrokes)
 		states.resize(curIndex + 1);
 	else if (nStrokes == UH_MAX_UNDO)
 		states.erase(states.begin());
 	states.push_back(std::move(uspp));
-	curIndex = static_cast<int>(states.size()) - 1;
+	curIndex = static_cast<uint32_t>(states.size() - 1);
 	return states.back().get();
 }
 
 bool UndoHistory::BackStepHistory() {
-	if (curIndex != -1) {
+	if (curIndex != UH_NONE) {
 		curIndex--;
 		return true;
 	}
@@ -45,8 +45,8 @@ bool UndoHistory::ForwardStepHistory() {
 	if (states.empty())
 		return false;
 
-	int nStrokes = states.size();
-	if (curIndex == -1 || curIndex < nStrokes - 1) {
+	size_t nStrokes = states.size();
+	if (curIndex == UH_NONE || curIndex < nStrokes - 1) {
 		++curIndex;
 		return true;
 	}

--- a/src/components/UndoHistory.h
+++ b/src/components/UndoHistory.h
@@ -11,10 +11,11 @@ See the included LICENSE file
 struct UndoStateProject;
 
 class UndoHistory {
-	static constexpr uint32_t UH_NONE = 0xFFFFFFFF;
-	static constexpr uint32_t UH_MAX_UNDO = 40;
+	static constexpr int UH_MAX_UNDO = 40;
 
-	uint32_t curIndex = UH_NONE;
+	// Note that -1 on the next line is NOT a magic number.  It's the actual
+	// index.  The same is true everywhere in UndoHistory.
+	int curIndex = -1;
 	std::vector<std::unique_ptr<UndoStateProject>> states;
 
 public:
@@ -24,12 +25,12 @@ public:
 	bool ForwardStepHistory();
 	void ClearHistory();
 
-	bool CanUndo() const { return curIndex != UH_NONE; }
+	bool CanUndo() const { return curIndex != -1; }
 
 	bool CanRedo() const { return !states.empty() && curIndex + 1 < static_cast<int>(states.size()); }
 
 	UndoStateProject* GetCurState() const {
-		if (curIndex == UH_NONE)
+		if (curIndex == -1)
 			return nullptr;
 		return states[curIndex].get();
 	}

--- a/src/components/UndoHistory.h
+++ b/src/components/UndoHistory.h
@@ -11,11 +11,10 @@ See the included LICENSE file
 struct UndoStateProject;
 
 class UndoHistory {
-	static constexpr int UH_MAX_UNDO = 40;
+	static constexpr uint32_t UH_NONE = 0xFFFFFFFF;
+	static constexpr uint32_t UH_MAX_UNDO = 40;
 
-	// Note that -1 on the next line is NOT a magic number.  It's the actual
-	// index.  The same is true everywhere in UndoHistory.
-	int curIndex = -1;
+	uint32_t curIndex = UH_NONE;
 	std::vector<std::unique_ptr<UndoStateProject>> states;
 
 public:
@@ -25,12 +24,12 @@ public:
 	bool ForwardStepHistory();
 	void ClearHistory();
 
-	bool CanUndo() const { return curIndex != -1; }
+	bool CanUndo() const { return curIndex != UH_NONE; }
 
-	bool CanRedo() const { return !states.empty() && curIndex + 1 < static_cast<int>(states.size()); }
+	bool CanRedo() const { return !states.empty() && curIndex + 1 < states.size(); }
 
 	UndoStateProject* GetCurState() const {
-		if (curIndex == -1)
+		if (curIndex == UH_NONE)
 			return nullptr;
 		return states[curIndex].get();
 	}
@@ -42,7 +41,7 @@ public:
 	}
 
 	UndoStateProject* GetNextState() const {
-		if (curIndex + 1 >= static_cast<int>(states.size()))
+		if (curIndex + 1 >= states.size())
 			return nullptr;
 		return states[curIndex + 1].get();
 	}

--- a/src/files/ObjFile.cpp
+++ b/src/files/ObjFile.cpp
@@ -57,7 +57,7 @@ int ObjFile::LoadForNif(std::fstream& base, const ObjOptionsImport& options) {
 	std::string facept2;
 	std::string facept3;
 	std::string facept4;
-	uint32_t f[4];
+	int f[4];
 	uint32_t ft[4];
 	uint32_t fn[4];
 	uint32_t nPoints = 0;
@@ -201,7 +201,7 @@ int ObjFile::LoadForNif(std::fstream& base, const ObjOptionsImport& options) {
 					curPoints.push_back(pt);
 
 				if (v_idx[i] == current->verts.size()) {
-					if (verts.size() > f[i]) {
+					if (static_cast<int>(verts.size()) > f[i]) {
 						current->verts.push_back(verts[f[i]]);
 
 						if (uvs.size() > ft[i])

--- a/src/files/ResourceLoader.h
+++ b/src/files/ResourceLoader.h
@@ -12,10 +12,14 @@ See the included LICENSE file
 
 #include "../utils/StringStuff.h"
 
+#ifdef _MSC_VER
 #pragma warning(push, 0)
+#endif
 #include "../SOIL2/SOIL2.h"
 #include "gli.hpp"
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
 typedef unsigned int GLuint;
 class GLMaterial;

--- a/src/files/ResourceLoader.h
+++ b/src/files/ResourceLoader.h
@@ -12,19 +12,8 @@ See the included LICENSE file
 
 #include "../utils/StringStuff.h"
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#endif
 #include "../SOIL2/SOIL2.h"
 #include "gli.hpp"
-#ifdef _MSC_VER
-#pragma warning(pop)
-#else
-#pragma GCC diagnostic pop
-#endif
 
 typedef unsigned int GLuint;
 class GLMaterial;

--- a/src/files/ResourceLoader.h
+++ b/src/files/ResourceLoader.h
@@ -14,11 +14,16 @@ See the included LICENSE file
 
 #ifdef _MSC_VER
 #pragma warning(push, 0)
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 #endif
 #include "../SOIL2/SOIL2.h"
 #include "gli.hpp"
 #ifdef _MSC_VER
 #pragma warning(pop)
+#else
+#pragma GCC diagnostic pop
 #endif
 
 typedef unsigned int GLuint;

--- a/src/files/TriFile.cpp
+++ b/src/files/TriFile.cpp
@@ -16,7 +16,7 @@ bool TriFile::Read(const std::string& fileName) {
 		char hdr[4];
 		triFile.read(hdr, 4);
 
-		uint32_t magic = 'TRIP';
+		uint32_t magic = "TRIP"_mci;
 		if (memcmp(hdr, &magic, 4) != 0)
 			return false;
 
@@ -139,7 +139,7 @@ bool TriFile::Write(const std::string& fileName) {
 	PlatformUtil::OpenFileStream(triFile, fileName, std::ios::out | std::ios::binary);
 
 	if (triFile.is_open()) {
-		uint32_t hdr = 'TRIP';
+		uint32_t hdr = "TRIP"_mci;
 		triFile.write((char*)&hdr, 4);
 
 		uint16_t shapeCount = GetShapeCount(MORPHTYPE_POSITION);

--- a/src/files/wxDDSImage.cpp
+++ b/src/files/wxDDSImage.cpp
@@ -5,18 +5,7 @@ See the included LICENSE file
 
 #include "wxDDSImage.h"
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#endif
 #include "gli.hpp"
-#ifdef _MSC_VER
-#pragma warning(pop)
-#else
-#pragma GCC diagnostic pop
-#endif
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxDDSHandler, wxImageHandler);
 

--- a/src/files/wxDDSImage.cpp
+++ b/src/files/wxDDSImage.cpp
@@ -5,9 +5,13 @@ See the included LICENSE file
 
 #include "wxDDSImage.h"
 
+#ifdef _MSC_VER
 #pragma warning(push, 0)
+#endif
 #include "gli.hpp"
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxDDSHandler, wxImageHandler);
 

--- a/src/files/wxDDSImage.cpp
+++ b/src/files/wxDDSImage.cpp
@@ -7,10 +7,15 @@ See the included LICENSE file
 
 #ifdef _MSC_VER
 #pragma warning(push, 0)
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 #endif
 #include "gli.hpp"
 #ifdef _MSC_VER
 #pragma warning(pop)
+#else
+#pragma GCC diagnostic pop
 #endif
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxDDSHandler, wxImageHandler);

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -2903,6 +2903,7 @@ BodySlideFrame::BodySlideFrame(BodySlideApp* a, const wxSize& size)
 			case FO4VR:
 			case SKYRIMSE:
 			case SKYRIMVR: cbMorphs->Show(); break;
+			default: break;
 		}
 	}
 
@@ -2915,6 +2916,7 @@ BodySlideFrame::BodySlideFrame(BodySlideApp* a, const wxSize& size)
 			switch (app->targetGame) {
 				case SKYRIMSE:
 				case SKYRIMVR: cbForceBodyNormals->Show(); break;
+				default: break;
 			}
 		}
 	}
@@ -4033,6 +4035,7 @@ void BodySlideFrame::OnSettings(wxCommandEvent& WXUNUSED(event)) {
 					switch (app->targetGame) {
 						case SKYRIMSE:
 						case SKYRIMVR: cbForceBodyNormals->Show(); break;
+						default: break;
 					}
 				}
 				else

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -906,10 +906,6 @@ void BodySlideApp::EditProject(const std::string& projectName) {
 	if (project == outfitNameSource.end())
 		return;
 
-	int select = wxNOT_FOUND;
-	if (sliderView->outfitChoice)
-		select = sliderView->outfitChoice->GetSelection();
-
 	wxLogMessage("Launching Outfit Studio with project file '%s' and project '%s'...", project->second, project->first);
 	LaunchOutfitStudio(wxString::Format("-proj \"%s\" \"%s\"", wxString::FromUTF8(project->first), wxString::FromUTF8(project->second)));
 }

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -798,7 +798,7 @@ void BodySlideApp::DisplayActiveSet() {
 	}
 
 	// Create category UI
-	int iter = 0;
+	size_t iter = 0;
 	if (catSliders.size() > 0) {
 		for (auto& cat : sliderCategories) {
 			std::string name = std::get<0>(cat);
@@ -982,7 +982,7 @@ bool BodySlideApp::WriteMorphTRI(const std::string& triPath, SliderSet& sliderSe
 		if (shapeZapIndices.size() > 0 && shapeZapIndices.back() >= shapeVertCount)
 			continue;
 
-		for (int s = 0; s < sliderSet.size(); s++) {
+		for (size_t s = 0; s < sliderSet.size(); s++) {
 			std::string dn = sliderSet[s].TargetDataName(targetShape->second.targetShape);
 			std::string target = targetShape->second.targetShape;
 			if (dn.empty())
@@ -2473,7 +2473,7 @@ int BodySlideApp::BuildListBodies(
 			std::vector<int> clamps;
 			zapIdxAll.emplace(it->first, std::vector<uint16_t>());
 
-			for (int s = 0; s < currentSet.size(); s++) {
+			for (size_t s = 0; s < currentSet.size(); s++) {
 				std::string target = it->second.targetShape;
 				std::string dn = currentSet[s].TargetDataName(target);
 				if (dn.empty())
@@ -3606,7 +3606,7 @@ void BodySlideFrame::OnConflictPopup(wxMouseEvent& WXUNUSED(event)) {
 	int id = fileCollisionMenu->GetMenuItemCount();
 	while (id--)
 		fileCollisionMenu->Delete(id);
-	for (id = 0; id < conflictingOutfits.size(); id++)
+	for (id = 0; id < static_cast<int>(conflictingOutfits.size()); id++)
 		fileCollisionMenu->Append(id, conflictingOutfits[id], "", wxITEM_NORMAL);
 	id = GetPopupMenuSelectionFromUser(*fileCollisionMenu, wxDefaultPosition);
 	if (0 > id)
@@ -3934,7 +3934,7 @@ void BodySlideFrame::OnSettings(wxCommandEvent& WXUNUSED(event)) {
 		cbBrushSettingsNearCursor->SetValue(Config.GetBoolValue("Input/BrushSettingsNearCursor"));
 
 		wxChoice* choiceLanguage = XRCCTRL(*settings, "choiceLanguage", wxChoice);
-		for (int i = 0; i < SupportedLangs.size(); i++)
+		for (size_t i = 0; i < SupportedLangs.size(); i++)
 			choiceLanguage->AppendString(wxLocale::GetLanguageName(SupportedLangs[i]));
 
 		if (!choiceLanguage->SetStringSelection(wxLocale::GetLanguageName(Config.GetIntValue("Language"))))

--- a/src/program/EditUV.cpp
+++ b/src/program/EditUV.cpp
@@ -589,6 +589,9 @@ void EditUVCanvas::OnLeftDown(wxMouseEvent& event) {
 	editUV->StartTool();
 
 	switch (editUV->GetActiveTool()) {
+		case EditUVTool::VertexSelection:
+			break;
+
 		case EditUVTool::BoxSelection:
 			boxSelectMesh->verts[0] = Vector3(click.x, click.y, 0.0f);
 			boxSelectMesh->verts[1] = Vector3(click.x, click.y, 0.0f);

--- a/src/program/NormalsGenDialog.cpp
+++ b/src/program/NormalsGenDialog.cpp
@@ -252,7 +252,7 @@ void NormalsGenDialog::addBGLayer(NormalGenLayer& newLayer) {
 	resolutions.Add("4096");
 
 	int selectedRes = 0;
-	for (int i = 0; i < resolutions.size(); i++) {
+	for (int i = 0; i < static_cast<int>(resolutions.size()); i++) {
 		if (resolutions[i] == std::to_string(newLayer.resolution)) {
 			selectedRes = i;
 			break;

--- a/src/program/NormalsGenDialog.cpp
+++ b/src/program/NormalsGenDialog.cpp
@@ -242,7 +242,6 @@ wxString NormalsGenDialog::nextLayerName() {
 }
 
 void NormalsGenDialog::addBGLayer(NormalGenLayer& newLayer) {
-	wxPGProperty* newCat;
 	wxPGProperty* newProp;
 	wxArrayString resolutions;
 	resolutions.Add("256");
@@ -259,7 +258,7 @@ void NormalsGenDialog::addBGLayer(NormalGenLayer& newLayer) {
 		}
 	}
 
-	newCat = pgLayers->Append(new wxPropertyCategory(newLayer.layerName, "Background"));
+	pgLayers->Append(new wxPropertyCategory(newLayer.layerName, "Background"));
 
 	newProp = pgLayers->Append(new wxImageFileProperty(_("Background File"), _("Background File"), newLayer.sourceFileName));
 	pgLayers->SetPropertyHelpString(newProp, _("File source for this layer."));

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -3995,7 +3995,7 @@ void OutfitProject::ChooseClothData(NifFile& nif) {
 			std::string selString{clothFileNames[sel[i]].ToUTF8()};
 			if (!selString.empty()) {
 				auto clothBlock = clothData[selString]->Clone();
-				int id = nif.GetHeader().AddBlock(std::move(clothBlock));
+				uint32_t id = nif.GetHeader().AddBlock(std::move(clothBlock));
 				if (id != 0xFFFFFFFF) {
 					auto root = nif.GetRootNode();
 					if (root)

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -1280,7 +1280,7 @@ void OutfitStudioFrame::OnMenuItem(wxCommandEvent& event) {
 	int id = event.GetId();
 	if (id >= 1000 && id < 2000) {
 		// Load project history entry
-		if (projectHistory.size() > id - 1000) {
+		if (static_cast<int>(projectHistory.size()) > id - 1000) {
 			if (!CheckPendingChanges())
 				return;
 
@@ -1863,7 +1863,7 @@ void OutfitStudioFrame::OnSettings(wxCommandEvent& WXUNUSED(event)) {
 		cbBrushSettingsNearCursor->SetValue(Config.GetBoolValue("Input/BrushSettingsNearCursor"));
 
 		wxChoice* choiceLanguage = XRCCTRL(*settings, "choiceLanguage", wxChoice);
-		for (int i = 0; i < SupportedLangs.size(); i++)
+		for (size_t i = 0; i < SupportedLangs.size(); i++)
 			choiceLanguage->AppendString(wxLocale::GetLanguageName(SupportedLangs[i]));
 
 		if (!choiceLanguage->SetStringSelection(wxLocale::GetLanguageName(Config.GetIntValue("Language"))))

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -3349,7 +3349,6 @@ void OutfitStudioFrame::UpdateUndoTools() {
 void OutfitStudioFrame::OnNewProject(wxCommandEvent& WXUNUSED(event)) {
 	wxWizard wiz;
 	wxWizardPage* pg1;
-	wxWizardPage* pg2;
 	bool result = false;
 
 	if (!CheckPendingChanges())
@@ -3363,7 +3362,6 @@ void OutfitStudioFrame::OnNewProject(wxCommandEvent& WXUNUSED(event)) {
 		XRCCTRL(wiz, "npSliderSetFile", wxFilePickerCtrl)->Bind(wxEVT_FILEPICKER_CHANGED, &OutfitStudioFrame::OnNPWizChangeSliderSetFile, this);
 		XRCCTRL(wiz, "npSliderSetName", wxChoice)->Bind(wxEVT_CHOICE, &OutfitStudioFrame::OnNPWizChangeSetNameChoice, this);
 
-		pg2 = (wxWizardPage*)XRCCTRL(wiz, "wizpgNewProj2", wxWizardPageSimple);
 		XRCCTRL(wiz, "npWorkFilename", wxFilePickerCtrl)->Bind(wxEVT_FILEPICKER_CHANGED, &OutfitStudioFrame::OnLoadOutfitFP_File, this);
 		XRCCTRL(wiz, "npTexFilename", wxFilePickerCtrl)->Bind(wxEVT_FILEPICKER_CHANGED, &OutfitStudioFrame::OnLoadOutfitFP_Texture, this);
 
@@ -12815,7 +12813,6 @@ void wxGLPanel::OnLeftUp(wxMouseEvent& event) {
 	if (!isLDragging && !isPainting && activeTool == ToolID::Select) {
 		int x, y;
 		event.GetPosition(&x, &y);
-		wxPoint p = event.GetPosition();
 
 		mesh* m = gls.PickMesh(x, y);
 		if (m)

--- a/src/utils/AABBTree.cpp
+++ b/src/utils/AABBTree.cpp
@@ -180,7 +180,6 @@ bool AABB::IntersectAABB(const AABB& other) {
 
 bool AABB::IntersectRay(const Vector3& Origin, const Vector3& Direction, Vector3* outCoord) {
 	//char side[3];  // side of potential collision plane: 0=left 1=right 2 = middle
-	float candidatePlane[3]; // x,y,z values for potential candidate plane intersection.
 	Vector3 maxT(-1, -1, -1);
 	Vector3 collisionCoord;
 	bool inside = true;
@@ -190,14 +189,12 @@ bool AABB::IntersectRay(const Vector3& Origin, const Vector3& Direction, Vector3
 	// X Axis candidacy
 	if (Origin.x < min.x) {
 		inside = false;
-		candidatePlane[0] = min.x;
 		if (Direction.x != 0.0f) {
 			maxT.x = (min.x - Origin.x) / Direction.x;
 		}
 	}
 	else if (Origin.x > max.x) {
 		inside = false;
-		candidatePlane[0] = max.x;
 		if (Direction.x != 0.0f) {
 			maxT.x = (max.x - Origin.x) / Direction.x;
 		}
@@ -206,14 +203,12 @@ bool AABB::IntersectRay(const Vector3& Origin, const Vector3& Direction, Vector3
 	// Y Axis candidacy
 	if (Origin.y < min.y) {
 		inside = false;
-		candidatePlane[1] = min.y;
 		if (Direction.y != 0.0f) {
 			maxT.y = (min.y - Origin.y) / Direction.y;
 		}
 	}
 	else if (Origin.y > max.y) {
 		inside = false;
-		candidatePlane[1] = max.y;
 		if (Direction.y != 0.0f) {
 			maxT.y = (max.y - Origin.y) / Direction.y;
 		}
@@ -225,14 +220,12 @@ bool AABB::IntersectRay(const Vector3& Origin, const Vector3& Direction, Vector3
 	// Z Axis candidacy
 	if (Origin.z < min.z) {
 		inside = false;
-		candidatePlane[2] = min.z;
 		if (Direction.z != 0.0f) {
 			maxT.z = (min.z - Origin.z) / Direction.z;
 		}
 	}
 	else if (Origin.z > max.z) {
 		inside = false;
-		candidatePlane[2] = max.z;
 		if (Direction.z != 0.0f) {
 			maxT.z = (max.z - Origin.z) / Direction.z;
 		}

--- a/src/utils/PlatformUtil.h
+++ b/src/utils/PlatformUtil.h
@@ -28,3 +28,14 @@ void OpenFileStream(std::fstream& file, const std::string& fileName, std::ios_ba
 void OpenFileStream(std::fstream& file, const std::wstring& fileName, unsigned int mode);
 #endif
 } // namespace PlatformUtil
+
+// This user-defined literal allows you to specify an int with a
+// multi-character string: "OSD\0"_mci
+inline constexpr uint32_t operator"" _mci(const char* p, size_t n) {
+	uint32_t v = 0;
+	for (size_t i = 0; i < n; ++i) {
+		v <<= 8;
+		v += static_cast<unsigned char>(p[i]);
+	}
+	return v;
+}


### PR DESCRIPTION
To ease readability, I broke the different warnings down into different commits.  One warning was only generated with optimization on.  I avoided making changes to lib/gli, but lib/gli was only producing one warning message, so I wonder if it should be fixed rather than disabling warnings for lib/gli.

I wonder if disabling warnings is still necessary with MSVC (see commit f209980).