### PR TITLE
BodySlide: Use game's data path if there's no project files in appdir

### DIFF
--- a/BodySlide.vcxproj
+++ b/BodySlide.vcxproj
@@ -793,6 +793,7 @@
     <ClInclude Include="src\utils\ConfigurationManager.h" />
     <ClInclude Include="src\utils\Log.h" />
     <ClInclude Include="src\utils\PlatformUtil.h" />
+    <ClInclude Include="src\utils\ProjectUtil.h" />
     <ClInclude Include="src\utils\StackTrace.h" />
     <ClInclude Include="src\utils\StringStuff.h" />
   </ItemGroup>
@@ -867,6 +868,7 @@
     <ClCompile Include="src\utils\ConfigurationManager.cpp" />
     <ClCompile Include="src\utils\Log.cpp" />
     <ClCompile Include="src\utils\PlatformUtil.cpp" />
+    <ClCompile Include="src\utils\ProjectUtil.cpp" />
     <ClCompile Include="src\utils\StackTrace.cpp" />
     <ClCompile Include="src\utils\StringStuff.cpp" />
     <ClCompile Include="src\utils\WxBuildConfigCheck.cpp" />

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,7 @@ set(BSOS_COMMON_SOURCES
 	src/utils/ConfigurationManager.cpp
 	src/utils/Log.cpp
 	src/utils/PlatformUtil.cpp
+	src/utils/ProjectUtil.cpp
 	src/utils/StackTrace.cpp
 	src/utils/StringStuff.cpp
 	src/utils/WxBuildConfigCheck.cpp

--- a/OutfitStudio.vcxproj
+++ b/OutfitStudio.vcxproj
@@ -865,6 +865,7 @@
     <ClInclude Include="src\utils\ConfigDialogUtil.h" />
     <ClInclude Include="src\utils\Log.h" />
     <ClInclude Include="src\utils\PlatformUtil.h" />
+    <ClInclude Include="src\utils\ProjectUtil.h" />
     <ClInclude Include="src\utils\StackTrace.h" />
     <ClInclude Include="src\utils\StringStuff.h" />
   </ItemGroup>
@@ -960,6 +961,7 @@
     <ClCompile Include="src\utils\ConfigurationManager.cpp" />
     <ClCompile Include="src\utils\Log.cpp" />
     <ClCompile Include="src\utils\PlatformUtil.cpp" />
+    <ClCompile Include="src\utils\ProjectUtil.cpp" />
     <ClCompile Include="src\utils\StackTrace.cpp" />
     <ClCompile Include="src\utils\StringStuff.cpp" />
     <ClCompile Include="src\utils\WxBuildConfigCheck.cpp" />

--- a/src/program/AutomationDialog.cpp
+++ b/src/program/AutomationDialog.cpp
@@ -10,6 +10,7 @@ See the included LICENSE file
 #include "PartitionTypeChoices.h"
 
 #include "../files/MaskFile.h"
+#include "../utils/ProjectUtil.h"
 
 #include <NifFile.hpp>
 
@@ -1200,7 +1201,7 @@ void AutomationDialog::UpdateUIFromStep(const AutomationStep& step) {
 				if (!path.IsEmpty()) {
 					wxFileName fn(path);
 					if (fn.IsRelative()) {
-						std::string projPath = GetProjectPath();
+						std::string projPath = ProjectUtil::GetProjectPath();
 						fn.MakeAbsolute(wxString::FromUTF8(projPath));
 					}
 					fp->SetPath(fn.GetFullPath());
@@ -1260,7 +1261,7 @@ void AutomationDialog::UpdateUIFromStep(const AutomationStep& step) {
 				if (!path.IsEmpty()) {
 					wxFileName fn(path);
 					if (fn.IsRelative()) {
-						std::string projPath = GetProjectPath();
+						std::string projPath = ProjectUtil::GetProjectPath();
 						fn.MakeAbsolute(wxString::FromUTF8(projPath));
 					}
 					fp->SetPath(fn.GetFullPath());
@@ -1575,7 +1576,7 @@ void AutomationDialog::UpdateUIFromStep(const AutomationStep& step) {
 				if (!path.IsEmpty()) {
 					wxFileName fn(path);
 					if (fn.IsRelative()) {
-						std::string projPath = GetProjectPath();
+						std::string projPath = ProjectUtil::GetProjectPath();
 						fn.MakeAbsolute(wxString::FromUTF8(projPath));
 					}
 					fp->SetPath(fn.GetFullPath());
@@ -2049,7 +2050,7 @@ std::vector<NiShape*> AutomationDialog::ResolveTargetShapes(const AutomationStep
 }
 
 std::string AutomationDialog::GetAutomationsFolder() {
-	return GetProjectPath() + "/Automations";
+	return ProjectUtil::GetProjectPath() + "/Automations";
 }
 
 void AutomationDialog::CollectScripts(const wxString& baseFolder, const wxString& currentFolder, std::vector<std::pair<wxString, wxString>>& entries) {
@@ -2343,7 +2344,7 @@ int AutomationDialog::RunHeadless(const wxString& scriptName, const wxArrayStrin
 		}
 		else {
 			// Resolve set project names against <ProjectPath>/SliderSets/*.{osp,xml}.
-			std::string projPath = GetProjectPath();
+			std::string projPath = ProjectUtil::GetProjectPath();
 			wxArrayString files;
 			wxDir::GetAllFiles(wxString::FromUTF8(projPath) + "/SliderSets", &files, "*.osp");
 			wxDir::GetAllFiles(wxString::FromUTF8(projPath) + "/SliderSets", &files, "*.xml");
@@ -3006,7 +3007,7 @@ void AutomationDialog::OnRefTemplateChanged(wxCommandEvent& WXUNUSED(event)) {
 		if (!source.IsEmpty()) {
 			wxFileName fn(source);
 			if (fn.IsRelative()) {
-				std::string projPath = GetProjectPath();
+				std::string projPath = ProjectUtil::GetProjectPath();
 				fn.MakeAbsolute(wxString::FromUTF8(projPath));
 			}
 			fp->SetPath(fn.GetFullPath());
@@ -3375,7 +3376,7 @@ wxString AutomationDialog::MakeRelativeToProject(const wxString& absolutePath) c
 	if (fn.IsRelative())
 		return absolutePath; // Already relative
 
-	if (fn.MakeRelativeTo(wxString::FromUTF8(GetProjectPath())))
+	if (fn.MakeRelativeTo(wxString::FromUTF8(ProjectUtil::GetProjectPath())))
 		return fn.GetFullPath();
 
 	return absolutePath; // Couldn't make relative, return as-is
@@ -3389,7 +3390,7 @@ wxString AutomationDialog::MakeAbsoluteToProject(const wxString& path) const {
 	if (!fn.IsRelative())
 		return path;
 
-	fn.MakeAbsolute(wxString::FromUTF8(GetProjectPath()));
+	fn.MakeAbsolute(wxString::FromUTF8(ProjectUtil::GetProjectPath()));
 	return fn.GetFullPath();
 }
 
@@ -3727,7 +3728,7 @@ std::vector<std::string> AutomationDialog::GatherBatchFiles() {
 std::vector<std::pair<std::string, std::string>> AutomationDialog::GatherBatchSliderSets() {
 	std::vector<std::pair<std::string, std::string>> result; // (fileName, setName) pairs
 
-	std::string projPath = GetProjectPath();
+	std::string projPath = ProjectUtil::GetProjectPath();
 	wxArrayString files;
 	wxDir::GetAllFiles(wxString::FromUTF8(projPath) + "/SliderSets", &files, "*.osp");
 	wxDir::GetAllFiles(wxString::FromUTF8(projPath) + "/SliderSets", &files, "*.xml");

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -645,7 +645,22 @@ std::string BodySlideApp::GetOutputDataPath() const {
 
 std::string BodySlideApp::GetProjectPath() const {
 	std::string res = Config["ProjectPath"];
-	return res.empty() ? Config["AppDir"] : res;
+	std::string path1 = Config["GameDataPath"] + PathSepStr + "CalienteTools" + PathSepStr + "BodySlide";
+	std::string path2 = Config["GameDataPath"] + PathSepStr + "Tools" + PathSepStr + "BodySlide";
+	if (res.empty()) {
+		if (wxDir::Exists(Config["AppDir"] + PathSepStr + "SliderSets")) {
+			return Config["AppDir"];
+		}
+		else if (wxDir::Exists(path1)) {
+			return path1;
+		}
+		else {
+			return path2;
+		}
+	}
+	else {
+		return res;
+	}
 }
 
 bool BodySlideApp::PresetExists(const std::string& name) {

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "../utils/ParallelFor.h"
 #include "../utils/StackTrace.h"
 #include "../utils/StringStuff.h"
+#include "../utils/ProjectUtil.h"
 
 #include <algorithm>
 #include <atomic>
@@ -595,7 +596,7 @@ int BodySlideApp::CreateSetSliders(const std::string& outfit) {
 		activeSet.Clear();
 		sliderManager.ClearSliders();
 		if (!sliderDoc.GetSet(outfit, activeSet)) {
-			activeSet.SetBaseDataPath(GetProjectPath() + PathSepStr + "ShapeData");
+			activeSet.SetBaseDataPath(ProjectUtil::GetProjectPath() + PathSepStr + "ShapeData");
 			sliderManager.AddSlidersInSet(activeSet);
 			DisplayActiveSet();
 		}
@@ -628,7 +629,7 @@ int BodySlideApp::AddProjectSliders(const std::string& projectFile, const std::s
 	if (sliderDoc.GetSet(setName, pp->sliderSet))
 		return 3;
 
-	pp->sliderSet.SetBaseDataPath(GetProjectPath() + PathSepStr + "ShapeData");
+	pp->sliderSet.SetBaseDataPath(ProjectUtil::GetProjectPath() + PathSepStr + "ShapeData");
 	pp->setName = setName;
 
 	// Add sliders from this set (additive)
@@ -643,25 +644,6 @@ std::string BodySlideApp::GetOutputDataPath() const {
 	return res.empty() ? Config["GameDataPath"] : res;
 }
 
-std::string BodySlideApp::GetProjectPath() const {
-	std::string res = Config["ProjectPath"];
-	std::string path1 = Config["GameDataPath"] + PathSepStr + "CalienteTools" + PathSepStr + "BodySlide";
-	std::string path2 = Config["GameDataPath"] + PathSepStr + "Tools" + PathSepStr + "BodySlide";
-	if (res.empty()) {
-		if (wxDir::Exists(Config["AppDir"] + PathSepStr + "SliderSets")) {
-			return Config["AppDir"];
-		}
-		else if (wxDir::Exists(path1)) {
-			return path1;
-		}
-		else {
-			return path2;
-		}
-	}
-	else {
-		return res;
-	}
-}
 
 bool BodySlideApp::PresetExists(const std::string& name) {
 	if (name.empty())
@@ -821,8 +803,8 @@ int BodySlideApp::LoadSliderSets() {
 	outFileCount.clear();
 
 	wxArrayString files;
-	wxDir::GetAllFiles(wxString::FromUTF8(GetProjectPath()) + "/SliderSets", &files, "*.osp");
-	wxDir::GetAllFiles(wxString::FromUTF8(GetProjectPath()) + "/SliderSets", &files, "*.xml");
+	wxDir::GetAllFiles(wxString::FromUTF8(ProjectUtil::GetProjectPath()) + "/SliderSets", &files, "*.osp");
+	wxDir::GetAllFiles(wxString::FromUTF8(ProjectUtil::GetProjectPath()) + "/SliderSets", &files, "*.xml");
 
 	bool filterHasZaps = false;
 
@@ -2286,7 +2268,7 @@ bool BodySlideApp::LoadExternalReference(const SliderSet& sliderSet) {
 	// Resolve project file path relative to project directory
 	wxFileName refProjectFileName(wxString::FromUTF8(projectFile));
 	if (refProjectFileName.IsRelative())
-		refProjectFileName.MakeAbsolute(wxString::FromUTF8(GetProjectPath()));
+		refProjectFileName.MakeAbsolute(wxString::FromUTF8(ProjectUtil::GetProjectPath()));
 
 	std::string projectFilePath = refProjectFileName.GetFullPath().ToUTF8().data();
 
@@ -2303,7 +2285,7 @@ bool BodySlideApp::LoadExternalReference(const SliderSet& sliderSet) {
 		return false;
 	}
 
-	referenceSliderSet.SetBaseDataPath(GetProjectPath() + PathSepStr + "ShapeData");
+	referenceSliderSet.SetBaseDataPath(ProjectUtil::GetProjectPath() + PathSepStr + "ShapeData");
 
 	// Load diff data for the reference shape
 	referenceDiffData.Clear();
@@ -3102,7 +3084,7 @@ void BodySlideApp::InitLanguage() {
 void BodySlideApp::LoadAllCategories() {
 	wxLogMessage("Loading all slider categories...");
 	cCollection.Clear();
-	cCollection.LoadCategories(GetProjectPath() + "/SliderCategories");
+	cCollection.LoadCategories(ProjectUtil::GetProjectPath() + "/SliderCategories");
 }
 
 void BodySlideApp::SetPresetGroups(const std::string& setName) {
@@ -3132,7 +3114,7 @@ void BodySlideApp::SetPresetGroups(const std::string& setName) {
 
 void BodySlideApp::LoadAllGroups() {
 	wxLogMessage("Loading all slider groups...");
-	gCollection.LoadGroups(GetProjectPath() + "/SliderGroups");
+	gCollection.LoadGroups(ProjectUtil::GetProjectPath() + "/SliderGroups");
 
 	ungroupedOutfits.clear();
 	for (auto& o : outfitNameSource) {
@@ -3366,7 +3348,7 @@ void BodySlideApp::LoadPresets(const std::string& sliderSet) {
 				groups_and_aliases.push_back(ag.first);
 	}
 
-	sliderManager.LoadPresets(GetProjectPath() + "/SliderPresets", outfit, groups_and_aliases, groups_and_aliases.empty());
+	sliderManager.LoadPresets(ProjectUtil::GetProjectPath() + "/SliderPresets", outfit, groups_and_aliases, groups_and_aliases.empty());
 }
 
 void BodySlideApp::GetPresetNames(std::vector<std::string>& outNames) {
@@ -4241,7 +4223,7 @@ int BodySlideApp::BuildListBodies(
 			return;
 		}
 
-		currentSet.SetBaseDataPath(GetProjectPath() + PathSepStr + "ShapeData");
+		currentSet.SetBaseDataPath(ProjectUtil::GetProjectPath() + PathSepStr + "ShapeData");
 
 		// ALT key
 		if (clean && custPath.empty()) {
@@ -4727,7 +4709,7 @@ void BodySlideApp::GroupBuild(const std::vector<std::string>& groupNames) {
 	}
 
 	std::vector<std::string> groups;
-	sliderManager.LoadPresets(GetProjectPath() + "/SliderPresets", "", groups, true);
+	sliderManager.LoadPresets(ProjectUtil::GetProjectPath() + "/SliderPresets", "", groups, true);
 
 	// Apply saved build selections for CLI group builds before entering batch build conflict handling.
 	BuildSelectionFile buildSelFile;
@@ -5848,7 +5830,7 @@ void BodySlideFrame::OnBrowseOutfitFolder(wxCommandEvent& WXUNUSED(event)) {
 
 	wxFileName folderPath(wxString::FromUTF8(activeSet.GetInputFileName()));
 	if (folderPath.IsRelative())
-		folderPath.MakeAbsolute(wxString::FromUTF8(app->GetProjectPath()));
+		folderPath.MakeAbsolute(wxString::FromUTF8(ProjectUtil::GetProjectPath()));
 
 	folderPath.SetFullName("");
 
@@ -5862,7 +5844,7 @@ void BodySlideFrame::OnSaveGroups(wxCommandEvent& WXUNUSED(event)) {
 
 	wxFileDialog saveGroupDialog(this,
 								 _("Choose or create group file"),
-								 wxString::FromUTF8(app->GetProjectPath()) + "/SliderGroups",
+								 wxString::FromUTF8(ProjectUtil::GetProjectPath()) + "/SliderGroups",
 								 wxEmptyString,
 								 "Group Files (*.xml)|*.xml",
 								 wxFD_SAVE);

--- a/src/program/BodySlideApp.h
+++ b/src/program/BodySlideApp.h
@@ -174,7 +174,6 @@ public:
 	wxString GetGameDataPath(TargetGame targ);
 
 	std::string GetOutputDataPath() const;
-	std::string GetProjectPath() const;
 	SliderSet& GetActiveSet() { return projects[0]->sliderSet; }
 	DiffDataSets& GetActiveDataSets() { return projects[0]->dataSets; }
 	bool HasActiveProject() const { return !projects.empty(); }

--- a/src/program/ConvertBodyReferenceDialog.cpp
+++ b/src/program/ConvertBodyReferenceDialog.cpp
@@ -9,6 +9,7 @@ See the included LICENSE file
 
 #include "../utils/ConfigDialogUtil.h"
 #include "../utils/ConfigurationManager.h"
+#include "../utils/ProjectUtil.h"
 
 #include <regex>
 
@@ -329,7 +330,7 @@ int ConvertBodyReferenceDialog::LoadReferenceTemplate(const wxString& refTemplat
 	auto tmpl = find_if(refTemplates.begin(), refTemplates.end(), [&tmplName](const RefTemplate& rt) { return rt.GetName() == tmplName; });
 	if (tmpl != refTemplates.end()) {
 		if (wxFileName(wxString::FromUTF8(tmpl->GetSource())).IsRelative())
-			error = project->LoadReferenceTemplate(GetProjectPath() + PathSepStr + tmpl->GetSource(),
+			error = project->LoadReferenceTemplate(ProjectUtil::GetProjectPath() + PathSepStr + tmpl->GetSource(),
 												   tmpl->GetSetName(),
 												   tmpl->GetShape(),
 												   tmpl->GetLoadAll(),

--- a/src/program/GroupManager.cpp
+++ b/src/program/GroupManager.cpp
@@ -5,6 +5,7 @@ See the included LICENSE file
 
 #include "GroupManager.h"
 #include "../utils/ConfigurationManager.h"
+#include "../utils/ProjectUtil.h"
 
 #include <wx/srchctrl.h>
 
@@ -38,7 +39,7 @@ GroupManager::GroupManager(wxWindow* parent, std::vector<std::string> outfits)
 	SetDoubleBuffered(true);
 	CenterOnParent();
 
-	XRCCTRL(*this, "fpGroupXML", wxFilePickerCtrl)->SetInitialDirectory(wxString::FromUTF8(GetProjectPath()) + "/SliderGroups");
+	XRCCTRL(*this, "fpGroupXML", wxFilePickerCtrl)->SetInitialDirectory(wxString::FromUTF8(ProjectUtil::GetProjectPath()) + "/SliderGroups");
 	listGroups = XRCCTRL(*this, "listGroups", wxListBox);
 	groupName = XRCCTRL(*this, "groupName", wxTextCtrl);
 	btAddGroup = XRCCTRL(*this, "btAddGroup", wxButton);
@@ -62,11 +63,6 @@ GroupManager::GroupManager(wxWindow* parent, std::vector<std::string> outfits)
 
 GroupManager::~GroupManager() {
 	wxXmlResource::Get()->Unload(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/GroupManager.xrc");
-}
-
-std::string GroupManager::GetProjectPath() const {
-	std::string res = Config["ProjectPath"];
-	return res.empty() ? Config["AppDir"] : res;
 }
 
 void GroupManager::RefreshUI(const bool clearGroups) {
@@ -107,7 +103,7 @@ void GroupManager::RefreshUI(const bool clearGroups) {
 bool GroupManager::ChooseFile() {
 	wxFileDialog file(this,
 					  "Saving group XML file...",
-					  wxString::FromUTF8(GetProjectPath()) + "/SliderGroups",
+					  wxString::FromUTF8(ProjectUtil::GetProjectPath()) + "/SliderGroups",
 					  fileName,
 					  "Group Files (*.xml)|*.xml",
 					  wxFD_SAVE | wxFD_OVERWRITE_PROMPT);

--- a/src/program/GroupManager.h
+++ b/src/program/GroupManager.h
@@ -37,8 +37,6 @@ private:
 	std::map<std::string, std::vector<std::string>> groupMembers;
 	std::vector<std::string> allOutfits;
 
-	std::string GetProjectPath() const;
-
 	void RefreshUI(const bool = false);
 	bool ChooseFile();
 	void SaveGroup();

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -17,6 +17,7 @@ See the included LICENSE file
 #include "ObjImportDialog.h"
 #include "../utils/PlatformUtil.h"
 #include "../utils/StringStuff.h"
+#include "../utils/ProjectUtil.h"
 #include "NifUtil.hpp"
 
 #include "FSEngine/FSEngine.h"
@@ -362,7 +363,7 @@ std::string OutfitProject::Save(const wxFileName& sliderSetFile,
 	}
 
 	if (ssFileName.IsRelative())
-		ssFileName.MakeAbsolute(wxString::FromUTF8(GetProjectPath()));
+		ssFileName.MakeAbsolute(wxString::FromUTF8(ProjectUtil::GetProjectPath()));
 
 	mFileName = ssFileName.GetFullPath();
 	mOutfitName = wxString::FromUTF8(outfit);
@@ -380,7 +381,7 @@ std::string OutfitProject::Save(const wxFileName& sliderSetFile,
 
 	auto shapes = workNif.GetShapes();
 
-	wxString folder(wxString::Format("%s/%s/%s", wxString::FromUTF8(GetProjectPath()), "ShapeData", strDataDir));
+	wxString folder(wxString::Format("%s/%s/%s", wxString::FromUTF8(ProjectUtil::GetProjectPath()), "ShapeData", strDataDir));
 	wxFileName::Mkdir(folder, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
 
 	int prog = 5;
@@ -501,7 +502,7 @@ std::string OutfitProject::Save(const wxFileName& sliderSetFile,
 		}
 	}
 
-	std::string saveDataPath = GetProjectPath() + PathSepStr + "ShapeData" + PathSepStr + mDataDir.ToUTF8().data();
+	std::string saveDataPath = ProjectUtil::GetProjectPath() + PathSepStr + "ShapeData" + PathSepStr + mDataDir.ToUTF8().data();
 	SaveSliderData(saveDataPath + PathSepStr + osdFileName, copyRef);
 
 	prog = 60;
@@ -3090,7 +3091,7 @@ int OutfitProject::LoadReference(const std::string& fileName, const std::string&
 		return 1;
 	}
 
-	refSet.SetBaseDataPath(GetProjectPath() + PathSepStr + "ShapeData");
+	refSet.SetBaseDataPath(ProjectUtil::GetProjectPath() + PathSepStr + "ShapeData");
 	std::string refFile = refSet.GetInputFileName();
 
 	std::fstream file;
@@ -3138,7 +3139,7 @@ int OutfitProject::LoadReference(const std::string& fileName, const std::string&
 
 	ResolveTargetConflictsForIncomingShapes({{shape, refSet.ShapeToTarget(shape)}});
 	sset.GetSet(setName, activeSet, appendNewSliders);
-	activeSet.SetBaseDataPath(GetProjectPath() + PathSepStr + "ShapeData");
+	activeSet.SetBaseDataPath(ProjectUtil::GetProjectPath() + PathSepStr + "ShapeData");
 
 	std::vector<std::string> deletedShapes;
 
@@ -3199,9 +3200,9 @@ int OutfitProject::LoadReference(const std::string& fileName, const std::string&
 	{
 		wxFileName refFileName(wxString::FromUTF8(fileName));
 		if (refFileName.IsRelative())
-			refFileName.MakeAbsolute(wxString::FromUTF8(GetProjectPath()));
+			refFileName.MakeAbsolute(wxString::FromUTF8(ProjectUtil::GetProjectPath()));
 
-		if (refFileName.MakeRelativeTo(wxString::FromUTF8(GetProjectPath())))
+		if (refFileName.MakeRelativeTo(wxString::FromUTF8(ProjectUtil::GetProjectPath())))
 			mRefProjectFile = refFileName.GetFullPath().ToUTF8().data();
 		else
 			mRefProjectFile = fileName;
@@ -3237,7 +3238,7 @@ int OutfitProject::LoadFromSliderSet(const std::string& fileName, const std::str
 		return 3;
 	}
 
-	activeSet.SetBaseDataPath(GetProjectPath() + PathSepStr + "ShapeData");
+	activeSet.SetBaseDataPath(ProjectUtil::GetProjectPath() + PathSepStr + "ShapeData");
 
 	std::string inputNif = activeSet.GetInputFileName();
 
@@ -3353,7 +3354,7 @@ int OutfitProject::AddFromSliderSet(const std::string& fileName, const std::stri
 	if (!addSet.GetReferenceShapeName().empty())
 		mRefShapeName = addSet.GetReferenceShapeName();
 
-	addSet.SetBaseDataPath(GetProjectPath() + PathSepStr + "ShapeData");
+	addSet.SetBaseDataPath(ProjectUtil::GetProjectPath() + PathSepStr + "ShapeData");
 	std::string inputNif = addSet.GetInputFileName();
 
 	std::map<std::string, std::string> renamedShapes;
@@ -3430,9 +3431,9 @@ int OutfitProject::AddFromSliderSet(const std::string& fileName, const std::stri
 	if (baseShape && !hadBaseShape && mRefProjectFile.empty() && mRefProjectName.empty() && mRefShapeName.empty()) {
 		wxFileName refFileName(wxString::FromUTF8(fileName));
 		if (refFileName.IsRelative())
-			refFileName.MakeAbsolute(wxString::FromUTF8(GetProjectPath()));
+			refFileName.MakeAbsolute(wxString::FromUTF8(ProjectUtil::GetProjectPath()));
 
-		if (refFileName.MakeRelativeTo(wxString::FromUTF8(GetProjectPath())))
+		if (refFileName.MakeRelativeTo(wxString::FromUTF8(ProjectUtil::GetProjectPath())))
 			mRefProjectFile = refFileName.GetFullPath().ToUTF8().data();
 		else
 			mRefProjectFile = fileName;

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -33,6 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "SliderDataImportDialog.h"
 #include "AutomationDialog.h"
 #include "../components/ClippingFixer.h"
+#include "../utils/ProjectUtil.h"
 #include "../utils/StackTrace.h"
 #include "../utils/StringStuff.h"
 
@@ -394,10 +395,7 @@ const std::array<wxLanguage, 37> SupportedLangs = {wxLANGUAGE_ENGLISH,	  wxLANGU
 												   wxLANGUAGE_ALBANIAN,	  wxLANGUAGE_SWEDISH,		   wxLANGUAGE_TAMIL,   wxLANGUAGE_TURKISH,	  wxLANGUAGE_UKRAINIAN,
 												   wxLANGUAGE_VIETNAMESE, wxLANGUAGE_CHINESE};
 
-std::string GetProjectPath() {
-	std::string res = Config["ProjectPath"];
-	return res.empty() ? Config["AppDir"] : res;
-}
+
 
 // Load files into the current project
 void OutfitStudioFrame::LoadFiles(const wxArrayString& files, const wxString& projectName) {
@@ -1788,8 +1786,8 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 		});
 
 		wxArrayString files;
-		wxDir::GetAllFiles(wxString::FromUTF8(GetProjectPath()) + "/SliderSets", &files, "*.osp");
-		wxDir::GetAllFiles(wxString::FromUTF8(GetProjectPath()) + "/SliderSets", &files, "*.xml");
+		wxDir::GetAllFiles(wxString::FromUTF8(ProjectUtil::GetProjectPath()) + "/SliderSets", &files, "*.osp");
+		wxDir::GetAllFiles(wxString::FromUTF8(ProjectUtil::GetProjectPath()) + "/SliderSets", &files, "*.xml");
 
 		for (auto& file : files) {
 			std::string fileName{file.ToUTF8()};
@@ -1833,7 +1831,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 		});
 
 		auto groupFile = XRCCTRL(*packProjects, "groupFile", wxFilePickerCtrl);
-		groupFile->SetInitialDirectory(wxString::FromUTF8(GetProjectPath()) + "/SliderGroups");
+		groupFile->SetInitialDirectory(wxString::FromUTF8(ProjectUtil::GetProjectPath()) + "/SliderGroups");
 
 		auto mergedFileName = XRCCTRL(*packProjects, "mergedFileName", wxTextCtrl);
 		auto packFolder = XRCCTRL(*packProjects, "packFolder", wxButton);
@@ -1867,7 +1865,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 				projectFile.UpdateSet(set);
 
 				// Add input file to folder
-				wxString inputFilePath = wxString::FromUTF8(GetProjectPath() + sep + "ShapeData" + sep + set.GetInputFileName());
+				wxString inputFilePath = wxString::FromUTF8(ProjectUtil::GetProjectPath() + sep + "ShapeData" + sep + set.GetInputFileName());
 				wxFileInputStream inputFileStream(inputFilePath);
 				if (!inputFileStream.IsOk()) {
 					wxLogError("Failed to open input file '%s'!", inputFilePath);
@@ -1914,7 +1912,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 
 				// Add data files to folder
 				for (auto& df : dataFiles) {
-					wxString dataFilePath = wxString::FromUTF8(GetProjectPath() + sep + "ShapeData" + sep + df);
+					wxString dataFilePath = wxString::FromUTF8(ProjectUtil::GetProjectPath() + sep + "ShapeData" + sep + df);
 					wxFileInputStream dataFileStream(dataFilePath);
 					if (!dataFileStream.IsOk()) {
 						wxLogError("Failed to open input file '%s'!", dataFilePath);
@@ -2017,7 +2015,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 				projectFile.UpdateSet(set);
 
 				// Add input file to archive
-				wxString inputFilePath = wxString::FromUTF8(GetProjectPath() + sep + "ShapeData" + sep + set.GetInputFileName());
+				wxString inputFilePath = wxString::FromUTF8(ProjectUtil::GetProjectPath() + sep + "ShapeData" + sep + set.GetInputFileName());
 				wxFileInputStream inputFileStream(inputFilePath);
 				if (!inputFileStream.IsOk()) {
 					wxLogError("Failed to open input file '%s'!", inputFilePath);
@@ -2068,7 +2066,7 @@ void OutfitStudioFrame::OnPackProjects(wxCommandEvent& WXUNUSED(event)) {
 
 				// Add data files to archive
 				for (auto& df : dataFiles) {
-					wxString dataFilePath = wxString::FromUTF8(GetProjectPath() + sep + "ShapeData" + sep + df);
+					wxString dataFilePath = wxString::FromUTF8(ProjectUtil::GetProjectPath() + sep + "ShapeData" + sep + df);
 					wxFileInputStream dataFileStream(dataFilePath);
 					if (!dataFileStream.IsOk()) {
 						wxLogError("Failed to open data file '%s'!", dataFilePath);
@@ -2581,7 +2579,7 @@ bool OutfitStudioFrame::SaveProjectAs() {
 		wxString sssName = wxString::FromUTF8(outName);
 
 		XRCCTRL(dlg, "sssName", wxTextCtrl)->SetValue(sssName);
-		XRCCTRL(dlg, "sssSliderSetFile", wxFilePickerCtrl)->SetInitialDirectory(wxString::FromUTF8(GetProjectPath()) + "/SliderSets");
+		XRCCTRL(dlg, "sssSliderSetFile", wxFilePickerCtrl)->SetInitialDirectory(wxString::FromUTF8(ProjectUtil::GetProjectPath()) + "/SliderSets");
 
 		if (!project->mFileName.empty())
 			XRCCTRL(dlg, "sssSliderSetFile", wxFilePickerCtrl)->SetPath(project->mFileName);
@@ -2691,7 +2689,7 @@ bool OutfitStudioFrame::SaveProjectAs() {
 
 	wxFileName relativeFolder(strDataDir);
 	if (!relativeFolder.IsRelative()) {
-		wxString dataFolder(wxString::Format("%s/%s", wxString::FromUTF8(GetProjectPath()), "ShapeData"));
+		wxString dataFolder(wxString::Format("%s/%s", wxString::FromUTF8(ProjectUtil::GetProjectPath()), "ShapeData"));
 		relativeFolder.MakeRelativeTo(dataFolder);
 		strDataDir = relativeFolder.GetFullPath();
 	}
@@ -4189,7 +4187,7 @@ void OutfitStudioFrame::OnNewProject(wxCommandEvent& WXUNUSED(event)) {
 		auto tmpl = find_if(refTemplates.begin(), refTemplates.end(), [&tmplName](const RefTemplate& rt) { return rt.GetName() == tmplName; });
 		if (tmpl != refTemplates.end()) {
 			if (wxFileName(wxString::FromUTF8(tmpl->GetSource())).IsRelative())
-				error = project->LoadReferenceTemplate(GetProjectPath() + PathSepStr + tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), tmpl->GetLoadAll());
+				error = project->LoadReferenceTemplate(ProjectUtil::GetProjectPath() + PathSepStr + tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), tmpl->GetLoadAll());
 			else
 				error = project->LoadReferenceTemplate(tmpl->GetSource(), tmpl->GetSetName(), tmpl->GetShape(), tmpl->GetLoadAll());
 		}
@@ -4267,7 +4265,7 @@ void OutfitStudioFrame::OnNewProject(wxCommandEvent& WXUNUSED(event)) {
 void OutfitStudioFrame::OnLoadProject(wxCommandEvent& WXUNUSED(event)) {
 	wxFileDialog loadProjectDialog(this,
 								   _("Select a slider set to load"),
-								   wxString::FromUTF8(GetProjectPath()) + "/SliderSets",
+								   wxString::FromUTF8(ProjectUtil::GetProjectPath()) + "/SliderSets",
 								   wxEmptyString,
 								   "Slider Set Files (*.osp;*.xml)|*.osp;*.xml",
 								   wxFD_FILE_MUST_EXIST);
@@ -4284,7 +4282,7 @@ void OutfitStudioFrame::OnLoadProject(wxCommandEvent& WXUNUSED(event)) {
 void OutfitStudioFrame::OnAddProject(wxCommandEvent& WXUNUSED(event)) {
 	wxFileDialog addProjectDialog(this,
 								  _("Select a slider set to add"),
-								  wxString::FromUTF8(GetProjectPath()) + "/SliderSets",
+								  wxString::FromUTF8(ProjectUtil::GetProjectPath()) + "/SliderSets",
 								  wxEmptyString,
 								  "Slider Set Files (*.osp;*.xml)|*.osp;*.xml",
 								  wxFD_FILE_MUST_EXIST);
@@ -4345,7 +4343,7 @@ void OutfitStudioFrame::OnLoadReference(wxCommandEvent& WXUNUSED(event)) {
 		auto tmpl = find_if(refTemplates.begin(), refTemplates.end(), [&tmplName](const RefTemplate& rt) { return rt.GetName() == tmplName; });
 		if (tmpl != refTemplates.end()) {
 			if (wxFileName(wxString::FromUTF8(tmpl->GetSource())).IsRelative())
-				error = project->LoadReferenceTemplate(GetProjectPath() + PathSepStr + tmpl->GetSource(),
+				error = project->LoadReferenceTemplate(ProjectUtil::GetProjectPath() + PathSepStr + tmpl->GetSource(),
 													   tmpl->GetSetName(),
 													   tmpl->GetShape(),
 													   tmpl->GetLoadAll(),
@@ -4551,14 +4549,14 @@ void OutfitStudioFrame::ResetProject() {
 void OutfitStudioFrame::UpdateReferenceTemplates() {
 	refTemplates.clear();
 
-	std::string fileName = GetProjectPath() + "/RefTemplates.xml";
+	std::string fileName = ProjectUtil::GetProjectPath() + "/RefTemplates.xml";
 	if (wxFileName::IsFileReadable(fileName)) {
 		RefTemplateFile refTemplateFile(fileName);
 		refTemplateFile.GetAll(refTemplates);
 	}
 
 	RefTemplateCollection refTemplateCol;
-	refTemplateCol.Load(GetProjectPath() + "/RefTemplates");
+	refTemplateCol.Load(ProjectUtil::GetProjectPath() + "/RefTemplates");
 	refTemplateCol.GetAll(refTemplates);
 }
 
@@ -4820,7 +4818,7 @@ void OutfitStudioFrame::UpdateAnimationGUI() {
 	auto cPoseName = (wxComboBox*)FindWindowByName("cPoseName");
 	cPoseName->Clear();
 
-	std::string poseDataPath = GetProjectPath() + "/PoseData";
+	std::string poseDataPath = ProjectUtil::GetProjectPath() + "/PoseData";
 	poseDataCollection.LoadData(poseDataPath);
 
 	// Additionally load community-supplied ScreenArcherMenu/SAF poses if the
@@ -8609,7 +8607,7 @@ void OutfitStudioFrame::OnLoadPreset(wxCommandEvent& WXUNUSED(event)) {
 
 	CloseBrushSettings();
 
-	presets.LoadPresets(GetProjectPath() + "/SliderPresets", choice, names, true);
+	presets.LoadPresets(ProjectUtil::GetProjectPath() + "/SliderPresets", choice, names, true);
 	presets.GetPresetNames(names);
 
 	if (wxXmlResource::Get()->LoadDialog(&dlg, this, "dlgChoosePreset")) {
@@ -8678,7 +8676,7 @@ void OutfitStudioFrame::OnSavePreset(wxCommandEvent& WXUNUSED(event)) {
 	CloseBrushSettings();
 
 	SliderSetGroupCollection groupCollection;
-	groupCollection.LoadGroups(GetProjectPath() + "/SliderGroups");
+	groupCollection.LoadGroups(ProjectUtil::GetProjectPath() + "/SliderGroups");
 
 	std::set<std::string> allGroups;
 	groupCollection.GetAllGroups(allGroups);
@@ -13531,7 +13529,7 @@ void OutfitStudioFrame::OnSavePose(wxCommandEvent& WXUNUSED(event)) {
 		cPoseName->SetSelection(poseSel);
 	}
 
-	wxString dirName = wxString::FromUTF8(GetProjectPath()) + "/PoseData";
+	wxString dirName = wxString::FromUTF8(ProjectUtil::GetProjectPath()) + "/PoseData";
 	wxFileName::Mkdir(dirName, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
 
 	wxString fileName = dirName + "/" + wxString::FromUTF8(poseData->name) + ".xml";
@@ -13563,7 +13561,7 @@ void OutfitStudioFrame::OnDeletePose(wxCommandEvent& WXUNUSED(event)) {
 		if (result != wxYES)
 			return;
 
-		wxString fileName = wxString::FromUTF8(GetProjectPath()) + "/PoseData/" + wxString::FromUTF8(poseData->name) + ".xml";
+		wxString fileName = wxString::FromUTF8(ProjectUtil::GetProjectPath()) + "/PoseData/" + wxString::FromUTF8(poseData->name) + ".xml";
 		wxRemoveFile(fileName);
 
 		cPoseName->Delete(poseSel);

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -874,8 +874,6 @@ static const wxCmdLineEntryDesc g_cmdLineDesc[] = {{wxCMD_LINE_OPTION, "proj", "
 												   {wxCMD_LINE_PARAM, nullptr, nullptr, "Files", wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL | wxCMD_LINE_PARAM_MULTIPLE},
 												   wxCMD_LINE_DESC_END};
 
-std::string GetProjectPath();
-
 class OutfitStudio : public wxApp {
 public:
 	virtual ~OutfitStudio();

--- a/src/program/PresetSaveDialog.cpp
+++ b/src/program/PresetSaveDialog.cpp
@@ -5,6 +5,7 @@ See the included LICENSE file
 
 #include "PresetSaveDialog.h"
 #include "../utils/ConfigurationManager.h"
+#include "../utils/ProjectUtil.h"
 
 #include <regex>
 
@@ -43,11 +44,6 @@ PresetSaveDialog::PresetSaveDialog(wxWindow* parent) {
 
 PresetSaveDialog::~PresetSaveDialog() {
 	wxXmlResource::Get()->Unload(wxString::FromUTF8(Config["AppDir"]) + "/res/xrc/SavePreset.xrc");
-}
-
-std::string PresetSaveDialog::GetProjectPath() const {
-	std::string res = Config["ProjectPath"];
-	return res.empty() ? Config["AppDir"] : res;
 }
 
 void PresetSaveDialog::SetExistingPreset(const std::string& presetName, const std::string& presetFileName, const std::vector<std::string>& groups) {
@@ -131,7 +127,7 @@ void PresetSaveDialog::OnSave(wxCommandEvent& WXUNUSED(event)) {
 
 	wxFileDialog savePresetDialog(this,
 								  "Choose a preset file",
-								  wxString::FromUTF8(GetProjectPath()) + "/SliderPresets",
+								  wxString::FromUTF8(ProjectUtil::GetProjectPath()) + "/SliderPresets",
 								  wxString::FromUTF8(presetFile),
 								  "Preset Files (*.xml)|*.xml",
 								  wxFD_SAVE);

--- a/src/program/PresetSaveDialog.h
+++ b/src/program/PresetSaveDialog.h
@@ -24,7 +24,7 @@ public:
 	PresetSaveDialog(wxWindow* parent);
 	~PresetSaveDialog();
 
-	std::string GetProjectPath() const;
+
 	void SetExistingPreset(const std::string& presetName, const std::string& presetFileName, const std::vector<std::string>& groups);
 
 	void FilterGroups(const std::string& filter = "");

--- a/src/utils/ProjectUtil.cpp
+++ b/src/utils/ProjectUtil.cpp
@@ -1,0 +1,41 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#include "ProjectUtil.h"
+#include "ConfigurationManager.h"
+#include "StringStuff.h"
+
+#include <wx/dir.h>
+
+extern ConfigurationManager Config;
+
+std::string ProjectUtil::GetProjectPath() {
+	std::string projectPath = Config["ProjectPath"];
+	std::string appDir = Config["AppDir"];
+	std::string gameDataPath = Config["GameDataPath"];
+
+	// Build list of paths to check in order of preference
+	std::vector<std::string> pathsToCheck;
+
+	// First priority: configured ProjectPath (if set)
+	if (!projectPath.empty()) {
+		pathsToCheck.push_back(projectPath);
+	}
+
+	// Fallback paths in order of preference
+	pathsToCheck.push_back(appDir + PathSepStr + "SliderSets");
+	pathsToCheck.push_back(gameDataPath + PathSepStr + "CalienteTools" + PathSepStr + "BodySlide");
+	pathsToCheck.push_back(gameDataPath + PathSepStr + "Tools" + PathSepStr + "BodySlide");
+
+	// Return first existing path
+	for (const auto& path : pathsToCheck) {
+		if (wxDir::Exists(path)) {
+			return path;
+		}
+	}
+
+	// If no path exists, return projectPath if configured, otherwise AppDir
+	return !projectPath.empty() ? projectPath : appDir;
+}

--- a/src/utils/ProjectUtil.h
+++ b/src/utils/ProjectUtil.h
@@ -1,0 +1,19 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#pragma once
+
+#include <string>
+
+namespace ProjectUtil {
+	/// Get the project path with directory existence checks.
+	/// If ProjectPath config is set and exists, returns it.
+	/// Otherwise, checks fallback paths in order:
+	///   1. AppDir/SliderSets
+	///   2. GameDataPath/CalienteTools/BodySlide
+	///   3. GameDataPath/Tools/BodySlide
+	/// Falls back to AppDir if no configured path and no fallback exists.
+	std::string GetProjectPath();
+} // namespace ProjectUtil


### PR DESCRIPTION
If there's no `SliderSets` folder next to BodySlide executable it will use `Data/CalienteTools/BodySlide` directory as project path. Otherwise, it will fall back to appdir.

Fixes #585 