### PR TITLE
Add option to hide virtual shapes in preview

### DIFF
--- a/src/components/Mesh.h
+++ b/src/components/Mesh.h
@@ -127,6 +127,7 @@ public:
 	std::shared_ptr<AABBTree> bvh = nullptr;
 
 	bool bVisible = true;
+	bool bHelperShape = false; // true for shapes with no shader or with the hidden flag set (e.g. collisions)
 	bool bShowPoints = false;
 	bool smoothSeamNormals = true; // Smoothing for normals on seams.
 	float smoothSeamNormalsAngle = 60.0f; // Smoothing threshold in degrees for generating smooth normals on seams.

--- a/src/render/GLSurface.cpp
+++ b/src/render/GLSurface.cpp
@@ -1276,6 +1276,7 @@ Mesh* GLSurface::AddMeshFromNif(NifFile* nif, const std::string& shapeName, Vect
 	}
 
 	NiShader* shader = nif->GetShader(shape);
+	m->bHelperShape = !shader || (shape->flags & 1) != 0;
 	if (shader) {
 		m->doublesided = shader->IsDoubleSided();
 		m->modelSpace = shader->IsModelSpace();

--- a/src/ui/PreviewPanel.cpp
+++ b/src/ui/PreviewPanel.cpp
@@ -70,6 +70,10 @@ PreviewPanel::PreviewPanel(wxWindow* parent, BodySlideApp* app)
 	showReferenceCheckbox->Bind(wxEVT_CHECKBOX, &PreviewPanel::OnShowReference, this);
 	showReferenceCheckbox->Hide();
 
+	hideVirtualCheckbox = new wxCheckBox(uiPanel, wxID_ANY, _("Hide Virtual"), wxDefaultPosition, wxDefaultSize);
+	hideVirtualCheckbox->SetToolTip(_("Hide shapes whose names start with \"Virtual\"."));
+	hideVirtualCheckbox->Bind(wxEVT_CHECKBOX, &PreviewPanel::OnHideVirtual, this);
+
 	uiPanel->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE));
 
 	// Pop-out button (placed in uiPanel, below Lock Shape)
@@ -95,6 +99,7 @@ PreviewPanel::PreviewPanel(wxWindow* parent, BodySlideApp* app)
 	sizerButtons->Add(lockShapeButton, 0, wxALIGN_CENTER_VERTICAL);
 	sizerButtons->Add(popoutButton, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 4);
 	sizerRight->Add(sizerButtons, 0, wxTOP | wxALIGN_CENTER_HORIZONTAL, 2);
