### PR TITLE
BodySlide: Add a 'Build Logbook' feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 *.vs
 
 /build
+/.vscode

--- a/BodySlide.vcxproj
+++ b/BodySlide.vcxproj
@@ -826,6 +826,7 @@
     <ClCompile Include="src\components\Anim.cpp" />
     <ClCompile Include="src\components\Automorph.cpp" />
     <ClCompile Include="src\components\BuildSelection.cpp" />
+    <ClCompile Include="src\components\BuildLogbook.cpp" />
     <ClCompile Include="src\components\ClippingFixer.cpp" />
     <ClCompile Include="src\components\DiffData.cpp" />
     <ClCompile Include="src\components\Mesh.cpp" />

--- a/BodySlide.vcxproj.filters
+++ b/BodySlide.vcxproj.filters
@@ -1899,6 +1899,9 @@
     <ClCompile Include="src\components\BuildSelection.cpp">
       <Filter>Components</Filter>
     </ClCompile>
+    <ClCompile Include="src\components\BuildLogbook.cpp">
+      <Filter>Components</Filter>
+    </ClCompile>
     <ClCompile Include="src\components\ClippingFixer.cpp">
       <Filter>Components</Filter>
     </ClCompile>

--- a/BuildLogbook.xml
+++ b/BuildLogbook.xml
@@ -11,13 +11,13 @@ If a mesh gets deleted, its entry in this file will be removed.
 <BuildLogbook>
 
     <!--
-    A simple entry that lists a Mesh (identified by its path), which set it was built with, and which preset was used. 
+    A simple entry that lists a Mesh (identified by its path), which set it was built with, and which preset was used.
     Each "path" should be unique across the file.
     This simple entry did not register any change to the default values of the set or preset sliders.
     -->
     <Mesh path="meshes\armor\studded\female\boots" set="DH 3BA Leather boots" preset="The Female Gaze v2 Outfit"/>
 
-    <!-- 
+    <!--
     An entry that describes a Mesh, and stores information about any sliders that have been modified.
     Only Sliders that don't match the default values of the set and the preset should be listed.
     -->

--- a/BuildLogbook.xml
+++ b/BuildLogbook.xml
@@ -1,28 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- A file to keep track of the currently built meshes -->
+<!--
+This file should represent the contents of the game/ouput folder by keeping track of each mesh that has been built with BodySlide.
+
+Every time a mesh is built, either on its own or as part of a batch build, an entry will be created in this file.
+If a mesh that already exists in this file is rebuilt, its entry will be updated.
+If a mesh gets deleted, its entry in this file will be removed.
+
+-->
 <BuildLogbook>
 
-    <!-- 
-    A simple entry that lists the mesh, which set it was built with, and which preset was used.
-
-    There should be only one "Mesh" entry per path.
-    If a mesh is built again, the old entry should be deleted and replaced with the new one, 
-    so that the logbook represents the contents of the game/ouput folder.
+    <!--
+    A simple entry that lists a Mesh (identified by its path), which set it was built with, and which preset was used. 
+    Each "path" should be unique across the file.
+    This simple entry did not register any change to the default values of the set or preset sliders.
     -->
     <Mesh path="meshes\armor\studded\female\boots" set="DH 3BA Leather boots" preset="The Female Gaze v2 Outfit"/>
 
     <!-- 
-    A "Mesh" can contain slider information.
-    Ideally, this should be limited to sliders that were modified from the set's and preset's default values.
+    An entry that describes a Mesh, and stores information about any sliders that have been modified.
+    Only Sliders that don't match the default values of the set and the preset should be listed.
     -->
     <Mesh path="meshes\armor\imperial\f\cuirasslight" set="DH 3BA Imperial light armor" preset="The Female Gaze v2 Pushup">
-        <!-- For example, modifications of the set's Zaps -->
+        <!-- Example modifications of the set's Zaps -->
         <SetSlider name="Outfit var.1" size="big" value="100"/>
         <SetSlider name="Outfit var.1" size="small" value="100"/>
         <SetSlider name="Outfit var.2" size="big" value="0"/>
         <SetSlider name="Outfit var.2" size="small" value="0"/>
-        <!-- Or edits of the preset's sliders-->
+        <!-- Example modifications of the preset's sliders-->
         <SetSlider name="BreastsPressed_v2" size="big" value="24"/>
     </Mesh>
 </BuildLogbook>

--- a/BuildLogbook.xml
+++ b/BuildLogbook.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- A file to keep track of the currently built meshes -->
+<BuildLogbook>
+
+    <!-- 
+    A simple entry that lists the mesh, which set it was built with, and which preset was used.
+
+    There should be only one "Mesh" entry per path.
+    If a mesh is built again, the old entry should be deleted and replaced with the new one, 
+    so that the logbook represents the contents of the game/ouput folder.
+    -->
+    <Mesh path="meshes\armor\studded\female\boots" set="DH 3BA Leather boots" preset="The Female Gaze v2 Outfit"/>
+
+    <!-- 
+    A "Mesh" can contain slider information.
+    Ideally, this should be limited to sliders that were modified from the set's and preset's default values.
+    -->
+    <Mesh path="meshes\armor\imperial\f\cuirasslight" set="DH 3BA Imperial light armor" preset="The Female Gaze v2 Pushup">
+        <!-- For example, modifications of the set's Zaps -->
+        <SetSlider name="Outfit var.1" size="big" value="100"/>
+        <SetSlider name="Outfit var.1" size="small" value="100"/>
+        <SetSlider name="Outfit var.2" size="big" value="0"/>
+        <SetSlider name="Outfit var.2" size="small" value="0"/>
+        <!-- Or edits of the preset's sliders-->
+        <SetSlider name="BreastsPressed_v2" size="big" value="24"/>
+    </Mesh>
+</BuildLogbook>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,7 @@ set(BSOS_OUTFIT_STUDIO_SOURCES
 set(BSOS_BODYSLIDE_SOURCES
 	${BSOS_COMMON_SOURCES}
 	src/components/BuildSelection.cpp
+	src/components/BuildLogbook.cpp
 	src/files/ObjFile.cpp
 	src/files/SFMorphFile.cpp
 	src/files/wxDDSImage.cpp

--- a/res/xrc/BodySlide.xrc
+++ b/res/xrc/BodySlide.xrc
@@ -380,7 +380,7 @@
 					</object>
 					<object class="sizeritem">
 						<cellpos>1,0</cellpos>
-						<cellspan>1,3</cellspan>
+						<cellspan>1,2</cellspan>
 						<flag>wxLEFT</flag>
 						<border>5</border>
 						<object class="wxBoxSizer">
@@ -543,6 +543,19 @@
 							<fg>wxSYS_COLOUR_BTNTEXT</fg>
 							<tooltip>Copy the high weight slider values to the low weight section.</tooltip>
 							<label translate="0">&#8592;</label>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<cellpos>1,2</cellpos>
+						<cellspan>1,1</cellspan>
+						<flag>wxALIGN_RIGHT|wxLEFT|wxRIGHT</flag>
+						<border>5</border>
+						<object class="wxStaticText" name="inLogbookLabel">
+							<style>wxALIGN_RIGHT</style>
+							<fg>#c8c8d8</fg>
+							<tooltip>Here you'll see the last outfit and preset it was built with.</tooltip>
+							<label>No build record for this outfit.</label>
+							<wrap>-1</wrap>
 						</object>
 					</object>
 					<object class="sizeritem">

--- a/res/xrc/BodySlide.xrc
+++ b/res/xrc/BodySlide.xrc
@@ -553,8 +553,8 @@
 						<object class="wxStaticText" name="inLogbookLabel">
 							<style>wxALIGN_RIGHT</style>
 							<fg>#c8c8d8</fg>
-							<tooltip>Here you'll see the last outfit and preset it was built with.</tooltip>
-							<label>No build record for this outfit.</label>
+							<tooltip>Build this mesh to record the last outfit, preset, and any slider modifications it was built with.</tooltip>
+							<label></label>
 							<wrap>-1</wrap>
 						</object>
 					</object>
@@ -652,5 +652,16 @@
 		</object>
 	</object>
 	<object class="wxMenu" name="menuFileCollision">
+	</object>
+	<object class="wxMenu" name="menuLogbook">
+		<object class="wxMenuItem" name="menuLoadFromLogbook">
+			<label>Load the latest build</label>
+			<help>Loads the outfit, preset and any slider modifications of the last build back to BodySlide</help>
+		</object>
+		<object class="separator" />
+		<object class="wxMenuItem" name="menuRemoveFromLogbook">
+			<label>Forget the latest build</label>
+			<help>Removes this outfit's data from the logbook, but doesn't delete the mesh</help>
+		</object>
 	</object>
 </resource>

--- a/src/components/BuildLogbook.cpp
+++ b/src/components/BuildLogbook.cpp
@@ -6,6 +6,11 @@ See the included LICENSE file
 #include "BuildLogbook.h"
 #include "../utils/PlatformUtil.h"
 
+std::string BuildLogbookEntry::GetSummary() {
+	std::string summary = "Outfit: " + set + "\nPreset: " + preset + "\nSlider modifications: " + (sliders.size() > 0 ? "Yes" : "No");
+	return summary;
+}
+
 int BuildLogbook::LoadBuildLogbook(XMLElement* srcElement) {
 	if (srcElement == nullptr)
 		return 1;

--- a/src/components/BuildLogbook.cpp
+++ b/src/components/BuildLogbook.cpp
@@ -37,13 +37,13 @@ int BuildLogbook::LoadBuildLogbook(XMLElement* srcElement) {
 				BuildLogbookEntry::SliderValue val;
 				val.name = sliderElem->Attribute("name");
 				val.size = sliderElem->Attribute("size");
-				val.value = sliderElem->FloatAttribute("value") / 100.0f;
+				val.value = sliderElem->FloatAttribute("value") / 100.0f; // Scale percentage value back to 0-1 range
 				entry.sliders.push_back(val);
 			}
 			sliderElem = sliderElem->NextSiblingElement("SetSlider");
 		}
 
-		entries[entry.path] = entry;
+		entries[entry.path] = entry; // Store entry mapped by its output path
 		elem = elem->NextSiblingElement("Mesh");
 	}
 
@@ -72,111 +72,84 @@ const std::map<std::string, BuildLogbookEntry>& BuildLogbook::GetEntries() const
 	return entries;
 }
 
