### PR TITLE
Add Starfield material texture support to BodySlide preview

### DIFF
--- a/BodySlide.vcxproj
+++ b/BodySlide.vcxproj
@@ -96,7 +96,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\wxWidgets\include\msvc;..\wxWidgets\include;lib;lib\gli;lib\nifly\include;lib\nifly\external;lib\TinyXML-2</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\wxWidgets\include\msvc;..\wxWidgets\include;lib;lib\gli;lib\nifly\include;lib\nifly\external;lib\TinyXML-2;lib\nlohmannjson\include</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -125,7 +125,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\wxWidgets\include\msvc;..\wxWidgets\include;lib;lib\gli;lib\nifly\include;lib\nifly\external;lib\TinyXML-2</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\wxWidgets\include\msvc;..\wxWidgets\include;lib;lib\gli;lib\nifly\include;lib\nifly\external;lib\TinyXML-2;lib\nlohmannjson\include</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN64;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -155,7 +155,7 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>..\wxWidgets\include\msvc;..\wxWidgets\include;lib;lib\gli;lib\nifly\include;lib\nifly\external;lib\TinyXML-2</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\wxWidgets\include\msvc;..\wxWidgets\include;lib;lib\gli;lib\nifly\include;lib\nifly\external;lib\TinyXML-2;lib\nlohmannjson\include</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>
@@ -192,7 +192,7 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>..\wxWidgets\include\msvc;..\wxWidgets\include;lib;lib\gli;lib\nifly\include;lib\nifly\external;lib\TinyXML-2</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\wxWidgets\include\msvc;..\wxWidgets\include;lib;lib\gli;lib\nifly\include;lib\nifly\external;lib\TinyXML-2;lib\nlohmannjson\include</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>
@@ -769,7 +769,11 @@
     <ClInclude Include="src\files\MaterialFile.h" />
     <ClInclude Include="src\files\ObjFile.h" />
     <ClInclude Include="src\files\ResourceLoader.h" />
+    <ClInclude Include="src\files\SFMaterialDatabase.h" />
+    <ClInclude Include="src\files\SFMaterialFile.h" />
+    <ClInclude Include="src\files\SFMaterialGraph.h" />
     <ClInclude Include="src\files\SFMorphFile.h" />
+    <ClInclude Include="src\files\SFResourceHash.h" />
     <ClInclude Include="src\files\TriFile.h" />
     <ClInclude Include="src\files\wxDDSImage.h" />
     <ClInclude Include="src\program\BodySlideApp.h" />
@@ -839,7 +843,11 @@
     <ClCompile Include="src\files\MaterialFile.cpp" />
     <ClCompile Include="src\files\ObjFile.cpp" />
     <ClCompile Include="src\files\ResourceLoader.cpp" />
+    <ClCompile Include="src\files\SFMaterialDatabase.cpp" />
+    <ClCompile Include="src\files\SFMaterialFile.cpp" />
+    <ClCompile Include="src\files\SFMaterialGraph.cpp" />
     <ClCompile Include="src\files\SFMorphFile.cpp" />
+    <ClCompile Include="src\files\SFResourceHash.cpp" />
     <ClCompile Include="src\files\TriFile.cpp" />
     <ClCompile Include="src\files\wxDDSImage.cpp" />
     <ClCompile Include="src\program\BodySlideApp.cpp" />

--- a/BodySlide.vcxproj.filters
+++ b/BodySlide.vcxproj.filters
@@ -694,7 +694,19 @@
     <ClInclude Include="src\files\ResourceLoader.h">
       <Filter>Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\files\SFMaterialDatabase.h">
+      <Filter>Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\files\SFMaterialFile.h">
+      <Filter>Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\files\SFMaterialGraph.h">
+      <Filter>Files</Filter>
+    </ClInclude>
     <ClInclude Include="src\files\SFMorphFile.h">
+      <Filter>Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\files\SFResourceHash.h">
       <Filter>Files</Filter>
     </ClInclude>
     <ClInclude Include="src\files\TriFile.h">
@@ -1800,7 +1812,19 @@
     <ClCompile Include="src\files\ResourceLoader.cpp">
       <Filter>Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\files\SFMaterialDatabase.cpp">
+      <Filter>Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\files\SFMaterialFile.cpp">
+      <Filter>Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\files\SFMaterialGraph.cpp">
+      <Filter>Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\files\SFMorphFile.cpp">
+      <Filter>Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\files\SFResourceHash.cpp">
       <Filter>Files</Filter>
     </ClCompile>
     <ClCompile Include="src\files\TriFile.cpp">

--- a/src/ui/PreviewPanel.cpp
+++ b/src/ui/PreviewPanel.cpp
@@ -4,6 +4,8 @@ See the included LICENSE file
 */
 
 #include "PreviewPanel.h"
+#include "../files/SFMaterialDatabase.h"
+#include "../files/SFMaterialFile.h"
 #include "../program/BodySlideApp.h"
 #include "../utils/PlatformUtil.h"
 
@@ -434,8 +436,42 @@ void PreviewPanel::RefreshMeshFromNif(const std::vector<NifFile*>& nifs) {
 	gls.RenderOneFrame();
 }
 
