### PR TITLE
Fixes for wxWidgets-gtk3 3.1.6

### DIFF
--- a/Readme-linux.txt
+++ b/Readme-linux.txt
@@ -2,15 +2,16 @@ Building BodySlide and Outfit Studio on Linux
 
 There's just one file that specifies the build process: CMakeLists.txt.
 
-Install wxWidgets 3.1.3 or newer.  Use the "--enable-stl" option to
-configure.  If you get errors about an ABI mismatch, that means you
-compiled wxWidgets with a different compiler version than BS&OS (and
-wxWidgets is strangely picky about that).  Either gtk2 or gtk3 works.
-With gtk2, you have more background color problems; with gtk3, many
-widgets are distorted because they don't have enough space.  Note that
-many of wxWidget's configure options (such as --enable-universal)
-result in a broken wxWidgets library, so prefer to use as few options
-as possible.
+Install wxWidgets 3.1.3 or newer.  If you get errors about an ABI
+mismatch, that means you compiled wxWidgets with a different compiler
+version than BS&OS.  Either gtk2 or gtk3 works.  With gtk2, you have
+more background color problems; with gtk3, many widgets are distorted
+because they don't have enough space.  Note that many of wxWidget's
+configure options (such as --enable-universal) result in a broken
+wxWidgets library, so prefer to use as few options as possible.
+Also note that some distribution-provided wxWidgets packages are
+broken, so it's likely that you'll have to build wxWidgets yourself
+(which is really easy).
 
 Install FBX SDK.  Put the path to your FBX SDK installation in the
 fbxsdk_dir variable in CMakeLists.txt.
@@ -30,9 +31,14 @@ The possible values for CMAKE_BUILD_TYPE:
 	MinSizeRel
 	(nothing)
 
