### PR TITLE
Fixed include order of DDS.h in FSBSA.cpp

### DIFF
--- a/lib/FSEngine/FSBSA.cpp
+++ b/lib/FSEngine/FSBSA.cpp
@@ -31,7 +31,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***** END LICENCE BLOCK *****/
 
 #include "FSBSA.h"
-#include "../DDS.h"
 
 #include <wx/mstream.h>
 #include <wx/zstream.h>
@@ -39,6 +38,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <algorithm>
 
 #include <../LZ4F/lz4frame_static.h>
+#include "../DDS.h"
 
 
 wxUint32 BSA::BSAFile::size() const {


### PR DESCRIPTION
This is to ensure that all wxWidgets includes happen before including
winuser.h, which defines GetClassInfo to GetClassInfoW, which breaks
wxWidgets headers.