### PR TITLE
Fix Starfield morph.dat export writing wrong key marker indices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,11 +380,13 @@ if(BSOS_BUILD_TESTS)
 		tests/HkxFileTest.cpp
 		tests/SFMaterialDatabaseTest.cpp
 		tests/SFMaterialFileTest.cpp
+		tests/SFMorphFileTest.cpp
 		tests/SFResourceHashTest.cpp
 		src/files/HkxFile.cpp
 		src/files/SFMaterialDatabase.cpp
 		src/files/SFMaterialFile.cpp
 		src/files/SFMaterialGraph.cpp
+		src/files/SFMorphFile.cpp
 		src/files/SFResourceHash.cpp
 		src/utils/PlatformUtil.cpp
 		src/utils/StringStuff.cpp
@@ -392,6 +394,8 @@ if(BSOS_BUILD_TESTS)
 	target_include_directories(BSOSTests PRIVATE
 		${CMAKE_CURRENT_SOURCE_DIR}/src
 		${CMAKE_CURRENT_SOURCE_DIR}/lib/nlohmannjson/include
+		${CMAKE_CURRENT_SOURCE_DIR}/lib/nifly/include
+		${CMAKE_CURRENT_SOURCE_DIR}/lib/nifly/external
 	)
 	target_compile_definitions(BSOSTests PRIVATE ${BSOS_PLATFORM_DEFINITIONS})
 	target_link_libraries(BSOSTests PRIVATE Catch2::Catch2WithMain)

