### PR TITLE
BodySlide: Use default size for sliders

### DIFF
--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -6990,7 +6990,7 @@ bool SliderDisplay::Create(wxScrolledWindow* scrollWindow,
 		sliderLayout->Add(zapCheckLo, 0, wxALIGN_LEFT, 0);
 	}
 
-	sliderLo = new wxSlider(scrollWindow, wxID_ANY, 0, minValue, maxValue, wxDefaultPosition, wxSize(-1, scrollWindow->FromDIP(24)), wxSL_AUTOTICKS | wxSL_BOTTOM | wxSL_HORIZONTAL);
+	sliderLo = new wxSlider(scrollWindow, wxID_ANY, 0, minValue, maxValue, wxDefaultPosition, wxDefaultSize, wxSL_AUTOTICKS | wxSL_BOTTOM | wxSL_HORIZONTAL);
 	sliderLo->SetTickFreq(5);
 	sliderLo->SetName(nameStr + "|LO");
 	sliderLo->Show(!oneSize && !isZap);
@@ -7017,7 +7017,7 @@ bool SliderDisplay::Create(wxScrolledWindow* scrollWindow,
 		sliderLayout->Add(zapCheckHi, 0, wxALIGN_LEFT, 0);
 	}
 
-	sliderHi = new wxSlider(scrollWindow, wxID_ANY, 0, minValue, maxValue, wxDefaultPosition, wxSize(-1, scrollWindow->FromDIP(24)), wxSL_AUTOTICKS | wxSL_HORIZONTAL);
+	sliderHi = new wxSlider(scrollWindow, wxID_ANY, 0, minValue, maxValue, wxDefaultPosition, wxDefaultSize, wxSL_AUTOTICKS | wxSL_HORIZONTAL);
 	sliderHi->SetTickFreq(5);
 	sliderHi->SetName(nameStr + "|HI");
 	sliderHi->Show(!isZap);


### PR DESCRIPTION
Fixes #586 

Didn't test on Windows though

<img width="2220" height="2012" alt="изображение" src="https://github.com/user-attachments/assets/d018881e-7ed9-41fe-8384-fe46b5b99e67" />