-BuildLogbookFile::BuildLogbookFile(const std::string& srcFileName) {
-	Open(srcFileName);
-}
+bool BuildLogbook::LoadFromFile(const std::string& path) {
+	fileName = path;
+	entries.clear();
 
-void BuildLogbookFile::Clear() {
-	root = nullptr;
-	doc.Clear();
-	error = 0;
-}
-
-void BuildLogbookFile::New(const std::string& newFileName) {
-	if (root)
-		return;
-
-	Clear();
-
-	XMLElement* newElement = doc.NewElement("BuildLogbook");
-	root = doc.InsertEndChild(newElement)->ToElement();
-
-	fileName = newFileName;
-	doc.SetUserData(&fileName);
-
-	error = 0;
-}
-
-void BuildLogbookFile::Open(const std::string& srcFileName) {
-	root = nullptr;
-	error = 0;
-	fileName = srcFileName;
-
+	XMLDocument doc;
 	FILE* fp = nullptr;
 
 #ifdef _WINDOWS
-	std::wstring winFileName = PlatformUtil::MultiByteToWideUTF8(srcFileName);
-	error = _wfopen_s(&fp, winFileName.c_str(), L"rb");
-	if (error || !fp)
-		return;
+	std::wstring winFileName = PlatformUtil::MultiByteToWideUTF8(path);
+	if (_wfopen_s(&fp, winFileName.c_str(), L"rb") != 0 || !fp)
+		return false;
 #else
-	fp = fopen(srcFileName.c_str(), "rb");
-	if (!fp) {
-		error = errno;
-		return;
-	}
+	fp = fopen(path.c_str(), "rb");
+	if (!fp)
+		return false;
 #endif
 
-	error = doc.LoadFile(fp);
+	if (doc.LoadFile(fp) != 0) {
+		fclose(fp);
+		return false;
+	}
 	fclose(fp);
 
-	if (error)
-		return;
+	XMLElement* root = doc.FirstChildElement("BuildLogbook");
+	if (!root)
+		return false;
 
-	doc.SetUserData(&fileName);
-	root = doc.FirstChildElement("BuildLogbook");
-	if (!root) {
-		error = 2;
-		return;
-	}
-
-	error = 0;
+	LoadBuildLogbook(root);
+	return true;
 }
 
-void BuildLogbookFile::Rename(const std::string& newFileName) {
-	fileName = newFileName;
-}
+bool BuildLogbook::SaveToFile() {
+	if (fileName.empty()) return false;
 
-bool BuildLogbookFile::Save() {
+	XMLDocument doc;
+	XMLElement* root = nullptr;
 	FILE* fp = nullptr;
 
 #ifdef _WINDOWS
 	std::wstring winFileName = PlatformUtil::MultiByteToWideUTF8(fileName);
-	error = _wfopen_s(&fp, winFileName.c_str(), L"w");
-	if (error || !fp)
-		return false;
+	if (_wfopen_s(&fp, winFileName.c_str(), L"rb") == 0 && fp) {
+		doc.LoadFile(fp);
+		fclose(fp);
+		root = doc.FirstChildElement("BuildLogbook");
+	}
 #else
-	fp = fopen(fileName.c_str(), "w");
-	if (!fp) {
-		error = errno;
-		return false;
+	fp = fopen(fileName.c_str(), "rb");
+	if (fp) {
+		doc.LoadFile(fp);
+		fclose(fp);
+		root = doc.FirstChildElement("BuildLogbook");
 	}
 #endif
 
-	doc.SetBOM(true);
+	if (!root) {
+		doc.Clear();
+		XMLElement* newElement = doc.NewElement("BuildLogbook");
+		root = doc.InsertEndChild(newElement)->ToElement();
+	}
 
-	const tinyxml2::XMLNode* firstChild = doc.FirstChild();
-	if (!firstChild || !firstChild->ToDeclaration())
-		doc.InsertFirstChild(doc.NewDeclaration());
+	// Remove Mesh elements that are no longer in our entries map
+	XMLElement* meshElem = root->FirstChildElement("Mesh");
+	while (meshElem) {
+		XMLElement* nextElem = meshElem->NextSiblingElement("Mesh");
+		const char* attrPath = meshElem->Attribute("path");
+		if (attrPath && !HasEntry(attrPath)) {
+			root->DeleteChild(meshElem);
+		}
+		meshElem = nextElem;
+	}
 
-	error = doc.SaveFile(fp);
-	fclose(fp);
-	if (error)
-		return false;
-
-	return true;
-}
-
-void BuildLogbookFile::Get(BuildLogbook& outLogbook) {
-	outLogbook = root;
-}
-
-int BuildLogbookFile::UpdateEntries(const BuildLogbook& inLogbook) {
-	for (const auto& pair : inLogbook.GetEntries()) {
+	// Update existing elements and add new ones
+	for (const auto& pair : GetEntries()) {
 		const BuildLogbookEntry& entry = pair.second;
 		XMLElement* elem = nullptr;
 
-		XMLElement* meshElem = root->FirstChildElement("Mesh");
+		// Try to find an existing <Mesh> element with the matching path
+		meshElem = root->FirstChildElement("Mesh");
 		while (meshElem) {
 			const char* attrPath = meshElem->Attribute("path");
 			if (attrPath && entry.path.compare(attrPath) == 0) {
@@ -186,12 +159,14 @@ int BuildLogbookFile::UpdateEntries(const BuildLogbook& inLogbook) {
 			meshElem = meshElem->NextSiblingElement("Mesh");
 		}
 
+		// If no matching <Mesh> element was found, create a new one and append it to the root
 		if (!elem) {
 			XMLElement* newElement = doc.NewElement("Mesh");
 			elem = root->InsertEndChild(newElement)->ToElement();
 		}
 
 		if (elem) {
+			// Update the attributes of the <Mesh> element
 			elem->SetAttribute("path", entry.path.c_str());
 			if (!entry.set.empty())
 				elem->SetAttribute("set", entry.set.c_str());
@@ -200,26 +175,37 @@ int BuildLogbookFile::UpdateEntries(const BuildLogbook& inLogbook) {
 				
 			elem->DeleteChildren(); // Clear existing sliders to update them
 			
+			// Recreate the <SetSlider> child elements based on the current data
 			for (const auto& slider : entry.sliders) {
 				XMLElement* sliderElem = doc.NewElement("SetSlider");
 				sliderElem->SetAttribute("name", slider.name.c_str());
 				sliderElem->SetAttribute("size", slider.size.c_str());
-				sliderElem->SetAttribute("value", (int)(slider.value * 100.0f));
+				sliderElem->SetAttribute("value", (int)(slider.value * 100.0f)); // Convert 0-1 scale back to percentage for XML
 				elem->InsertEndChild(sliderElem);
 			}
 		}
 	}
 
-	return 0;
-}
+#ifdef _WINDOWS
+	if (_wfopen_s(&fp, winFileName.c_str(), L"w") != 0 || !fp)
+		return false;
+#else
+	fp = fopen(fileName.c_str(), "w");
+	if (!fp)
+		return false;
+#endif
 
-void BuildLogbookFile::RemoveEntry(const std::string& path) {
-	XMLElement* elem = root->FirstChildElement("Mesh");
-	while (elem) {
-		if (path.compare(elem->Attribute("path")) == 0) {
-			root->DeleteChild(elem);
-			return;
-		}
-		elem = elem->NextSiblingElement("Mesh");
-	}
+	// Enable Byte Order Mark for UTF-8 when saving
+	doc.SetBOM(true);
+
+	// Ensure there is an XML declaration
+	const tinyxml2::XMLNode* firstChild = doc.FirstChild();
+	if (!firstChild || !firstChild->ToDeclaration())
+		doc.InsertFirstChild(doc.NewDeclaration());
+
+	// Save the XML document to the file pointer
+	int error = doc.SaveFile(fp);
+	fclose(fp);
+
+	return error == 0;
 }

--- a/src/components/BuildLogbook.cpp
+++ b/src/components/BuildLogbook.cpp
@@ -38,6 +38,9 @@ int BuildLogbook::LoadBuildLogbook(XMLElement* srcElement) {
 				val.name = sliderElem->Attribute("name");
 				val.size = sliderElem->Attribute("size");
 				val.value = sliderElem->FloatAttribute("value") / 100.0f; // Scale percentage value back to 0-1 range
+				if (sliderElem->Attribute("zap"))
+					val.zap = sliderElem->BoolAttribute("zap");
+				else val.zap = false;
 				entry.sliders.push_back(val);
 			}
 			sliderElem = sliderElem->NextSiblingElement("SetSlider");
@@ -181,6 +184,8 @@ bool BuildLogbook::SaveToFile() {
 				sliderElem->SetAttribute("name", slider.name.c_str());
 				sliderElem->SetAttribute("size", slider.size.c_str());
 				sliderElem->SetAttribute("value", (int)(slider.value * 100.0f)); // Convert 0-1 scale back to percentage for XML
+				if (slider.zap)
+					sliderElem->SetAttribute("zap", "true");
 				elem->InsertEndChild(sliderElem);
 			}
 		}

--- a/src/components/BuildLogbook.cpp
+++ b/src/components/BuildLogbook.cpp
@@ -24,10 +24,10 @@ int BuildLogbook::LoadBuildLogbook(XMLElement* srcElement) {
 
 		BuildLogbookEntry entry;
 		entry.path = elem->Attribute("path");
-		
+
 		if (elem->Attribute("set"))
 			entry.set = elem->Attribute("set");
-			
+
 		if (elem->Attribute("preset"))
 			entry.preset = elem->Attribute("preset");
 
@@ -172,9 +172,9 @@ bool BuildLogbook::SaveToFile() {
 				elem->SetAttribute("set", entry.set.c_str());
 			if (!entry.preset.empty())
 				elem->SetAttribute("preset", entry.preset.c_str());
-				
+
 			elem->DeleteChildren(); // Clear existing sliders to update them
-			
+
 			// Recreate the <SetSlider> child elements based on the current data
 			for (const auto& slider : entry.sliders) {
 				XMLElement* sliderElem = doc.NewElement("SetSlider");

--- a/src/components/BuildLogbook.cpp
+++ b/src/components/BuildLogbook.cpp
@@ -1,0 +1,220 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#include "BuildLogbook.h"
+#include "../utils/PlatformUtil.h"
+
+int BuildLogbook::LoadBuildLogbook(XMLElement* srcElement) {
+	if (srcElement == nullptr)
+		return 1;
+
+	XMLElement* elem = srcElement->FirstChildElement("Mesh");
+	while (elem) {
+		if (!elem->Attribute("path")) {
+			elem = elem->NextSiblingElement("Mesh");
+			continue;
+		}
+
+		BuildLogbookEntry entry;
+		entry.path = elem->Attribute("path");
+		
+		if (elem->Attribute("set"))
+			entry.set = elem->Attribute("set");
+			
+		if (elem->Attribute("preset"))
+			entry.preset = elem->Attribute("preset");
+
+		XMLElement* sliderElem = elem->FirstChildElement("SetSlider");
+		while (sliderElem) {
+			if (sliderElem->Attribute("name") && sliderElem->Attribute("size") && sliderElem->Attribute("value")) {
+				BuildLogbookEntry::SliderValue val;
+				val.name = sliderElem->Attribute("name");
+				val.size = sliderElem->Attribute("size");
+				val.value = sliderElem->FloatAttribute("value") / 100.0f;
+				entry.sliders.push_back(val);
+			}
+			sliderElem = sliderElem->NextSiblingElement("SetSlider");
+		}
+
+		entries[entry.path] = entry;
+		elem = elem->NextSiblingElement("Mesh");
+	}
+
+	return 0;
+}
+
+void BuildLogbook::AddEntry(const BuildLogbookEntry& entry) {
+	entries[entry.path] = entry;
+}
+
+void BuildLogbook::RemoveEntry(const std::string& path) {
+	entries.erase(path);
+}
+
+bool BuildLogbook::HasEntry(const std::string& path) {
+	return entries.find(path) != entries.end();
+}
+
+BuildLogbookEntry BuildLogbook::GetEntry(const std::string& path) {
+	if (HasEntry(path))
+		return entries[path];
+	return BuildLogbookEntry();
+}
+
+const std::map<std::string, BuildLogbookEntry>& BuildLogbook::GetEntries() const {
+	return entries;
+}
+
+BuildLogbookFile::BuildLogbookFile(const std::string& srcFileName) {
+	Open(srcFileName);
+}
+
+void BuildLogbookFile::Clear() {
+	root = nullptr;
+	doc.Clear();
+	error = 0;
+}
+
+void BuildLogbookFile::New(const std::string& newFileName) {
+	if (root)
+		return;
+
+	Clear();
+
+	XMLElement* newElement = doc.NewElement("BuildLogbook");
+	root = doc.InsertEndChild(newElement)->ToElement();
+
+	fileName = newFileName;
+	doc.SetUserData(&fileName);
+
+	error = 0;
+}
+
+void BuildLogbookFile::Open(const std::string& srcFileName) {
+	root = nullptr;
+	error = 0;
+	fileName = srcFileName;
+
+	FILE* fp = nullptr;
+
+#ifdef _WINDOWS
+	std::wstring winFileName = PlatformUtil::MultiByteToWideUTF8(srcFileName);
+	error = _wfopen_s(&fp, winFileName.c_str(), L"rb");
+	if (error || !fp)
+		return;
+#else
+	fp = fopen(srcFileName.c_str(), "rb");
+	if (!fp) {
+		error = errno;
+		return;
+	}
+#endif
+
+	error = doc.LoadFile(fp);
+	fclose(fp);
+
+	if (error)
+		return;
+
+	doc.SetUserData(&fileName);
+	root = doc.FirstChildElement("BuildLogbook");
+	if (!root) {
+		error = 2;
+		return;
+	}
+
+	error = 0;
+}
+
+void BuildLogbookFile::Rename(const std::string& newFileName) {
+	fileName = newFileName;
+}
+
+bool BuildLogbookFile::Save() {
+	FILE* fp = nullptr;
+
+#ifdef _WINDOWS
+	std::wstring winFileName = PlatformUtil::MultiByteToWideUTF8(fileName);
+	error = _wfopen_s(&fp, winFileName.c_str(), L"w");
+	if (error || !fp)
+		return false;
+#else
+	fp = fopen(fileName.c_str(), "w");
+	if (!fp) {
+		error = errno;
+		return false;
+	}
+#endif
+
+	doc.SetBOM(true);
+
+	const tinyxml2::XMLNode* firstChild = doc.FirstChild();
+	if (!firstChild || !firstChild->ToDeclaration())
+		doc.InsertFirstChild(doc.NewDeclaration());
+
+	error = doc.SaveFile(fp);
+	fclose(fp);
+	if (error)
+		return false;
+
+	return true;
+}
+
+void BuildLogbookFile::Get(BuildLogbook& outLogbook) {
+	outLogbook = root;
+}
+
+int BuildLogbookFile::UpdateEntries(const BuildLogbook& inLogbook) {
+	for (const auto& pair : inLogbook.GetEntries()) {
+		const BuildLogbookEntry& entry = pair.second;
+		XMLElement* elem = nullptr;
+
+		XMLElement* meshElem = root->FirstChildElement("Mesh");
+		while (meshElem) {
+			const char* attrPath = meshElem->Attribute("path");
+			if (attrPath && entry.path.compare(attrPath) == 0) {
+				elem = meshElem;
+				break;
+			}
+			meshElem = meshElem->NextSiblingElement("Mesh");
+		}
+
+		if (!elem) {
+			XMLElement* newElement = doc.NewElement("Mesh");
+			elem = root->InsertEndChild(newElement)->ToElement();
+		}
+
+		if (elem) {
+			elem->SetAttribute("path", entry.path.c_str());
+			if (!entry.set.empty())
+				elem->SetAttribute("set", entry.set.c_str());
+			if (!entry.preset.empty())
+				elem->SetAttribute("preset", entry.preset.c_str());
+				
+			elem->DeleteChildren(); // Clear existing sliders to update them
+			
+			for (const auto& slider : entry.sliders) {
+				XMLElement* sliderElem = doc.NewElement("SetSlider");
+				sliderElem->SetAttribute("name", slider.name.c_str());
+				sliderElem->SetAttribute("size", slider.size.c_str());
+				sliderElem->SetAttribute("value", (int)(slider.value * 100.0f));
+				elem->InsertEndChild(sliderElem);
+			}
+		}
+	}
+
+	return 0;
+}
+
+void BuildLogbookFile::RemoveEntry(const std::string& path) {
+	XMLElement* elem = root->FirstChildElement("Mesh");
+	while (elem) {
+		if (path.compare(elem->Attribute("path")) == 0) {
+			root->DeleteChild(elem);
+			return;
+		}
+		elem = elem->NextSiblingElement("Mesh");
+	}
+}

--- a/src/components/BuildLogbook.h
+++ b/src/components/BuildLogbook.h
@@ -24,6 +24,7 @@ public:
 		std::string name;
 		std::string size;
 		float value;
+		bool zap;
 	};
 	std::vector<SliderValue> sliders;
 

--- a/src/components/BuildLogbook.h
+++ b/src/components/BuildLogbook.h
@@ -26,6 +26,8 @@ public:
 		float value;
 	};
 	std::vector<SliderValue> sliders;
+
+	std::string GetSummary();
 };
 
 class BuildLogbook {

--- a/src/components/BuildLogbook.h
+++ b/src/components/BuildLogbook.h
@@ -1,0 +1,85 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#pragma once
+
+#include <tinyxml2.h>
+
+#include <map>
+#include <string>
+#include <vector>
+#include <wx/dir.h>
+
+using namespace tinyxml2;
+
+class BuildLogbookEntry {
+public:
+	std::string path;
+	std::string set;
+	std::string preset;
+
+	struct SliderValue {
+		std::string name;
+		std::string size;
+		float value;
+	};
+	std::vector<SliderValue> sliders;
+};
+
+class BuildLogbook {
+	std::map<std::string, BuildLogbookEntry> entries;
+
+public:
+	BuildLogbook() {}
+	BuildLogbook(XMLElement* srcElement) { LoadBuildLogbook(srcElement); }
+
+	int LoadBuildLogbook(XMLElement* srcElement);
+
+	void AddEntry(const BuildLogbookEntry& entry);
+	void RemoveEntry(const std::string& path);
+	bool HasEntry(const std::string& path);
+	BuildLogbookEntry GetEntry(const std::string& path);
+
+	const std::map<std::string, BuildLogbookEntry>& GetEntries() const;
+};
+
+class BuildLogbookFile {
+	XMLDocument doc;
+	XMLElement* root = nullptr;
+	int error = 0;
+
+public:
+	std::string fileName;
+	BuildLogbookFile() {}
+	BuildLogbookFile(const std::string& srcFileName);
+	~BuildLogbookFile() {}
+
+	bool fail() { return error != 0; }
+	int GetError() { return error; }
+
+	// Clears all data of the file
+	void Clear();
+
+	// Creates a new empty document structure
+	void New(const std::string& newFileName);
+
+	// Loads the XML document. On a failure, sets the internal error value.
+	void Open(const std::string& srcFileName);
+
+	// Changes the internal file name. The XML file isn't saved until the Save() function is used.
+	void Rename(const std::string& newFileName);
+
+	// Writes the XML file using the internal fileName (use Rename() to change the name).
+	bool Save();
+
+	// Get the build logbook in the file
+	void Get(BuildLogbook& outLogbook);
+
+	// Updates or adds entries in the XML document
+	int UpdateEntries(const BuildLogbook& inLogbook);
+
+	// Removes a single element from the XML document
+	void RemoveEntry(const std::string& path);
+};

--- a/src/components/BuildLogbook.h
+++ b/src/components/BuildLogbook.h
@@ -39,7 +39,7 @@ public:
 	BuildLogbook(XMLElement* srcElement) { LoadBuildLogbook(srcElement); }
 
 	int LoadBuildLogbook(XMLElement* srcElement);
-	
+
 	bool LoadFromFile(const std::string& path);
 	bool SaveToFile();
 

--- a/src/components/BuildLogbook.h
+++ b/src/components/BuildLogbook.h
@@ -32,12 +32,16 @@ public:
 
 class BuildLogbook {
 	std::map<std::string, BuildLogbookEntry> entries;
+	std::string fileName;
 
 public:
 	BuildLogbook() {}
 	BuildLogbook(XMLElement* srcElement) { LoadBuildLogbook(srcElement); }
 
 	int LoadBuildLogbook(XMLElement* srcElement);
+	
+	bool LoadFromFile(const std::string& path);
+	bool SaveToFile();
 
 	void AddEntry(const BuildLogbookEntry& entry);
 	void RemoveEntry(const std::string& path);
@@ -45,43 +49,4 @@ public:
 	BuildLogbookEntry GetEntry(const std::string& path);
 
 	const std::map<std::string, BuildLogbookEntry>& GetEntries() const;
-};
-
-class BuildLogbookFile {
-	XMLDocument doc;
-	XMLElement* root = nullptr;
-	int error = 0;
-
-public:
-	std::string fileName;
-	BuildLogbookFile() {}
-	BuildLogbookFile(const std::string& srcFileName);
-	~BuildLogbookFile() {}
-
-	bool fail() { return error != 0; }
-	int GetError() { return error; }
-
-	// Clears all data of the file
-	void Clear();
-
-	// Creates a new empty document structure
-	void New(const std::string& newFileName);
-
-	// Loads the XML document. On a failure, sets the internal error value.
-	void Open(const std::string& srcFileName);
-
-	// Changes the internal file name. The XML file isn't saved until the Save() function is used.
-	void Rename(const std::string& newFileName);
-
-	// Writes the XML file using the internal fileName (use Rename() to change the name).
-	bool Save();
-
-	// Get the build logbook in the file
-	void Get(BuildLogbook& outLogbook);
-
-	// Updates or adds entries in the XML document
-	int UpdateEntries(const BuildLogbook& inLogbook);
-
-	// Removes a single element from the XML document
-	void RemoveEntry(const std::string& path);
 };

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -1030,7 +1030,7 @@ void BodySlideApp::ActivateLogbookEntry() {
 
 		// If the logbook introduced any slider modification, mark it as such
 		if (entry.sliders.size() > 0) sliderView->SetPresetChanged(true);
-		
+
 		bool zapChanged = false;
 		if (UpdateZapChoices())
 			zapChanged = true;
@@ -1394,7 +1394,7 @@ void BodySlideApp::SetZapChoice(const std::string& zap, bool choice) {
 }
 
 std::vector<BuildLogbookEntry::SliderValue> BodySlideApp::CalculateLogbookSliders() {
-	
+
 	std::vector<BuildLogbookEntry::SliderValue> logbookSliders;
 	std::string activePreset = BodySlideConfig["SelectedPreset"];
 	float defaultValue = 0.0f;
@@ -1441,10 +1441,10 @@ void BodySlideApp::SaveSetToLogbook(SliderSet currentSet) {
 	entry.set = currentSet.GetName();
 	entry.preset = activePreset;
 	entry.sliders = CalculateLogbookSliders();
-	
+
 	// Append the newly populated entry to the logbook
 	buildLogbook.AddEntry(entry);
-	
+
 	// Save the changes to the BuildLogbook.xml file
 	buildLogbook.SaveToFile();
 
@@ -1463,7 +1463,7 @@ void BodySlideApp::RemoveSetFromLogbook(const std::string& outputPath) {
 	else {
 		buildLogbook.RemoveEntry(outputPath);
 	}
-		
+
 	buildLogbook.SaveToFile();
 
 	UpdateLogbookLabel();
@@ -4185,7 +4185,7 @@ int BodySlideApp::BuildListBodies(
 
 				treeListCtrl->Expand(rootItem);
 			}
-			
+
 			bool checkBoxReverting = false;
 			auto handler = [&](wxTreeListEvent& e) {
 				if (checkBoxReverting) {
@@ -4409,7 +4409,7 @@ int BodySlideApp::BuildListBodies(
 
 			if (wxFileName::FileExists(removeHigh))
 				wxRemoveFile(removeHigh);
-				
+
 			if (!genWeights)
 				return;
 

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -1393,7 +1393,43 @@ void BodySlideApp::SetZapChoice(const std::string& zap, bool choice) {
 	buildSelFile.Save();
 }
 
-void BodySlideApp::SaveToLogbook(SliderSet currentSet) {
+std::vector<BuildLogbookEntry::SliderValue> BodySlideApp::CalculateLogbookSliders() {
+	
+	std::vector<BuildLogbookEntry::SliderValue> logbookSliders;
+	std::string activePreset = BodySlideConfig["SelectedPreset"];
+	float defaultValue = 0.0f;
+
+	// Iterate over all sliders
+	for (size_t i = 0; i < sliderManager.slidersBig.size(); i++) {
+		auto& sliderBig = sliderManager.slidersBig[i];
+		auto& sliderSmall = sliderManager.slidersSmall[i];
+
+		// Get the preset slider value, or if it doesn't exist, the slider default
+		defaultValue = sliderManager.GetBigPresetValue(activePreset, sliderBig.name, sliderBig.defValue);
+		if (sliderBig.value != defaultValue) {
+			// If the slider value has changed, save it
+			BuildLogbookEntry::SliderValue v;
+			v.name = sliderBig.name;
+			v.size = "big";
+			v.value = sliderBig.value;
+			logbookSliders.push_back(v);
+		}
+
+		// Do the same for the small value. For outfits with a single weight, it should be always 0 so nothing should happen
+		defaultValue = sliderManager.GetSmallPresetValue(activePreset, sliderSmall.name, sliderSmall.defValue);
+		if (sliderSmall.value != defaultValue) {
+			BuildLogbookEntry::SliderValue v;
+			v.name = sliderSmall.name;
+			v.size = "small";
+			v.value = sliderSmall.value;
+			logbookSliders.push_back(v);
+		}
+	}
+
+	return logbookSliders;
+}
+
+void BodySlideApp::SaveSetToLogbook(SliderSet currentSet) {
 
 	static std::mutex logbookMutex;
 	std::lock_guard<std::mutex> lock(logbookMutex);
@@ -1404,37 +1440,7 @@ void BodySlideApp::SaveToLogbook(SliderSet currentSet) {
 	entry.path = currentSet.GetOutputFilePath();
 	entry.set = currentSet.GetName();
 	entry.preset = activePreset;
-	
-	float defaultValue = 0.0f;
-
-	// Iterate over all sliders
-	for (size_t i = 0; i < sliderManager.slidersBig.size(); i++) {
-		auto& sliderBig = sliderManager.slidersBig[i];
-		auto& sliderSmall = sliderManager.slidersSmall[i];
-
-		// Get the preset slider value, or if it doesn't exist, the slider default
-		defaultValue = sliderManager.GetBigPresetValue(activePreset, sliderBig.name, sliderBig.defValue);
-
-		// If the slider value has changed, save it
-		if (sliderBig.value != defaultValue) {
-			BuildLogbookEntry::SliderValue v;
-			v.name = sliderBig.name;
-			v.size = "big";
-			v.value = sliderBig.value;
-			entry.sliders.push_back(v);
-		}
-
-		// Do the same for the small value. For outfits with a single weight, it should be always 0 so nothing should happen
-		defaultValue = sliderManager.GetSmallPresetValue(activePreset, sliderSmall.name, sliderSmall.defValue);
-
-		if (sliderSmall.value != defaultValue) {
-			BuildLogbookEntry::SliderValue v;
-			v.name = sliderSmall.name;
-			v.size = "small";
-			v.value = sliderSmall.value;
-			entry.sliders.push_back(v);
-		}
-	}
+	entry.sliders = CalculateLogbookSliders();
 	
 	// Append the newly populated entry to the logbook
 	buildLogbook.AddEntry(entry);
@@ -1446,7 +1452,7 @@ void BodySlideApp::SaveToLogbook(SliderSet currentSet) {
 	UpdateLogbookLabel();
 }
 
-void BodySlideApp::RemoveFromLogbook(const std::string& outputPath) {
+void BodySlideApp::RemoveSetFromLogbook(const std::string& outputPath) {
 	static std::mutex logbookMutex;
 	std::lock_guard<std::mutex> lock(logbookMutex);
 
@@ -3593,7 +3599,7 @@ int BodySlideApp::BuildBodies(bool localPath, bool clean, bool tri, bool forceNo
 			return 4;
 		}
 
-		RemoveFromLogbook(activeSet.GetOutputFilePath());
+		RemoveSetFromLogbook(activeSet.GetOutputFilePath());
 
 		wxString removeHigh, removeLow;
 		wxString msg = _("Removed the following files:\n");
@@ -3950,7 +3956,7 @@ int BodySlideApp::BuildBodies(bool localPath, bool clean, bool tri, bool forceNo
 	if (!savedHigh.IsEmpty())
 		msg.Append(savedHigh);
 
-	SaveToLogbook(activeSet);	
+	SaveSetToLogbook(activeSet);
 
 	wxLogMessage("%s", msg);
 	wxMessageBox(msg, _("Process Successful"));
@@ -4069,6 +4075,12 @@ int BodySlideApp::BuildListBodies(
 	}
 
 	std::string activePreset = BodySlideConfig["SelectedPreset"];
+
+	// Pre-calculate slider values for the logbook, since they are constant during the batch build
+	std::vector<BuildLogbookEntry::SliderValue> logbookSliders = CalculateLogbookSliders();
+
+	std::vector<BuildLogbookEntry> batchLogbookEntries;
+	std::vector<std::string> batchLogbookRemovals;
 
 	if (datapath.empty()) {
 		if (GetOutputDataPath().empty()) {
@@ -4390,7 +4402,10 @@ int BodySlideApp::BuildListBodies(
 			if (genWeights)
 				removeHigh = removePath + "_1.nif";
 
-			RemoveFromLogbook(currentSet.GetOutputFilePath());
+			{
+				std::lock_guard<std::mutex> lock(batchBuildMutex);
+				batchLogbookRemovals.push_back(currentSet.GetOutputFilePath());
+			}
 
 			if (wxFileName::FileExists(removeHigh))
 				wxRemoveFile(removeHigh);
@@ -4812,7 +4827,16 @@ int BodySlideApp::BuildListBodies(
 			}
 		}
 
-		SaveToLogbook(currentSet);
+		BuildLogbookEntry entry;
+		entry.path = currentSet.GetOutputFilePath();
+		entry.set = currentSet.GetName();
+		entry.preset = activePreset;
+		entry.sliders = logbookSliders;
+
+		{
+			std::lock_guard<std::mutex> lock(batchBuildMutex);
+			batchLogbookEntries.push_back(std::move(entry));
+		}
 	};
 
 	// Multi-threading for 64-bit only due to memory limits of 32-bit builds
@@ -4841,6 +4865,17 @@ int BodySlideApp::BuildListBodies(
 	progWnd.Update(1000);
 
 	failedOutfits.insert(failedOutfitsCon.begin(), failedOutfitsCon.end());
+
+	if (batchLogbookEntries.size() > 0 || batchLogbookRemovals.size() > 0) {
+		for (auto& entry : batchLogbookEntries) {
+			buildLogbook.AddEntry(entry);
+		}
+		for (auto& path : batchLogbookRemovals) {
+			buildLogbook.RemoveEntry(path);
+		}
+		buildLogbook.SaveToFile();
+		UpdateLogbookLabel();
+	}
 
 	if (failedOutfits.size() > 0)
 		return 3;
@@ -6279,7 +6314,7 @@ void BodySlideFrame::OnLogbookSelect(wxCommandEvent& event) {
 		UpdateFavoriteButtons();
 	}
 	else if (event.GetId() == XRCID("menuRemoveFromLogbook")) {
-		app->RemoveFromLogbook("");
+		app->RemoveSetFromLogbook("");
 	}
 }
 

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -6292,6 +6292,14 @@ void BodySlideFrame::OnOutfitChoiceSelect(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void BodySlideFrame::OnLogbookPopup(wxMouseEvent& WXUNUSED(event)) {
+	BuildLogbookFile logbookFile;
+	BuildLogbook logbook;
+	app->GetBuildLogbook(logbookFile, logbook);
+
+	std::string outputPath = app->GetActiveSet().GetOutputFilePath();
+	if (!logbook.HasEntry(outputPath))
+		return;
+
 	wxMenu* menu = wxXmlResource::Get()->LoadMenu("menuLogbook");
 	if (menu) {
 		menu->Bind(wxEVT_MENU, &BodySlideFrame::OnLogbookSelect, this);

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -1014,11 +1014,39 @@ void BodySlideApp::ActivateLogbookEntry() {
 			ActivateOutfit(entry.set);
 		}
 
-		// Always activate the preset to reset sliders and re-apply the logbook entry
-		ActivatePreset(entry.preset, false);
-		PopulatePresetList(entry.preset);
+		// Re-implementing a section of ActivatePreset(entry.preset, false)
+		// To load the preset without applying BuildSelection zaps
+		BodySlideConfig.SetValue("SelectedPreset", entry.preset);
+		sliderManager.InitializeSliders(entry.preset);
 
+		bool zapChanged = false;
+		Slider* sliderSmall = nullptr;
+		Slider* sliderBig = nullptr;
+		for (size_t i = 0; i < sliderManager.slidersBig.size(); i++) {
+			sliderSmall = &sliderManager.slidersSmall[i];
+			sliderBig = &sliderManager.slidersBig[i];
+
+			if (sliderBig->zap && !sliderBig->uv && !zapChanged) {
+				auto* sd = sliderView->GetSliderDisplay(sliderBig->name);
+				if (sd) {
+					float zapValueUI = sd->zapCheckHi->IsChecked() ? 0.01f : 0.0f;
+					if (sliderBig->value != zapValueUI)
+						zapChanged = true;
+				}
+			}
+
+			sliderView->SetSliderPosition(sliderSmall->name.c_str(), sliderSmall->value, SLIDER_LO);
+			sliderView->SetSliderPosition(sliderBig->name.c_str(), sliderBig->value, SLIDER_HI);
+		}
+
+		// Load Logbook slider modifications
 		for (const auto& sv : entry.sliders) {
+
+			// Check how we need to update the preview
+			// Loading a Logbook entry doesn't apply its zap choices to BuildSelection
+			if (sv.zap)
+				zapChanged = true;
+
 			if (sv.size == "big") {
 				sliderManager.SetSlider(sv.name, false, sv.value);
 				sliderView->SetSliderPosition(sv.name.c_str(), sv.value, SLIDER_HI);
@@ -1029,12 +1057,12 @@ void BodySlideApp::ActivateLogbookEntry() {
 		}
 
 		// If the logbook introduced any slider modification, mark it as such
-		if (entry.sliders.size() > 0) sliderView->SetPresetChanged(true);
+		sliderView->SetPresetChanged(entry.sliders.size() > 0);
 
-		bool zapChanged = false;
-		if (UpdateZapChoices())
-			zapChanged = true;
+		PopulatePresetList(entry.preset);
+		UpdateLogbookLabel();
 
+		// We have waited until now to update the preview
 		if (preview)
 			zapChanged ? RebuildPreviewMeshes() : UpdatePreview();
 
@@ -1404,6 +1432,8 @@ std::vector<BuildLogbookEntry::SliderValue> BodySlideApp::CalculateLogbookSlider
 		auto& sliderBig = sliderManager.slidersBig[i];
 		auto& sliderSmall = sliderManager.slidersSmall[i];
 
+		// Note that zaps are calculated against defaults, not against BuildSelections
+
 		// Get the preset slider value, or if it doesn't exist, the slider default
 		defaultValue = sliderManager.GetBigPresetValue(activePreset, sliderBig.name, sliderBig.defValue);
 		if (sliderBig.value != defaultValue) {
@@ -1412,6 +1442,7 @@ std::vector<BuildLogbookEntry::SliderValue> BodySlideApp::CalculateLogbookSlider
 			v.name = sliderBig.name;
 			v.size = "big";
 			v.value = sliderBig.value;
+			v.zap = sliderBig.zap;
 			logbookSliders.push_back(v);
 		}
 
@@ -1422,6 +1453,7 @@ std::vector<BuildLogbookEntry::SliderValue> BodySlideApp::CalculateLogbookSlider
 			v.name = sliderSmall.name;
 			v.size = "small";
 			v.value = sliderSmall.value;
+			v.zap = sliderBig.zap;
 			logbookSliders.push_back(v);
 		}
 	}

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -947,7 +947,7 @@ void BodySlideApp::ActivatePreset(const std::string& presetName, const bool upda
 
 	sliderView->SetPresetChanged(false);
 
-	LoadLogbookEntry();
+	UpdateLogbookLabel();
 
 	if (UpdateZapChoices())
 		zapChanged = true;
@@ -956,7 +956,7 @@ void BodySlideApp::ActivatePreset(const std::string& presetName, const bool upda
 		zapChanged ? RebuildPreviewMeshes() : UpdatePreview();
 }
 
-void BodySlideApp::LoadLogbookEntry() {
+void BodySlideApp::UpdateLogbookLabel() {
 
 	std::string outfitName = BodySlideConfig["SelectedOutfit"];
 	std::string activePreset = BodySlideConfig["SelectedPreset"];
@@ -977,24 +977,24 @@ void BodySlideApp::LoadLogbookEntry() {
 
 		if (entry.set != outfitName) {
 			inLogbookLabel->SetLabel("Already built with another outfit.");
-			inLogbookLabel->SetToolTip("This mesh was last built with:\n" + wxString::FromUTF8(entrySummary) + "\nClick here to load this to BodySlide.");
+			inLogbookLabel->SetToolTip("This mesh was last built with:\n" + wxString::FromUTF8(entrySummary) + "\nRight click to load or forget it.");
 			inLogbookLabel->SetForegroundColour(wxColour("#FFD769"));
 		}
 
 		if (entry.set == outfitName && entry.preset != activePreset) {
 			inLogbookLabel->SetLabel("Already built with another preset.");
-			inLogbookLabel->SetToolTip("This mesh was last built with:\n" + wxString::FromUTF8(entrySummary) + "\nClick here to load this to BodySlide.");
+			inLogbookLabel->SetToolTip("This mesh was last built with:\n" + wxString::FromUTF8(entrySummary) + "\nRight click to load or forget it.");
 			inLogbookLabel->SetForegroundColour(wxColour("#FFD769"));
 		}
 
 		if (entry.set == outfitName && entry.preset == activePreset) {
 			inLogbookLabel->SetLabel("Already built with this preset!");
-			inLogbookLabel->SetToolTip("This mesh was last built with:\n" + wxString::FromUTF8(entrySummary) + "\nClick here to load this to BodySlide.");
+			inLogbookLabel->SetToolTip("This mesh was last built with:\n" + wxString::FromUTF8(entrySummary) + "\nRight click to load or forget it.");
 			inLogbookLabel->SetForegroundColour(wxColour("#00FFFF"));
 		}
 	} else {
 		inLogbookLabel->SetLabel("No build record for this outfit.");
-		inLogbookLabel->SetToolTip("Here you'll see the last outfit and preset it was built with.");
+		inLogbookLabel->SetToolTip("Build this mesh to record the last outfit, preset, and any slider modifications it was built with.");
 		inLogbookLabel->SetForegroundColour(wxColour("#c8c8d8"));
 	}
 
@@ -1018,17 +1018,18 @@ void BodySlideApp::ActivateLogbookEntry() {
 		std::string activePreset = BodySlideConfig["SelectedPreset"];
 
 		if (entry.set != activeOutfit) {
-			if (sliderView->outfitChoice) {
-				sliderView->outfitChoice->SetStringSelection(entry.set);
-			}
+			//if (sliderView->outfitChoice) {
+			//	sliderView->outfitChoice->SetStringSelection(entry.set);
+			//}
 			ActivateOutfit(entry.set);
 		}
 		
 		if (entry.preset != activePreset) {
-			if (sliderView->presetChoice) {
-				sliderView->presetChoice->SetStringSelection(entry.preset);
-			}
+			//if (sliderView->presetChoice) {
+			//	sliderView->presetChoice->SetStringSelection(entry.preset);
+			//}
 			ActivatePreset(entry.preset);
+			PopulatePresetList(entry.preset);
 		}
 
 		for (const auto& sv : entry.sliders) {
@@ -1411,7 +1412,7 @@ void BodySlideApp::SetZapChoice(const std::string& zap, bool choice) {
 	buildSelFile.Save();
 }
 
-void BodySlideApp::UpdateBuildLogbook(SliderSet currentSet, bool remove) {
+void BodySlideApp::SaveToLogbook(SliderSet currentSet) {
 	std::mutex logbookMutex;
 	std::lock_guard<std::mutex> lock(logbookMutex);
 
@@ -1421,61 +1422,78 @@ void BodySlideApp::UpdateBuildLogbook(SliderSet currentSet, bool remove) {
 
 	std::string outputPath = currentSet.GetOutputFilePath();
 
-	if (remove) {
-		// If requested, remove any existing entry that matches the output path to keep the logbook clean
-		logbook.RemoveEntry(outputPath);
-		logbookFile.RemoveEntry(outputPath);
-	} else {
-		// Create a new entry for the current build
-		BuildLogbookEntry entry;
-		entry.path = outputPath;
-		entry.set = currentSet.GetName();
-		
-		// Record the preset that is currently active
-		std::string activePreset = BodySlideConfig["SelectedPreset"];
-		entry.preset = activePreset;
-		
-		float defaultValue = 0.0f;
+	// Create a new entry for the current build
+	BuildLogbookEntry entry;
+	entry.path = outputPath;
+	entry.set = currentSet.GetName();
+	
+	// Record the preset that is currently active
+	std::string activePreset = BodySlideConfig["SelectedPreset"];
+	entry.preset = activePreset;
+	
+	float defaultValue = 0.0f;
 
-		// Iterate over all sliders
-		for (size_t i = 0; i < sliderManager.slidersBig.size(); i++) {
-			auto& sliderBig = sliderManager.slidersBig[i];
-			auto& sliderSmall = sliderManager.slidersSmall[i];
+	// Iterate over all sliders
+	for (size_t i = 0; i < sliderManager.slidersBig.size(); i++) {
+		auto& sliderBig = sliderManager.slidersBig[i];
+		auto& sliderSmall = sliderManager.slidersSmall[i];
 
-			// Get the preset slider value, or if it doesn't exist, the slider default
-			defaultValue = sliderManager.GetBigPresetValue(activePreset, sliderBig.name, sliderBig.defValue);
+		// Get the preset slider value, or if it doesn't exist, the slider default
+		defaultValue = sliderManager.GetBigPresetValue(activePreset, sliderBig.name, sliderBig.defValue);
 
-			// If the slider value has changed, save it
-			if (sliderBig.value != defaultValue) {
-				BuildLogbookEntry::SliderValue v;
-				v.name = sliderBig.name;
-				v.size = "big";
-				v.value = sliderBig.value;
-				entry.sliders.push_back(v);
-			}
-
-			defaultValue = sliderManager.GetSmallPresetValue(activePreset, sliderSmall.name, sliderSmall.defValue);
-
-			if (sliderSmall.value != defaultValue) {
-				// If the slider value has changed, save it
-				BuildLogbookEntry::SliderValue v;
-				v.name = sliderSmall.name;
-				v.size = "small";
-				v.value = sliderSmall.value;
-				entry.sliders.push_back(v);
-			}
+		// If the slider value has changed, save it
+		if (sliderBig.value != defaultValue) {
+			BuildLogbookEntry::SliderValue v;
+			v.name = sliderBig.name;
+			v.size = "big";
+			v.value = sliderBig.value;
+			entry.sliders.push_back(v);
 		}
-		
-		// Append the newly populated entry to the logbook
-		logbook.AddEntry(entry);
-		logbookFile.UpdateEntries(logbook);
-	}
 
+		defaultValue = sliderManager.GetSmallPresetValue(activePreset, sliderSmall.name, sliderSmall.defValue);
+
+		if (sliderSmall.value != defaultValue) {
+			// If the slider value has changed, save it
+			BuildLogbookEntry::SliderValue v;
+			v.name = sliderSmall.name;
+			v.size = "small";
+			v.value = sliderSmall.value;
+			entry.sliders.push_back(v);
+		}
+	}
+	
+	// Append the newly populated entry to the logbook
+	logbook.AddEntry(entry);
+	logbookFile.UpdateEntries(logbook);
+	
 	// Commit the changes to the BuildLogbook.xml file
 	logbookFile.Save();
 
 	// Reload the inLogbook label
-	LoadLogbookEntry();
+	UpdateLogbookLabel();
+}
+
+void BodySlideApp::RemoveFromLogbook(const std::string& outputPath) {
+	std::mutex logbookMutex;
+	std::lock_guard<std::mutex> lock(logbookMutex);
+
+	BuildLogbookFile logbookFile;
+	BuildLogbook logbook;
+	GetBuildLogbook(logbookFile, logbook);
+
+	// If none is specified, remove the active one
+	if (outputPath == "") {
+		logbook.RemoveEntry(GetActiveSet().GetOutputFilePath());
+		logbookFile.RemoveEntry(GetActiveSet().GetOutputFilePath());
+	}
+	else {
+		logbook.RemoveEntry(outputPath);
+		logbookFile.RemoveEntry(outputPath);
+	}
+		
+	logbookFile.Save();
+
+	UpdateLogbookLabel();
 }
 
 void BodySlideApp::EditProject(const std::string& projectName) {
@@ -3608,7 +3626,7 @@ int BodySlideApp::BuildBodies(bool localPath, bool clean, bool tri, bool forceNo
 			return 4;
 		}
 
-		UpdateBuildLogbook(activeSet, true);
+		RemoveFromLogbook(activeSet.GetOutputFilePath());
 
 		wxString removeHigh, removeLow;
 		wxString msg = _("Removed the following files:\n");
@@ -3965,7 +3983,7 @@ int BodySlideApp::BuildBodies(bool localPath, bool clean, bool tri, bool forceNo
 	if (!savedHigh.IsEmpty())
 		msg.Append(savedHigh);
 
-	UpdateBuildLogbook(activeSet);	
+	SaveToLogbook(activeSet);	
 
 	wxLogMessage("%s", msg);
 	wxMessageBox(msg, _("Process Successful"));
@@ -4405,7 +4423,7 @@ int BodySlideApp::BuildListBodies(
 			if (genWeights)
 				removeHigh = removePath + "_1.nif";
 
-			UpdateBuildLogbook(currentSet, true);
+			RemoveFromLogbook(currentSet.GetOutputFilePath());
 
 			if (wxFileName::FileExists(removeHigh))
 				wxRemoveFile(removeHigh);
@@ -4814,8 +4832,6 @@ int BodySlideApp::BuildListBodies(
 				recordFailure(outfit, _("Unable to save nif file: ") + outFileNameSmall);
 				return;
 			}
-
-			UpdateBuildLogbook(currentSet);
 		}
 		else {
 			outFileNameBig += ".nif";
@@ -4827,9 +4843,9 @@ int BodySlideApp::BuildListBodies(
 				recordFailure(outfit, _("Unable to save nif file: ") + outFileNameBig);
 				return;
 			}
-
-			UpdateBuildLogbook(currentSet);
 		}
+
+		SaveToLogbook(currentSet);
 	};
 
 	// Multi-threading for 64-bit only due to memory limits of 32-bit builds
@@ -5123,6 +5139,7 @@ BodySlideFrame::BodySlideFrame(BodySlideApp* a, const wxSize& size)
 		}
 	}
 	fileCollisionMenu = xrc->LoadMenu("menuFileCollision");
+	logbookMenu = xrc->LoadMenu("menuLogbook");
 
 	search = new wxSearchCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
 	search->ShowSearchButton(true);
@@ -5162,7 +5179,7 @@ BodySlideFrame::BodySlideFrame(BodySlideApp* a, const wxSize& size)
 
 	auto inLogbookLabel = (wxStaticText*)FindWindowByName("inLogbookLabel", this);
 	if (inLogbookLabel)
-		inLogbookLabel->Bind(wxEVT_LEFT_DOWN, &BodySlideFrame::OnLoadLogbook, this);
+		inLogbookLabel->Bind(wxEVT_RIGHT_DOWN, &BodySlideFrame::OnLogbookPopup, this);
 
 	xrc->AttachUnknownControl("searchHolder", search, this);
 	xrc->AttachUnknownControl("outfitsearchHolder", outfitsearch, this);
@@ -6274,9 +6291,25 @@ void BodySlideFrame::OnOutfitChoiceSelect(wxCommandEvent& WXUNUSED(event)) {
 	app->SetDefaultBuildSelection();
 }
 
-void BodySlideFrame::OnLoadLogbook(wxMouseEvent& WXUNUSED(event)) {
-	app->ActivateLogbookEntry();
+void BodySlideFrame::OnLogbookPopup(wxMouseEvent& WXUNUSED(event)) {
+	wxMenu* menu = wxXmlResource::Get()->LoadMenu("menuLogbook");
+	if (menu) {
+		menu->Bind(wxEVT_MENU, &BodySlideFrame::OnLogbookSelect, this);
+		PopupMenu(menu);
+		delete menu;
+	}
 }
+
+void BodySlideFrame::OnLogbookSelect(wxCommandEvent& event) {
+	if (event.GetId() == XRCID("menuLoadFromLogbook")) {
+		app->ActivateLogbookEntry();
+		UpdateFavoriteButtons();
+	}
+	else if (event.GetId() == XRCID("menuRemoveFromLogbook")) {
+		app->RemoveFromLogbook("");
+	}
+}
+
 
 void BodySlideFrame::OnHighToLow(wxCommandEvent& WXUNUSED(event)) {
 	app->CopySliderValues(false);
@@ -6741,8 +6774,8 @@ void BodySlideFrame::OnSettings(wxCommandEvent& WXUNUSED(event)) {
 		cbPreviewAlwaysDetached->SetValue(BodySlideConfig.GetBoolValue("BodySlideFrame.previewAlwaysDetached", false));
 
 		// Hide the single instance setting (only relevant for Outfit Studio)
-		//XRCCTRL(*settings, "lbSingleInstanceBehavior", wxStaticText)->Hide();
-		//XRCCTRL(*settings, "choiceSingleInstanceBehavior", wxChoice)->Hide();
+		XRCCTRL(*settings, "lbSingleInstanceBehavior", wxStaticText)->Hide();
+		XRCCTRL(*settings, "choiceSingleInstanceBehavior", wxChoice)->Hide();
 
 		wxChoice* choiceLanguage = XRCCTRL(*settings, "choiceLanguage", wxChoice);
 		for (size_t i = 0; i < SupportedLangs.size(); i++)

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -27,6 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <algorithm>
 #include <atomic>
+#include <mutex>
 #include <regex>
 #include <thread>
 #include <unordered_map>
@@ -1258,13 +1259,7 @@ void BodySlideApp::GetBuildSelection(BuildSelectionFile& file, BuildSelection& b
 
 void BodySlideApp::InitBuildLogbook() {
 	const std::string buildLogFileName = Config["AppDir"] + PathSepStr + "BuildLogbook.xml";
-
-	buildLogbookFile.Open(buildLogFileName);
-
-	if (buildLogbookFile.fail())
-		buildLogbookFile.New(buildLogFileName);
-
-	buildLogbookFile.Get(buildLogbook);
+	buildLogbook.LoadFromFile(buildLogFileName);
 }
 
 void BodySlideApp::UpdateConflictManager() {
@@ -1400,6 +1395,7 @@ void BodySlideApp::SetZapChoice(const std::string& zap, bool choice) {
 
 void BodySlideApp::SaveToLogbook(SliderSet currentSet) {
 
+	static std::mutex logbookMutex;
 	std::lock_guard<std::mutex> lock(logbookMutex);
 
 	std::string activePreset = BodySlideConfig["SelectedPreset"];
@@ -1409,7 +1405,6 @@ void BodySlideApp::SaveToLogbook(SliderSet currentSet) {
 	entry.set = currentSet.GetName();
 	entry.preset = activePreset;
 	
-
 	float defaultValue = 0.0f;
 
 	// Iterate over all sliders
@@ -1443,29 +1438,27 @@ void BodySlideApp::SaveToLogbook(SliderSet currentSet) {
 	
 	// Append the newly populated entry to the logbook
 	buildLogbook.AddEntry(entry);
-
+	
 	// Save the changes to the BuildLogbook.xml file
-	buildLogbookFile.UpdateEntries(buildLogbook);
-	buildLogbookFile.Save();
+	buildLogbook.SaveToFile();
 
 	// Reload the inLogbook label
 	UpdateLogbookLabel();
 }
 
 void BodySlideApp::RemoveFromLogbook(const std::string& outputPath) {
+	static std::mutex logbookMutex;
 	std::lock_guard<std::mutex> lock(logbookMutex);
 
 	// If none is specified, remove the active one
 	if (outputPath == "") {
 		buildLogbook.RemoveEntry(GetActiveSet().GetOutputFilePath());
-		buildLogbookFile.RemoveEntry(GetActiveSet().GetOutputFilePath());
 	}
 	else {
 		buildLogbook.RemoveEntry(outputPath);
-		buildLogbookFile.RemoveEntry(outputPath);
 	}
 		
-	buildLogbookFile.Save();
+	buildLogbook.SaveToFile();
 
 	UpdateLogbookLabel();
 }

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -458,7 +458,6 @@ void BodySlideApp::LoadData() {
 		std::string activePreset = BodySlideConfig["SelectedPreset"];
 		PopulatePresetList(activePreset);
 		ActivatePreset(activePreset);
-		LoadBuildLogbookEntry(activeOutfit, activePreset);
 
 		wxLogMessage("Finished setting up '%s'.", activeOutfit);
 	}
@@ -912,8 +911,6 @@ void BodySlideApp::ActivateOutfit(const std::string& outfitName) {
 
 	ActivatePreset(activePreset, false);
 
-	LoadBuildLogbookEntry(outfitName, activePreset);
-
 	InitPreview();
 
 	sliderView->Layout();
@@ -950,6 +947,8 @@ void BodySlideApp::ActivatePreset(const std::string& presetName, const bool upda
 
 	sliderView->SetPresetChanged(false);
 
+	LoadLogbookEntry();
+
 	if (UpdateZapChoices())
 		zapChanged = true;
 
@@ -957,18 +956,81 @@ void BodySlideApp::ActivatePreset(const std::string& presetName, const bool upda
 		zapChanged ? RebuildPreviewMeshes() : UpdatePreview();
 }
 
-void BodySlideApp::LoadBuildLogbookEntry(const std::string& outfitName, const std::string& activePreset) {
+void BodySlideApp::LoadLogbookEntry() {
+
+	std::string outfitName = BodySlideConfig["SelectedOutfit"];
+	std::string activePreset = BodySlideConfig["SelectedPreset"];
 
 	wxLogMessage("Loading logbook entry for set '%s' and preset '%s'...", outfitName, activePreset);
+
+	auto inLogbookLabel = (wxStaticText*)sliderView->FindWindowByName("inLogbookLabel");
 
 	BuildLogbookFile logbookFile;
 	BuildLogbook logbook;
 	GetBuildLogbook(logbookFile, logbook);
+	
+	std::string outputPath = GetActiveSet().GetOutputFilePath();
+
+	if (logbook.HasEntry(outputPath)) {
+		BuildLogbookEntry entry = logbook.GetEntry(outputPath);
+		std::string entrySummary = entry.GetSummary();
+
+		if (entry.set != outfitName) {
+			inLogbookLabel->SetLabel("Already built with another outfit.");
+			inLogbookLabel->SetToolTip("This mesh was last built with:\n" + wxString::FromUTF8(entrySummary) + "\nClick here to load this to BodySlide.");
+			inLogbookLabel->SetForegroundColour(wxColour("#FFD769"));
+		}
+
+		if (entry.set == outfitName && entry.preset != activePreset) {
+			inLogbookLabel->SetLabel("Already built with another preset.");
+			inLogbookLabel->SetToolTip("This mesh was last built with:\n" + wxString::FromUTF8(entrySummary) + "\nClick here to load this to BodySlide.");
+			inLogbookLabel->SetForegroundColour(wxColour("#FFD769"));
+		}
+
+		if (entry.set == outfitName && entry.preset == activePreset) {
+			inLogbookLabel->SetLabel("Already built with this preset!");
+			inLogbookLabel->SetToolTip("This mesh was last built with:\n" + wxString::FromUTF8(entrySummary) + "\nClick here to load this to BodySlide.");
+			inLogbookLabel->SetForegroundColour(wxColour("#00FFFF"));
+		}
+	} else {
+		inLogbookLabel->SetLabel("No build record for this outfit.");
+		inLogbookLabel->SetToolTip("Here you'll see the last outfit and preset it was built with.");
+		inLogbookLabel->SetForegroundColour(wxColour("#c8c8d8"));
+	}
+
+	inLogbookLabel->GetParent()->Layout();
+}
+
+void BodySlideApp::ActivateLogbookEntry() {
+	BuildLogbookFile logbookFile;
+	BuildLogbook logbook;
+	GetBuildLogbook(logbookFile, logbook);
+
+	wxLogMessage("Activating logbook entry...");
 
 	std::string outputPath = GetActiveSet().GetOutputFilePath();
-	BuildLogbookEntry entry = logbook.GetEntry(outputPath);
 
-	if (entry.set == outfitName && entry.preset == activePreset) {
+	if (logbook.HasEntry(outputPath)) {
+
+		BuildLogbookEntry entry = logbook.GetEntry(outputPath);
+
+		std::string activeOutfit = BodySlideConfig["SelectedOutfit"];
+		std::string activePreset = BodySlideConfig["SelectedPreset"];
+
+		if (entry.set != activeOutfit) {
+			if (sliderView->outfitChoice) {
+				sliderView->outfitChoice->SetStringSelection(entry.set);
+			}
+			ActivateOutfit(entry.set);
+		}
+		
+		if (entry.preset != activePreset) {
+			if (sliderView->presetChoice) {
+				sliderView->presetChoice->SetStringSelection(entry.preset);
+			}
+			ActivatePreset(entry.preset);
+		}
+
 		for (const auto& sv : entry.sliders) {
 			if (sv.size == "big") {
 				sliderManager.SetSlider(sv.name, false, sv.value);
@@ -978,6 +1040,16 @@ void BodySlideApp::LoadBuildLogbookEntry(const std::string& outfitName, const st
 				sliderView->SetSliderPosition(sv.name.c_str(), sv.value, SLIDER_LO);
 			}
 		}
+
+		if (entry.sliders.size() > 0) sliderView->SetPresetChanged(true);
+		
+		bool zapChanged = false;
+		if (UpdateZapChoices())
+			zapChanged = true;
+
+		if (preview)
+			zapChanged ? RebuildPreviewMeshes() : UpdatePreview();
+
 	}
 }
 
@@ -1401,6 +1473,9 @@ void BodySlideApp::UpdateBuildLogbook(SliderSet currentSet, bool remove) {
 
 	// Commit the changes to the BuildLogbook.xml file
 	logbookFile.Save();
+
+	// Reload the inLogbook label
+	LoadLogbookEntry();
 }
 
 void BodySlideApp::EditProject(const std::string& projectName) {
@@ -5085,6 +5160,10 @@ BodySlideFrame::BodySlideFrame(BodySlideApp* a, const wxSize& size)
 	if (conflictInfo)
 		conflictInfo->Bind(wxEVT_RIGHT_DOWN, &BodySlideFrame::OnConflictPopup, this);
 
+	auto inLogbookLabel = (wxStaticText*)FindWindowByName("inLogbookLabel", this);
+	if (inLogbookLabel)
+		inLogbookLabel->Bind(wxEVT_LEFT_DOWN, &BodySlideFrame::OnLoadLogbook, this);
+
 	xrc->AttachUnknownControl("searchHolder", search, this);
 	xrc->AttachUnknownControl("outfitsearchHolder", outfitsearch, this);
 	xrc->AttachUnknownControl("sliderFilter", sliderFilter, this);
@@ -6195,6 +6274,10 @@ void BodySlideFrame::OnOutfitChoiceSelect(wxCommandEvent& WXUNUSED(event)) {
 	app->SetDefaultBuildSelection();
 }
 
+void BodySlideFrame::OnLoadLogbook(wxMouseEvent& WXUNUSED(event)) {
+	app->ActivateLogbookEntry();
+}
+
 void BodySlideFrame::OnHighToLow(wxCommandEvent& WXUNUSED(event)) {
 	app->CopySliderValues(false);
 }
@@ -6658,8 +6741,8 @@ void BodySlideFrame::OnSettings(wxCommandEvent& WXUNUSED(event)) {
 		cbPreviewAlwaysDetached->SetValue(BodySlideConfig.GetBoolValue("BodySlideFrame.previewAlwaysDetached", false));
 
 		// Hide the single instance setting (only relevant for Outfit Studio)
-		XRCCTRL(*settings, "lbSingleInstanceBehavior", wxStaticText)->Hide();
-		XRCCTRL(*settings, "choiceSingleInstanceBehavior", wxChoice)->Hide();
+		//XRCCTRL(*settings, "lbSingleInstanceBehavior", wxStaticText)->Hide();
+		//XRCCTRL(*settings, "choiceSingleInstanceBehavior", wxChoice)->Hide();
 
 		wxChoice* choiceLanguage = XRCCTRL(*settings, "choiceLanguage", wxChoice);
 		for (size_t i = 0; i < SupportedLangs.size(); i++)

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -1169,6 +1169,17 @@ void BodySlideApp::GetBuildSelection(BuildSelectionFile& file, BuildSelection& b
 	file.Get(buildSel);
 }
 
+void BodySlideApp::GetBuildLogbook(BuildLogbookFile& file, BuildLogbook& buildLog) {
+	const std::string buildLogFileName = Config["AppDir"] + PathSepStr + "BuildLogbook.xml";
+
+	file.Open(buildLogFileName);
+
+	if (file.fail())
+		file.New(buildLogFileName);
+
+	file.Get(buildLog);
+}
+
 void BodySlideApp::UpdateConflictManager() {
 	if (projects.empty())
 		return;
@@ -1298,6 +1309,75 @@ void BodySlideApp::SetZapChoice(const std::string& zap, bool choice) {
 	buildSelFile.UpdateZapChoices(buildSelection);
 
 	buildSelFile.Save();
+}
+
+#include <mutex>
+std::mutex logbookMutex;
+
+void BodySlideApp::UpdateBuildLogbook(SliderSet currentSet, bool remove) {
+	std::lock_guard<std::mutex> lock(logbookMutex);
+
+	BuildLogbookFile logbookFile;
+	BuildLogbook logbook;
+	GetBuildLogbook(logbookFile, logbook);
+
+	std::string outputPath = currentSet.GetOutputFilePath();
+
+	if (remove) {
+		// If requested, remove any existing entry that matches the output path to keep the logbook clean
+		logbook.RemoveEntry(outputPath);
+		logbookFile.RemoveEntry(outputPath);
+	} else {
+		// Create a new entry for the current build
+		BuildLogbookEntry entry;
+		entry.path = outputPath;
+		entry.set = currentSet.GetName();
+		
+		// Record the preset that is currently active, if any
+		std::string activePreset = BodySlideConfig["SelectedPreset"];
+		entry.preset = activePreset;
+		
+		float defaultValue = 0.0f;
+
+		// Iterate over all 'big' (100 weight) sliders
+		for (auto& sliderBig : sliderManager.slidersBig) {
+
+			// Get the preset slider value, or if it doesn't exist, the slider default
+			defaultValue = sliderManager.GetBigPresetValue(activePreset, sliderBig.name, sliderBig.defValue);
+
+			// If the slider value has changed, save it
+			if (sliderBig.value != defaultValue) {
+				BuildLogbookEntry::SliderValue v;
+				v.name = sliderBig.name;
+				v.size = "big";
+				v.value = sliderBig.value;
+				entry.sliders.push_back(v);
+			}
+		}
+
+		// Iterate over all 'small' (0 weight) sliders
+		for (auto& sliderSmall : sliderManager.slidersSmall) {
+
+			defaultValue = sliderManager.GetSmallPresetValue(activePreset, sliderSmall.name, sliderSmall.defValue);
+
+			if (sliderSmall.value != defaultValue) {
+				// If the slider value has changed, save it
+				BuildLogbookEntry::SliderValue v;
+				v.name = sliderSmall.name;
+				v.size = "small";
+				v.value = sliderSmall.value;
+				entry.sliders.push_back(v);
+			}
+		}
+		
+	
+		// Append the newly populated entry to the logbook
+		logbook.AddEntry(entry);
+		logbookFile.UpdateEntries(logbook);
+	}
+
+	// Commit the changes to the BuildLogbook.xml file
+	logbookFile.Save();
 }
 
 void BodySlideApp::EditProject(const std::string& projectName) {
@@ -3430,6 +3510,8 @@ int BodySlideApp::BuildBodies(bool localPath, bool clean, bool tri, bool forceNo
 			return 4;
 		}
 
+		UpdateBuildLogbook(activeSet, true);
+
 		wxString removeHigh, removeLow;
 		wxString msg = _("Removed the following files:\n");
 		bool genWeights = activeSet.GenWeights();
@@ -3784,6 +3866,8 @@ int BodySlideApp::BuildBodies(bool localPath, bool clean, bool tri, bool forceNo
 
 	if (!savedHigh.IsEmpty())
 		msg.Append(savedHigh);
+
+	UpdateBuildLogbook(activeSet);	
 
 	wxLogMessage("%s", msg);
 	wxMessageBox(msg, _("Process Successful"));
@@ -4223,9 +4307,11 @@ int BodySlideApp::BuildListBodies(
 			if (genWeights)
 				removeHigh = removePath + "_1.nif";
 
+			UpdateBuildLogbook(currentSet, true);
+
 			if (wxFileName::FileExists(removeHigh))
 				wxRemoveFile(removeHigh);
-
+				
 			if (!genWeights)
 				return;
 
@@ -4630,6 +4716,8 @@ int BodySlideApp::BuildListBodies(
 				recordFailure(outfit, _("Unable to save nif file: ") + outFileNameSmall);
 				return;
 			}
+
+			UpdateBuildLogbook(currentSet);
 		}
 		else {
 			outFileNameBig += ".nif";
@@ -4641,6 +4729,8 @@ int BodySlideApp::BuildListBodies(
 				recordFailure(outfit, _("Unable to save nif file: ") + outFileNameBig);
 				return;
 			}
+
+			UpdateBuildLogbook(currentSet);
 		}
 	};
 

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -27,7 +27,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <algorithm>
 #include <atomic>
-#include <mutex>
 #include <regex>
 #include <thread>
 #include <unordered_map>
@@ -253,6 +252,7 @@ bool BodySlideApp::OnInit() {
 				wxICON_WARNING);
 	}
 
+	InitBuildLogbook();
 	LoadAllCategories();
 	LoadAllGroups();
 	LoadSliderSets();
@@ -964,15 +964,10 @@ void BodySlideApp::UpdateLogbookLabel() {
 	wxLogMessage("Loading logbook entry for set '%s' and preset '%s'...", outfitName, activePreset);
 
 	auto inLogbookLabel = (wxStaticText*)sliderView->FindWindowByName("inLogbookLabel");
-
-	BuildLogbookFile logbookFile;
-	BuildLogbook logbook;
-	GetBuildLogbook(logbookFile, logbook);
-	
 	std::string outputPath = GetActiveSet().GetOutputFilePath();
 
-	if (logbook.HasEntry(outputPath)) {
-		BuildLogbookEntry entry = logbook.GetEntry(outputPath);
+	if (buildLogbook.HasEntry(outputPath)) {
+		BuildLogbookEntry entry = buildLogbook.GetEntry(outputPath);
 		std::string entrySummary = entry.GetSummary();
 
 		if (entry.set != outfitName) {
@@ -1002,35 +997,25 @@ void BodySlideApp::UpdateLogbookLabel() {
 }
 
 void BodySlideApp::ActivateLogbookEntry() {
-	BuildLogbookFile logbookFile;
-	BuildLogbook logbook;
-	GetBuildLogbook(logbookFile, logbook);
 
 	wxLogMessage("Activating logbook entry...");
 
 	std::string outputPath = GetActiveSet().GetOutputFilePath();
 
-	if (logbook.HasEntry(outputPath)) {
+	if (buildLogbook.HasEntry(outputPath)) {
 
-		BuildLogbookEntry entry = logbook.GetEntry(outputPath);
+		BuildLogbookEntry entry = buildLogbook.GetEntry(outputPath);
 
 		std::string activeOutfit = BodySlideConfig["SelectedOutfit"];
 		std::string activePreset = BodySlideConfig["SelectedPreset"];
 
 		if (entry.set != activeOutfit) {
-			//if (sliderView->outfitChoice) {
-			//	sliderView->outfitChoice->SetStringSelection(entry.set);
-			//}
 			ActivateOutfit(entry.set);
 		}
-		
-		if (entry.preset != activePreset) {
-			//if (sliderView->presetChoice) {
-			//	sliderView->presetChoice->SetStringSelection(entry.preset);
-			//}
-			ActivatePreset(entry.preset);
-			PopulatePresetList(entry.preset);
-		}
+
+		// Always activate the preset to reset sliders and re-apply the logbook entry
+		ActivatePreset(entry.preset, false);
+		PopulatePresetList(entry.preset);
 
 		for (const auto& sv : entry.sliders) {
 			if (sv.size == "big") {
@@ -1042,6 +1027,7 @@ void BodySlideApp::ActivateLogbookEntry() {
 			}
 		}
 
+		// If the logbook introduced any slider modification, mark it as such
 		if (entry.sliders.size() > 0) sliderView->SetPresetChanged(true);
 		
 		bool zapChanged = false;
@@ -1270,15 +1256,15 @@ void BodySlideApp::GetBuildSelection(BuildSelectionFile& file, BuildSelection& b
 	file.Get(buildSel);
 }
 
-void BodySlideApp::GetBuildLogbook(BuildLogbookFile& file, BuildLogbook& buildLog) {
+void BodySlideApp::InitBuildLogbook() {
 	const std::string buildLogFileName = Config["AppDir"] + PathSepStr + "BuildLogbook.xml";
 
-	file.Open(buildLogFileName);
+	buildLogbookFile.Open(buildLogFileName);
 
-	if (file.fail())
-		file.New(buildLogFileName);
+	if (buildLogbookFile.fail())
+		buildLogbookFile.New(buildLogFileName);
 
-	file.Get(buildLog);
+	buildLogbookFile.Get(buildLogbook);
 }
 
 void BodySlideApp::UpdateConflictManager() {
@@ -1413,24 +1399,17 @@ void BodySlideApp::SetZapChoice(const std::string& zap, bool choice) {
 }
 
 void BodySlideApp::SaveToLogbook(SliderSet currentSet) {
-	std::mutex logbookMutex;
+
 	std::lock_guard<std::mutex> lock(logbookMutex);
 
-	BuildLogbookFile logbookFile;
-	BuildLogbook logbook;
-	GetBuildLogbook(logbookFile, logbook);
-
-	std::string outputPath = currentSet.GetOutputFilePath();
-
-	// Create a new entry for the current build
-	BuildLogbookEntry entry;
-	entry.path = outputPath;
-	entry.set = currentSet.GetName();
-	
-	// Record the preset that is currently active
 	std::string activePreset = BodySlideConfig["SelectedPreset"];
+
+	BuildLogbookEntry entry;
+	entry.path = currentSet.GetOutputFilePath();
+	entry.set = currentSet.GetName();
 	entry.preset = activePreset;
 	
+
 	float defaultValue = 0.0f;
 
 	// Iterate over all sliders
@@ -1450,10 +1429,10 @@ void BodySlideApp::SaveToLogbook(SliderSet currentSet) {
 			entry.sliders.push_back(v);
 		}
 
+		// Do the same for the small value. For outfits with a single weight, it should be always 0 so nothing should happen
 		defaultValue = sliderManager.GetSmallPresetValue(activePreset, sliderSmall.name, sliderSmall.defValue);
 
 		if (sliderSmall.value != defaultValue) {
-			// If the slider value has changed, save it
 			BuildLogbookEntry::SliderValue v;
 			v.name = sliderSmall.name;
 			v.size = "small";
@@ -1463,35 +1442,30 @@ void BodySlideApp::SaveToLogbook(SliderSet currentSet) {
 	}
 	
 	// Append the newly populated entry to the logbook
-	logbook.AddEntry(entry);
-	logbookFile.UpdateEntries(logbook);
-	
-	// Commit the changes to the BuildLogbook.xml file
-	logbookFile.Save();
+	buildLogbook.AddEntry(entry);
+
+	// Save the changes to the BuildLogbook.xml file
+	buildLogbookFile.UpdateEntries(buildLogbook);
+	buildLogbookFile.Save();
 
 	// Reload the inLogbook label
 	UpdateLogbookLabel();
 }
 
 void BodySlideApp::RemoveFromLogbook(const std::string& outputPath) {
-	std::mutex logbookMutex;
 	std::lock_guard<std::mutex> lock(logbookMutex);
-
-	BuildLogbookFile logbookFile;
-	BuildLogbook logbook;
-	GetBuildLogbook(logbookFile, logbook);
 
 	// If none is specified, remove the active one
 	if (outputPath == "") {
-		logbook.RemoveEntry(GetActiveSet().GetOutputFilePath());
-		logbookFile.RemoveEntry(GetActiveSet().GetOutputFilePath());
+		buildLogbook.RemoveEntry(GetActiveSet().GetOutputFilePath());
+		buildLogbookFile.RemoveEntry(GetActiveSet().GetOutputFilePath());
 	}
 	else {
-		logbook.RemoveEntry(outputPath);
-		logbookFile.RemoveEntry(outputPath);
+		buildLogbook.RemoveEntry(outputPath);
+		buildLogbookFile.RemoveEntry(outputPath);
 	}
 		
-	logbookFile.Save();
+	buildLogbookFile.Save();
 
 	UpdateLogbookLabel();
 }
@@ -6292,9 +6266,7 @@ void BodySlideFrame::OnOutfitChoiceSelect(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void BodySlideFrame::OnLogbookPopup(wxMouseEvent& WXUNUSED(event)) {
-	BuildLogbookFile logbookFile;
-	BuildLogbook logbook;
-	app->GetBuildLogbook(logbookFile, logbook);
+	BuildLogbook& logbook = app->buildLogbook;
 
 	std::string outputPath = app->GetActiveSet().GetOutputFilePath();
 	if (!logbook.HasEntry(outputPath))

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -458,6 +458,7 @@ void BodySlideApp::LoadData() {
 		std::string activePreset = BodySlideConfig["SelectedPreset"];
 		PopulatePresetList(activePreset);
 		ActivatePreset(activePreset);
+		LoadBuildLogbookEntry(activeOutfit, activePreset);
 
 		wxLogMessage("Finished setting up '%s'.", activeOutfit);
 	}
@@ -911,6 +912,8 @@ void BodySlideApp::ActivateOutfit(const std::string& outfitName) {
 
 	ActivatePreset(activePreset, false);
 
+	LoadBuildLogbookEntry(outfitName, activePreset);
+
 	InitPreview();
 
 	sliderView->Layout();
@@ -953,6 +956,31 @@ void BodySlideApp::ActivatePreset(const std::string& presetName, const bool upda
 	if (preview && updatePreview)
 		zapChanged ? RebuildPreviewMeshes() : UpdatePreview();
 }
+
+void BodySlideApp::LoadBuildLogbookEntry(const std::string& outfitName, const std::string& activePreset) {
+
+	wxLogMessage("Loading logbook entry for set '%s' and preset '%s'...", outfitName, activePreset);
+
+	BuildLogbookFile logbookFile;
+	BuildLogbook logbook;
+	GetBuildLogbook(logbookFile, logbook);
+
+	std::string outputPath = GetActiveSet().GetOutputFilePath();
+	BuildLogbookEntry entry = logbook.GetEntry(outputPath);
+
+	if (entry.set == outfitName && entry.preset == activePreset) {
+		for (const auto& sv : entry.sliders) {
+			if (sv.size == "big") {
+				sliderManager.SetSlider(sv.name, false, sv.value);
+				sliderView->SetSliderPosition(sv.name.c_str(), sv.value, SLIDER_HI);
+			} else if (sv.size == "small") {
+				sliderManager.SetSlider(sv.name, true, sv.value);
+				sliderView->SetSliderPosition(sv.name.c_str(), sv.value, SLIDER_LO);
+			}
+		}
+	}
+}
+
 
 void BodySlideApp::DeleteOutfit(const std::string& outfitName) {
 	auto outfit = outfitNameSource.find(outfitName);
@@ -1311,10 +1339,8 @@ void BodySlideApp::SetZapChoice(const std::string& zap, bool choice) {
 	buildSelFile.Save();
 }
 
-#include <mutex>
-std::mutex logbookMutex;
-
 void BodySlideApp::UpdateBuildLogbook(SliderSet currentSet, bool remove) {
+	std::mutex logbookMutex;
 	std::lock_guard<std::mutex> lock(logbookMutex);
 
 	BuildLogbookFile logbookFile;
@@ -1333,14 +1359,16 @@ void BodySlideApp::UpdateBuildLogbook(SliderSet currentSet, bool remove) {
 		entry.path = outputPath;
 		entry.set = currentSet.GetName();
 		
-		// Record the preset that is currently active, if any
+		// Record the preset that is currently active
 		std::string activePreset = BodySlideConfig["SelectedPreset"];
 		entry.preset = activePreset;
 		
 		float defaultValue = 0.0f;
 
-		// Iterate over all 'big' (100 weight) sliders
-		for (auto& sliderBig : sliderManager.slidersBig) {
+		// Iterate over all sliders
+		for (size_t i = 0; i < sliderManager.slidersBig.size(); i++) {
+			auto& sliderBig = sliderManager.slidersBig[i];
+			auto& sliderSmall = sliderManager.slidersSmall[i];
 
 			// Get the preset slider value, or if it doesn't exist, the slider default
 			defaultValue = sliderManager.GetBigPresetValue(activePreset, sliderBig.name, sliderBig.defValue);
@@ -1353,10 +1381,6 @@ void BodySlideApp::UpdateBuildLogbook(SliderSet currentSet, bool remove) {
 				v.value = sliderBig.value;
 				entry.sliders.push_back(v);
 			}
-		}
-
-		// Iterate over all 'small' (0 weight) sliders
-		for (auto& sliderSmall : sliderManager.slidersSmall) {
 
 			defaultValue = sliderManager.GetSmallPresetValue(activePreset, sliderSmall.name, sliderSmall.defValue);
 
@@ -1370,7 +1394,6 @@ void BodySlideApp::UpdateBuildLogbook(SliderSet currentSet, bool remove) {
 			}
 		}
 		
-	
 		// Append the newly populated entry to the logbook
 		logbook.AddEntry(entry);
 		logbookFile.UpdateEntries(logbook);

--- a/src/program/BodySlideApp.h
+++ b/src/program/BodySlideApp.h
@@ -60,7 +60,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <cstdint>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -231,8 +230,6 @@ public:
 	void GetBuildSelection(BuildSelectionFile& file, BuildSelection& buildSel);
 	void InitBuildLogbook();
 
-	std::mutex logbookMutex;
-	BuildLogbookFile buildLogbookFile;
 	BuildLogbook buildLogbook;
 
 	void UpdateConflictManager();

--- a/src/program/BodySlideApp.h
+++ b/src/program/BodySlideApp.h
@@ -313,8 +313,9 @@ public:
 						bool forceNormals = false,
 						const std::string& custPath = "");
 
-	void SaveToLogbook(SliderSet currentSet);
-	void RemoveFromLogbook(const std::string& outputPath);
+	std::vector<BuildLogbookEntry::SliderValue> CalculateLogbookSliders();
+	void SaveSetToLogbook(SliderSet currentSet);
+	void RemoveSetFromLogbook(const std::string& outputPath);
 
 	int ShowBuildOverrideWithPreview(wxDialog* dlg, wxTreeListCtrl* treeListCtrl);
 	void GroupBuild(const std::vector<std::string>& groupNames);

--- a/src/program/BodySlideApp.h
+++ b/src/program/BodySlideApp.h
@@ -243,6 +243,7 @@ public:
 
 	void ActivateOutfit(const std::string& outfitName);
 	void ActivatePreset(const std::string& presetName, const bool updatePreview = true);
+	void LoadBuildLogbookEntry(const std::string& outfitName, const std::string& activePreset);
 
 	std::vector<std::string> GetConflictingOutfits() {
 		if (projects.empty())

--- a/src/program/BodySlideApp.h
+++ b/src/program/BodySlideApp.h
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #include "../components/BuildSelection.h"
+#include "../components/BuildLogbook.h"
 #include "../components/ClippingFixer.h"
 #include "../components/SliderCategories.h"
 #include "../components/SliderData.h"
@@ -227,6 +228,7 @@ public:
 	void DisplayActiveSet();
 
 	void GetBuildSelection(BuildSelectionFile& file, BuildSelection& buildSel);
+	void GetBuildLogbook(BuildLogbookFile& file, BuildLogbook& buildLog);
 
 	void UpdateConflictManager();
 	void SetDefaultBuildSelection();
@@ -305,6 +307,9 @@ public:
 						bool tri = false,
 						bool forceNormals = false,
 						const std::string& custPath = "");
+
+	void UpdateBuildLogbook(SliderSet currentSet, bool remove = false);
+
 	int ShowBuildOverrideWithPreview(wxDialog* dlg, wxTreeListCtrl* treeListCtrl);
 	void GroupBuild(const std::vector<std::string>& groupNames);
 

--- a/src/program/BodySlideApp.h
+++ b/src/program/BodySlideApp.h
@@ -247,7 +247,7 @@ public:
 	void ActivatePreset(const std::string& presetName, const bool updatePreview = true);
 	void UpdateLogbookLabel();
 	void ActivateLogbookEntry();
-	
+
 
 	std::vector<std::string> GetConflictingOutfits() {
 		if (projects.empty())

--- a/src/program/BodySlideApp.h
+++ b/src/program/BodySlideApp.h
@@ -60,6 +60,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -228,7 +229,11 @@ public:
 	void DisplayActiveSet();
 
 	void GetBuildSelection(BuildSelectionFile& file, BuildSelection& buildSel);
-	void GetBuildLogbook(BuildLogbookFile& file, BuildLogbook& buildLog);
+	void InitBuildLogbook();
+
+	std::mutex logbookMutex;
+	BuildLogbookFile buildLogbookFile;
+	BuildLogbook buildLogbook;
 
 	void UpdateConflictManager();
 	void SetDefaultBuildSelection();

--- a/src/program/BodySlideApp.h
+++ b/src/program/BodySlideApp.h
@@ -243,7 +243,7 @@ public:
 
 	void ActivateOutfit(const std::string& outfitName);
 	void ActivatePreset(const std::string& presetName, const bool updatePreview = true);
-	void LoadLogbookEntry();
+	void UpdateLogbookLabel();
 	void ActivateLogbookEntry();
 	
 
@@ -311,7 +311,8 @@ public:
 						bool forceNormals = false,
 						const std::string& custPath = "");
 
-	void UpdateBuildLogbook(SliderSet currentSet, bool remove = false);
+	void SaveToLogbook(SliderSet currentSet);
+	void RemoveFromLogbook(const std::string& outputPath);
 
 	int ShowBuildOverrideWithPreview(wxDialog* dlg, wxTreeListCtrl* treeListCtrl);
 	void GroupBuild(const std::vector<std::string>& groupNames);
@@ -439,6 +440,7 @@ public:
 
 	wxCheckListBox* batchBuildList = nullptr;
 	wxMenu* fileCollisionMenu = nullptr;
+	wxMenu* logbookMenu = nullptr;
 	std::vector<std::string> outfitChoiceNames;
 	std::vector<std::string> presetChoiceNames;
 	bool populatingChoices = false;
@@ -549,7 +551,8 @@ private:
 	void OnConflictPopup(wxMouseEvent& event);
 	void OnOutfitChoiceSelect(wxCommandEvent& event);
 
-	void OnLoadLogbook(wxMouseEvent& event);
+	void OnLogbookPopup(wxMouseEvent& event);
+	void OnLogbookSelect(wxCommandEvent& event);
 
 	void OnPreview(wxCommandEvent& event);
 	void OnSashPosChanging(wxSplitterEvent& event);

--- a/src/program/BodySlideApp.h
+++ b/src/program/BodySlideApp.h
@@ -243,7 +243,9 @@ public:
 
 	void ActivateOutfit(const std::string& outfitName);
 	void ActivatePreset(const std::string& presetName, const bool updatePreview = true);
-	void LoadBuildLogbookEntry(const std::string& outfitName, const std::string& activePreset);
+	void LoadLogbookEntry();
+	void ActivateLogbookEntry();
+	
 
 	std::vector<std::string> GetConflictingOutfits() {
 		if (projects.empty())
@@ -546,6 +548,8 @@ private:
 	void OnGroupManager(wxCommandEvent& event);
 	void OnConflictPopup(wxMouseEvent& event);
 	void OnOutfitChoiceSelect(wxCommandEvent& event);
+
+	void OnLoadLogbook(wxMouseEvent& event);
 
 	void OnPreview(wxCommandEvent& event);
 	void OnSashPosChanging(wxSplitterEvent& event);


### PR DESCRIPTION
<img width="1010" height="467" alt="logbook" src="https://github.com/user-attachments/assets/e2c0bd84-7247-44b1-9e70-0aaf7cad737b" />

# Build Logbook (name open to change, of course)

## Why
I have a lot of outfit and preset mods that I tinker with constantly. Keeping track of what I already built, with which preset, and what I didn't built yet was a challenge- manually writing them down or adding them to groups is slow and error-prone. So I looked at the code.

- `Log_BS.txt` is not meant to be persistent, and while it could be parsed by an external script, it doesn't have all the information I wanted. 
- `BuildSelection.xml` is persistent, but it only stores decisions about zaps and preferences when there's mesh conflicts- it doesn't reflect what has been actually _built_.

So I created a new log file. At first I just wanted it to be a simple list with "outfit name, preset name, has edits yes/no", so I could play around with BS, and parse that log file when I'm done to create groups for each preset. But I got carried away, and ended up with something that might be useful for more people!

## What
A new `BuildLogbook.xml` file that should be a record of BodySlide outputs to the game's mod folders (or the designated Output Path):
- Whenever an outfit is built, be it on its own or as a batch build, an entry is created in the Logbook.
- If an outfit with the same mesh path as a previous one is built, its Logbook entry is _replaced_ with the newest info.
- If an outfit is deleted from BodySlide using the ALT key, its Logbook entry is also deleted.

*Note: This does not scan the game folders for previous BodySlide builds, or is aware of anything that changed outside BodySlide.*

Additionally, a text label in the bottom right of the BodySlide UI shows if the selected outfit has been built.
- Hovering over it shows information about the last build
- Right-clicking allows users to load the latest build back to BodySlide, or to remove the entry from the Logbook (but the mesh stays in the game/output folder)

### BuildLogbook.xml file
```xml
<BuildLogbook>
    <!-- A simple entry that lists a Mesh (identified by its path), which set it was built with, and which preset was used. -->
    <Mesh path="meshes\armor\studded\female\boots" set="DH 3BA Leather boots" preset="CBBE Curvy"/>

    <!--
    An entry that describes a Mesh, and stores information about any sliders that have been modified.
    Only Sliders that don't match the default values of the set and the preset are listed here.
    -->
    <Mesh path="meshes\armor\imperial\f\cuirasslight" set="DH 3BA Imperial light armor" preset="CBBE Curvy (Outfit)">
        <!-- Example modifications of the set's Zaps -->
        <SetSlider name="Stockings" size="big" value="100"/>
        <SetSlider name="Stockings" size="small" value="100"/>
        <!-- Example modifications of the preset's sliders-->
        <SetSlider name="BreastsPressed_v2" size="big" value="49"/>
    </Mesh>
</BuildLogbook>
```

## How

My C++ is a bit rusty and it's the first time I work with wxWidgets, but I tried to copy the way other features are implemented as much as possible.

### BodySlide.xrc
The box containing the `BuildSelection` choice was reduced from stretching through 3 columns to occupying 2.
In that freed up space, I added a `wxStaticText` Label that shows if the current outfit has been built or not.
I also added the right-click menu near the end of the file.

### BuildLogbook.h/cpp
This module contains the classes BuildLogbook and BuildLogbookFile. Heavily inspired from `BuildSelection.h/cpp`, they mostly create, populate and hold the data structure and XML file respectively, and convert it back and forth. They don't contain heavy logic.

### BodySlideApp.h/cpp
Where all the magic happens!

As this is a hefty module, I have tried to keep new functions close to their BuildSelection siblings to ease navigation.

When the app loads, `InitBuildLogbook()` reads `BuildLogbook.xml` and loads it to a `BuildLogbook` object that will persist during execution. \*
*Note: Check 'Known Issues' section below.*

Then, and whenever a new outfit or a new preset are selected, `UpdateLogbookLabel()` checks if there is a matching Logbook entry, and sets up the text, tooltip and right-click menu accordingly. The text color follows the same logic as BuildSelection: grey if there's no entry, yellow if there is an entry but it's not the current one, and blue if the entry matches the currently loaded set and preset.

When the "Build" button is clicked, `SaveSetToLogbook()` or `RemoveSetFromLogbook()` are called, depending on the ALT key.
`SaveSetToLogbook()` runs near the end of `BuildBodies()` if everything was built correctly. It creates a new `BuildLogbookEntry` and stores the mesh path, set name and preset we're building with. With `CalculateLogbookSliders()`, it checks the `sliderManager` sliders to find out if the preset was modified before building. This allows to save micro-adjustments (i.e. fixing nipples poking through cloth, outfits with squeeze sliders) without having to save a preset variant only for that outfit. This also saves the actual Zap values the outfit was built with (vs the last selected ones in BuildSelection)
After saving or removing an entry from the BuildLogbook, the XML file is updated.

*Note: I know there are similar slider calculations in the code, but I wanted to disturb existing functions as little as possible, so I chose to make a small one that can be plugged in with one line.*

To respect "Batch Build" parallelism, `CalculateLogbookSliders()` only runs once at the start (since the whole batch should be using the same Preset and slider values)\*\*. Then, `BuildLogbookEntries` (or OutputPath strings, if we're batch deleting) are created and stored in a separate vector inside `batchBuildMutex`. The main BuildLogbook and the XML file are only updated at the end of the batch build operation.
*Note: Check 'Known Issues' section below.*

If "Load the latest build" is selected in the label's right-click menu, `ActivateLogbookEntry()` is called. This selects and loads the last recorded Outfit and Preset (and also updates the outfit/preset/favorite buttons selection UI at the top of the screen). If the entry contains any slider data, it applies the changes to the affected sliders. The Preview and the Logbook label are refreshed when it finished loading everything.

## Known issues
As a draft, this feature is not perfect, complete, or 100% robust. Here is a list of things I am currently aware of. Some could be fixed, some will be fixed (even if just for my personal use), and some might be left as a skill issue.

- \*Speedy, not robust against external changes to the XML during executions
  -  I'm aware `BuildSelection` opens, loads and closes the file constantly. But I thought doing that only to check `hasEntry()` would be a waste, especially with a file that can grow very big. I'm careful with the file, but this should be re-evaluated if this were to be made public
- \*\*In Batch Builds, if the currently loaded outfit has a Zap, it gets applied to all entries regardless if they even have that zap
  - Well, if an entry has a slider that isn't found in the outfit/preset, it simply doesn't get loaded. But it's still an annoying bug I have to fix, plus it _can_ mess with entries if they so happen to have the same Zap name. I have to test how much calculating sliders for every outfit impacts performance.
- ~~Inconsistent behavior when loading Zaps that conflict with BuildSelection~~
  - Fixed in 8c8c268cbc66f47e220fb02d5d394715ecad51c3.
- As mentioned, it's not aware of any changes made outside BodySlide, or when this feature isn't active.
  - Very likely out of scope. We'd have to instruct the user to delete or back up their BuildLogbook.xml at their convenience.
- Outfit or preset renames don't update the Logbook, so those won't be detected as entries anymore.
  - Acceptable 'skill issue'. Easy enough for a mid-level user to open the .xml and "Find and replace" the affected items
- If a preset is re-saved with different slider values, the Logbook won't know that. Loading an entry will load the preset with its current values, not with the values it was actually built with.
  - Not sure if this is a good or a bad thing. Let's assume people will create a different preset if they want a new body shape.
  
## Possible improvements
The current state of this feature (minus the bugs) is enough for my personal use, but some things that could be added are:

- A toggle in the Settings / Config file / CLI argument to enable or disable this feature
- A checkbox next to the Logbook Label to automatically load the Logbook entry when a Set/outfit that has one is loaded
  - It would load the Preset and apply slider edits. Loading/reloading a preset shouldn't trigger it, though.
- When Batch building, an option to apply Logbook entries to any outfit with a matching one
  - BuildSelection would still take priority to decide which Set to build for each Mesh. Then we'd attempt to find a Logbook entry for that Set.
  - This would be useful to quickly re-apply a Logbook with lots of micro-adjustments. Could be useful when reinstalling mods, or if a modder wants to share their zap and squeeze refinements for a certain SliderPreset and Outfit pack combination.
- Adding translations and Automation support
  - I'm not familiar with those, so I'd only look into them if this feature is useful enough to be merged