### PR TITLE
Add option to Hide Conflict Losers in Outfit/Body list

### DIFF
--- a/res/xrc/BodySlide.xrc
+++ b/res/xrc/BodySlide.xrc
@@ -617,6 +617,11 @@
 			<help>Show only outfits that have zap options.</help>
 			<checkable>1</checkable>
 		</object>
+		<object class="wxMenuItem" name="menuFilterOutputWinners">
+			<label>Hide Conflict Losers</label>
+			<help>Show only outfits winning or unresolved in their output file conflict.</help>
+			<checkable>1</checkable>
+		</object>
 		<object class="separator" />
 		<object class="wxMenuItem" name="menuBrowseOutfitFolder">
 			<label>Browse outfit folder...</label>

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -108,6 +108,7 @@ wxBEGIN_EVENT_TABLE(BodySlideFrame, wxFrame)
 	EVT_MENU(XRCID("menuRefreshOutfits"), BodySlideFrame::OnRefreshOutfits)
 	EVT_MENU(XRCID("menuRegexOutfits"), BodySlideFrame::OnRegexOutfits)
 	EVT_MENU(XRCID("menuFilterHasZaps"), BodySlideFrame::OnFilterHasZaps)
+	EVT_MENU(XRCID("menuFilterOutputWinners"), BodySlideFrame::OnFilterOutputWinners)
 	EVT_MENU(XRCID("menuBrowseOutfitFolder"), BodySlideFrame::OnBrowseOutfitFolder)
 	EVT_MENU(XRCID("menuSaveGroups"), BodySlideFrame::OnSaveGroups)
 
@@ -3150,6 +3151,7 @@ void BodySlideApp::ApplyOutfitFilter() {
 	bool showUngrouped = false;
 	bool regexFilterOutfits = false;
 	bool filterHasZaps = false;
+	bool filterBatchBuildSelected = false;
 
 	auto menuOutfitSrchContext = sliderView->outfitsearch->GetMenu();
 	if (menuOutfitSrchContext) {
@@ -3160,7 +3162,16 @@ void BodySlideApp::ApplyOutfitFilter() {
 		auto menuFilterHasZaps = menuOutfitSrchContext->FindItem(XRCID("menuFilterHasZaps"));
 		if (menuFilterHasZaps)
 			filterHasZaps = menuFilterHasZaps->IsChecked();
+
+		auto menuFilterOutputWinners = menuOutfitSrchContext->FindItem(XRCID("menuFilterOutputWinners"));
+		if (menuFilterOutputWinners)
+			filterBatchBuildSelected = menuFilterOutputWinners->IsChecked();
 	}
+
+	BuildSelectionFile buildSelFile;
+	BuildSelection buildSelection;
+	if (filterBatchBuildSelected)
+		GetBuildSelection(buildSelFile, buildSelection);
 
 	wxString grpSrch = sliderView->search->GetValue();
 	std::string outfitSrch{sliderView->outfitsearch->GetValue()};
@@ -3208,6 +3219,21 @@ void BodySlideApp::ApplyOutfitFilter() {
 		if (!filteredOut && filterHasZaps) {
 			if (std::find(outfitHasZaps.cbegin(), outfitHasZaps.cend(), no) == outfitHasZaps.cend())
 				filteredOut = true;
+		}
+
+		if (!filteredOut && filterBatchBuildSelected) {
+			for (auto& outFile : outFileCount) {
+				if (outFile.second.size() > 1) {
+					bool isInConflict = std::find(outFile.second.cbegin(), outFile.second.cend(), no) != outFile.second.cend();
+					if (isInConflict) {
+						std::string choice = buildSelection.GetOutputChoice(outFile.first);
+						if (!choice.empty() && choice != no) {
+							filteredOut = true;
+							break;
+						}
+					}
+				}
+			}
 		}
 
 		if (!filteredOut)
@@ -5843,6 +5869,11 @@ void BodySlideFrame::OnRegexOutfits(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void BodySlideFrame::OnFilterHasZaps(wxCommandEvent& WXUNUSED(event)) {
+	app->PopulateFilterData();
+	app->PopulateOutfitList("");
+}
+
+void BodySlideFrame::OnFilterOutputWinners(wxCommandEvent& WXUNUSED(event)) {
 	app->PopulateFilterData();
 	app->PopulateOutfitList("");
 }

--- a/src/program/BodySlideApp.h
+++ b/src/program/BodySlideApp.h
@@ -521,6 +521,7 @@ private:
 	void OnRefreshOutfits(wxCommandEvent& event);
 	void OnRegexOutfits(wxCommandEvent& event);
 	void OnFilterHasZaps(wxCommandEvent& event);
+	void OnFilterOutputWinners(wxCommandEvent& event);
 
 	void OnChooseOutfit(wxCommandEvent& event);
 	void OnChoosePreset(wxCommandEvent& event);


### PR DESCRIPTION
Adds a new checkable filter option to the outfit search context menu that hides outfits which lost a resolved output file conflict, showing only winners and unresolved outfits.

Didn't touch translations since they seem to be generally outdated

<img width="319" height="222" alt="image" src="https://github.com/user-attachments/assets/7f4e95b0-b269-4ee9-9ac6-b7e3209daed0" />
