### PR TITLE
Starfield: fix exploded/stretched body mesh on edit + export

### DIFF
--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -435,6 +435,12 @@ void AnimInfo::SetWeights(const std::string& shape, const std::string& boneName,
 }
 
 void AnimInfo::CleanupBones() {
+	// Starfield BSGeometry binds skin to skeleton by bone name via SkinAttach block, per vertex weights index into that list
+	// "cleaning" up bones break those indices so skip for starfield. ASSUMPTION: keeping unused bones in SF is harmless
+	if (refNif && refNif->IsValid() && refNif->GetHeader().GetVersion().IsSF()) {
+		return;
+	}
+
 	for (auto& skin : shapeSkinning) {
 		std::vector<std::string> bonesToDelete;
 
@@ -616,7 +622,8 @@ void AnimInfo::WriteToNif(NifFile* nif, const std::string& shapeException) {
 		if (!shape)
 			continue;
 
-		bool isBSShape = shape->HasType<BSTriShape>();
+		// BSGeometry (Starfield) stores per-vertex weights inline (like BSTriShape's vertex data). so we want to make sure they get updated.
+		bool isBSShape = shape->HasType<BSTriShape>() || shape->HasType<BSGeometry>();
 
 		std::unordered_map<uint16_t, VertexBoneWeights> vertWeights;
 		for (auto& boneName : shapeBoneList.second) {

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -6476,6 +6476,7 @@ int OutfitProject::ExportNIF(const std::string& fileName, const std::vector<Mesh
 	clone.SetShapeOrder(owner->GetShapeList());
 	clone.GetHeader().SetExportInfo("Exported using Outfit Studio.");
 
+	GenerateStarfieldMeshlets(clone);
 	ConfigureInternalGeometry(clone, fileName, useInternalGeom);
 
 	std::fstream file;
@@ -6543,6 +6544,7 @@ int OutfitProject::ExportShapeNIF(const std::string& fileName, const std::vector
 
 	clone.GetHeader().SetExportInfo("Exported using Outfit Studio.");
 
+	GenerateStarfieldMeshlets(clone);
 	ConfigureInternalGeometry(clone, fileName, useInternalGeom);
 
 	std::fstream file;
@@ -6563,6 +6565,22 @@ void OutfitProject::ForceInternalGeometry(NifFile& nif) {
 		auto bsgeo = dynamic_cast<BSGeometry*>(s);
 		if (bsgeo)
 			bsgeo->SetInternalGeomData(true);
+	}
+}
+
+void OutfitProject::GenerateStarfieldMeshlets(NifFile& nif) {
+	if (!nif.GetHeader().GetVersion().IsSF()) {
+		return;
+	}
+
+	// Generate meshlets for any BSGeometry that lacks them (freshly authored shapes, or shapes whose meshlets were dropped by an edit that changed the triangle list).
+	std::vector<NiShape*> toConvert;
+	for (auto& s : nif.GetShapes()) {
+		auto bsgeo = dynamic_cast<BSGeometry*>(s);
+        if (!bsgeo || bsgeo->HasMeshlets()) {
+            continue;
+		}
+		bsgeo->GenerateMeshlets();
 	}
 }
 

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -489,6 +489,10 @@ public:
 	// Save external .mesh files for Starfield BSGeometry shapes alongside the NIF.
 	bool SaveExternalMeshes(nifly::NifFile& nif, const std::string& nifFileName);
 
+	// Generate mesh-shader meshlets + cull data for any Starfield BSGeometry shape that lacks them
+	// No-op for non-Starfield NIFs.
+	void GenerateStarfieldMeshlets(nifly::NifFile& nif);
+
 	int ImportOBJ(const std::string& fileName, const std::string& shapeName = "", nifly::NiShape* mergeShape = nullptr);
 	int ExportOBJ(const std::string& fileName,
 				  const std::vector<nifly::NiShape*>& shapes,


### PR DESCRIPTION
skinning bugs in the Starfield export path, plus meshlet regeneration wiring.
Depends on https://github.com/ousnius/nifly/pull/63

- **CleanupBones**: skip for SF. Culling/reindexing bones desyncs `BSSkin::BoneData` from the name-bound `SkinAttach`

- **WriteToNif**: include `BSGeometry` in `isBSShape` so per-vertex weights are actually written. 

- **GenerateStarfieldMeshlets**: new export pass (in `ExportNIF`/`ExportShapeNIF`) that regenerates meshlets for any SF shape missing them; intact ones are left alone.
