### PR TITLE
Minor Linux fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
 project(BSOS)
 set(CMAKE_CXX_STANDARD 17)

--- a/src/program/FBXImportDialog.cpp
+++ b/src/program/FBXImportDialog.cpp
@@ -170,6 +170,9 @@ void FBXImportDialog::OnShown() {
 }
 
 void FBXImportDialog::UpdateVertexPositions() {
+	if (!scale || !rotateX || !rotateY || !rotateZ)
+		return;
+
 	Matrix4 mat;
 
 	float scaleValue = std::atof(scale->GetValue().c_str());
@@ -243,6 +246,9 @@ void FBXImportDialog::UpdateVertexPositions() {
 }
 
 void FBXImportDialog::UpdateTextureCoords() {
+	if (!cbInvertU || !cbInvertV)
+		return;
+
 	std::vector<std::string> shapes;
 	fbxw.GetShapeNames(shapes);
 
@@ -275,8 +281,11 @@ void FBXImportDialog::UpdateTextureCoords() {
 }
 
 void FBXImportDialog::UpdateItemSelection() {
+	if (!meshesList)
+		return;
+
 	for (int item = 0; item < meshesList->GetItemCount(); item++) {
-		std::string name = meshesList->GetItemText(item).ToUTF8();
+		std::string name{meshesList->GetItemText(item).ToUTF8()};
 
 		auto m = GetSurface().GetMesh(name);
 		if (m) {
@@ -291,9 +300,12 @@ void FBXImportDialog::UpdateItemSelection() {
 }
 
 void FBXImportDialog::DeleteItemSelection() {
+	if (!meshesList)
+		return;
+
 	for (int item = meshesList->GetItemCount() - 1; item >= 0; item--) {
 		if (meshesList->GetItemState(item, wxLIST_STATE_SELECTED) == wxLIST_STATE_SELECTED) {
-			std::string name = meshesList->GetItemText(item).ToUTF8();
+			std::string name{meshesList->GetItemText(item).ToUTF8()};
 			GetSurface().DeleteMesh(name);
 			meshesList->DeleteItem(item);
 		}
@@ -376,7 +388,7 @@ void FBXImportDialog::OnImport(wxCommandEvent& WXUNUSED(event)) {
 	options.ImportAll = false;
 
 	for (int item = 0; item < meshesList->GetItemCount(); item++) {
-		std::string name = meshesList->GetItemText(item).ToUTF8();
+		std::string name{meshesList->GetItemText(item).ToUTF8()};
 		options.ImportShapes.insert(name);
 	}
 

--- a/src/program/FBXImportDialog.h
+++ b/src/program/FBXImportDialog.h
@@ -34,13 +34,13 @@ private:
 
 	FBXImportOptions options;
 	wxStaticText* lbWarning;
-	wxCheckBox* cbInvertU;
-	wxCheckBox* cbInvertV;
-	wxTextCtrl* scale;
-	wxChoice* rotateX;
-	wxChoice* rotateY;
-	wxChoice* rotateZ;
-	wxListCtrl* meshesList;
+	wxCheckBox* cbInvertU = nullptr;
+	wxCheckBox* cbInvertV = nullptr;
+	wxTextCtrl* scale = nullptr;
+	wxChoice* rotateX = nullptr;
+	wxChoice* rotateY = nullptr;
+	wxChoice* rotateZ = nullptr;
+	wxListCtrl* meshesList = nullptr;
 
 	void UpdateVertexPositions();
 	void UpdateTextureCoords();

--- a/src/program/ObjImportDialog.cpp
+++ b/src/program/ObjImportDialog.cpp
@@ -179,6 +179,9 @@ void ObjImportDialog::OnShown() {
 }
 
 void ObjImportDialog::UpdateVertexPositions() {
+	if (!scale || !rotateX || !rotateY || !rotateZ)
+		return;
+
 	Matrix4 mat;
 
 	float scaleValue = std::atof(scale->GetValue().c_str());
@@ -255,6 +258,9 @@ void ObjImportDialog::UpdateVertexPositions() {
 }
 
 void ObjImportDialog::UpdateTextureCoords() {
+	if (!cbInvertU || !cbInvertV)
+		return;
+
 	auto shapes = obj.GetGroupList();
 
 	for (auto& s : shapes) {
@@ -289,8 +295,11 @@ void ObjImportDialog::UpdateTextureCoords() {
 }
 
 void ObjImportDialog::UpdateItemSelection() {
+	if (!meshesList)
+		return;
+
 	for (int item = 0; item < meshesList->GetItemCount(); item++) {
-		std::string name = meshesList->GetItemText(item).ToUTF8();
+		std::string name{meshesList->GetItemText(item).ToUTF8()};
 
 		auto m = GetSurface().GetMesh(name);
 		if (m) {
@@ -305,9 +314,12 @@ void ObjImportDialog::UpdateItemSelection() {
 }
 
 void ObjImportDialog::DeleteItemSelection() {
+	if (!meshesList)
+		return;
+
 	for (int item = meshesList->GetItemCount() - 1; item >= 0; item--) {
 		if (meshesList->GetItemState(item, wxLIST_STATE_SELECTED) == wxLIST_STATE_SELECTED) {
-			std::string name = meshesList->GetItemText(item).ToUTF8();
+			std::string name{meshesList->GetItemText(item).ToUTF8()};
 			GetSurface().DeleteMesh(name);
 			meshesList->DeleteItem(item);
 		}
@@ -390,7 +402,7 @@ void ObjImportDialog::OnImport(wxCommandEvent& WXUNUSED(event)) {
 	options.ImportAll = false;
 
 	for (int item = 0; item < meshesList->GetItemCount(); item++) {
-		std::string name = meshesList->GetItemText(item).ToUTF8();
+		std::string name{meshesList->GetItemText(item).ToUTF8()};
 		options.ImportShapes.insert(name);
 	}
 

--- a/src/program/ObjImportDialog.h
+++ b/src/program/ObjImportDialog.h
@@ -34,13 +34,13 @@ private:
 
 	ObjImportOptions options;
 	wxStaticText* lbWarning;
-	wxCheckBox* cbInvertU;
-	wxCheckBox* cbInvertV;
-	wxTextCtrl* scale;
-	wxChoice* rotateX;
-	wxChoice* rotateY;
-	wxChoice* rotateZ;
-	wxListCtrl* meshesList;
+	wxCheckBox* cbInvertU = nullptr;
+	wxCheckBox* cbInvertV = nullptr;
+	wxTextCtrl* scale = nullptr;
+	wxChoice* rotateX = nullptr;
+	wxChoice* rotateY = nullptr;
+	wxChoice* rotateZ = nullptr;
+	wxListCtrl* meshesList = nullptr;
 
 	void UpdateVertexPositions();
 	void UpdateTextureCoords();

--- a/src/render/GLDialog.h
+++ b/src/render/GLDialog.h
@@ -5,10 +5,10 @@ See the included LICENSE file
 
 #pragma once
 
-#include <wx/wx.h>
-
-#include "GLCanvas.h"
 #include "GLSurface.h"
+#include "GLCanvas.h"
+
+#include <wx/wx.h>
 
 class GLDialog : public wxDialog {
 public:


### PR DESCRIPTION
- Update minimum cmake version from 3.10 to 3.11 so it uses libOpenGL instead
of libGL, silencing the warning for cmake policy CMP0072.
- If GLEW and WXWidgets headers are both included, GLEW must be included
first.
- Fix wxString::ToUTF8 std::string initialization style.
- wxXmlResource::LoadDialog calls some of the event handlers, so
the event handlers need to check for null pointers.