+	sizerRight->Add(hideVirtualCheckbox, 0, wxTOP | wxALIGN_CENTER_HORIZONTAL, 2);
 
 	sizerPanel->Add(sizerRight, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
 
@@ -393,9 +398,22 @@ Mesh* PreviewPanel::GetMesh(const std::string& shapeName) {
 	return gls.GetMesh(shapeName);
 }
 
+static bool IsVirtualShape(const std::string& name) {
+	if (name.size() < 7)
+		return false;
+	static const char prefix[] = "virtual";
+	for (int i = 0; i < 7; i++) {
+		if (std::tolower((unsigned char)name[i]) != prefix[i])
+			return false;
+	}
+	return true;
+}
+
 void PreviewPanel::AddMeshFromNif(NifFile* nif, char* shapeName) {
 	if (!glInitialized || !gls.SetContext())
 		return;
+
+	bool hideVirtual = hideVirtualCheckbox->IsChecked();
 
 	std::vector<std::string> shapeList = nif->GetShapeNames();
 	for (size_t i = 0; i < shapeList.size(); i++) {
@@ -408,6 +426,9 @@ void PreviewPanel::AddMeshFromNif(NifFile* nif, char* shapeName) {
 			SetShapeVertexColors(nif, shapeListName, m);
 			m->BuildVertexAdjacency();
 			m->CreateBuffers();
+
+			if (hideVirtual && IsVirtualShape(shapeListName))
+				gls.SetMeshVisibility(shapeListName, false);
 		}
 	}
 }
@@ -417,6 +438,8 @@ void PreviewPanel::RefreshMeshFromNif(const std::vector<NifFile*>& nifs) {
 		return;
 
 	gls.ClearMeshes();
+
+	bool hideVirtual = hideVirtualCheckbox->IsChecked();
 
 	for (auto* nif : nifs) {
 		for (auto& shapeListName : nif->GetShapeNames()) {
@@ -434,6 +457,9 @@ void PreviewPanel::RefreshMeshFromNif(const std::vector<NifFile*>& nifs) {
 				m->material = iter->second;
 			else
 				AddNifShapeTextures(nif, shapeListName);
+
+			if (hideVirtual && IsVirtualShape(shapeListName))
+				gls.SetMeshVisibility(shapeListName, false);
 		}
 	}
 
@@ -722,6 +748,15 @@ void PreviewPanel::OnLockShape(wxCommandEvent& WXUNUSED(event)) {
 
 void PreviewPanel::OnShowReference(wxCommandEvent& WXUNUSED(event)) {
 	app->UpdatePreview();
+}
+
+void PreviewPanel::OnHideVirtual(wxCommandEvent& WXUNUSED(event)) {
+	bool hide = hideVirtualCheckbox->IsChecked();
+	for (auto* m : gls.GetMeshes()) {
+		if (IsVirtualShape(m->shapeName))
+			gls.SetMeshVisibility(m->shapeName, !hide);
+	}
+	gls.RenderOneFrame();
 }
 
 void PreviewPanel::OnPopout(wxCommandEvent& WXUNUSED(event)) {

--- a/src/ui/PreviewPanel.cpp
+++ b/src/ui/PreviewPanel.cpp
@@ -70,9 +70,9 @@ PreviewPanel::PreviewPanel(wxWindow* parent, BodySlideApp* app)
 	showReferenceCheckbox->Bind(wxEVT_CHECKBOX, &PreviewPanel::OnShowReference, this);
 	showReferenceCheckbox->Hide();
 
-	hideVirtualCheckbox = new wxCheckBox(uiPanel, wxID_ANY, _("Hide Virtual"), wxDefaultPosition, wxDefaultSize);
-	hideVirtualCheckbox->SetToolTip(_("Hide shapes whose names start with \"Virtual\"."));
-	hideVirtualCheckbox->Bind(wxEVT_CHECKBOX, &PreviewPanel::OnHideVirtual, this);
+	showHelperShapesCheckbox = new wxCheckBox(uiPanel, wxID_ANY, _("Show Helper Shapes"), wxDefaultPosition, wxDefaultSize);
+	showHelperShapesCheckbox->SetToolTip(_("Show helper shapes (e.g. collisions) - shapes with no shader or with the hidden flag set."));
+	showHelperShapesCheckbox->Bind(wxEVT_CHECKBOX, &PreviewPanel::OnShowHelperShapes, this);
 
 	uiPanel->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE));
 
@@ -99,7 +99,7 @@ PreviewPanel::PreviewPanel(wxWindow* parent, BodySlideApp* app)
 	sizerButtons->Add(lockShapeButton, 0, wxALIGN_CENTER_VERTICAL);
 	sizerButtons->Add(popoutButton, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 4);
 	sizerRight->Add(sizerButtons, 0, wxTOP | wxALIGN_CENTER_HORIZONTAL, 2);
-	sizerRight->Add(hideVirtualCheckbox, 0, wxTOP | wxALIGN_CENTER_HORIZONTAL, 2);
+	sizerRight->Add(showHelperShapesCheckbox, 0, wxTOP | wxALIGN_CENTER_HORIZONTAL, 2);
 
 	sizerPanel->Add(sizerRight, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
 
@@ -398,22 +398,11 @@ Mesh* PreviewPanel::GetMesh(const std::string& shapeName) {
 	return gls.GetMesh(shapeName);
 }
 
-static bool IsVirtualShape(const std::string& name) {
-	if (name.size() < 7)
-		return false;
-	static const char prefix[] = "virtual";
-	for (int i = 0; i < 7; i++) {
-		if (std::tolower((unsigned char)name[i]) != prefix[i])
-			return false;
-	}
-	return true;
-}
-
 void PreviewPanel::AddMeshFromNif(NifFile* nif, char* shapeName) {
 	if (!glInitialized || !gls.SetContext())
 		return;
 
-	bool hideVirtual = hideVirtualCheckbox->IsChecked();
+	bool showHelperShapes = showHelperShapesCheckbox->IsChecked();
 
 	std::vector<std::string> shapeList = nif->GetShapeNames();
 	for (size_t i = 0; i < shapeList.size(); i++) {
@@ -427,7 +416,7 @@ void PreviewPanel::AddMeshFromNif(NifFile* nif, char* shapeName) {
 			m->BuildVertexAdjacency();
 			m->CreateBuffers();
 
-			if (hideVirtual && IsVirtualShape(shapeListName))
+			if (m->bHelperShape && !showHelperShapes)
 				gls.SetMeshVisibility(shapeListName, false);
 		}
 	}
@@ -439,7 +428,7 @@ void PreviewPanel::RefreshMeshFromNif(const std::vector<NifFile*>& nifs) {
 
 	gls.ClearMeshes();
 
-	bool hideVirtual = hideVirtualCheckbox->IsChecked();
+	bool showHelperShapes = showHelperShapesCheckbox->IsChecked();
 
 	for (auto* nif : nifs) {
 		for (auto& shapeListName : nif->GetShapeNames()) {
@@ -458,7 +447,7 @@ void PreviewPanel::RefreshMeshFromNif(const std::vector<NifFile*>& nifs) {
 			else
 				AddNifShapeTextures(nif, shapeListName);
 
-			if (hideVirtual && IsVirtualShape(shapeListName))
+			if (m->bHelperShape && !showHelperShapes)
 				gls.SetMeshVisibility(shapeListName, false);
 		}
 	}
@@ -750,11 +739,11 @@ void PreviewPanel::OnShowReference(wxCommandEvent& WXUNUSED(event)) {
 	app->UpdatePreview();
 }
 
-void PreviewPanel::OnHideVirtual(wxCommandEvent& WXUNUSED(event)) {
-	bool hide = hideVirtualCheckbox->IsChecked();
+void PreviewPanel::OnShowHelperShapes(wxCommandEvent& WXUNUSED(event)) {
+	bool show = showHelperShapesCheckbox->IsChecked();
 	for (auto* m : gls.GetMeshes()) {
-		if (IsVirtualShape(m->shapeName))
-			gls.SetMeshVisibility(m->shapeName, !hide);
+		if (m->bHelperShape)
+			gls.SetMeshVisibility(m->shapeName, show);
 	}
 	gls.RenderOneFrame();
 }

--- a/src/ui/PreviewPanel.h
+++ b/src/ui/PreviewPanel.h
@@ -42,6 +42,7 @@ class PreviewPanel : public wxPanel {
 	wxButton* optButton = nullptr;
 	wxButton* lockShapeButton = nullptr;
 	wxCheckBox* showReferenceCheckbox = nullptr;
+	wxCheckBox* hideVirtualCheckbox = nullptr;
 	wxStaticText* projectLabel = nullptr;
 	wxChoice* projectChoice = nullptr;
 	wxStaticText* presetLabel = nullptr;
@@ -85,6 +86,7 @@ public:
 	void ShowNormalGenWindow(wxCommandEvent& event);
 	void OnLockShape(wxCommandEvent& event);
 	void OnShowReference(wxCommandEvent& event);
+	void OnHideVirtual(wxCommandEvent& event);
 	void OnPopout(wxCommandEvent& event);
 
 	void ShowPopoutButton(bool show);

--- a/src/ui/PreviewPanel.h
+++ b/src/ui/PreviewPanel.h
@@ -42,7 +42,7 @@ class PreviewPanel : public wxPanel {
 	wxButton* optButton = nullptr;
 	wxButton* lockShapeButton = nullptr;
 	wxCheckBox* showReferenceCheckbox = nullptr;
-	wxCheckBox* hideVirtualCheckbox = nullptr;
+	wxCheckBox* showHelperShapesCheckbox = nullptr;
 	wxStaticText* projectLabel = nullptr;
 	wxChoice* projectChoice = nullptr;
 	wxStaticText* presetLabel = nullptr;
@@ -86,7 +86,7 @@ public:
 	void ShowNormalGenWindow(wxCommandEvent& event);
 	void OnLockShape(wxCommandEvent& event);
 	void OnShowReference(wxCommandEvent& event);
-	void OnHideVirtual(wxCommandEvent& event);
+	void OnShowHelperShapes(wxCommandEvent& event);
 	void OnPopout(wxCommandEvent& event);
 
 	void ShowPopoutButton(bool show);


### PR DESCRIPTION
Add option to hide virtual shapes (used for HDT/SMP collisions) from preview

<img width="50" height="100" alt="image" src="https://github.com/user-attachments/assets/dd0cb962-c607-445e-96be-3c579f00fcbb" />
<img width="50" height="100" alt="image" src="https://github.com/user-attachments/assets/ff0447d2-0351-479a-ae74-96ac826f04ac" />
