### PR TITLE
Fixed BSShaderTextureSet not being created

### DIFF
--- a/src/program/ShapeProperties.cpp
+++ b/src/program/ShapeProperties.cpp
@@ -326,7 +326,7 @@ void ShapeProperties::AddShader() {
 	}
 
 	NiShader* shader = nif->GetShader(shape);
-	if (shader && shader->HasTextureSet()) {
+	if (shader) {
 		auto nifTexSet = std::make_unique<BSShaderTextureSet>(nif->GetHeader().GetVersion());
 		shader->TextureSetRef()->index = nif->GetHeader().AddBlock(std::move(nifTexSet));
 	}


### PR DESCRIPTION
The failure would occur when clicking "Add Shader" or "Copy from shape..." (if the shape does not have a shader) in the Shape Properties window.