### PR TITLE
Accessors for transforms between shape and global

### DIFF
--- a/res/xrc/ShapeProperties.xrc
+++ b/res/xrc/ShapeProperties.xrc
@@ -633,7 +633,7 @@
 									<flag>wxALIGN_CENTER_VERTICAL|wxTOP|wxLEFT|wxRIGHT</flag>
 									<border>10</border>
 									<object class="wxStaticText" name="lbCoordIntro">
-										<label>Transform from global to skin coordinates:</label>
+										<label>Transform from shape to global coordinates:</label>
 										<wrap>500</wrap>
 									</object>
 								</object>

--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -35,7 +35,7 @@ bool AnimInfo::RemoveShapeBone(const std::string& shape, const std::string& bone
 
 	AnimSkeleton::getInstance().ReleaseBone(boneName);
 
-	if (refNif && refNif->IsValid()) {
+	if (refNif->IsValid()) {
 		if (AnimSkeleton::getInstance().GetBoneRefCount(boneName) <= 0) {
 			if (refNif->CanDeleteNode(boneName))
 				refNif->DeleteNode(boneName);
@@ -46,7 +46,7 @@ bool AnimInfo::RemoveShapeBone(const std::string& shape, const std::string& bone
 }
 
 void AnimInfo::Clear() {
-	if (refNif && refNif->IsValid()) {
+	if (refNif->IsValid()) {
 		for (auto& shapeBoneList : shapeBones) {
 			for (auto& boneName : shapeBoneList.second) {
 				AnimSkeleton::getInstance().ReleaseBone(boneName);
@@ -79,7 +79,7 @@ void AnimInfo::ClearShape(const std::string& shape) {
 	for (auto& boneName : shapeBones[shape]) {
 		AnimSkeleton::getInstance().ReleaseBone(boneName);
 
-		if (refNif && refNif->IsValid()) {
+		if (refNif->IsValid()) {
 			if (AnimSkeleton::getInstance().GetBoneRefCount(boneName) <= 0) {
 				if (refNif->CanDeleteNode(boneName))
 					refNif->DeleteNode(boneName);
@@ -158,16 +158,12 @@ bool AnimInfo::LoadFromNif(NifFile* nif) {
 	for (auto& s : nif->GetShapes())
 		LoadFromNif(nif, s);
 
-	refNif = nif;
 	return true;
 }
 
-bool AnimInfo::LoadFromNif(NifFile* nif, NiShape* shape, bool newRefNif) {
+bool AnimInfo::LoadFromNif(NifFile* nif, NiShape* shape) {
 	std::vector<std::string> boneNames;
 	std::string nonRefBones;
-
-	if (newRefNif)
-		refNif = nif;
 
 	if (!shape)
 		return false;
@@ -292,7 +288,7 @@ void AnimInfo::ChangeGlobalToSkinTransform(const std::string& shape, const MatTr
 }
 
 bool AnimInfo::CalcShapeSkinBounds(const std::string& shapeName, const int& boneIndex) {
-	if (!refNif || !refNif->IsValid()) // Check for existence of reference nif
+	if (!refNif->IsValid()) // Check for existence of reference nif
 		return false;
 
 	if (shapeSkinning.find(shapeName) == shapeSkinning.end()) // Check for shape in skinning data

--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -35,7 +35,7 @@ bool AnimInfo::RemoveShapeBone(const std::string& shape, const std::string& bone
 
 	AnimSkeleton::getInstance().ReleaseBone(boneName);
 
-	if (refNif->IsValid()) {
+	if (refNif && refNif->IsValid()) {
 		if (AnimSkeleton::getInstance().GetBoneRefCount(boneName) <= 0) {
 			if (refNif->CanDeleteNode(boneName))
 				refNif->DeleteNode(boneName);
@@ -46,7 +46,7 @@ bool AnimInfo::RemoveShapeBone(const std::string& shape, const std::string& bone
 }
 
 void AnimInfo::Clear() {
-	if (refNif->IsValid()) {
+	if (refNif && refNif->IsValid()) {
 		for (auto& shapeBoneList : shapeBones) {
 			for (auto& boneName : shapeBoneList.second) {
 				AnimSkeleton::getInstance().ReleaseBone(boneName);
@@ -79,7 +79,7 @@ void AnimInfo::ClearShape(const std::string& shape) {
 	for (auto& boneName : shapeBones[shape]) {
 		AnimSkeleton::getInstance().ReleaseBone(boneName);
 
-		if (refNif->IsValid()) {
+		if (refNif && refNif->IsValid()) {
 			if (AnimSkeleton::getInstance().GetBoneRefCount(boneName) <= 0) {
 				if (refNif->CanDeleteNode(boneName))
 					refNif->DeleteNode(boneName);
@@ -158,12 +158,16 @@ bool AnimInfo::LoadFromNif(NifFile* nif) {
 	for (auto& s : nif->GetShapes())
 		LoadFromNif(nif, s);
 
+	refNif = nif;
 	return true;
 }
 
-bool AnimInfo::LoadFromNif(NifFile* nif, NiShape* shape) {
+bool AnimInfo::LoadFromNif(NifFile* nif, NiShape* shape, bool newRefNif) {
 	std::vector<std::string> boneNames;
 	std::string nonRefBones;
+
+	if (newRefNif)
+		refNif = nif;
 
 	if (!shape)
 		return false;
@@ -288,7 +292,7 @@ void AnimInfo::ChangeGlobalToSkinTransform(const std::string& shape, const MatTr
 }
 
 bool AnimInfo::CalcShapeSkinBounds(const std::string& shapeName, const int& boneIndex) {
-	if (!refNif->IsValid()) // Check for existence of reference nif
+	if (!refNif || !refNif->IsValid()) // Check for existence of reference nif
 		return false;
 
 	if (shapeSkinning.find(shapeName) == shapeSkinning.end()) // Check for shape in skinning data

--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -61,6 +61,8 @@ void AnimInfo::Clear() {
 		shapeSkinning.clear();
 		for (auto& s : refNif->GetShapeNames())
 			shapeBones[s].clear();
+
+		refNif = nullptr;
 	}
 	else {
 		for (auto& shapeBoneList : shapeBones)

--- a/src/components/Anim.h
+++ b/src/components/Anim.h
@@ -135,7 +135,6 @@ public:
 	std::map<std::string, std::vector<std::string>> shapeBones;
 	std::unordered_map<std::string, AnimSkin> shapeSkinning; // Shape to skin association.
 
-	AnimInfo(nifly::NifFile* initRefNif): refNif(initRefNif) {}
 	nifly::NifFile* GetRefNif() { return refNif; };
 	const nifly::NifFile* GetRefNif() const { return refNif; };
 	void SetRefNif(nifly::NifFile* nif) { refNif = nif; };

--- a/src/components/Anim.h
+++ b/src/components/Anim.h
@@ -135,6 +135,7 @@ public:
 	std::map<std::string, std::vector<std::string>> shapeBones;
 	std::unordered_map<std::string, AnimSkin> shapeSkinning; // Shape to skin association.
 
+	AnimInfo(nifly::NifFile* initRefNif): refNif(initRefNif) {}
 	nifly::NifFile* GetRefNif() { return refNif; };
 	const nifly::NifFile* GetRefNif() const { return refNif; };
 	void SetRefNif(nifly::NifFile* nif) { refNif = nif; };
@@ -145,7 +146,6 @@ public:
 
 	void Clear();
 	void ClearShape(const std::string& shape);
-	bool HasSkinnedShape(nifly::NiShape* shape) const;
 	void DeleteVertsForShape(const std::string& shape, const std::vector<uint16_t>& indices);
 
 	// Loads the skinning information contained in the nif for all shapes.
@@ -175,6 +175,11 @@ public:
 	void WriteToNif(nifly::NifFile* nif, const std::string& shapeException = "");
 
 	void RenameShape(const std::string& shapeName, const std::string& newShapeName);
+
+	nifly::MatTransform GetTransformShapeToGlobal(nifly::NiShape* shape) const;
+	nifly::MatTransform GetTransformGlobalToShape(nifly::NiShape* shape) const;
+	void SetTransformShapeToGlobal(nifly::NiShape* shape, const nifly::MatTransform& newShapeToGlobal);
+	void SetTransformGlobalToShape(nifly::NiShape* shape, const nifly::MatTransform& newGlobalToShape);
 };
 
 class AnimSkeleton {

--- a/src/components/Anim.h
+++ b/src/components/Anim.h
@@ -136,9 +136,6 @@ public:
 	std::unordered_map<std::string, AnimSkin> shapeSkinning; // Shape to skin association.
 
 	AnimInfo(nifly::NifFile* initRefNif): refNif(initRefNif) {}
-	nifly::NifFile* GetRefNif() { return refNif; };
-	const nifly::NifFile* GetRefNif() const { return refNif; };
-	void SetRefNif(nifly::NifFile* nif) { refNif = nif; };
 
 	// Returns true if a new bone is added, false if the bone already exists.
 	bool AddShapeBone(const std::string& shape, const std::string& boneName);
@@ -151,7 +148,7 @@ public:
 	// Loads the skinning information contained in the nif for all shapes.
 	// Returns false if there is no skinning information.
 	bool LoadFromNif(nifly::NifFile* nif);
-	bool LoadFromNif(nifly::NifFile* nif, nifly::NiShape* shape, bool newRefNif = true);
+	bool LoadFromNif(nifly::NifFile* nif, nifly::NiShape* shape);
 	bool CloneShape(nifly::NifFile* nif, nifly::NiShape* shape, const std::string& newShape);
 
 	int GetShapeBoneIndex(const std::string& shapeName, const std::string& boneName) const;

--- a/src/components/Anim.h
+++ b/src/components/Anim.h
@@ -136,6 +136,9 @@ public:
 	std::unordered_map<std::string, AnimSkin> shapeSkinning; // Shape to skin association.
 
 	AnimInfo(nifly::NifFile* initRefNif): refNif(initRefNif) {}
+	nifly::NifFile* GetRefNif() { return refNif; };
+	const nifly::NifFile* GetRefNif() const { return refNif; };
+	void SetRefNif(nifly::NifFile* nif) { refNif = nif; };
 
 	// Returns true if a new bone is added, false if the bone already exists.
 	bool AddShapeBone(const std::string& shape, const std::string& boneName);
@@ -148,7 +151,7 @@ public:
 	// Loads the skinning information contained in the nif for all shapes.
 	// Returns false if there is no skinning information.
 	bool LoadFromNif(nifly::NifFile* nif);
-	bool LoadFromNif(nifly::NifFile* nif, nifly::NiShape* shape);
+	bool LoadFromNif(nifly::NifFile* nif, nifly::NiShape* shape, bool newRefNif = true);
 	bool CloneShape(nifly::NifFile* nif, nifly::NiShape* shape, const std::string& newShape);
 
 	int GetShapeBoneIndex(const std::string& shapeName, const std::string& boneName) const;

--- a/src/components/Automorph.cpp
+++ b/src/components/Automorph.cpp
@@ -174,27 +174,7 @@ void Automorph::MeshFromNifShape(Mesh* m, NifFile& ref, NiShape* shape, const An
 
 	m->shapeName = shape->name.get();
 
-	if (!shape->IsSkinned()) {
-		// Calculate transform from shape's CS to global CS
-		MatTransform ttg = shape->GetTransformToParent();
-		NiNode* parent = ref.GetParentNode(shape);
-		while (parent) {
-			ttg = parent->GetTransformToParent().ComposeTransforms(ttg);
-			parent = ref.GetParentNode(parent);
-		}
-
-		m->SetXformMeshToModel(ttg);
-	}
-	else {
-		// For skinned meshes with appropriate global-to-skin transform
-		const auto skinning = workAnim->shapeSkinning.find(m->shapeName);
-		if (skinning != workAnim->shapeSkinning.end()) {
-			const MatTransform& gts = skinning->second.xformGlobalToSkin;
-			m->SetXformModelToMesh(gts);
-		}
-		else
-			m->SetXformModelToMesh(MatTransform());
-	}
+	m->SetXformMeshToModel(workAnim->GetTransformShapeToGlobal(shape));
 
 	m->nVerts = nifVerts.size();
 	m->verts = std::make_unique<Vector3[]>(m->nVerts);

--- a/src/files/FBXWrangler.cpp
+++ b/src/files/FBXWrangler.cpp
@@ -317,7 +317,7 @@ void FBXWrangler::AddNif(NifFile* nif, AnimInfo* anim, bool transToGlobal, NiSha
 
 				std::vector<Vector3> gVerts, gNorms;
 				if (verts && transToGlobal) {
-					MatTransform toGlobal = anim->shapeSkinning[s->name.get()].xformGlobalToSkin.InverseTransform();
+					MatTransform toGlobal = anim->GetTransformShapeToGlobal(s);
 
 					gVerts.resize(verts->size());
 					for (size_t i = 0; i < gVerts.size(); ++i)

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -22,8 +22,9 @@ extern ConfigurationManager Config;
 
 using namespace nifly;
 
-OutfitProject::OutfitProject(OutfitStudioFrame* inOwner): workAnim(&workNif) {
+OutfitProject::OutfitProject(OutfitStudioFrame* inOwner) {
 	owner = inOwner;
+	workAnim.SetRefNif(&workNif);
 
 	std::string defSkelFile = Config["Anim/DefaultSkeletonReference"];
 	if (wxFileName(wxString::FromUTF8(defSkelFile)).IsRelative())

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -4020,6 +4020,10 @@ int OutfitProject::ExportShapeNIF(const std::string& fileName, const std::vector
 }
 
 int OutfitProject::ImportOBJ(const std::string& fileName, const std::string& shapeName, NiShape* mergeShape) {
+	// Set reference NIF in case nothing was loaded yet
+	if (!workAnim.GetRefNif())
+		workAnim.SetRefNif(&workNif);
+
 	if (!baseShape) {
 		int res = wxMessageBox(_("No reference has been loaded.  For correct bone transforms, you might need to load a reference before importing OBJ files.  Import anyway?"),
 							   _("Import without reference"),
@@ -4178,6 +4182,10 @@ int OutfitProject::ExportOBJ(const std::string& fileName, const std::vector<NiSh
 }
 
 int OutfitProject::ImportFBX(const std::string& fileName, const std::string& shapeName, NiShape* mergeShape) {
+	// Set reference NIF in case nothing was loaded yet
+	if (!workAnim.GetRefNif())
+		workAnim.SetRefNif(&workNif);
+
 	if (!baseShape) {
 		int res = wxMessageBox(_("No reference has been loaded.  For correct bone transforms, you might need to load a reference before importing FBX files.  Import anyway?"),
 							   _("Import without reference"),

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -3896,11 +3896,14 @@ int OutfitProject::ImportNIF(const std::string& fileName, bool clear, const std:
 			std::string shapeName = s->name.get();
 			auto clonedShape = workNif.CloneShape(s, shapeName, &nif);
 			workAnim.LoadFromNif(&workNif, clonedShape);
+			CheckShapeForDistantOrigin(clonedShape);
 		}
 	}
 	else {
 		workNif.CopyFrom(nif);
 		workAnim.LoadFromNif(&workNif);
+		for (NiShape* s : workNif.GetShapes())
+			CheckShapeForDistantOrigin(s);
 	}
 
 	return 0;
@@ -4123,6 +4126,8 @@ int OutfitProject::ImportOBJ(const std::string& fileName, const std::string& sha
 
 			if (copyBaseSkinTrans)
 				workAnim.SetTransformGlobalToShape(newShape, workAnim.GetTransformGlobalToShape(baseShape));
+
+			CheckShapeForDistantOrigin(newShape);
 		}
 	}
 
@@ -4296,6 +4301,8 @@ int OutfitProject::ImportFBX(const std::string& fileName, const std::string& sha
 
 		if (!nonRefBones.empty())
 			wxLogMessage("Bones in shape '%s' not found in reference skeleton:\n%s", useShapeName, nonRefBones);
+
+		CheckShapeForDistantOrigin(newShape);
 	}
 
 	return 0;
@@ -4416,4 +4423,62 @@ void OutfitProject::RemoveSkinning() {
 	}
 
 	workNif.DeleteUnreferencedNodes();
+}
+
+void OutfitProject::CheckShapeForDistantOrigin(NiShape* s) {
+	bool nifUsesHalfPrecision = false;
+	auto targetGame = (TargetGame)Config.GetIntValue("TargetGame");
+	switch (targetGame) {
+		case OB:
+		case FO3:
+		case FONV:
+		case SKYRIM:
+		case SKYRIMSE:
+		case SKYRIMVR:
+			nifUsesHalfPrecision = false; break;
+		case FO4:
+		case FO4VR:
+		case FO76:
+			nifUsesHalfPrecision = true; break;
+	}
+	if (!nifUsesHalfPrecision)
+		return;
+
+	// Find shape's minimum, maximum, and average vertex coordinates
+	const std::vector<Vector3>* verts = workNif.GetVertsForShape(s);
+	if (!verts || verts->empty())
+		return;
+	Vector3 minv, maxv, avgv;
+	minv = maxv = avgv = (*verts)[0];
+	for (size_t i = 1; i < verts->size(); ++i) {
+		const Vector3& v = (*verts)[i];
+		minv.x = std::min(minv.x, v.x);
+		minv.y = std::min(minv.y, v.y);
+		minv.z = std::min(minv.z, v.z);
+		maxv.x = std::max(maxv.x, v.x);
+		maxv.y = std::max(maxv.y, v.y);
+		maxv.z = std::max(maxv.z, v.z);
+		avgv += v;
+	}
+	avgv /= verts->size();
+
+	// Determine maximum extent
+	Vector3 extvec = maxv - minv;
+	float extent = std::max(extvec.x, std::max(extvec.y, extvec.z));
+
+	// Check for distant origin
+	MatTransform shapeToGlobal = workAnim.GetTransformShapeToGlobal(s);
+	float distAvgToOrigin = shapeToGlobal.translation.DistanceTo(avgv);
+	bool distantOrigin = distAvgToOrigin > 0.3f * extent;
+	if (!distantOrigin)
+		return;
+
+	if (wxMessageBox(wxString() << _("The shape '") << s->name.get() << _("' has an origin that is ") << distAvgToOrigin << _(" units from its center.  (The shape's extent is ") << extent << _(".)  Moving the origin to the center could reduce the precision loss when saving the NIF.  Move the origin to the center?"), _("Adjust shape origin"), wxYES_NO|wxYES_DEFAULT|wxICON_WARNING) == wxNO)
+		return;
+
+	MatTransform newShapeToGlobal;
+	newShapeToGlobal.translation = shapeToGlobal.ApplyTransform(avgv);
+	MatTransform oldToNew = newShapeToGlobal.InverseTransform().ComposeTransforms(shapeToGlobal);
+	ApplyTransformToShapeGeometry(s, oldToNew);
+	workAnim.SetTransformShapeToGlobal(s, newShapeToGlobal);
 }

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -4020,10 +4020,6 @@ int OutfitProject::ExportShapeNIF(const std::string& fileName, const std::vector
 }
 
 int OutfitProject::ImportOBJ(const std::string& fileName, const std::string& shapeName, NiShape* mergeShape) {
-	// Set reference NIF in case nothing was loaded yet
-	if (!workAnim.GetRefNif())
-		workAnim.SetRefNif(&workNif);
-
 	if (!baseShape) {
 		int res = wxMessageBox(_("No reference has been loaded.  For correct bone transforms, you might need to load a reference before importing OBJ files.  Import anyway?"),
 							   _("Import without reference"),
@@ -4182,10 +4178,6 @@ int OutfitProject::ExportOBJ(const std::string& fileName, const std::vector<NiSh
 }
 
 int OutfitProject::ImportFBX(const std::string& fileName, const std::string& shapeName, NiShape* mergeShape) {
-	// Set reference NIF in case nothing was loaded yet
-	if (!workAnim.GetRefNif())
-		workAnim.SetRefNif(&workNif);
-
 	if (!baseShape) {
 		int res = wxMessageBox(_("No reference has been loaded.  For correct bone transforms, you might need to load a reference before importing FBX files.  Import anyway?"),
 							   _("Import without reference"),

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -290,5 +290,4 @@ public:
 
 	int ImportFBX(const std::string& fileName, const std::string& shapeName = "", nifly::NiShape* mergeShape = nullptr);
 	int ExportFBX(const std::string& fileName, const std::vector<nifly::NiShape*>& shapes, bool transToGlobal);
-	void CheckShapeForDistantOrigin(nifly::NiShape* s);
 };

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -215,7 +215,6 @@ public:
 	void AddCustomBoneRef(const std::string& boneName, const std::string& parentBone, const nifly::MatTransform& xformToParent);
 	void ModifyCustomBone(AnimBone* bPtr, const std::string& parentBone, const nifly::MatTransform& xformToParent);
 
-	nifly::MatTransform GetTransformShapeToGlobal(nifly::NiShape* shape);
 	// CopySegPart returns the number of failed triangles, or 0 for success.
 	int CopySegPart(nifly::NiShape* shape);
 
@@ -273,6 +272,9 @@ public:
 
 	void ChooseClothData(nifly::NifFile& nif);
 	void ResetTransforms();
+
+	void CreateSkinning(nifly::NiShape* s);
+	void RemoveSkinning(nifly::NiShape* s);
 	void RemoveSkinning();
 
 	int ImportNIF(const std::string& fileName, bool clear = true, const std::string& inOutfitName = "", std::map<std::string, std::string>* renamedShapes = nullptr);

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -290,4 +290,5 @@ public:
 
 	int ImportFBX(const std::string& fileName, const std::string& shapeName = "", nifly::NiShape* mergeShape = nullptr);
 	int ExportFBX(const std::string& fileName, const std::vector<nifly::NiShape*>& shapes, bool transToGlobal);
+	void CheckShapeForDistantOrigin(nifly::NiShape* s);
 };


### PR DESCRIPTION
The new accessor functions are in AnimInfo.  If the shape is skinned, they access AnimSkin::xformGlobalToSkin.  If the shape is unskinned, they access the shape's node-to-global transform from workNif.  The purpose of this is so that skinned and unskinned meshes can be treated the same when it comes to this important transform.

The reason these accessor functions need to be in AnimInfo and not, say, OutfitProject, is that some of the places where this information is needed (Automorph and FBXWrangler) don't have access to OutfitProject but do have access to AnimInfo.

I searched for all instances of xformGlobalToSkin outside Anim.{h,cpp} and replaced them with calls of the accessor functions.  This had the following benefits:
- ShapeProperties shows the same transform for both skinned and unskinned.
- FBX export might work for unskinned shapes now.
- The weld option to the move-vertex tool should work for unskinned shapes.
- The copy-skin-coordinates option to ImportOBJ works now, fixing issue #432 .
- ~~ResetTransforms now should have the same effect on unskinned shapes as it has on skinned.  Before, it did nothing on unskinned shapes.~~
- The Copy Bone Weights dialog now correctly shows the transform options for unskinned shapes.
- Some code was simplified.

I also added CreateSkinning and RemoveSkinning functions to OutfitProject that wrap the NifFile functions CreateSkinning and DeleteSkinning.  These functions make sure the transforms between shape and global coordinates do not change when the shape is skinned and unskinned.  I searched for all calls of the NifFile functions and replaced them.

I also made sure AnimInfo::refNif is initialized on construction and never set to nullptr.

While this PR does not directly fix issue #429 , it does open up new options:
- The user can copy a good transform from the reference shape on ImportOBJ.  But this only makes sense if the shape's vertices are already in the reference's shape coordinate system; if they're in global coordinates, copying the transform will misplace the shape.
- The user can set a good transform in Shape Properties immediately after ImportOBJ, and this transform will be preserved.
- Copy Bone Weights now shows the right options, so it can set a good transform.
