### PR TITLE
Optimize shape zapping when generating morphs

### DIFF
--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -1091,6 +1091,8 @@ bool BodySlideApp::WriteMorphTRI(const std::string& triPath, SliderSet& sliderSe
 		if (shapeZapIndices.size() > 0 && shapeZapIndices.back() >= shapeVertCount)
 			continue;
 
+		auto zapRanges = FindContinuousRanges(shapeZapIndices);
+
 		for (size_t s = 0; s < sliderSet.size(); s++) {
 			std::string dn = sliderSet[s].TargetDataName(targetShape->second.targetShape);
 			std::string target = targetShape->second.targetShape;
@@ -1109,8 +1111,10 @@ bool BodySlideApp::WriteMorphTRI(const std::string& triPath, SliderSet& sliderSe
 
 					currentDiffs.ApplyUVDiff(dn, target, 1.0f, &uvs);
 
-					for (int i = shapeZapIndices.size() - 1; i >= 0; i--)
-						uvs.erase(uvs.begin() + shapeZapIndices[i]);
+					for (auto range = zapRanges.rbegin(); range != zapRanges.rend(); ++range) {
+						const auto start = uvs.cbegin() + range->index;
+						uvs.erase(start, start + range->length);
+					}
 
 					int i = 0;
 					for (auto& uv : uvs) {
@@ -1128,8 +1132,7 @@ bool BodySlideApp::WriteMorphTRI(const std::string& triPath, SliderSet& sliderSe
 
 					currentDiffs.ApplyDiff(dn, target, 1.0f, &verts);
 
-					auto ranges = FindContinuousRanges(shapeZapIndices);
-					for (auto range = ranges.rbegin(); range != ranges.rend(); ++range) {
+					for (auto range = zapRanges.rbegin(); range != zapRanges.rend(); ++range) {
 						const auto start = verts.cbegin() + range->index;
 						verts.erase(start, start + range->length);
 					}

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -1039,6 +1039,35 @@ void BodySlideApp::ApplySliders(
 				dataSets.ApplyClamp(slider.linkedDataSets[j], targetShape, &verts);
 }
 
+struct ContinuousRange {
+	uint16_t index = 0;
+	size_t length = 0;
+};
+
+static std::vector<ContinuousRange> FindContinuousRanges(const std::vector<uint16_t>& source) {
+	std::vector<ContinuousRange> ranges;
+	if (source.size() == 0) {
+		return ranges;
+	}
+
+	size_t startIndex = 0;
+	size_t endIndex = 1;
+	int lastValue = (int)source[0]; // Cast to int to avoid potential uint16_t overflow in comparison below
+
+	for (; endIndex < source.size(); ++endIndex) {
+		int value = (int)source[endIndex];
+		if (value != lastValue + 1) {
+			ranges.emplace_back(ContinuousRange{ source[startIndex], endIndex - startIndex });
+			startIndex = endIndex;
+		}
+		lastValue = value;
+	}
+
+	ranges.emplace_back(ContinuousRange{ source[startIndex], endIndex - startIndex });
+
+	return ranges;
+}
+
 bool BodySlideApp::WriteMorphTRI(const std::string& triPath, SliderSet& sliderSet, NifFile& nif, std::unordered_map<std::string, std::vector<uint16_t>>& zapIndices) {
 	DiffDataSets currentDiffs;
 	sliderSet.LoadSetDiffData(currentDiffs);
@@ -1099,8 +1128,11 @@ bool BodySlideApp::WriteMorphTRI(const std::string& triPath, SliderSet& sliderSe
 
 					currentDiffs.ApplyDiff(dn, target, 1.0f, &verts);
 
-					for (int i = shapeZapIndices.size() - 1; i >= 0; i--)
-						verts.erase(verts.begin() + shapeZapIndices[i]);
+					auto ranges = FindContinuousRanges(shapeZapIndices);
+					for (auto range = ranges.rbegin(); range != ranges.rend(); ++range) {
+						const auto start = verts.cbegin() + range->index;
+						verts.erase(start, start + range->length);
+					}
 
 					int i = 0;
 					for (auto& v : verts) {


### PR DESCRIPTION
`shapeZapIndices` contains ranges of vertices to delete, instead of deleting vertices one by one calculate continuous range and delete vertices in big chunks.

In my tests this change has improved batch build time by 20% (single-thread performance).

<details><summary>Before (00:03:01)</summary>
<p>

![image](https://github.com/user-attachments/assets/308bd01b-164d-41af-a539-448b65c387c6)

</p>
</details> 

<details><summary>After (00:02:26)</summary>
<p>

![image](https://github.com/user-attachments/assets/490b7c2c-500f-4752-8234-361252a30f7f)


</p>
</details> 


Profiling results:

<details><summary>Before (39.69 s)</summary>
<p>

![image](https://github.com/user-attachments/assets/8dd9b603-49b3-4e13-904b-7afde713c2e8)

</p>
</details> 

<details><summary>After (1.93 s)</summary>
<p>

![image](https://github.com/user-attachments/assets/8c5c9995-b202-43a1-894f-e0e668481f10)


</p>
</details> 

ShapeZapIndices zone in traces above refers to this part of code:

```c++
for (int i = shapeZapIndices.size() - 1; i >= 0; i--)
    verts.erase(verts.begin() + shapeZapIndices[i]);
}
``` 