--- a/src/files/SFMorphFile.cpp
+++ b/src/files/SFMorphFile.cpp
@@ -222,7 +222,6 @@ void SFMorphFile::CacheToFileData() {
 	for (uint16_t i = 0; i < numVerticesShort; i++) {
 		std::vector<uint32_t> morphKeyIndices;
 
-		uint32_t morphKey = 0;
 		for (auto& morph : morphNames) {
 			if (morphKeyIndices.size() < 128) {
 				auto& morphIndex = morphNamesCacheMap[morph];
@@ -270,8 +269,11 @@ void SFMorphFile::CacheToFileData() {
 
 						morphDataRaw.push_back(morphData);
 
-						morphKeyIndices.push_back(morphKey);
-						morphKey++;
+						// The key marker bit must be the morph's index in the shape key name
+						// table, not a per-vertex sequence number. Consumers pair the vertex's
+						// data run with the set bits in ascending order, so a sequence number
+						// misattributes every morph's deltas once two or more morphs overlap.
+						morphKeyIndices.push_back(morphIndex);
 					}
 				}
 			}

--- a/src/files/SFMorphFile.cpp
+++ b/src/files/SFMorphFile.cpp
@@ -223,9 +223,12 @@ void SFMorphFile::CacheToFileData() {
 		std::vector<uint32_t> morphKeyIndices;
 
 		for (auto& morph : morphNames) {
-			if (morphKeyIndices.size() < 128) {
-				auto& morphIndex = morphNamesCacheMap[morph];
+			auto& morphIndex = morphNamesCacheMap[morph];
 
+			// The 128-bit keyMarker can only address shape keys 0-127, so a morph
+			// beyond that index cannot be represented in the morph.dat format. Skip
+			// it rather than setting a bit past the end of the 4-word keyMarker.
+			if (morphIndex < SFMaxShapeKeys) {
 				auto& morphOffsets = morphOffsetsCache[morphIndex];
 				auto& morphColors = morphColorsCache[morphIndex];
 				auto& morphNormals = morphNormalsCache[morphIndex];

--- a/src/files/SFMorphFile.h
+++ b/src/files/SFMorphFile.h
@@ -70,6 +70,10 @@ struct SFMorphOffset {
 	SFMorphKey keyMarker[4];
 };
 
+// The per-vertex keyMarker is a fixed 128-bit field (4 x 32-bit words), so the
+// morph.dat format can only reference shape keys with indices 0-127.
+constexpr uint32_t SFMaxShapeKeys = 128;
+
 class SFMorphFile {
 	uint32_t numAxis = 3;
 	uint32_t numShapeKeys = 0;

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -1572,6 +1572,11 @@ bool BodySlideApp::WriteSFMorphFile(const std::string& morphFolder, SliderSet& s
 			}
 		}
 
+		if (morphFile.morphOffsetsCache.size() >= SFMaxShapeKeys) {
+			wxLogWarning("Starfield morph.dat supports at most 128 morphs; '%s' and any remaining morphs were skipped.", sliderSet[s].name);
+			break;
+		}
+
 		morphFile.AddMorph(sliderSet[s].name, morphOffsets, {}, morphNormals, morphTangents);
 	}
 

--- a/tests/SFMorphFileTest.cpp
+++ b/tests/SFMorphFileTest.cpp
@@ -1,0 +1,177 @@
+#include "../src/files/SFMorphFile.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+
+using nifly::Vector3;
+
+namespace {
+
+// Position deltas round-trip through an fp16 quantization at a 1/69.969 scale,
+// so reloaded values are close but not bit-exact.
+constexpr float HalfTolerance = 0.02f;
+
+using OffsetMap = std::unordered_map<uint16_t, Vector3>;
+
+// Writes to a uniquely named temp file so test cases never collide, even when
+// ctest runs them as separate processes in parallel.
+struct TempMorphFile {
+    std::string path;
+
+    explicit TempMorphFile(const char* name) {
+        path = (std::filesystem::temp_directory_path() / name).string();
+        std::error_code ec;
+        std::filesystem::remove(path, ec);
+    }
+
+    ~TempMorphFile() {
+        std::error_code ec;
+        std::filesystem::remove(path, ec);
+    }
+};
+
+OffsetMap GetMorphOffsets(SFMorphFile& file, const std::string& morphName) {
+    auto it = file.morphNamesCacheMap.find(morphName);
+    REQUIRE(it != file.morphNamesCacheMap.end());
+    REQUIRE(it->second < file.morphOffsetsCache.size());
+    return file.morphOffsetsCache[it->second];
+}
+
+void RequireOffsetsMatch(const OffsetMap& actual, const OffsetMap& expected) {
+    // Exact same vertex set: a mismatch here means morph data was attributed to
+    // the wrong morph.
+    REQUIRE(actual.size() == expected.size());
+
+    for (const auto& [index, expectedDelta] : expected) {
+        INFO("vertex " << index);
+        auto it = actual.find(index);
+        REQUIRE(it != actual.end());
+
+        REQUIRE(std::fabs(it->second.x - expectedDelta.x) < HalfTolerance);
+        REQUIRE(std::fabs(it->second.y - expectedDelta.y) < HalfTolerance);
+        REQUIRE(std::fabs(it->second.z - expectedDelta.z) < HalfTolerance);
+    }
+}
+
+} // namespace
+
+TEST_CASE("Starfield morph file round-trips overlapping morphs", "[SFMorphFile]") {
+    // Three morphs with overlapping vertex sets. Overlap is the regression target:
+    // the key marker bits must identify each morph by its name table index, so a
+    // vertex affected by multiple morphs must get each morph's own deltas back.
+    // Vertex 3 is touched by all three; verts 4/5/6 are touched by morphs whose
+    // index is not their position in the vertex's contributor list, which is
+    // exactly what a per-vertex sequence counter mislabeled.
+    OffsetMap morphA{
+        {0, Vector3(1.0f, 0.0f, 0.0f)},
+        {1, Vector3(0.0f, 2.0f, 0.0f)},
+        {2, Vector3(0.0f, 0.0f, 3.0f)},
+        {3, Vector3(1.0f, 1.0f, 1.0f)},
+    };
+    OffsetMap morphB{
+        {2, Vector3(-1.0f, 0.0f, 0.0f)},
+        {3, Vector3(0.0f, -2.0f, 0.0f)},
+        {4, Vector3(0.0f, 0.0f, -3.0f)},
+        {5, Vector3(-1.0f, -1.0f, -1.0f)},
+    };
+    OffsetMap morphC{
+        {3, Vector3(4.0f, 0.0f, 0.0f)},
+        {5, Vector3(0.0f, 5.0f, 0.0f)},
+        {6, Vector3(0.0f, 0.0f, 6.0f)},
+    };
+
+    SFMorphFile outFile;
+    outFile.SetVertexCount(8);
+    REQUIRE(outFile.AddMorph("MorphA", morphA, {}, {}, {}));
+    REQUIRE(outFile.AddMorph("MorphB", morphB, {}, {}, {}));
+    REQUIRE(outFile.AddMorph("MorphC", morphC, {}, {}, {}));
+
+    outFile.CacheToFileData();
+
+    TempMorphFile temp("bsos_sfmorph_overlap.dat");
+    REQUIRE(outFile.Write(temp.path));
+
+    // Same sequence the Outfit Studio import path uses.
+    SFMorphFile inFile;
+    REQUIRE(inFile.Read(temp.path));
+    REQUIRE(inFile.FileToCacheData());
+    inFile.UpdateCachedMorphData();
+
+    const auto names = inFile.GetMorphNames();
+    REQUIRE(names.size() == 3);
+    REQUIRE(names[0] == "MorphA");
+    REQUIRE(names[1] == "MorphB");
+    REQUIRE(names[2] == "MorphC");
+
+    RequireOffsetsMatch(GetMorphOffsets(inFile, "MorphA"), morphA);
+    RequireOffsetsMatch(GetMorphOffsets(inFile, "MorphB"), morphB);
+    RequireOffsetsMatch(GetMorphOffsets(inFile, "MorphC"), morphC);
+}
+
+TEST_CASE("Starfield morph file round-trips a single morph", "[SFMorphFile]") {
+    OffsetMap morph{
+        {0, Vector3(0.5f, 0.0f, 0.0f)},
+        {7, Vector3(0.0f, 0.0f, -0.5f)},
+    };
+
+    SFMorphFile outFile;
+    outFile.SetVertexCount(8);
+    REQUIRE(outFile.AddMorph("Morph", morph, {}, {}, {}));
+
+    outFile.CacheToFileData();
+
+    TempMorphFile temp("bsos_sfmorph_single.dat");
+    REQUIRE(outFile.Write(temp.path));
+
+    SFMorphFile inFile;
+    REQUIRE(inFile.Read(temp.path));
+    REQUIRE(inFile.FileToCacheData());
+    inFile.UpdateCachedMorphData();
+
+    REQUIRE(inFile.GetMorphCount() == 1);
+    RequireOffsetsMatch(GetMorphOffsets(inFile, "Morph"), morph);
+}
+
+TEST_CASE("Starfield morph file caps shape keys at the 128-bit keyMarker width", "[SFMorphFile]") {
+    // The per-vertex keyMarker is a fixed 128-bit field, so only shape keys 0-127
+    // can be referenced. Exporting more must not write a bit past the 4-word
+    // marker (an out-of-bounds write); the extra morphs are simply unaddressable.
+    constexpr uint32_t morphCount = SFMaxShapeKeys + 2; // 130
+
+    SFMorphFile outFile;
+    outFile.SetVertexCount(morphCount);
+    for (uint32_t i = 0; i < morphCount; i++) {
+        const std::string name = "Morph" + std::to_string(i);
+        REQUIRE(outFile.AddMorph(name, OffsetMap{{static_cast<uint16_t>(i), Vector3(1.0f, 0.0f, 0.0f)}}, {}, {}, {}));
+    }
+
+    outFile.CacheToFileData();
+
+    TempMorphFile temp("bsos_sfmorph_limit.dat");
+    REQUIRE(outFile.Write(temp.path));
+
+    SFMorphFile inFile;
+    REQUIRE(inFile.Read(temp.path));
+    REQUIRE(inFile.FileToCacheData());
+    inFile.UpdateCachedMorphData();
+
+    for (uint32_t i = 0; i < SFMaxShapeKeys; i++) {
+        const std::string name = "Morph" + std::to_string(i);
+        INFO("addressable morph " << name);
+        REQUIRE(inFile.morphNamesCacheMap.count(name) == 1);
+
+        const uint32_t idx = inFile.morphNamesCacheMap.at(name);
+        REQUIRE(inFile.morphOffsetsCache[idx].count(static_cast<uint16_t>(i)) == 1);
+    }
+
+    for (uint32_t i = SFMaxShapeKeys; i < morphCount; i++) {
+        const std::string name = "Morph" + std::to_string(i);
+        INFO("unaddressable morph " << name);
+        // Index >= 128 cannot be encoded, so it carries no data after round-trip.
+        REQUIRE(inFile.morphNamesCacheMap.count(name) == 0);
+    }
+}


### PR DESCRIPTION
When exporting morph.dat, CacheToFileData wrote each vertex's key marker bits from a per-vertex counter instead of the morph's shape key index. 

the game pairs a vertex's morph data with its set key-marker bits in ascending order, so the counter attached each morph's deltas to the wrong morph name whenever a vertex wasn't touched by exactly the first morphs in the table. In game this showed up as morphs applying the wrong deformation.