### PR TITLE
Fix build error in FSBSA.h

### DIFF
--- a/lib/FSEngine/FSBSA.h
+++ b/lib/FSEngine/FSBSA.h
@@ -39,6 +39,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <wx/filename.h>
 #include <wx/thread.h>
 #include <unordered_map>
+#include <memory>
 
 
 /* Default header data */


### PR DESCRIPTION
Fixes following error when building BodySlide:

```
Build started at 3:20 PM...
1>------ Build started: Project: BodySlide, Configuration: Debug x64 ------
1>FSBSA.cpp
1>FSEngine.cpp
1>C:\dev\BodySlide-and-Outfit-Studio\lib\FSEngine\FSBSA.h(341,7): error C2039: 'unique_ptr': is not a member of 'std'
1>(compiling source file 'lib/FSEngine/FSBSA.cpp')
1>    C:\vs2022\ide\VC\Tools\MSVC\14.42.34433\include\iterator(20,1):
1>    see declaration of 'std'
...
```