### PR TITLE
Fix some problems with importing OBJ and FBX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,6 @@ set(commonsources
 	src/components/SliderPresets.cpp
 	src/components/SliderSet.cpp
 	src/files/MaterialFile.cpp
-	src/files/ObjFile.cpp
 	src/files/ResourceLoader.cpp
 	src/files/TriFile.cpp
 	src/program/GroupManager.cpp
@@ -75,6 +74,7 @@ set(OSsources
 	src/components/UndoHistory.cpp
 	src/components/WeightNorm.cpp
 	src/files/FBXWrangler.cpp
+	src/files/ObjFile.cpp
 	src/ui/wxBrushSettingsPopup.cpp
 	src/program/EditUV.cpp
 	src/program/FBXImportDialog.cpp

--- a/src/files/FBXWrangler.cpp
+++ b/src/files/FBXWrangler.cpp
@@ -495,26 +495,21 @@ bool FBXWrangler::Priv::LoadMeshes(const FBXImportOptions& options) {
 				}
 
 				for (int t = 0; t < numTris; t++) {
-					if (m->GetPolygonSize(t) != 3)
-						continue;
+					int nverts = m->GetPolygonSize(t);
+					std::vector<int> pverts(nverts);
+					for (int tvi = 0; tvi < nverts; ++tvi)
+						pverts[tvi] = m->GetPolygonVertex(t, tvi);
 
-					int p1 = m->GetPolygonVertex(t, 0);
-					int p2 = m->GetPolygonVertex(t, 1);
-					int p3 = m->GetPolygonVertex(t, 2);
-					shape.tris.emplace_back(p1, p2, p3);
+					for (int tvi = 2; tvi < nverts; ++tvi)
+						shape.tris.emplace_back(pverts[0], pverts[tvi - 1], pverts[tvi]);
 
 					if (uv && uv->GetMappingMode() == FbxGeometryElement::eByPolygonVertex) {
 						FbxVector2 v_uv;
 						bool isUnmapped;
 
-						if (m->GetPolygonVertexUV(t, 0, uvName, v_uv, isUnmapped))
-							shape.uvs[p1] = Vector2(v_uv.mData[0], v_uv.mData[1]);
-
-						if (m->GetPolygonVertexUV(t, 1, uvName, v_uv, isUnmapped))
-							shape.uvs[p2] = Vector2(v_uv.mData[0], v_uv.mData[1]);
-
-						if (m->GetPolygonVertexUV(t, 2, uvName, v_uv, isUnmapped))
-							shape.uvs[p3] = Vector2(v_uv.mData[0], v_uv.mData[1]);
+						for (int tvi = 0; tvi < nverts; ++tvi)
+							if (m->GetPolygonVertexUV(t, tvi, uvName, v_uv, isUnmapped))
+								shape.uvs[pverts[tvi]] = Vector2(v_uv.mData[0], v_uv.mData[1]);
 					}
 				}
 

--- a/src/files/FBXWrangler.cpp
+++ b/src/files/FBXWrangler.cpp
@@ -495,21 +495,26 @@ bool FBXWrangler::Priv::LoadMeshes(const FBXImportOptions& options) {
 				}
 
 				for (int t = 0; t < numTris; t++) {
-					int nverts = m->GetPolygonSize(t);
-					std::vector<int> pverts(nverts);
-					for (int tvi = 0; tvi < nverts; ++tvi)
-						pverts[tvi] = m->GetPolygonVertex(t, tvi);
+					if (m->GetPolygonSize(t) != 3)
+						continue;
 
-					for (int tvi = 2; tvi < nverts; ++tvi)
-						shape.tris.emplace_back(pverts[0], pverts[tvi - 1], pverts[tvi]);
+					int p1 = m->GetPolygonVertex(t, 0);
+					int p2 = m->GetPolygonVertex(t, 1);
+					int p3 = m->GetPolygonVertex(t, 2);
+					shape.tris.emplace_back(p1, p2, p3);
 
 					if (uv && uv->GetMappingMode() == FbxGeometryElement::eByPolygonVertex) {
 						FbxVector2 v_uv;
 						bool isUnmapped;
 
-						for (int tvi = 0; tvi < nverts; ++tvi)
-							if (m->GetPolygonVertexUV(t, tvi, uvName, v_uv, isUnmapped))
-								shape.uvs[pverts[tvi]] = Vector2(v_uv.mData[0], v_uv.mData[1]);
+						if (m->GetPolygonVertexUV(t, 0, uvName, v_uv, isUnmapped))
+							shape.uvs[p1] = Vector2(v_uv.mData[0], v_uv.mData[1]);
+
+						if (m->GetPolygonVertexUV(t, 1, uvName, v_uv, isUnmapped))
+							shape.uvs[p2] = Vector2(v_uv.mData[0], v_uv.mData[1]);
+
+						if (m->GetPolygonVertexUV(t, 2, uvName, v_uv, isUnmapped))
+							shape.uvs[p3] = Vector2(v_uv.mData[0], v_uv.mData[1]);
 					}
 				}
 

--- a/src/files/ObjFile.cpp
+++ b/src/files/ObjFile.cpp
@@ -6,6 +6,7 @@ See the included LICENSE file
 #include "ObjFile.h"
 #include "../utils/PlatformUtil.h"
 #include <sstream>
+#include <unordered_map>
 
 using namespace nifly;
 
@@ -280,7 +281,7 @@ void ObjFile::LoadForNif(std::istream& ins) {
 		// Map the triangle vertex indices from grpvi to finvi
 		for (Triangle& t : d.tris)
 			for (int tvi = 0; tvi < 3; ++tvi)
-				t[tvi] = grpviToFinvi[t[tvi]];
+				t[tvi] = static_cast<uint16_t>(grpviToFinvi[t[tvi]]);
 	}
 }
 

--- a/src/files/ObjFile.cpp
+++ b/src/files/ObjFile.cpp
@@ -5,29 +5,22 @@ See the included LICENSE file
 
 #include "ObjFile.h"
 #include "../utils/PlatformUtil.h"
+#include <sstream>
 
 using namespace nifly;
-
-ObjFile::ObjFile() {}
-
-ObjFile::~ObjFile() {
-	for (auto& d : data)
-		delete d.second;
-}
 
 int ObjFile::AddGroup(
 	const std::string& name, const std::vector<Vector3>& verts, const std::vector<Triangle>& tris, const std::vector<Vector2>& uvs, const std::vector<Vector3>& norms) {
 	if (name.empty() || verts.empty())
 		return 1;
 
-	ObjData* newData = new ObjData();
-	newData->name = name;
-	newData->verts = verts;
-	newData->tris = tris;
-	newData->uvs = uvs;
-	newData->norms = norms;
+	ObjData& newData = data[name];
+	newData.name = name;
+	newData.verts = verts;
+	newData.tris = tris;
+	newData.uvs = uvs;
+	newData.norms = norms;
 
-	data[name] = newData;
 	return 0;
 }
 
@@ -37,223 +30,259 @@ int ObjFile::LoadForNif(const std::string& fileName, const ObjOptionsImport& opt
 	if (file.fail())
 		return 1;
 
-	LoadForNif(file, options);
+	if (options.noFaces)
+		LoadNoFaces(file);
+	else
+		LoadForNif(file);
 	return 0;
 }
 
-int ObjFile::LoadForNif(std::fstream& base, const ObjOptionsImport& options) {
-	constexpr auto maxVertexCount = std::numeric_limits<uint16_t>::max();
+void ObjFile::LoadNoFaces(std::istream& ins) {
+	ObjData d;
 
-	auto current = new ObjData();
+	while (!ins.eof()) {
+		std::string line;
+		std::getline(ins, line);
+		if (line.empty() || line[0] == '#')
+			continue;
 
-	Vector3 v;
-	Vector2 uv;
-	Vector3 vn;
-	Triangle t;
+		std::istringstream lineiss(line);
+		std::string cmd;
+		lineiss >> cmd;
 
-	std::string dump;
-	std::string curgrp;
-	std::string facept1;
-	std::string facept2;
-	std::string facept3;
-	std::string facept4;
-	int f[4];
-	uint32_t ft[4];
-	uint32_t fn[4];
-	uint32_t nPoints = 0;
-	uint32_t v_idx[4];
+		if (cmd == "v") {
+			Vector3 v;
+			lineiss >> v.x >> v.y >> v.z;
+			d.verts.push_back(v);
+		}
+		else if (cmd == "o" || cmd == "g") {
+			std::string curgrp;
+			lineiss >> curgrp;
 
+			if (!d.name.empty()) {
+				data[d.name] = std::move(d);
+				d = ObjData();
+			}
+
+			d.name = curgrp;
+		}
+		else if (cmd == "vt") {
+			Vector2 uv;
+			lineiss >> uv.u >> uv.v;
+			uv.v = 1.0f - uv.v;
+			d.uvs.push_back(uv);
+		}
+	}
+
+	if (d.name.empty())
+		d.name = "object";
+
+	if (!d.verts.empty())
+		data[d.name] = std::move(d);
+	else
+		data.erase(d.name);
+}
+
+void ObjFile::LoadForNif(std::istream& ins) {
+	// First, parse the file into verts, uvs, norms, and faces.  Faces
+	// are grouped by group/object name; the rest are not.
 	std::vector<Vector3> verts;
 	std::vector<Vector2> uvs;
 	std::vector<Vector3> norms;
-	size_t pos;
-
-	std::map<std::string, std::vector<ObjPoint>> grpPoints;
-
-	bool gotface = false;
-
-	while (!base.eof()) {
-		if (!gotface)
-			base >> dump;
-		else
-			gotface = false;
-
-		if (options.noFaces) {
-			if (dump.compare("v") == 0) {
-				base >> v.x >> v.y >> v.z;
-				current->verts.push_back(v);
-			}
-			else if (dump.compare("o") == 0 || dump.compare("g") == 0) {
-				base >> curgrp;
-
-				if (!current->name.empty()) {
-					data[current->name] = current;
-					current = new ObjData();
-				}
-
-				current->name = curgrp;
-			}
-			else if (dump.compare("vt") == 0) {
-				base >> uv.u >> uv.v;
-				uv.v = 1.0f - uv.v;
-				current->uvs.push_back(uv);
-			}
-
-			continue;
+	struct FaceVertex {
+		// vi, ti, and ni are indexes into verts, uvs, and norms.  In the
+		// file, the three are offset by 1 so vi==1 means verts[0].
+		// Negative values are also possible, and indicate offsets from the end
+		// of the respective array using its size at the moment the face line
+		// is encountered.
+		int vi = 0, ti = 0, ni = 0;
+		void Parse(const std::string& s) {
+			vi = atoi(s.c_str());
+			size_t pos = s.find('/');
+			ti = atoi(s.substr(pos + 1).c_str());
+			pos = s.find('/', pos + 1);
+			ni = atoi(s.substr(pos + 1).c_str());
 		}
+	};
+	// groups[group/object name][face index][face-vertex index]
+	std::unordered_map<std::string, std::vector<std::vector<FaceVertex>>> groups;
+	std::vector<std::vector<FaceVertex>>* currentgroup = &groups["object"];
 
-		if (dump.compare("v") == 0) {
-			base >> v.x >> v.y >> v.z;
+	while (!ins.eof()) {
+		std::string line;
+		std::getline(ins, line);
+		if (line.empty() || line[0] == '#')
+			continue;
+
+		std::istringstream lineiss(line);
+		std::string cmd;
+		lineiss >> cmd;
+
+		if (cmd == "v") {
+			Vector3 v;
+			lineiss >> v.x >> v.y >> v.z;
 			verts.push_back(v);
 		}
-		else if (dump.compare("o") == 0 || dump.compare("g") == 0) {
-			base >> curgrp;
-
-			if (!current->name.empty()) {
-				if (!current->tris.empty()) {
-					// Keep current group if it's not empty
-					data[current->name] = current;
-				}
-				else {
-					// Don't keep empty group
-					data.erase(current->name);
-					current->name.clear();
-				}
-			}
-
-			auto grp = data.find(curgrp);
-			if (grp != data.end()) {
-				// Re-use group with matching name
-				current = grp->second;
-			}
-			else {
-				// Add new group
-				if (!current->name.empty())
-					current = new ObjData();
-
-				current->name = curgrp;
-			}
+		else if (cmd == "o" || cmd == "g") {
+			std::string grp;
+			lineiss >> grp;
+			currentgroup = &groups[grp];
 		}
-		else if (dump.compare("vt") == 0) {
-			base >> uv.u >> uv.v;
+		else if (cmd == "vt") {
+			Vector2 uv;
+			lineiss >> uv.u >> uv.v;
 			uv.v = 1.0f - uv.v;
 			uvs.push_back(uv);
 		}
-		else if (dump.compare("vn") == 0) {
-			base >> vn.x >> vn.y >> vn.z;
+		else if (cmd == "vn") {
+			Vector3 vn;
+			lineiss >> vn.x >> vn.y >> vn.z;
 			norms.push_back(vn);
 		}
-		else if (dump.compare("f") == 0) {
-			base >> facept1 >> facept2 >> facept3;
-
-			f[0] = atoi(facept1.c_str()) - 1;
-			pos = facept1.find('/');
-			ft[0] = atoi(facept1.substr(pos + 1).c_str()) - 1;
-			pos = facept1.find('/', pos + 1);
-			fn[0] = atoi(facept1.substr(pos + 1).c_str()) - 1;
-
-			f[1] = atoi(facept2.c_str()) - 1;
-			pos = facept2.find('/');
-			ft[1] = atoi(facept2.substr(pos + 1).c_str()) - 1;
-			pos = facept2.find('/', pos + 1);
-			fn[1] = atoi(facept2.substr(pos + 1).c_str()) - 1;
-
-			f[2] = atoi(facept3.c_str()) - 1;
-			pos = facept3.find('/');
-			ft[2] = atoi(facept3.substr(pos + 1).c_str()) - 1;
-			pos = facept3.find('/', pos + 1);
-			fn[2] = atoi(facept3.substr(pos + 1).c_str()) - 1;
-
-			if (f[0] == -1 || f[1] == -1 || f[2] == -1)
-				continue;
-
-			base >> facept4;
-			dump = facept4;
-
-			nPoints = 3;
-			gotface = true;
-
-			if (facept4.length() > 0) {
-				f[3] = atoi(facept4.c_str()) - 1;
-
-				if (f[3] != -1) {
-					pos = facept4.find('/');
-					ft[3] = atoi(facept4.substr(pos + 1).c_str()) - 1;
-					pos = facept4.find('/', pos + 1);
-					fn[3] = atoi(facept4.substr(pos + 1).c_str()) - 1;
-					nPoints = 4;
-					gotface = false;
-				}
-			}
-
-			auto& curPoints = grpPoints[curgrp];
-
-			bool skipFace = false;
-			for (size_t i = 0; i < nPoints; i++) {
-				v_idx[i] = static_cast<uint32_t>(current->verts.size());
-
-				ObjPoint pt(f[i], ft[i], fn[i]);
-
-				auto ptIt = std::find(curPoints.begin(), curPoints.end(), pt);
-				if (ptIt != curPoints.end())
-					v_idx[i] = static_cast<uint32_t>(ptIt - curPoints.begin());
+		else if (cmd == "f") {
+			currentgroup->emplace_back();
+			std::vector<FaceVertex>& face = currentgroup->back();
+			while (true) {
+				std::string vertstring;
+				lineiss >> vertstring;
+				FaceVertex v;
+				v.Parse(vertstring);
+				if (v.vi == 0)
+					break;
+				if (v.vi < 0)
+					v.vi += static_cast<int>(verts.size());
 				else
-					curPoints.push_back(pt);
-
-				if (v_idx[i] == current->verts.size()) {
-					if (static_cast<int>(verts.size()) > f[i]) {
-						current->verts.push_back(verts[f[i]]);
-
-						if (uvs.size() > ft[i])
-							current->uvs.push_back(uvs[ft[i]]);
-
-						if (norms.size() > fn[i])
-							current->norms.push_back(norms[fn[i]]);
-					}
-					else {
-						skipFace = true;
-						break;
-					}
-				}
-			}
-
-			if (skipFace)
-				continue;
-
-			if (v_idx[0] >= maxVertexCount || v_idx[1] >= maxVertexCount || v_idx[2] >= maxVertexCount)
-				continue;
-
-			t.p1 = static_cast<uint16_t>(v_idx[0]);
-			t.p2 = static_cast<uint16_t>(v_idx[1]);
-			t.p3 = static_cast<uint16_t>(v_idx[2]);
-			current->tris.push_back(t);
-
-			if (nPoints == 4) {
-				if (v_idx[3] >= maxVertexCount)
-					continue;
-
-				t.p1 = static_cast<uint16_t>(v_idx[0]);
-				t.p2 = static_cast<uint16_t>(v_idx[2]);
-				t.p3 = static_cast<uint16_t>(v_idx[3]);
-				current->tris.push_back(t);
+					--v.vi;
+				if (v.ti < 0)
+					v.ti += static_cast<int>(uvs.size());
+				else
+					--v.ti;
+				if (v.ni < 0)
+					v.ni += static_cast<int>(norms.size());
+				else
+					--v.ni;
+				face.push_back(v);
 			}
 		}
 	}
 
-	if (current->name.empty())
-		current->name = "object";
+	int nVerts = static_cast<int>(verts.size());
+	int nUvs = static_cast<int>(uvs.size());
+	int nNorms = static_cast<int>(norms.size());
 
-	if (!current->verts.empty()) {
-		data[current->name] = current;
-	}
-	else {
-		data.erase(current->name);
-		delete current;
-	}
+	// Each vertex in verts may need to be duplicated if it's used with
+	// different texture coordinates or normal.  vdata keeps track of all the
+	// duplicates for a vertex in a group.
+	struct VertData {
+		// grpvi: index into vertices used by this group, in order encountered
+		// in the group's face vertices.  This is not the same as the final
+		// vertex ordering.
+		int grpvi;
+		Vector2 uv;
+		Vector3 nrm;
+	};
+	std::vector<std::vector<VertData>> vdata;
+	std::vector<int> facegrpvi;
 
-	return 0;
+	// We're done parsing the file, but the data needs a lot more work to
+	// get it into the right form.  We work on one group/object at a time.
+	for (auto& gfp : groups) {
+		std::string groupName = gfp.first;
+		const std::vector<std::vector<FaceVertex>>& faces = gfp.second;
+		if (faces.empty())
+			continue;
+
+		// Determine if we have UVs or normals
+		bool haveUVs = true, haveNorms = true, goodVerts = true;
+		for (const std::vector<FaceVertex>& face : faces)
+			for (const FaceVertex& fv : face) {
+				if (fv.vi < 0 || fv.vi >= nVerts)
+					goodVerts = false;
+				if (fv.ti < 0 || fv.ti >= nUvs)
+					haveUVs = false;
+				if (fv.ni < 0 || fv.ni >= nNorms)
+					haveNorms = false;
+			}
+		if (!goodVerts)
+			continue;
+
+		ObjData& d = data[groupName];
+		d.name = groupName;
+		vdata.clear();
+		vdata.resize(nVerts);
+
+		// Collect list of all vertices used by group, temporarily indexed
+		// by grpvi and listed in vdata; also fill in d.tris.
+		int grpvi = 0;
+		for (const std::vector<FaceVertex>& face : faces) {
+			// Find grpvi for each vertex of this face.
+			facegrpvi.clear();
+			for (const FaceVertex& fv : face) {
+				// Look up vertex's uv and nrm.
+				Vector2 uv;
+				if (haveUVs)
+					uv = uvs[fv.ti];
+				Vector3 nrm;
+				if (haveNorms)
+					nrm = norms[fv.ni];
+
+				// Search for vertex in vdata so we can get its grpvi
+				std::vector<VertData>& vds = vdata[fv.vi];
+				bool found = false;
+				for (VertData& vd : vds) {
+					if (haveUVs && uv != vd.uv)
+						continue;
+					if (haveNorms && nrm != vd.nrm)
+						continue;
+					found = true;
+					// Found existing grpvi
+					facegrpvi.push_back(vd.grpvi);
+					break;
+				}
+				if (!found) {
+					// New vertex: add to vdata and use new grpvi
+					vds.push_back(VertData{grpvi, uv, nrm});
+					facegrpvi.push_back(grpvi++);
+				}
+			}
+			// facegrpvi now has the grpvi for each of the face's vertices.
+			// Turn this into triangles.  Note that the vertex indices are
+			// _group_ vertex indices (grpvi), not finished vertex indices.
+			for (size_t fvi = 2; fvi < facegrpvi.size(); ++fvi)
+				d.tris.emplace_back(facegrpvi[0], facegrpvi[fvi - 1], facegrpvi[fvi]);
+		}
+
+		// vdata now has a complete list of vertices used by this group.
+		// The number of vertices used is grpvi.  We create
+		// the "finished" vertex ordering by going through vdata in order,
+		// assigning a finvi to each used vertex found.  We prepare
+		// a map from grpvi to finvi.  We store the data in d.verts, d.uvs,
+		// and d.norms.
+		int finvi = 0;
+		std::vector<int> grpviToFinvi(grpvi);
+		d.verts.resize(grpvi);
+		if (haveUVs)
+			d.uvs.resize(grpvi);
+		if (haveNorms)
+			d.norms.resize(grpvi);
+		for (int filevi = 0; filevi < nVerts; ++filevi)
+			for (VertData& vd : vdata[filevi]) {
+				grpviToFinvi[vd.grpvi] = finvi;
+				d.verts[finvi] = verts[filevi];
+				if (haveUVs)
+					d.uvs[finvi] = vd.uv;
+				if (haveNorms)
+					d.norms[finvi] = vd.nrm;
+				++finvi;
+			}
+		// assert(finvi == grpvi);
+
+		// Map the triangle vertex indices from grpvi to finvi
+		for (Triangle& t : d.tris)
+			for (int tvi = 0; tvi < 3; ++tvi)
+				t[tvi] = grpviToFinvi[t[tvi]];
+	}
 }
-
 
 int ObjFile::Save(const std::string& fileName) {
 	std::fstream file;
@@ -267,76 +296,77 @@ int ObjFile::Save(const std::string& fileName) {
 	size_t groupCount = 1;
 	size_t pointOffset = 1;
 
-	for (auto& d : data) {
-		file << "# object " << d.first << std::endl;
-		file << "# " << d.second->verts.size() << " vertices" << std::endl;
-		file << "# " << d.second->uvs.size() << " texture coordinates" << std::endl;
-		file << "# " << d.second->norms.size() << " normals" << std::endl;
-		file << "# " << d.second->tris.size() << " triangles" << std::endl;
+	for (auto& odp : data) {
+		const ObjData& d = odp.second;
+		file << "# object " << d.name << std::endl;
+		file << "# " << d.verts.size() << " vertices" << std::endl;
+		file << "# " << d.uvs.size() << " texture coordinates" << std::endl;
+		file << "# " << d.norms.size() << " normals" << std::endl;
+		file << "# " << d.tris.size() << " triangles" << std::endl;
 
-		for (size_t i = 0; i < d.second->verts.size(); i++) {
-			file << "v " << (d.second->verts[i].x + offset.x) * scale.x << " " << (d.second->verts[i].y + offset.y) * scale.y << " " << (d.second->verts[i].z + offset.z) * scale.z
+		for (size_t i = 0; i < d.verts.size(); i++) {
+			file << "v " << (d.verts[i].x + offset.x) * scale.x << " " << (d.verts[i].y + offset.y) * scale.y << " " << (d.verts[i].z + offset.z) * scale.z
 				 << std::endl;
 		}
 		file << std::endl;
 
-		for (size_t i = 0; i < d.second->uvs.size(); i++) {
-			file << "vt " << d.second->uvs[i].u << " " << (1.0f - d.second->uvs[i].v) << std::endl;
+		for (size_t i = 0; i < d.uvs.size(); i++) {
+			file << "vt " << d.uvs[i].u << " " << (1.0f - d.uvs[i].v) << std::endl;
 		}
 		file << std::endl;
 
-		for (size_t i = 0; i < d.second->norms.size(); i++) {
-			file << "vn " << d.second->norms[i].x << " " << d.second->norms[i].y << " " << d.second->norms[i].z << std::endl;
+		for (size_t i = 0; i < d.norms.size(); i++) {
+			file << "vn " << d.norms[i].x << " " << d.norms[i].y << " " << d.norms[i].z << std::endl;
 		}
 		file << std::endl;
 
-		file << "g " << d.first << std::endl;
+		file << "g " << d.name << std::endl;
 		file << "usemtl NoMaterial_" << groupCount << std::endl << std::endl;
 
 		file << "s 1" << std::endl;
 
-		for (size_t i = 0; i < d.second->tris.size(); i++) {
-			file << "f " << d.second->tris[i].p1 + pointOffset;
+		for (size_t i = 0; i < d.tris.size(); i++) {
+			file << "f " << d.tris[i].p1 + pointOffset;
 
-			if (!d.second->uvs.empty())
-				file << "/" << d.second->tris[i].p1 + pointOffset;
+			if (!d.uvs.empty())
+				file << "/" << d.tris[i].p1 + pointOffset;
 
-			if (!d.second->norms.empty()) {
-				if (d.second->uvs.empty())
+			if (!d.norms.empty()) {
+				if (d.uvs.empty())
 					file << "/";
 
-				file << "/" << d.second->tris[i].p1 + pointOffset;
+				file << "/" << d.tris[i].p1 + pointOffset;
 			}
 
-			file << " " << d.second->tris[i].p2 + pointOffset;
+			file << " " << d.tris[i].p2 + pointOffset;
 
-			if (!d.second->uvs.empty())
-				file << "/" << d.second->tris[i].p2 + pointOffset;
+			if (!d.uvs.empty())
+				file << "/" << d.tris[i].p2 + pointOffset;
 
-			if (!d.second->norms.empty()) {
-				if (d.second->uvs.empty())
+			if (!d.norms.empty()) {
+				if (d.uvs.empty())
 					file << "/";
 
-				file << "/" << d.second->tris[i].p2 + pointOffset;
+				file << "/" << d.tris[i].p2 + pointOffset;
 			}
 
-			file << " " << d.second->tris[i].p3 + pointOffset;
+			file << " " << d.tris[i].p3 + pointOffset;
 
-			if (!d.second->uvs.empty())
-				file << "/" << d.second->tris[i].p3 + pointOffset;
+			if (!d.uvs.empty())
+				file << "/" << d.tris[i].p3 + pointOffset;
 
-			if (!d.second->norms.empty()) {
-				if (d.second->uvs.empty())
+			if (!d.norms.empty()) {
+				if (d.uvs.empty())
 					file << "/";
 
-				file << "/" << d.second->tris[i].p3 + pointOffset;
+				file << "/" << d.tris[i].p3 + pointOffset;
 			}
 
 			file << std::endl;
 		}
 		file << std::endl;
 
-		pointOffset += d.second->verts.size();
+		pointOffset += d.verts.size();
 		groupCount++;
 	}
 
@@ -348,37 +378,23 @@ bool ObjFile::CopyDataForGroup(const std::string& name, std::vector<Vector3>* v,
 	if (data.find(name) == data.end())
 		return false;
 
-	ObjData* od = data[name];
+	ObjData& d = data[name];
 	if (v) {
 		v->clear();
-		v->resize(od->verts.size());
-		for (size_t i = 0; i < od->verts.size(); i++) {
-			(*v)[i].x = (od->verts[i].x + offset.x) * scale.x;
-			(*v)[i].y = (od->verts[i].y + offset.y) * scale.y;
-			(*v)[i].z = (od->verts[i].z + offset.z) * scale.z;
+		v->resize(d.verts.size());
+		for (size_t i = 0; i < d.verts.size(); i++) {
+			(*v)[i].x = (d.verts[i].x + offset.x) * scale.x;
+			(*v)[i].y = (d.verts[i].y + offset.y) * scale.y;
+			(*v)[i].z = (d.verts[i].z + offset.z) * scale.z;
 		}
 	}
 
-	if (t) {
-		t->clear();
-		t->resize(od->tris.size());
-		for (size_t i = 0; i < od->tris.size(); i++)
-			(*t)[i] = od->tris[i];
-	}
-
-	if (uv) {
-		uv->clear();
-		uv->resize(od->uvs.size());
-		for (size_t i = 0; i < od->uvs.size(); i++)
-			(*uv)[i] = od->uvs[i];
-	}
-
-	if (norms) {
-		norms->clear();
-		norms->resize(od->norms.size());
-		for (size_t i = 0; i < od->norms.size(); i++)
-			(*norms)[i] = od->norms[i];
-	}
+	if (t)
+		*t = d.tris;
+	if (uv)
+		*uv = d.uvs;
+	if (norms)
+		*norms = d.norms;
 
 	return true;
 }

--- a/src/files/ObjFile.h
+++ b/src/files/ObjFile.h
@@ -15,20 +15,6 @@ struct ObjOptionsImport {
 	bool noFaces = false;
 };
 
-struct ObjPoint {
-	int v = 0;
-	int vt = 0;
-	int vn = 0;
-
-	ObjPoint(const int inV, const int inVT, const int inVN) {
-		v = inV;
-		vt = inVT;
-		vn = inVN;
-	}
-
-	bool operator==(const ObjPoint& other) const { return v == other.v && vt == other.vt && vn == other.vn; }
-};
-
 struct ObjData {
 	std::string name;
 	std::vector<nifly::Vector3> verts;
@@ -38,14 +24,11 @@ struct ObjData {
 };
 
 class ObjFile {
-	std::map<std::string, ObjData*> data;
+	std::map<std::string, ObjData> data;
 
 public:
 	nifly::Vector3 scale = nifly::Vector3(1.0f, 1.0f, 1.0f);
 	nifly::Vector3 offset;
-
-	ObjFile();
-	~ObjFile();
 
 	int AddGroup(const std::string& name,
 				 const std::vector<nifly::Vector3>& verts,
@@ -57,7 +40,8 @@ public:
 	void SetOffset(const nifly::Vector3& inOffset) { offset = inOffset; }
 
 	int LoadForNif(const std::string& fileName, const ObjOptionsImport& options = ObjOptionsImport());
-	int LoadForNif(std::fstream& base, const ObjOptionsImport& options = ObjOptionsImport());
+	void LoadNoFaces(std::istream& base);
+	void LoadForNif(std::istream& base);
 
 	int Save(const std::string& fileName);
 

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -5094,6 +5094,10 @@ int OutfitProject::ImportFBX(const std::string& fileName, const std::string& sha
 					if (ret == wxYES)
 						workNif.SetUvsForShape(mergeShape, fbxShape->uvs);
 
+					ret = wxMessageBox(_("Update Normals?"), _("Normals Update"), wxYES_NO | wxICON_QUESTION, owner);
+					if (ret == wxYES)
+						workNif.SetNormalsForShape(mergeShape, fbxShape->normals);
+
 					ret = wxMessageBox(_("Update Animation Weighting?"), _("Animation Weight Update"), wxYES_NO | wxICON_QUESTION, owner);
 					if (ret == wxYES)
 						for (auto& bn : fbxShape->boneNames)

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -4940,6 +4940,10 @@ int OutfitProject::ImportOBJ(const std::string& fileName, const std::string& sha
 					if (ret == wxYES)
 						workNif.SetUvsForShape(mergeShape, uv);
 
+					ret = wxMessageBox(_("Update Normals?"), _("Normals Update"), wxYES_NO | wxICON_QUESTION, owner);
+					if (ret == wxYES)
+						workNif.SetNormalsForShape(mergeShape, n);
+
 					return 101;
 				}
 			}

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -4936,13 +4936,17 @@ int OutfitProject::ImportOBJ(const std::string& fileName, const std::string& sha
 					if (ret == wxYES)
 						workNif.SetVertsForShape(mergeShape, v);
 
-					ret = wxMessageBox(_("Update Texture Coordinates?"), _("UV Update"), wxYES_NO | wxICON_QUESTION, owner);
-					if (ret == wxYES)
-						workNif.SetUvsForShape(mergeShape, uv);
+					if (uv.size() == vertCount) {
+						ret = wxMessageBox(_("Update Texture Coordinates?"), _("UV Update"), wxYES_NO | wxICON_QUESTION, owner);
+						if (ret == wxYES)
+							workNif.SetUvsForShape(mergeShape, uv);
+					}
 
-					ret = wxMessageBox(_("Update Normals?"), _("Normals Update"), wxYES_NO | wxICON_QUESTION, owner);
-					if (ret == wxYES)
-						workNif.SetNormalsForShape(mergeShape, n);
+					if (n.size() == vertCount) {
+						ret = wxMessageBox(_("Update Normals?"), _("Normals Update"), wxYES_NO | wxICON_QUESTION, owner);
+						if (ret == wxYES)
+							workNif.SetNormalsForShape(mergeShape, n);
+					}
 
 					return 101;
 				}
@@ -5090,13 +5094,17 @@ int OutfitProject::ImportFBX(const std::string& fileName, const std::string& sha
 					if (ret == wxYES)
 						workNif.SetVertsForShape(mergeShape, fbxShape->verts);
 
-					ret = wxMessageBox(_("Update Texture Coordinates?"), _("UV Update"), wxYES_NO | wxICON_QUESTION, owner);
-					if (ret == wxYES)
-						workNif.SetUvsForShape(mergeShape, fbxShape->uvs);
+					if (fbxShape->uvs.size() == vertCount) {
+						ret = wxMessageBox(_("Update Texture Coordinates?"), _("UV Update"), wxYES_NO | wxICON_QUESTION, owner);
+						if (ret == wxYES)
+							workNif.SetUvsForShape(mergeShape, fbxShape->uvs);
+					}
 
-					ret = wxMessageBox(_("Update Normals?"), _("Normals Update"), wxYES_NO | wxICON_QUESTION, owner);
-					if (ret == wxYES)
-						workNif.SetNormalsForShape(mergeShape, fbxShape->normals);
+					if (fbxShape->normals.size() == vertCount) {
+						ret = wxMessageBox(_("Update Normals?"), _("Normals Update"), wxYES_NO | wxICON_QUESTION, owner);
+						if (ret == wxYES)
+							workNif.SetNormalsForShape(mergeShape, fbxShape->normals);
+					}
 
 					ret = wxMessageBox(_("Update Animation Weighting?"), _("Animation Weight Update"), wxYES_NO | wxICON_QUESTION, owner);
 					if (ret == wxYES)

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -4944,8 +4944,10 @@ int OutfitProject::ImportOBJ(const std::string& fileName, const std::string& sha
 
 					if (n.size() == vertCount) {
 						ret = wxMessageBox(_("Update Normals?"), _("Normals Update"), wxYES_NO | wxICON_QUESTION, owner);
-						if (ret == wxYES)
+						if (ret == wxYES) {
 							workNif.SetNormalsForShape(mergeShape, n);
+							workNif.CalcTangentsForShape(mergeShape);
+						}
 					}
 
 					return 101;
@@ -5102,8 +5104,10 @@ int OutfitProject::ImportFBX(const std::string& fileName, const std::string& sha
 
 					if (fbxShape->normals.size() == vertCount) {
 						ret = wxMessageBox(_("Update Normals?"), _("Normals Update"), wxYES_NO | wxICON_QUESTION, owner);
-						if (ret == wxYES)
+						if (ret == wxYES) {
 							workNif.SetNormalsForShape(mergeShape, fbxShape->normals);
+							workNif.CalcTangentsForShape(mergeShape);
+						}
 					}
 
 					ret = wxMessageBox(_("Update Animation Weighting?"), _("Animation Weight Update"), wxYES_NO | wxICON_QUESTION, owner);


### PR DESCRIPTION
For importing OBJ:
- Preserve vertex order (issue #218 ).
- When merging data with an existing shape, give option to update normals (issue #218 ).
- Correctly handle faces with more than 4 vertices (issue #443 ).
- Handle OBJ comments correctly.
- Clean up a few things in ObjFile.{h,cpp}.
- Don't duplicate vertices when normals or uvs are duplicated in the file.
- Handle negative OBJ vertex/texture/normal indices correctly.

For importing FBX:
- When merging data with an existing shape, give option to update normals (issue #218 ).
- Split vertices with multiple UVs/normals.  (Problem mentioned in issue #443 by ousnius.)
- Swap x,y,z for normals the same way it already did for vertex coordinates (bug fix).

For exporting FBX:
- Swap x,y,z for normals the same way it already did for vertex coordinates (bug fix).