### PR TITLE
Outfit Studio: Fix Starfield mesh rotation and positioning

### DIFF
--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -399,6 +399,8 @@ bool AnimInfo::CalcShapeSkinBounds(const std::string& shapeName, const int& bone
 	if (verts.size() == 0) // Check for empty shape
 		return false;
 
+	bool isSF = refNif->GetHeader().GetVersion().IsSF();
+
 	std::vector<Vector3> boundVerts;
 	for (auto& w : shapeSkinning[shapeName].boneWeights[boneIndex].weights) {
 		if (w.first >= verts.size()) // Incoming weights have a larger set of possible verts.
@@ -408,6 +410,13 @@ bool AnimInfo::CalcShapeSkinBounds(const std::string& shapeName, const int& bone
 	}
 
 	BoundingSphere bounds(boundVerts);
+
+	// SF vertices are scaled by havokScale internally but BSSkin::BoneData
+	// bounds must be in the NIF's native meter-scale coordinate space
+	if (isSF) {
+		bounds.center /= sfHavokScale;
+		bounds.radius /= sfHavokScale;
+	}
 
 	const MatTransform& xformSkinToBone = shapeSkinning[shapeName].boneWeights[boneIndex].xformSkinToBone;
 

--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -165,13 +165,6 @@ void AnimSkin::LoadFromNif(NifFile* loadFromFile, NiShape* shape) {
 
 	if (!eachXformGlobalToSkin.empty()) {
 		xformGlobalToSkin = CalcMedianMatTransform(eachXformGlobalToSkin);
-
-		// SF skeleton transforms are in meters but mesh vertices are scaled
-		// by havokScale (69.969) during loading — match the translation
-		if (loadFromFile->GetHeader().GetVersion().IsSF()) {
-			constexpr float havokScale = 69.969f;
-			xformGlobalToSkin.translation *= havokScale;
-		}
 	}
 }
 

--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -156,16 +156,6 @@ void AnimSkin::LoadFromNif(NifFile* loadFromFile, NiShape* shape) {
 			if (!gotGTS) {
 				MatTransform xformBoneToGlobal;
 				if (AnimSkeleton::getInstance().GetBoneTransformToGlobal(bn, xformBoneToGlobal)) {
-					if (bn == "C_Spine1" || bn == "C_Hips") {
-						wxLogMessage("SF bone '%s': boneToGlobal t=(%.6f, %.6f, %.6f) scale=%.4f",
-							bn, xformBoneToGlobal.translation.x, xformBoneToGlobal.translation.y,
-							xformBoneToGlobal.translation.z, xformBoneToGlobal.scale);
-						wxLogMessage("  skinToBone t=(%.6f, %.6f, %.6f) scale=%.4f",
-							boneWeights[newID].xformSkinToBone.translation.x,
-							boneWeights[newID].xformSkinToBone.translation.y,
-							boneWeights[newID].xformSkinToBone.translation.z,
-							boneWeights[newID].xformSkinToBone.scale);
-					}
 					eachXformGlobalToSkin.push_back(xformBoneToGlobal.ComposeTransforms(boneWeights[newID].xformSkinToBone).InverseTransform());
 				}
 			}
@@ -175,14 +165,12 @@ void AnimSkin::LoadFromNif(NifFile* loadFromFile, NiShape* shape) {
 
 	if (!eachXformGlobalToSkin.empty()) {
 		xformGlobalToSkin = CalcMedianMatTransform(eachXformGlobalToSkin);
-		wxLogMessage("AnimSkin GTS: t=(%.6f, %.6f, %.6f) scale=%.6f from %zu bones",
-			xformGlobalToSkin.translation.x, xformGlobalToSkin.translation.y,
-			xformGlobalToSkin.translation.z, xformGlobalToSkin.scale,
-			eachXformGlobalToSkin.size());
-		if (!eachXformGlobalToSkin.empty()) {
-			auto& first = eachXformGlobalToSkin[0];
-			wxLogMessage("  first GTS entry: t=(%.6f, %.6f, %.6f) scale=%.6f",
-				first.translation.x, first.translation.y, first.translation.z, first.scale);
+
+		// SF skeleton transforms are in meters but mesh vertices are scaled
+		// by havokScale (69.969) during loading — match the translation
+		if (loadFromFile->GetHeader().GetVersion().IsSF()) {
+			constexpr float havokScale = 69.969f;
+			xformGlobalToSkin.translation *= havokScale;
 		}
 	}
 }
@@ -225,10 +213,6 @@ bool AnimInfo::LoadFromNif(NifFile* nif, NiShape* shape, bool newRefNif) {
 				if (!cstm->isStandardBone)
 					nonRefBones += bn + "\n";
 				AnimSkeleton::getInstance().RefBone(bn);
-			}
-			else {
-				wxLogWarning("Bone '%s' not found in NIF or reference skeleton, skipping.", bn);
-				continue;
 			}
 		}
 

--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -138,11 +138,6 @@ void AnimSkin::LoadFromNif(NifFile* loadFromFile, NiShape* shape) {
 		boneWeights[newID].LoadFromNif(loadFromFile, shape, newID);
 		boneNames[node->name.get()] = newID;
 		if (!gotGTS) {
-			// We don't have a global-to-skin transform, probably because
-			// the NIF has BSSkinBoneData instead of NiSkinData (FO4 or
-			// newer).  So calculate by:
-			// Compose: skin -> bone -> global
-			// and inverting.
 			MatTransform xformBoneToGlobal;
 			if (AnimSkeleton::getInstance().GetBoneTransformToGlobal(node->name.get(), xformBoneToGlobal)) {
 				eachXformGlobalToSkin.push_back(xformBoneToGlobal.ComposeTransforms(boneWeights[newID].xformSkinToBone).InverseTransform());
@@ -150,8 +145,46 @@ void AnimSkin::LoadFromNif(NifFile* loadFromFile, NiShape* shape) {
 		}
 		newID++;
 	}
-	if (!eachXformGlobalToSkin.empty())
+
+	// SF NIFs have no bone NiNodes — use bone names from SkinAttach instead
+	if (newID == 0) {
+		std::vector<std::string> nameList;
+		loadFromFile->GetShapeBoneList(shape, nameList);
+		for (auto& bn : nameList) {
+			boneWeights[newID].LoadFromNif(loadFromFile, shape, newID);
+			boneNames[bn] = newID;
+			if (!gotGTS) {
+				MatTransform xformBoneToGlobal;
+				if (AnimSkeleton::getInstance().GetBoneTransformToGlobal(bn, xformBoneToGlobal)) {
+					if (bn == "C_Spine1" || bn == "C_Hips") {
+						wxLogMessage("SF bone '%s': boneToGlobal t=(%.6f, %.6f, %.6f) scale=%.4f",
+							bn, xformBoneToGlobal.translation.x, xformBoneToGlobal.translation.y,
+							xformBoneToGlobal.translation.z, xformBoneToGlobal.scale);
+						wxLogMessage("  skinToBone t=(%.6f, %.6f, %.6f) scale=%.4f",
+							boneWeights[newID].xformSkinToBone.translation.x,
+							boneWeights[newID].xformSkinToBone.translation.y,
+							boneWeights[newID].xformSkinToBone.translation.z,
+							boneWeights[newID].xformSkinToBone.scale);
+					}
+					eachXformGlobalToSkin.push_back(xformBoneToGlobal.ComposeTransforms(boneWeights[newID].xformSkinToBone).InverseTransform());
+				}
+			}
+			newID++;
+		}
+	}
+
+	if (!eachXformGlobalToSkin.empty()) {
 		xformGlobalToSkin = CalcMedianMatTransform(eachXformGlobalToSkin);
+		wxLogMessage("AnimSkin GTS: t=(%.6f, %.6f, %.6f) scale=%.6f from %zu bones",
+			xformGlobalToSkin.translation.x, xformGlobalToSkin.translation.y,
+			xformGlobalToSkin.translation.z, xformGlobalToSkin.scale,
+			eachXformGlobalToSkin.size());
+		if (!eachXformGlobalToSkin.empty()) {
+			auto& first = eachXformGlobalToSkin[0];
+			wxLogMessage("  first GTS entry: t=(%.6f, %.6f, %.6f) scale=%.6f",
+				first.translation.x, first.translation.y, first.translation.z, first.scale);
+		}
+	}
 }
 
 bool AnimInfo::LoadFromNif(NifFile* nif) {
@@ -183,9 +216,20 @@ bool AnimInfo::LoadFromNif(NifFile* nif, NiShape* shape, bool newRefNif) {
 	for (auto& bn : boneNames) {
 		if (!AnimSkeleton::getInstance().RefBone(bn)) {
 			AnimBone* cstm = AnimSkeleton::getInstance().LoadCustomBoneFromNif(nif, bn);
-			if (!cstm->isStandardBone)
-				nonRefBones += bn + "\n";
-			AnimSkeleton::getInstance().RefBone(bn);
+			if (!cstm) {
+				// SF body NIFs have no bone NiNodes — look up in the reference skeleton
+				NifFile& skelNif = AnimSkeleton::getInstance().refSkeletonNif;
+				cstm = AnimSkeleton::getInstance().LoadCustomBoneFromNif(&skelNif, bn);
+			}
+			if (cstm) {
+				if (!cstm->isStandardBone)
+					nonRefBones += bn + "\n";
+				AnimSkeleton::getInstance().RefBone(bn);
+			}
+			else {
+				wxLogWarning("Bone '%s' not found in NIF or reference skeleton, skipping.", bn);
+				continue;
+			}
 		}
 
 		shapeBones[shapeName].push_back(bn);

--- a/src/components/Anim.h
+++ b/src/components/Anim.h
@@ -10,6 +10,10 @@ See the included LICENSE file
 
 #include <map>
 
+// Starfield meshes are normalized to metric units; vertices are scaled by this
+// factor during BSGeometryMeshData deserialization to match older-game units.
+constexpr float sfHavokScale = 69.969f;
+
 struct VertexBoneWeights {
 	std::vector<uint8_t> boneIds;
 	std::vector<float> weights;

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -1330,6 +1330,7 @@ void OutfitProject::GetLiveVerts(NiShape* shape, std::vector<Vector3>& outVerts,
 		std::vector<float> wv(nv, 0.0f);
 		AnimSkin& animSkin = workAnim.shapeSkinning[shape->name.get()];
 		MatTransform globalToSkin = workAnim.GetTransformGlobalToShape(shape);
+		bool isSF = workNif.GetHeader().GetVersion().IsSF();
 
 		for (auto& boneNamesIt : animSkin.boneNames) {
 			AnimBone* animB = AnimSkeleton::getInstance().GetBonePtr(boneNamesIt.first);
@@ -1338,6 +1339,10 @@ void OutfitProject::GetLiveVerts(NiShape* shape, std::vector<Vector3>& outVerts,
 
 				// Compose transform: skin -> (posed) bone -> global -> skin
 				MatTransform transform = globalToSkin.ComposeTransforms(animB->xformPoseToGlobal.ComposeTransforms(animW.xformSkinToBone));
+
+				if (isSF)
+					transform.translation *= sfHavokScale;
+
 				if (transform.IsNearlyEqualTo(MatTransform()))
 					transform.Clear();
 
@@ -6404,6 +6409,7 @@ void OutfitProject::GetAllPoseTransforms(NiShape* s, std::vector<MatTransform>& 
 
 	AnimSkin& animSkin = workAnim.shapeSkinning[s->name.get()];
 	MatTransform globalToSkin = workAnim.GetTransformGlobalToShape(s);
+	bool isSF = workNif.GetHeader().GetVersion().IsSF();
 
 	for (auto& boneNamesIt : animSkin.boneNames) {
 		AnimBone* animB = AnimSkeleton::getInstance().GetBonePtr(boneNamesIt.first);
@@ -6412,6 +6418,9 @@ void OutfitProject::GetAllPoseTransforms(NiShape* s, std::vector<MatTransform>& 
 		AnimWeight& animW = animSkin.boneWeights[boneNamesIt.second];
 		// Compose transform: skin -> (posed) bone -> global -> skin
 		MatTransform t = globalToSkin.ComposeTransforms(animB->xformPoseToGlobal.ComposeTransforms(animW.xformSkinToBone));
+
+		if (isSF)
+			t.translation *= sfHavokScale;
 		// Add weighted contributions to vertex transforms for this bone
 		for (auto& wIt : animW.weights) {
 			int vi = wIt.first;

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -15880,19 +15880,6 @@ void wxGLPanel::UpdateBones() {
 	auto workAnim = os->project->GetWorkAnim();
 	bool isSF = os->project->GetWorkNif()->GetHeader().GetVersion().IsSF();
 
-	MatTransform sfGlobalToSkin;
-	if (isSF) {
-		for (auto* s : os->project->GetWorkNif()->GetShapes()) {
-			if (s->IsSkinned()) {
-				sfGlobalToSkin = workAnim->GetTransformGlobalToShape(s);
-				wxLogMessage("SF UpdateBones: shape='%s' globalToSkin t=(%.4f, %.4f, %.4f) scale=%.4f",
-					s->name.get(), sfGlobalToSkin.translation.x, sfGlobalToSkin.translation.y,
-					sfGlobalToSkin.translation.z, sfGlobalToSkin.scale);
-				break;
-			}
-		}
-	}
-
 	std::function<bool(AnimBone*)> addChildBones = [&](AnimBone* parent) {
 		bool anyBoneInSelection = false;
 
@@ -15915,17 +15902,9 @@ void wxGLPanel::UpdateBones() {
 					Vector3 parentPosition = parentToGlobal.ApplyTransform(Vector3());
 
 					if (isSF) {
-						if (cb->boneName == "C_Spine1" || cb->boneName == "C_Hips") {
-							wxLogMessage("SF bone '%s': raw globalPos=(%.4f, %.4f, %.4f) gts.t=(%.4f, %.4f, %.4f)",
-								cb->boneName, position.x, position.y, position.z,
-								sfGlobalToSkin.translation.x, sfGlobalToSkin.translation.y, sfGlobalToSkin.translation.z);
-						}
-						position = (position + sfGlobalToSkin.translation) * sfHavokScale;
-						parentPosition = (parentPosition + sfGlobalToSkin.translation) * sfHavokScale;
-						if (cb->boneName == "C_Spine1" || cb->boneName == "C_Hips") {
-							wxLogMessage("SF bone '%s': after havokScale pos=(%.4f, %.4f, %.4f)",
-								cb->boneName, position.x, position.y, position.z);
-						}
+						constexpr float havokScale = 69.969f;
+						position *= havokScale;
+						parentPosition *= havokScale;
 					}
 
 					bool matchesParent = position.IsNearlyEqualTo(parentPosition);

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -15878,6 +15878,20 @@ void wxGLPanel::UpdateBones() {
 	bonesLines.clear();
 
 	auto workAnim = os->project->GetWorkAnim();
+	bool isSF = os->project->GetWorkNif()->GetHeader().GetVersion().IsSF();
+
+	MatTransform sfGlobalToSkin;
+	if (isSF) {
+		for (auto* s : os->project->GetWorkNif()->GetShapes()) {
+			if (s->IsSkinned()) {
+				sfGlobalToSkin = workAnim->GetTransformGlobalToShape(s);
+				wxLogMessage("SF UpdateBones: shape='%s' globalToSkin t=(%.4f, %.4f, %.4f) scale=%.4f",
+					s->name.get(), sfGlobalToSkin.translation.x, sfGlobalToSkin.translation.y,
+					sfGlobalToSkin.translation.z, sfGlobalToSkin.scale);
+				break;
+			}
+		}
+	}
 
 	std::function<bool(AnimBone*)> addChildBones = [&](AnimBone* parent) {
 		bool anyBoneInSelection = false;
@@ -15899,6 +15913,21 @@ void wxGLPanel::UpdateBones() {
 					Vector3 position = toGlobal.ApplyTransform(Vector3());
 					const MatTransform& parentToGlobal = os->project->bPose ? parent->xformPoseToGlobal : parent->xformToGlobal;
 					Vector3 parentPosition = parentToGlobal.ApplyTransform(Vector3());
+
+					if (isSF) {
+						if (cb->boneName == "C_Spine1" || cb->boneName == "C_Hips") {
+							wxLogMessage("SF bone '%s': raw globalPos=(%.4f, %.4f, %.4f) gts.t=(%.4f, %.4f, %.4f)",
+								cb->boneName, position.x, position.y, position.z,
+								sfGlobalToSkin.translation.x, sfGlobalToSkin.translation.y, sfGlobalToSkin.translation.z);
+						}
+						position = (position + sfGlobalToSkin.translation) * sfHavokScale;
+						parentPosition = (parentPosition + sfGlobalToSkin.translation) * sfHavokScale;
+						if (cb->boneName == "C_Spine1" || cb->boneName == "C_Hips") {
+							wxLogMessage("SF bone '%s': after havokScale pos=(%.4f, %.4f, %.4f)",
+								cb->boneName, position.x, position.y, position.z);
+						}
+					}
+
 					bool matchesParent = position.IsNearlyEqualTo(parentPosition);
 
 					Vector3 renderPosition = Mesh::TransformPosNifToMesh(position);

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -13224,6 +13224,8 @@ void wxGLPanel::AddMeshFromNif(NifFile* nif, const std::string& shapeName) {
 		if (shape && shape->IsSkinned()) {
 			// Overwrite skin matrix with the one from AnimInfo
 			MatTransform globalToShape = os->project->GetWorkAnim()->GetTransformGlobalToShape(shape);
+			if (nif->GetHeader().GetVersion().IsSF())
+				globalToShape.translation *= sfHavokScale;
 			m->SetXformModelToMesh(Mesh::xformNifToMesh.ComposeTransforms(globalToShape.ComposeTransforms(Mesh::xformMeshToNif)));
 		}
 
@@ -15902,9 +15904,8 @@ void wxGLPanel::UpdateBones() {
 					Vector3 parentPosition = parentToGlobal.ApplyTransform(Vector3());
 
 					if (isSF) {
-						constexpr float havokScale = 69.969f;
-						position *= havokScale;
-						parentPosition *= havokScale;
+						position *= sfHavokScale;
+						parentPosition *= sfHavokScale;
 					}
 
 					bool matchesParent = position.IsNearlyEqualTo(parentPosition);

--- a/src/render/GLSurface.cpp
+++ b/src/render/GLSurface.cpp
@@ -1384,20 +1384,6 @@ Mesh* GLSurface::AddMeshFromNif(NifFile* nif, const std::string& shapeName, Vect
 	for (int i = 0; i < m->nVerts; i++)
 		m->verts[i] = Mesh::TransformPosNifToMesh(nifVerts[i]);
 
-	if (!nifVerts.empty()) {
-		Vector3 vmin = nifVerts[0], vmax = nifVerts[0];
-		for (auto& v : nifVerts) {
-			if (v.x < vmin.x) vmin.x = v.x;
-			if (v.y < vmin.y) vmin.y = v.y;
-			if (v.z < vmin.z) vmin.z = v.z;
-			if (v.x > vmax.x) vmax.x = v.x;
-			if (v.y > vmax.y) vmax.y = v.y;
-			if (v.z > vmax.z) vmax.z = v.z;
-		}
-		wxLogMessage("Mesh '%s': %d verts, nif-space bounds min=(%.4f, %.4f, %.4f) max=(%.4f, %.4f, %.4f)",
-			shapeName, m->nVerts, vmin.x, vmin.y, vmin.z, vmax.x, vmax.y, vmax.z);
-	}
-
 	if (nifUvs && !nifUvs->empty()) {
 		for (int i = 0; i < m->nVerts; i++) {
 			m->texcoord[i].u = (*nifUvs)[i].u;

--- a/src/render/GLSurface.cpp
+++ b/src/render/GLSurface.cpp
@@ -1384,6 +1384,20 @@ Mesh* GLSurface::AddMeshFromNif(NifFile* nif, const std::string& shapeName, Vect
 	for (int i = 0; i < m->nVerts; i++)
 		m->verts[i] = Mesh::TransformPosNifToMesh(nifVerts[i]);
 
+	if (!nifVerts.empty()) {
+		Vector3 vmin = nifVerts[0], vmax = nifVerts[0];
+		for (auto& v : nifVerts) {
+			if (v.x < vmin.x) vmin.x = v.x;
+			if (v.y < vmin.y) vmin.y = v.y;
+			if (v.z < vmin.z) vmin.z = v.z;
+			if (v.x > vmax.x) vmax.x = v.x;
+			if (v.y > vmax.y) vmax.y = v.y;
+			if (v.z > vmax.z) vmax.z = v.z;
+		}
+		wxLogMessage("Mesh '%s': %d verts, nif-space bounds min=(%.4f, %.4f, %.4f) max=(%.4f, %.4f, %.4f)",
+			shapeName, m->nVerts, vmin.x, vmin.y, vmin.z, vmax.x, vmax.y, vmax.z);
+	}
+
 	if (nifUvs && !nifUvs->empty()) {
 		for (int i = 0; i < m->nVerts; i++) {
 			m->texcoord[i].u = (*nifUvs)[i].u;


### PR DESCRIPTION
## Summary
- Fix Starfield meshes appearing rotated and mispositioned in Outfit Studio
- Add SF bone loading via SkinAttach name-based fallback when NiNode block refs are empty
- Add skeleton NIF fallback for custom bone lookup (SF body NIFs have no bone NiNodes)
- Scale globalToSkin translation by havokScale (69.969) to bridge SF meters-to-vertex-units gap

## Details

**Root causes:**

1. `BSGeometry` was missing virtual overrides for `SkinInstanceRef()`, `IsSkinned()`, `HasShaderProperty()`, etc. — the members existed and were read in `Sync()`, but the base `NiShape` accessors always returned null/false. Fixed in nifly: ousnius/nifly#60

2. SF NIFs store bone names in `SkinAttach` extra data (all 38 `boneRefs` are `0xFFFFFFFF`). `AnimSkin::LoadFromNif` now falls back to `GetShapeBoneList` (which uses the SkinAttach fallback from nifly#60) when block ID lookup yields no NiNodes.

3. `LoadCustomBoneFromNif` returns nullptr for SF body NIFs since they contain no bone NiNodes. Added fallback to the reference skeleton NIF.

4. SF skeleton/skin transforms are in meters (Bethesda's documented engine change), but mesh vertices are scaled by `havokScale` (69.969) during `BSGeometryMeshData` deserialization. The computed `globalToSkin` translation must be scaled by the same factor.

**Depends on:** ousnius/nifly#60 (BSGeometry virtual overrides + SkinAttach bone fallback)

## Test plan
- [x] Load SF body NIF (`naked_f.nif`) — displays upright and centered with 38 bones
- [x] Load SF swimsuit NIF (`naked_f_swimsuit.nif`) — correct positioning
- [x] Load SF outfit NIF (`Outfit_Ajun_Torso_f.nif`) — correct positioning
- [x] Load SF multi-shape armor NIF (`redeemed_armor.nif`, 3 shapes) — all shapes correct
- [x] Load vanilla stream 175 NIF — loads correctly
- [x] FO4/SSE NIFs continue to load and display unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)