### PR TITLE
Fixed Linux wrong launch path for OutfitStudio

### DIFF
--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -1326,7 +1326,7 @@ void BodySlideApp::LaunchOutfitStudio(const wxString& args) {
 #ifdef _WIN32
 	const wxString osExec = "OutfitStudio.exe";
 #else
-	const wxString osExec = "OutfitStudio";
+	const wxString osExec = "/OutfitStudio";
 #endif
 
 	wxString osExecCmd = wxString::Format("\"%s\\%s\" %s", wxString::FromUTF8(Config["AppDir"]), osExec, args);

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -1326,10 +1326,11 @@ void BodySlideApp::LaunchOutfitStudio(const wxString& args) {
 #ifdef _WIN32
 	const wxString osExec = "OutfitStudio.exe";
 #else
-	const wxString osExec = "/OutfitStudio";
+	const wxString osExec = "OutfitStudio";
 #endif
 
-	wxString osExecCmd = wxString::Format("\"%s\\%s\" %s", wxString::FromUTF8(Config["AppDir"]), osExec, args);
+	wxFileName osExecFile(wxString::FromUTF8(Config["AppDir"]), osExec);
+	wxString osExecCmd = wxString::Format("\"%s\" %s", osExecFile.GetFullPath(), args);
 
 	if (!wxExecute(osExecCmd, wxEXEC_ASYNC)) {
 		wxLogError("Failed to execute '%s' process.", osExecCmd);


### PR DESCRIPTION
On the new Linux native build, if the user tries to launch Outfit Studio from within BodySlide, the application will silently fail and this error will appear in the terminal 

execvp(**/home/USER/Desktop/BodySlide-and-Outfit-Studio**OutfitStudio) failed with error 2!

Where: 
 - **/home/USER/Desktop/BodySlide-and-Outfit-Studio** - is where i  saved the compiled results locally
 - **OutfitStudio** - is the binary name.
 
 The fix is simple, just add a slash before the executable call
 
 Tested and worked locally.