### PR TITLE
Remove Mesh::BuildTriAdjacency

### DIFF
--- a/src/components/Mesh.cpp
+++ b/src/components/Mesh.cpp
@@ -31,25 +31,6 @@ std::shared_ptr<AABBTree> Mesh::CreateBVH() {
 	return bvh;
 }
 
-void Mesh::BuildTriAdjacency() {
-	if (!tris)
-		return;
-
-	vertTris = std::make_unique<std::vector<int>[]>(nVerts);
-	auto vt = vertTris.get();
-	for (int t = 0; t < nTris; t++) {
-		uint16_t i1 = tris[t].p1;
-		uint16_t i2 = tris[t].p2;
-		uint16_t i3 = tris[t].p3;
-		if (i1 >= nVerts || i2 >= nVerts || i3 >= nVerts)
-			continue;
-
-		vt[i1].push_back(t);
-		vt[i2].push_back(t);
-		vt[i3].push_back(t);
-	}
-}
-
 void Mesh::BuildVertexAdjacency() {
 	if (!tris)
 		return;

--- a/src/components/Mesh.h
+++ b/src/components/Mesh.h
@@ -87,7 +87,6 @@ public:
 
 	uint32_t overlayLayer = 0;					 // Layer for order of rendering overlays
 
-	std::unique_ptr<std::vector<int>[]> vertTris;		 // Map of triangles for which each vert is a member.
 	std::unique_ptr<std::vector<int>[]> vertEdges;		 // Map of edges for which each vert is a member.
 	WeldVertsType weldVerts; // Verts that are duplicated for UVs but are in the same position.
 	bool bGotWeldVerts = false;							 // Whether weldVerts has been calculated yet.
@@ -139,7 +138,6 @@ public:
 
 	void MakeEdges(); // Creates the list of edges from the list of triangles.
 
-	void BuildTriAdjacency();	 // Triangle adjacency optional to reduce overhead when it's not needed.
 	void BuildVertexAdjacency(); // Vertex adjacency optional to reduce overhead when it's not needed.
 	void BuildEdgeList();		 // Edge list optional to reduce overhead when it's not needed.
 

--- a/src/program/EditUV.cpp
+++ b/src/program/EditUV.cpp
@@ -1110,7 +1110,6 @@ void EditUVCanvas::InitMeshes() {
 	uvGridMesh->material = &uvGridMaterial;
 	uvGridMesh->shapeName = "UVGrid";
 
-	uvGridMesh->BuildTriAdjacency();
 	uvGridMesh->BuildVertexAdjacency();
 	uvGridMesh->BuildEdgeList();
 	uvGridMesh->CreateBVH();

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -11894,7 +11894,6 @@ void wxGLPanel::AddMeshFromNif(NifFile* nif, const std::string& shapeName) {
 			m->SetXformModelToMesh(Mesh::xformNifToMesh.ComposeTransforms(globalToShape.ComposeTransforms(Mesh::xformMeshToNif)));
 		}
 
-		m->BuildTriAdjacency();
 		m->BuildVertexAdjacency();
 		m->BuildEdgeList();
 		m->MaskFill(0.0f);

--- a/src/program/PreviewWindow.cpp
+++ b/src/program/PreviewWindow.cpp
@@ -144,7 +144,6 @@ void PreviewWindow::AddMeshFromNif(NifFile* nif, char* shapeName) {
 				continue;
 
 			SetShapeVertexColors(nif, shapeListName, m);
-			m->BuildTriAdjacency();
 			m->BuildVertexAdjacency();
 			m->CreateBuffers();
 		}
@@ -164,7 +163,6 @@ void PreviewWindow::RefreshMeshFromNif(NifFile* nif, char* shapeName) {
 				continue;
 
 			SetShapeVertexColors(nif, shapeListName, m);
-			m->BuildTriAdjacency();
 			m->BuildVertexAdjacency();
 			m->SmoothNormals();
 			m->CreateBuffers();


### PR DESCRIPTION
Data generated by this method was not used anywhere (stored in `vertTris` variable). Speeds up batch build time a little bit. 