### PR TITLE
Fixed some brush unwelding and normal bugs

### DIFF
--- a/src/components/Mesh.cpp
+++ b/src/components/Mesh.cpp
@@ -446,6 +446,9 @@ void Mesh::SmoothNormals(const std::set<int>& vertices) {
 	if (lockNormals || !norms)
 		return;
 
+	// Copy old normals into a working temporary
+	std::vector<Vector3> tnorms(norms.get(), norms.get() + nVerts);
+
 	// Zero old normals
 	bool noVertices = vertices.empty();
 	for (int i = 0; i < nVerts; i++) {
@@ -455,12 +458,10 @@ void Mesh::SmoothNormals(const std::set<int>& vertices) {
 		if (lockedNormalIndices.count(i) != 0)
 			continue;
 
-		Vector3& pn = norms[i];
-		pn.Zero();
+		tnorms[i].Zero();
 	}
 
 	// Face normals
-	Vector3 tn;
 	for (int t = 0; t < nTris; t++) {
 		Triangle& tri = tris[t];
 		bool bn1 = (noVertices || vertices.count(tri.p1) != 0);
@@ -471,30 +472,23 @@ void Mesh::SmoothNormals(const std::set<int>& vertices) {
 		if (!bn1 && !bn2 && !bn3)
 			continue;
 
-		tri.trinormal(verts.get(), &tn);
+		Vector3 tn = tri.trinormal(verts.get());
 
-		if (bn1 && lockedNormalIndices.count(tri.p1) == 0) {
-			Vector3& pn1 = norms[tri.p1];
-			pn1 += tn;
-		}
+		if (bn1 && lockedNormalIndices.count(tri.p1) == 0)
+			tnorms[tri.p1] += tn;
 
-		if (bn2 && lockedNormalIndices.count(tri.p2) == 0) {
-			Vector3& pn2 = norms[tri.p2];
-			pn2 += tn;
-		}
+		if (bn2 && lockedNormalIndices.count(tri.p2) == 0)
+			tnorms[tri.p2] += tn;
 
-		if (bn3 && lockedNormalIndices.count(tri.p3) == 0) {
-			Vector3& pn3 = norms[tri.p3];
-			pn3 += tn;
-		}
+		if (bn3 && lockedNormalIndices.count(tri.p3) == 0)
+			tnorms[tri.p3] += tn;
 	}
 
 	for (int i = 0; i < nVerts; i++) {
 		if (lockedNormalIndices.count(i) != 0)
 			continue;
 
-		Vector3& pn = norms[i];
-		pn.Normalize();
+		tnorms[i].Normalize();
 	}
 
 	// Smooth welded vertex normals
@@ -506,26 +500,29 @@ void Mesh::SmoothNormals(const std::set<int>& vertices) {
 
 		for (auto& wvp : weldVerts) {
 			auto& key = wvp.first;
-			if (!noVertices && vertices.count(key) != 0)
+			if (!noVertices && vertices.count(key) == 0)
 				continue;
 
 			if (lockedNormalIndices.count(key) != 0)
 				continue;
 
-			const Vector3& n = norms[key];
+			const Vector3& n = tnorms[key];
 			Vector3 sn = n;
 			auto& value = wvp.second;
 			for (int wvi : value)
-				if (n.angle(norms[wvi]) < smoothThresh)
-					sn += norms[wvi];
+				if (n.angle(tnorms[wvi]) < smoothThresh)
+					sn += tnorms[wvi];
 
 			sn.Normalize();
 			seamNorms.emplace_back(key, sn);
 		}
 
 		for (auto& snp : seamNorms)
-			norms[snp.first] = snp.second;
+			tnorms[snp.first] = snp.second;
 	}
+
+	// Copy temporary back into the main.
+	std::copy(tnorms.begin(), tnorms.end(), norms.get());
 
 	queueUpdate[UpdateType::Normals] = true;
 	CalcTangentSpace();
@@ -547,8 +544,7 @@ Vector3 Mesh::GetOneVertexNormal(int vi) {
 		const Triangle& t = tris[ti];
 		if (t.p1 != vi && t.p2 != vi && t.p3 != vi)
 			continue;
-		Vector3 tn;
-		t.trinormal(verts.get(), &tn);
+		Vector3 tn = t.trinormal(verts.get());
 		tn.Normalize();
 		sum += tn;
 	}
@@ -561,8 +557,7 @@ Vector3 Mesh::GetOneVertexNormal(int vi) {
 				const Triangle& t = tris[ti];
 				if (t.p1 != wvi && t.p2 != wvi && t.p3 != wvi)
 					continue;
-				Vector3 tn;
-				t.trinormal(verts.get(), &tn);
+				Vector3 tn = t.trinormal(verts.get());
 				tn.Normalize();
 				sum += tn;
 			}
@@ -584,13 +579,12 @@ void Mesh::FacetNormals() {
 		pn.Zero();
 	}
 
-	Vector3 tn;
 	for (int t = 0; t < nTris; t++) {
 		auto& tri = tris[t];
 		if (tri.p1 >= nVerts || tri.p2 >= nVerts || tri.p3 >= nVerts)
 			continue;
 
-		tri.trinormal(verts.get(), &tn);
+		Vector3 tn = tri.trinormal(verts.get());
 
 		if (lockedNormalIndices.find(tri.p1) == lockedNormalIndices.end()) {
 			Vector3& pn1 = norms[tri.p1];
@@ -748,149 +742,79 @@ void Mesh::CalcTangentSpace() {
 	queueUpdate[UpdateType::Bitangents] = true;
 }
 
-bool Mesh::ConnectedPointsInSphere(Vector3 center, float sqradius, int startTri, bool* trivisit, bool* pointvisit, int outPoints[], int& nOutPoints, std::vector<int>& outFacets) {
-	if (!vertTris)
-		return false;
-	if (!vertEdges)
-		return false;
-	if (startTri < 0)
-		return false;
-
-	outFacets.push_back(startTri);
-
-	if (trivisit)
-		trivisit[startTri] = true;
-
-	if (verts[tris[startTri].p1].DistanceSquaredTo(center) <= sqradius) {
-		outPoints[nOutPoints++] = tris[startTri].p1;
-		pointvisit[tris[startTri].p1] = true;
-		auto wv = weldVerts.find(tris[startTri].p1);
-		if (wv != weldVerts.end()) {
-			for (auto& w : wv->second) {
-				if (pointvisit[w])
-					continue;
-				outPoints[nOutPoints++] = w;
-				pointvisit[w] = true;
-			}
+void Mesh::ConnectedPointsInSphere(const Vector3& center, float sqradius, int startTri, std::vector<bool>& pointvisit, int outPoints[], int& nOutPoints) {
+	// Add the triangle's three vertices to the queue, if they're within the
+	// radius.
+	for (int tvi = 0; tvi < 3; ++tvi) {
+		auto p = tris[startTri][tvi];
+		if (!pointvisit[p] && verts[p].DistanceSquaredTo(center) <= sqradius) {
+			outPoints[nOutPoints++] = p;
+			pointvisit[p] = true;
 		}
 	}
 
-	if (verts[tris[startTri].p2].DistanceSquaredTo(center) <= sqradius) {
-		outPoints[nOutPoints++] = tris[startTri].p2;
-		pointvisit[tris[startTri].p2] = true;
-		auto wv = weldVerts.find(tris[startTri].p2);
-		if (wv != weldVerts.end()) {
-			for (auto& w : wv->second) {
-				if (pointvisit[w])
-					continue;
-				outPoints[nOutPoints++] = w;
-				pointvisit[w] = true;
-			}
-		}
-	}
+	// Loop through points in the queue
+	for (int adjCursor = 0; adjCursor < nOutPoints; ++adjCursor) {
+		int p = outPoints[adjCursor];
 
-	if (verts[tris[startTri].p3].DistanceSquaredTo(center) <= sqradius) {
-		outPoints[nOutPoints++] = tris[startTri].p3;
-		pointvisit[tris[startTri].p3] = true;
-		auto wv = weldVerts.find(tris[startTri].p3);
-		if (wv != weldVerts.end()) {
-			for (auto& w : wv->second) {
-				if (pointvisit[w])
-					continue;
-				outPoints[nOutPoints++] = w;
-				pointvisit[w] = true;
-			}
-		}
-	}
+		// Add welds of p to the queue
+		auto wvit = weldVerts.find(p);
+		if (wvit != weldVerts.end())
+			for (int wvi : wvit->second)
+				if (!pointvisit[wvi]) {
+					pointvisit[wvi] = true;
+					outPoints[nOutPoints++] = wvi;
+				}
 
-	int adjCursor = 0;
-	while (adjCursor < nOutPoints) {
-		int pointBuf[100];
-		int tp = outPoints[adjCursor++];
-		int n = GetAdjacentPoints(tp, pointBuf, 100);
-		for (int i = 0; i < n; i++) {
-			if (!pointvisit[pointBuf[i]] && verts[pointBuf[i]].DistanceSquaredTo(center) <= sqradius) {
-				pointvisit[pointBuf[i]] = true;
-				outPoints[nOutPoints++] = pointBuf[i];
+		// Add adjacent points of p to the queue, if they're within the radius
+		for (int ei : vertEdges[p]) {
+			int op = edges[ei].p1 == p ? edges[ei].p2 : edges[ei].p1;
+			if (!pointvisit[op] && verts[op].DistanceSquaredTo(center) <= sqradius) {
+				pointvisit[op] = true;
+				outPoints[nOutPoints++] = op;
 			}
 		}
 	}
-	return true;
 }
 
-bool Mesh::ConnectedPointsInSphere2(Vector3 center, float sqradius, int startTri, bool* trivisit, bool* pointvisit, int outPoints[], int& nOutPoints, std::vector<int>& outFacets) {
-	if (!vertTris)
-		return false;
-	if (startTri < 0)
-		return false;
-
-	outFacets.push_back(startTri);
-	trivisit[startTri] = true;
-
-	auto vtris = vertTris.get();
-	if (verts[tris[startTri].p1].DistanceSquaredTo(center) <= sqradius) {
-		if (!pointvisit[tris[startTri].p1]) {
-			pointvisit[tris[startTri].p1] = true;
-			outPoints[nOutPoints++] = tris[startTri].p1;
-		}
-		for (auto& t : vtris[tris[startTri].p1]) {
-			if (trivisit[t])
-				continue;
-			ConnectedPointsInSphere(center, sqradius, t, trivisit, pointvisit, outPoints, nOutPoints, outFacets);
-		}
-		auto wv = weldVerts.find(tris[startTri].p1);
-		if (wv != weldVerts.end()) {
-			for (auto& w : wv->second) {
-				for (auto& t : vtris[w]) {
-					if (trivisit[t])
-						continue;
-					ConnectedPointsInSphere(center, sqradius, t, trivisit, pointvisit, outPoints, nOutPoints, outFacets);
-				}
+void Mesh::ConnectedPointsInTwoSpheres(const Vector3& center1, const Vector3& center2, float sqradius, int startTri1, int startTri2, std::vector<bool>& pointvisit, int outPoints[], int& nOutPoints) {
+	// Add each triangle's three vertices to the queue, if they're within the
+	// radius.
+	for (int triInd = 0; triInd < 2; ++triInd) {
+		int startTri = triInd ? startTri2 : startTri1;
+		for (int tvi = 0; tvi < 3; ++tvi) {
+			auto p = tris[startTri][tvi];
+			if (!pointvisit[p] &&
+				(verts[p].DistanceSquaredTo(center1) <= sqradius ||
+				verts[p].DistanceSquaredTo(center2) <= sqradius)) {
+				outPoints[nOutPoints++] = p;
+				pointvisit[p] = true;
 			}
 		}
 	}
 
-	if (verts[tris[startTri].p2].DistanceSquaredTo(center) <= sqradius) {
-		if (!pointvisit[tris[startTri].p2]) {
-			pointvisit[tris[startTri].p2] = true;
-			outPoints[nOutPoints++] = tris[startTri].p2;
-		}
-		for (auto& t : vtris[tris[startTri].p2]) {
-			if (trivisit[t])
-				continue;
-			ConnectedPointsInSphere(center, sqradius, t, trivisit, pointvisit, outPoints, nOutPoints, outFacets);
-		}
-		auto wv = weldVerts.find(tris[startTri].p2);
-		if (wv != weldVerts.end()) {
-			for (auto& w : wv->second) {
-				for (auto& t : vtris[w]) {
-					if (trivisit[t])
-						continue;
-					ConnectedPointsInSphere(center, sqradius, t, trivisit, pointvisit, outPoints, nOutPoints, outFacets);
+	// Loop through points in the queue
+	for (int adjCursor = 0; adjCursor < nOutPoints; ++adjCursor) {
+		int p = outPoints[adjCursor];
+
+		// Add welds of p to the queue
+		auto wvit = weldVerts.find(p);
+		if (wvit != weldVerts.end())
+			for (int wvi : wvit->second)
+				if (!pointvisit[wvi]) {
+					pointvisit[wvi] = true;
+					outPoints[nOutPoints++] = wvi;
 				}
+
+		// Add adjacent points of p to the queue, if they're within the radius
+		for (int ei : vertEdges[p]) {
+			int op = edges[ei].p1 == p ? edges[ei].p2 : edges[ei].p1;
+			if (!pointvisit[op] &&
+				(verts[op].DistanceSquaredTo(center1) <= sqradius ||
+				verts[op].DistanceSquaredTo(center2) <= sqradius)) {
+				pointvisit[op] = true;
+				outPoints[nOutPoints++] = op;
 			}
 		}
 	}
-	if (verts[tris[startTri].p3].DistanceSquaredTo(center) <= sqradius) {
-		if (!pointvisit[tris[startTri].p3]) {
-			pointvisit[tris[startTri].p3] = true;
-			outPoints[nOutPoints++] = tris[startTri].p3;
-		}
-		for (auto& t : vtris[tris[startTri].p3]) {
-			if (trivisit[t])
-				continue;
-			ConnectedPointsInSphere(center, sqradius, t, trivisit, pointvisit, outPoints, nOutPoints, outFacets);
-		}
-		auto wv = weldVerts.find(tris[startTri].p3);
-		if (wv != weldVerts.end()) {
-			for (auto& w : wv->second) {
-				for (auto& t : vtris[w]) {
-					if (trivisit[t])
-						continue;
-					ConnectedPointsInSphere(center, sqradius, t, trivisit, pointvisit, outPoints, nOutPoints, outFacets);
-				}
-			}
-		}
-	}
-	return true;
 }

--- a/src/components/Mesh.h
+++ b/src/components/Mesh.h
@@ -152,15 +152,19 @@ public:
 	static void SmoothNormalsStatic(Mesh* m) { m->SmoothNormals(); }
 	static void SmoothNormalsStaticArray(Mesh* m, int* vertices, int nVertices) {
 		std::set<int> verts;
-		for (int i = 0; i < nVertices; i++)
+		for (int i = 0; i < nVertices; i++) {
 			verts.insert(vertices[i]);
+			m->GetAdjacentPoints(vertices[i], verts);
+		}
 
 		m->SmoothNormals(verts);
 	}
 	static void SmoothNormalsStaticMap(Mesh* m, const std::unordered_map<int, nifly::Vector3>& vertices) {
 		std::set<int> verts;
-		for (auto& v : vertices)
+		for (auto& v : vertices) {
 			verts.insert(v.first);
+			m->GetAdjacentPoints(v.first, verts);
+		}
 
 		m->SmoothNormals(verts);
 	}
@@ -169,16 +173,17 @@ public:
 
 	void CalcTangentSpace();
 
-	// Retrieve connected points in a sphere's radius (squared, requires tri adjacency to be set up).
-	// Also requires pointvisit to be allocated by the caller.
-	// Recursive - large query will overflow the stack!
-	bool ConnectedPointsInSphere(
-		nifly::Vector3 center, float sqradius, int startTri, bool* trivisit, bool* pointvisit, int outPoints[], int& nOutPoints, std::vector<int>& outFacets);
+	// List connected points within the squared radius of the center.
+	// Requires vertEdges and edges.  pointvisit.size() must be nVerts,
+	// and it must be initialized to false.  nOutPoints must be initialized
+	// to zero.
+	void ConnectedPointsInSphere(const nifly::Vector3& center, float sqradius, int startTri, std::vector<bool>& pointvisit, int outPoints[], int& nOutPoints);
 
-	// Similar to above, but uses an edge list to determine adjacency, with less risk of stack problems.
-	// Also requires trivisit and pointvisit to be allocated by the caller.
-	bool ConnectedPointsInSphere2(
-		nifly::Vector3 center, float sqradius, int startTri, bool* trivisit, bool* pointvisit, int outPoints[], int& nOutPoints, std::vector<int>& outFacets);
+	// List connected points within the squared radius of either center.
+	// Requires vertEdges and edges.  pointvisit.size() must be nVerts,
+	// and it must be initialized to false.  nOutPoints must be initialized
+	// to zero.
+	void ConnectedPointsInTwoSpheres(const nifly::Vector3& center1, const nifly::Vector3& center2, float sqradius, int startTri1, int startTri2, std::vector<bool>& pointvisit, int outPoints[], int& nOutPoints);
 
 	// Convenience function to gather connected points, taking into account "welded" vertices. Does not clear the output set.
 	void GetAdjacentPoints(int querypoint, std::set<int>& outPoints);

--- a/src/components/Mesh.h
+++ b/src/components/Mesh.h
@@ -148,10 +148,12 @@ public:
 	float GetSmoothThreshold();
 
 	void FacetNormals();
-	void SmoothNormals(const std::set<int>& vertices = std::set<int>());
+	void SmoothNormals(const std::unordered_set<int>& vertices = std::unordered_set<int>());
 	static void SmoothNormalsStatic(Mesh* m) { m->SmoothNormals(); }
 	static void SmoothNormalsStaticArray(Mesh* m, int* vertices, int nVertices) {
-		std::set<int> verts;
+		std::unordered_set<int> verts;
+		verts.reserve(nVertices);
+
 		for (int i = 0; i < nVertices; i++) {
 			verts.insert(vertices[i]);
 			m->GetAdjacentPoints(vertices[i], verts);
@@ -160,7 +162,9 @@ public:
 		m->SmoothNormals(verts);
 	}
 	static void SmoothNormalsStaticMap(Mesh* m, const std::unordered_map<int, nifly::Vector3>& vertices) {
-		std::set<int> verts;
+		std::unordered_set<int> verts;
+		verts.reserve(vertices.size());
+
 		for (auto& v : vertices) {
 			verts.insert(v.first);
 			m->GetAdjacentPoints(v.first, verts);
@@ -186,7 +190,7 @@ public:
 	void ConnectedPointsInTwoSpheres(const nifly::Vector3& center1, const nifly::Vector3& center2, float sqradius, int startTri1, int startTri2, std::vector<bool>& pointvisit, int outPoints[], int& nOutPoints);
 
 	// Convenience function to gather connected points, taking into account "welded" vertices. Does not clear the output set.
-	void GetAdjacentPoints(int querypoint, std::set<int>& outPoints);
+	void GetAdjacentPoints(int querypoint, std::unordered_set<int>& outPoints);
 
 	// More optimized adjacency fetch, using edge adjacency and storing the output in a static array.
 	// Requires that BuildEdgeList() be called prior to use.

--- a/src/components/TweakBrush.cpp
+++ b/src/components/TweakBrush.cpp
@@ -221,33 +221,33 @@ bool TweakBrush::queryPoints(
 	if (mergeMirror)
 		m->bvh->IntersectSphere(meshmirrororigin, meshradius, &IResults);
 
-	std::unique_ptr<bool[]> pointVisit = std::make_unique<bool[]>(m->nVerts);
+	std::vector<bool> pointVisit(m->nVerts, false);
 
 	if (bConnected && !IResults.empty()) {
-		int pickFacet = IResults[0].HitFacet;
+		int pickFacet1 = IResults[0].HitFacet;
 		float minDist = IResults[0].HitDistance;
 		for (unsigned int i = 0; i < mirrorStartInd; ++i) {
 			auto& r = IResults[i];
 			if (r.HitDistance < minDist) {
 				minDist = r.HitDistance;
-				pickFacet = r.HitFacet;
+				pickFacet1 = r.HitFacet;
 			}
 		}
 
-		std::vector<int> resultFacets;
-		m->ConnectedPointsInSphere(meshorigin, meshradius * meshradius, pickFacet, nullptr, pointVisit.get(), resultPoints, outResultCount, resultFacets);
 		if (mergeMirror && mirrorStartInd < IResults.size()) {
-			pickFacet = IResults[mirrorStartInd].HitFacet;
+			int pickFacet2 = IResults[mirrorStartInd].HitFacet;
 			minDist = IResults[mirrorStartInd].HitDistance;
 			for (unsigned int i = mirrorStartInd; i < IResults.size(); ++i) {
 				auto& r = IResults[i];
 				if (r.HitDistance < minDist) {
 					minDist = r.HitDistance;
-					pickFacet = r.HitFacet;
+					pickFacet2 = r.HitFacet;
 				}
 			}
-			m->ConnectedPointsInSphere(meshmirrororigin, meshradius * meshradius, pickFacet, nullptr, pointVisit.get(), resultPoints, outResultCount, resultFacets);
+			m->ConnectedPointsInTwoSpheres(meshorigin, meshmirrororigin, meshradius * meshradius, pickFacet1, pickFacet2, pointVisit, resultPoints, outResultCount);
 		}
+		else
+			m->ConnectedPointsInSphere(meshorigin, meshradius * meshradius, pickFacet1, pointVisit, resultPoints, outResultCount);
 	}
 	else
 		outResultCount = 0;

--- a/src/program/EditUV.cpp
+++ b/src/program/EditUV.cpp
@@ -778,7 +778,7 @@ void EditUVCanvas::SelectLess() {
 	std::set<int> unselectPoints;
 	for (int i = 0; i < uvGridMesh->nVerts; i++) {
 		if (uvGridMesh->vcolors[i].x > 0.0f) {
-			std::set<int> adjacentPoints;
+			std::unordered_set<int> adjacentPoints;
 			uvGridMesh->GetAdjacentPoints(i, adjacentPoints);
 
 			for (auto& adj : adjacentPoints) {
@@ -798,7 +798,7 @@ void EditUVCanvas::SelectLess() {
 }
 
 void EditUVCanvas::SelectMore() {
-	std::set<int> adjacentPoints;
+	std::unordered_set<int> adjacentPoints;
 	for (int i = 0; i < uvGridMesh->nVerts; i++)
 		if (uvGridMesh->vcolors[i].x > 0.0f)
 			uvGridMesh->GetAdjacentPoints(i, adjacentPoints);

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -2996,8 +2996,7 @@ bool OutfitProject::PrepareRefineMesh(NiShape* shape, UndoStateShape& uss, std::
 		Vector3 nsum;
 		for (const Triangle& t : tris)
 			if (t.HasVertex(vi)) {
-				Vector3 tn;
-				t.trinormal(*verts, &tn);
+				Vector3 tn = t.trinormal(*verts);
 				tn.Normalize();
 				nsum += tn;
 			}

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -495,7 +495,7 @@ public:
 			std::set<int> unmaskPoints;
 			for (int i = 0; i < m->nVerts; i++) {
 				if (m->mask[i] > 0.0f) {
-					std::set<int> adjacentPoints;
+					std::unordered_set<int> adjacentPoints;
 					m->GetAdjacentPoints(i, adjacentPoints);
 
 					for (auto& adj : adjacentPoints) {
@@ -516,7 +516,7 @@ public:
 
 	void MaskMore() {
 		for (auto& m : gls.GetActiveMeshes()) {
-			std::set<int> adjacentPoints;
+			std::unordered_set<int> adjacentPoints;
 			for (int i = 0; i < m->nVerts; i++)
 				if (m->mask[i] > 0.0f)
 					m->GetAdjacentPoints(i, adjacentPoints);

--- a/src/render/GLSurface.cpp
+++ b/src/render/GLSurface.cpp
@@ -408,7 +408,7 @@ bool GLSurface::CollideMeshes(int ScreenX, int ScreenY, Vector3& outOrigin, Vect
 					if (outFacet)
 						(*outFacet) = results[min_i].HitFacet;
 
-					m->tris[results[min_i].HitFacet].trinormal(m->verts.get(), &outNormal);
+					outNormal = m->tris[results[min_i].HitFacet].trinormal(m->verts.get());
 
 					if (hitMesh)
 						(*hitMesh) = m;
@@ -471,7 +471,7 @@ bool GLSurface::CollideOverlay(int ScreenX, int ScreenY, Vector3& outOrigin, Vec
 					if (outFacet)
 						(*outFacet) = results[min_i].HitFacet;
 
-					ov->tris[results[min_i].HitFacet].trinormal(ov->verts.get(), &outNormal);
+					outNormal = ov->tris[results[min_i].HitFacet].trinormal(ov->verts.get());
 				}
 			}
 		}
@@ -560,8 +560,7 @@ bool GLSurface::UpdateCursor(int ScreenX, int ScreenY, bool allMeshes, CursorHit
 
 					Vector3 morigin = m->TransformPosMeshToModel(origin);
 
-					Vector3 norm;
-					m->tris[results[min_i].HitFacet].trinormal(m->verts.get(), &norm);
+					Vector3 norm = m->tris[results[min_i].HitFacet].trinormal(m->verts.get());
 					norm = m->TransformDirMeshToModel(norm);
 
 					AddVisCircle(morigin, norm, cursorSize, "cursormesh");

--- a/src/utils/AABBTree.cpp
+++ b/src/utils/AABBTree.cpp
@@ -578,8 +578,10 @@ bool AABBTree::AABBTreeNode::IntersectSphere(Vector3& origin, const float radius
 		bool found = false;
 		for (uint32_t i = 0; i < nFacets; i++) {
 			uint32_t f = mIFacets[i];
-			if (tree->triRef[f].IntersectSphere(tree->vertexRef, origin, radius, &r.HitDistance)) {
+			float dist = tree->triRef[f].DistanceToPoint(tree->vertexRef, origin);
+			if (dist <= radius) {
 				if (results) {
+					r.HitDistance = dist;
 					r.HitFacet = mIFacets[i];
 					r.bvhNode = this;
 					results->push_back(r);


### PR DESCRIPTION
- Fixed bug in AABBTree::AABBTreeNode::IntersectSphere that would cause it to return a bad distance to the triangle.  I added Triangle::DistanceToPoint to correctly calculate this distance.  This bug would make TweakBrush::queryPoints often pick the wrong triangle as the center of its update with the Connected-Only brush option on.  This, in turn, would cause
Mesh::ConnectedPointsInSphere to misbehave, causing brushes to unweld vertices.  It might also sometimes cause brushes to have no effect on some vertices that they should effect.
- Fixed bug in Mesh::ConnectedPointsInSphere that would cause it to often miss welded vertices.  This would cause the Connected-Only brush option to sometimes make brushes unweld vertices.
- Simplified Mesh::ConnectedPointsInSphere a little.
- Added Mesh::ConnectedPointsInTwoSpheres for use by brushes with the "NeedMirrorMergedQuery" flag.  This fixes a bug that would rarely cause points to not get adjusted.
- Fixed flaw in Mesh::SmoothNormals that would cause triangles to sometimes flicker black.  The problem was that it would zero the normals before calculating them.  I made it do the calculation in a temporary copy of the normals.
- Fixed bug in Mesh::SmoothNormals that would cause it to produce bad results for welded vertices in a partial update.  ("!= 0" should have been "== 0").  This would make triangles flicker near welded vertices when using a brush with live normal updates.
- Fixed flaw in live-normals updating where it wouldn't update the normals of vertices adjacent to a changed vertex, despite the fact that those vertices have changed normals too.  This flaw would cause triangles to look wrong along the edge of the area affected by the brush until the brush stroke ended.
- Used new return-value version of trinormal several places.