+SFMaterialDatabase* PreviewPanel::GetSFMaterialDatabase() {
+	if (sfMaterialDb)
+		return sfMaterialDb->Failed() ? nullptr : sfMaterialDb.get();
+
+	sfMaterialDb = std::make_unique<SFMaterialDatabase>();
+
+	wxMemoryBuffer data;
+	for (FSArchiveFile* archive : FSManager::archiveList()) {
+		if (archive && archive->hasFile("materials/materialsbeta.cdb")) {
+			wxMemoryBuffer outData;
+			archive->fileContents("materials/materialsbeta.cdb", outData);
+			if (!outData.IsEmpty()) {
+				data = std::move(outData);
+				break;
+			}
+		}
+	}
+
+	if (data.IsEmpty())
+		return nullptr;
+
+	sfMaterialDbContent.assign(static_cast<const char*>(data.GetData()), data.GetDataLen());
+	sfMaterialDbStream = std::make_unique<std::istringstream>(sfMaterialDbContent, std::ios::in | std::ios::binary);
+
+	if (!sfMaterialDb->Load(*sfMaterialDbStream) || sfMaterialDb->Failed()) {
+		sfMaterialDbContent.clear();
+		sfMaterialDbStream.reset();
+		return nullptr;
+	}
+
+	return sfMaterialDb.get();
+}
+
 void PreviewPanel::AddNifShapeTextures(NifFile* fromNif, const std::string& shapeName) {
 	bool hasMat = false;
+	bool hasSFMat = false;
 	std::string matFile;
 
 	const uint8_t MAX_TEXTURE_PATHS = 10;
@@ -451,6 +487,13 @@ void PreviewPanel::AddNifShapeTextures(NifFile* fromNif, const std::string& shap
 				if (!matFile.empty())
 					hasMat = true;
 			}
+			else if (fromNif->GetHeader().GetVersion().IsSF()) {
+				matFile = shader->name.get();
+				if (!matFile.empty()) {
+					hasMat = true;
+					hasSFMat = true;
+				}
+			}
 		}
 	}
 
