### PR TITLE
Fix bug masking unmatched symmetric vertices

### DIFF
--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -4072,6 +4072,10 @@ std::vector<bool> CalcVertexListForAsymmetryTasks(const SymmetricVertices& symve
 		}
 	}
 
+	if (tasks.doUnmatched)
+		for (int vi : symverts.unmatched)
+			doVert[vi] = true;
+
 	return doVert;
 }
 


### PR DESCRIPTION
The "Unmatched Vertices" checkbox in the "Mask symmetric vertices" window
was being ignored.