-To specify the compiler, set CC and CXX before running cmake.  The build
-directory must be completely empty, or cmake will ignore CC and CXX and
-use the same compilers as it did last time.
+The -Wall option is optional.  If you don't care about compiler
+warnings, you should probably skip this option.
+
+To specify the compiler, set CC and CXX before running cmake.
+The build directory must be completely empty, or cmake will ignore CC
+and CXX and use the same compilers as it did last time.  Don't forget
+to build wxWidgets with the same compiler; the wxWidgets configure script
+also uses the CC and CXX environment variables.
 
 Some useful make options:
 make VERBOSE=1

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -318,7 +318,7 @@ void BodySlideApp::InitArchives() {
 
 void BodySlideApp::GetArchiveFiles(std::vector<std::string>& outList) {
 	TargetGame targ = (TargetGame)Config.GetIntValue("TargetGame");
-	std::string cp = "GameDataFiles/" + TargetGames[targ];
+	std::string cp = "GameDataFiles/" + TargetGames[targ].ToStdString();
 	wxString activatedFiles = Config[cp];
 
 	wxStringTokenizer tokenizer(activatedFiles, ";");
@@ -1810,7 +1810,7 @@ void BodySlideApp::ApplyOutfitFilter() {
 				wxString token = tokenizer.GetNextToken();
 				token.Trim();
 				token.Trim(false);
-				std::string group = token;
+				std::string group = token.ToStdString();
 				grouplist.insert(group);
 			}
 		}
@@ -3763,7 +3763,7 @@ void BodySlideFrame::OnBatchBuild(wxCommandEvent& WXUNUSED(event)) {
 	std::map<std::string, std::string> failedOutfits;
 	int ret;
 	if (custpath) {
-		std::string path = wxDirSelector(_("Choose a folder to contain the saved files"));
+		std::string path = wxDirSelector(_("Choose a folder to contain the saved files")).ToStdString();
 		if (path.empty())
 			return;
 

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -917,7 +917,7 @@ void OutfitStudio::InitArchives() {
 
 void OutfitStudio::GetArchiveFiles(std::vector<std::string>& outList) {
 	TargetGame targ = (TargetGame)Config.GetIntValue("TargetGame");
-	std::string cp = "GameDataFiles/" + TargetGames[targ];
+	std::string cp = "GameDataFiles/" + TargetGames[targ].ToStdString();
 	wxString activatedFiles = Config[cp];
 
 	wxStringTokenizer tokenizer(activatedFiles, ";");
@@ -3671,7 +3671,7 @@ void OutfitStudioFrame::OnLoadOutfit(wxCommandEvent& WXUNUSED(event)) {
 	if (result == wxID_CANCEL)
 		return;
 
-	std::string outfitName = XRCCTRL(dlg, "npOutfitName", wxTextCtrl)->GetValue();
+	std::string outfitName = XRCCTRL(dlg, "npOutfitName", wxTextCtrl)->GetValue().ToStdString();
 
 	menuBar->Enable(XRCID("fileSave"), false);
 
@@ -4637,7 +4637,7 @@ void OutfitStudioFrame::OnExportTRIHead(wxCommandEvent& WXUNUSED(event)) {
 		return;
 
 	for (auto& shape : project->GetWorkNif()->GetShapes()) {
-		std::string fn = dir + PathSepStr + shape->name.get() + ".tri";
+		std::string fn = dir.ToStdString() + PathSepStr + shape->name.get() + ".tri";
 
 		wxLogMessage("Exporting TRI (head) morphs of '%s' to '%s'...", shape->name.get(), fn);
 		if (!project->WriteHeadTRI(shape, fn)) {
@@ -5029,11 +5029,11 @@ void OutfitStudioFrame::OnBoneSelect(wxTreeEvent& event) {
 	outfitBones->GetSelections(selected);
 
 	activeBone.clear();
-	std::string selBone = outfitBones->GetItemText(item);
+	std::string selBone = outfitBones->GetItemText(item).ToStdString();
 
 	if (!outfitBones->IsSelected(item)) {
 		if (!selected.IsEmpty()) {
-			std::string frontBone = outfitBones->GetItemText(selected.front());
+			std::string frontBone = outfitBones->GetItemText(selected.front()).ToStdString();
 			activeBone = frontBone;
 		}
 	}
@@ -6098,7 +6098,7 @@ void OutfitStudioFrame::OnSliderCheckBox(wxCommandEvent& event) {
 	if (!box)
 		return;
 
-	std::string name = box->GetName().BeforeLast('|');
+	std::string name = box->GetName().BeforeLast('|').ToStdString();
 	ShowSliderEffect(name, event.IsChecked());
 	ApplySliders();
 }
@@ -9132,7 +9132,7 @@ void OutfitStudioFrame::OnAddBone(wxCommandEvent& WXUNUSED(event)) {
 		wxArrayTreeItemIds sel;
 		boneTree->GetSelections(sel);
 		for (size_t i = 0; i < sel.size(); i++) {
-			std::string bone = boneTree->GetItemText(sel[i]);
+			std::string bone = boneTree->GetItemText(sel[i]).ToStdString();
 			wxLogMessage("Adding bone '%s' to project.", bone);
 
 			project->AddBoneRef(bone);
@@ -9305,7 +9305,7 @@ void OutfitStudioFrame::OnDeleteBone(wxCommandEvent& WXUNUSED(event)) {
 	wxArrayTreeItemIds selItems;
 	outfitBones->GetSelections(selItems);
 	for (size_t i = 0; i < selItems.size(); i++) {
-		std::string bone = outfitBones->GetItemText(selItems[i]);
+		std::string bone = outfitBones->GetItemText(selItems[i]).ToStdString();
 		wxLogMessage("Deleting bone '%s' from project.", bone);
 
 		project->DeleteBone(bone);
@@ -9328,7 +9328,7 @@ void OutfitStudioFrame::OnDeleteBoneFromSelected(wxCommandEvent& WXUNUSED(event)
 	wxArrayTreeItemIds selItems;
 	outfitBones->GetSelections(selItems);
 	for (size_t i = 0; i < selItems.size(); i++) {
-		std::string bone = outfitBones->GetItemText(selItems[i]);
+		std::string bone = outfitBones->GetItemText(selItems[i]).ToStdString();
 		wxLogMessage("Deleting weights of bone '%s' from selected shapes.", bone);
 
 		for (auto& s : selectedItems)
@@ -10277,7 +10277,7 @@ void OutfitStudioFrame::OnMaskMore(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnNPWizChangeSliderSetFile(wxFileDirPickerEvent& event) {
-	std::string fn = event.GetPath();
+	std::string fn = event.GetPath().ToStdString();
 	std::vector<std::string> shapes;
 	wxWindow* npWiz = ((wxFilePickerCtrl*)event.GetEventObject())->GetParent();
 	wxChoice* setNameChoice = (wxChoice*)XRCCTRL((*npWiz), "npSliderSetName", wxChoice);
@@ -10327,7 +10327,7 @@ void OutfitStudioFrame::OnNPWizChangeSetNameChoice(wxCommandEvent& event) {
 	if (!file)
 		return;
 
-	std::string fn = file->GetPath();
+	std::string fn = file->GetPath().ToStdString();
 	SliderSetFile ssf(fn);
 	if (ssf.fail())
 		return;

--- a/src/program/ShapeProperties.cpp
+++ b/src/program/ShapeProperties.cpp
@@ -431,7 +431,7 @@ void ShapeProperties::OnSetTextures(wxCommandEvent& WXUNUSED(event)) {
 			auto dataPath = Config["GameDataPath"];
 			std::vector<std::string> texFiles(10);
 			for (int i = 0; i < 10; i++) {
-				std::string texPath = stTexGrid->GetCellValue(i, 0);
+				std::string texPath = stTexGrid->GetCellValue(i, 0).ToStdString();
 				std::string texPath_bs = ToBackslashes(texPath);
 				nif->SetTextureSlot(shape, texPath_bs, i);
 
@@ -848,7 +848,7 @@ void ShapeProperties::ApplyChanges() {
 
 	NiShader* shader = nif->GetShader(shape);
 	if (shader) {
-		std::string name = shaderName->GetValue();
+		std::string name = shaderName->GetValue().ToStdString();
 		uint32_t type = shaderType->GetSelection();
 
 		shader->name.get() = name;

--- a/src/render/GLExtensions.cpp
+++ b/src/render/GLExtensions.cpp
@@ -173,8 +173,11 @@ void InitExtensions() {
 	if (extInitialized)
 		return;
 	GLenum err = glewInit();
-	if (err != GLEW_OK) {
-		fprintf(stderr, "Error: %s\n", glewGetErrorString(err));
+	// TODO: figure out why we're getting GLEW_ERROR_NO_GLX_DISPLAY (error
+	// code 4) with gtk3 builds of wxWidgets and fix it.  Everything still
+	// seems to work if we ignore the error, though.
+	if (err != GLEW_OK && err != GLEW_ERROR_NO_GLX_DISPLAY) {
+		fprintf(stderr, "Error (%d): %s\n", (int)err, glewGetErrorString(err));
 		abort();
 	}
 	extGLISupported = glTexStorage1D && glTexStorage2D && glTexStorage3D && glTexSubImage3D && glCompressedTexSubImage1D && glCompressedTexSubImage2D && glCompressedTexSubImage3D;


### PR DESCRIPTION
- With gtk3 (and not gtk2), newer versions of wxWidgets tend to make the
function glewInit return the error GLEW_ERROR_NO_GLX_DISPLAY unless you
initialize things in exactly the right sequence, which can be messy.  GLEW
still seems to work if you ignore the error, though, so I added code to ignore
the error.
- Added ToStdString in a dozen or so places (where implicit conversion from
wxString to std::string was used) so that you don't have to build wxWidgets
with the --enable-stl option.
- Updated the linux build instructions, mostly to improve clarity.