@@ -461,54 +504,106 @@ void PreviewPanel::AddNifShapeTextures(NifFile* fromNif, const std::string& shap
 		matFile = std::regex_replace(matFile, std::regex("^/+"), "");
 		matFile = std::regex_replace(matFile, std::regex("^(?!^materials/)", std::regex_constants::icase), "materials/");
 
-		mat = MaterialFile(baseDataPath + matFile);
+		if (hasSFMat) {
+			if (!std::regex_search(matFile, std::regex("\\.mat$", std::regex_constants::icase)))
+				matFile += ".mat";
 
-		if (mat.Failed()) {
-			wxMemoryBuffer data;
-			for (FSArchiveFile* archive : FSManager::archiveList()) {
-				if (archive) {
-					if (archive->hasFile(matFile)) {
+			SFMaterialFile sfMat(baseDataPath + matFile);
+			if (!sfMat.Failed()) {
+				texFiles = sfMat.GetTextureFiles(MAX_TEXTURE_PATHS);
+			}
+			else {
+				bool resolvedFromArchive = false;
+				for (FSArchiveFile* archive : FSManager::archiveList()) {
+					if (archive && archive->hasFile(matFile)) {
 						wxMemoryBuffer outData;
 						archive->fileContents(matFile, outData);
-
 						if (!outData.IsEmpty()) {
-							data = std::move(outData);
+							std::string content(static_cast<const char*>(outData.GetData()), outData.GetDataLen());
+							std::istringstream contentStream(content, std::istringstream::binary);
+							SFMaterialFile archiveMat(contentStream);
+							if (!archiveMat.Failed()) {
+								texFiles = archiveMat.GetTextureFiles(MAX_TEXTURE_PATHS);
+								resolvedFromArchive = true;
+							}
 							break;
 						}
 					}
 				}
+
+				if (!resolvedFromArchive) {
+					std::string materialJson;
+					SFMaterialDatabase* cdb = GetSFMaterialDatabase();
+					if (cdb && cdb->GetMaterialJSON(matFile, materialJson)) {
+						std::istringstream materialStream(materialJson);
+						SFMaterialFile cdbMat(materialStream);
+						if (!cdbMat.Failed())
+							texFiles = cdbMat.GetTextureFiles(MAX_TEXTURE_PATHS);
+					}
+				}
+
+				bool hasAnyTex = false;
+				for (int i = 0; i < MAX_TEXTURE_PATHS && !hasAnyTex; i++)
+					hasAnyTex = !texFiles[i].empty();
+
+				if (!hasAnyTex && shader) {
+					for (int i = 0; i < MAX_TEXTURE_PATHS; i++)
+						fromNif->GetTextureSlot(shape, texFiles[i], i);
+				}
 			}
 
-			if (!data.IsEmpty()) {
-				std::string content((char*)data.GetData(), data.GetDataLen());
-				std::istringstream contentStream(content, std::istringstream::binary);
-
-				mat = MaterialFile(contentStream);
-			}
-		}
-
-		if (!mat.Failed()) {
-			if (mat.signature == MaterialFile::BGSM) {
-				texFiles[0] = mat.diffuseTexture.c_str();
-				texFiles[1] = mat.normalTexture.c_str();
-				texFiles[2] = mat.glowTexture.c_str();
-				texFiles[3] = mat.greyscaleTexture.c_str();
-				texFiles[4] = mat.envmapTexture.c_str();
-				texFiles[7] = mat.smoothSpecTexture.c_str();
-			}
-			else if (mat.signature == MaterialFile::BGEM) {
-				texFiles[0] = mat.baseTexture.c_str();
-				texFiles[1] = mat.fxNormalTexture.c_str();
-				texFiles[3] = mat.grayscaleTexture.c_str();
-				texFiles[4] = mat.fxEnvmapTexture.c_str();
-				texFiles[5] = mat.envmapMaskTexture.c_str();
-			}
-		}
-		else if (shader) {
 			hasMat = false;
+		}
+		else {
+			mat = MaterialFile(baseDataPath + matFile);
 
-			for (int i = 0; i < MAX_TEXTURE_PATHS; i++)
-				fromNif->GetTextureSlot(shape, texFiles[i], i);
+			if (mat.Failed()) {
+				wxMemoryBuffer data;
+				for (FSArchiveFile* archive : FSManager::archiveList()) {
+					if (archive) {
+						if (archive->hasFile(matFile)) {
+							wxMemoryBuffer outData;
+							archive->fileContents(matFile, outData);
+
+							if (!outData.IsEmpty()) {
+								data = std::move(outData);
+								break;
+							}
+						}
+					}
+				}
+
+				if (!data.IsEmpty()) {
+					std::string content((char*)data.GetData(), data.GetDataLen());
+					std::istringstream contentStream(content, std::istringstream::binary);
+
+					mat = MaterialFile(contentStream);
+				}
+			}
+
+			if (!mat.Failed()) {
+				if (mat.signature == MaterialFile::BGSM) {
+					texFiles[0] = mat.diffuseTexture.c_str();
+					texFiles[1] = mat.normalTexture.c_str();
+					texFiles[2] = mat.glowTexture.c_str();
+					texFiles[3] = mat.greyscaleTexture.c_str();
+					texFiles[4] = mat.envmapTexture.c_str();
+					texFiles[7] = mat.smoothSpecTexture.c_str();
+				}
+				else if (mat.signature == MaterialFile::BGEM) {
+					texFiles[0] = mat.baseTexture.c_str();
+					texFiles[1] = mat.fxNormalTexture.c_str();
+					texFiles[3] = mat.grayscaleTexture.c_str();
+					texFiles[4] = mat.fxEnvmapTexture.c_str();
+					texFiles[5] = mat.envmapMaskTexture.c_str();
+				}
+			}
+			else if (shader) {
+				hasMat = false;
+
+				for (int i = 0; i < MAX_TEXTURE_PATHS; i++)
+					fromNif->GetTextureSlot(shape, texFiles[i], i);
+			}
 		}
 	}
 	else if (shader) {

--- a/src/ui/PreviewPanel.h
+++ b/src/ui/PreviewPanel.h
@@ -13,6 +13,7 @@ See the included LICENSE file
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -23,6 +24,7 @@ See the included LICENSE file
 
 class BodySlideApp;
 class PreviewCanvas;
+class SFMaterialDatabase;
 
 extern ConfigurationManager Config;
 
@@ -56,6 +58,11 @@ class PreviewPanel : public wxPanel {
 	GLSurface gls;
 	std::unordered_map<std::string, GLMaterial*> shapeMaterials;
 	std::string baseDataPath;
+
+	std::unique_ptr<SFMaterialDatabase> sfMaterialDb;
+	std::string sfMaterialDbContent;
+	std::unique_ptr<std::istringstream> sfMaterialDbStream;
+	SFMaterialDatabase* GetSFMaterialDatabase();
 	std::vector<std::string> extraNifPaths;
 	std::vector<PreviewProjectEntry> projectEntries;
 	std::string initialPresetName;


### PR DESCRIPTION
## Summary
- PR #579 added SF material texture resolution to Outfit Studio but the BodySlide preview panel (`PreviewPanel::AddNifShapeTextures`) has its own independent texture loading path that was not updated
- Add SF `.mat` file resolution with the same 3-tier fallback as `OutfitProject::SetTextures`: loose file → BA2 archive → CDB (`materialsbeta.cdb`) lookup
- Add `SFMaterialDatabase`, `SFMaterialFile`, `SFMaterialGraph`, `SFResourceHash` sources and `nlohmann/json` include path to the BodySlide project

## Test plan
- [x] Load a Starfield body (e.g. Naked female) in BodySlide and verify the preview shows textured mesh
- [ ] Verify FO4/FO76 preview textures still work (no regression)
- [ ] Verify Outfit Studio viewport textures still work (no regression)
- [ ] Test with loose `.mat` files (modder materials)
- [ ] Test with archived `.mat` files (BA2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)