### PR TITLE
Add HDT-SMP physics preview using Bullet 

### DIFF
--- a/.github/workflows/cmake-release.yml
+++ b/.github/workflows/cmake-release.yml
@@ -46,7 +46,7 @@ jobs:
           $vcpkgCache = Join-Path $env:GITHUB_WORKSPACE "vcpkg-binary-cache"
           New-Item -ItemType Directory -Force -Path $vcpkgCache | Out-Null
           $env:VCPKG_BINARY_SOURCES = "clear;files,$vcpkgCache,readwrite"
-          & (Join-Path $vcpkgRoot "vcpkg.exe") install "wxwidgets[debug-support]:$env:VCPKG_TARGET_TRIPLET" "catch2:$env:VCPKG_TARGET_TRIPLET"
+          & (Join-Path $vcpkgRoot "vcpkg.exe") install "wxwidgets[debug-support]:$env:VCPKG_TARGET_TRIPLET" "catch2:$env:VCPKG_TARGET_TRIPLET" "bullet3:$env:VCPKG_TARGET_TRIPLET"
 
       - name: Configure CMake
         shell: pwsh
@@ -147,6 +147,7 @@ jobs:
             directx-headers-dev \
             g++ \
             gcc \
+            libbullet-dev \
             libglew-dev \
             libgl1-mesa-dev \
             libglu1-mesa-dev \

--- a/BodySlide.vcxproj
+++ b/BodySlide.vcxproj
@@ -125,8 +125,8 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\wxWidgets\include\msvc;..\wxWidgets\include;lib;lib\gli;lib\nifly\include;lib\nifly\external;lib\TinyXML-2;lib\nlohmannjson\include</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN64;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\bullet3\install\include\bullet;..\wxWidgets\include\msvc;..\wxWidgets\include;lib;lib\gli;lib\nifly\include;lib\nifly\external;lib\TinyXML-2;lib\nlohmannjson\include</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN64;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;NOMINMAX;USE_BULLET;BT_USE_SSE_IN_API;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -138,8 +138,8 @@
       <ExternalWarningLevel>Level1</ExternalWarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>glu32.lib;opengl32.lib;dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\wxWidgets\lib\vc_x64_lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>glu32.lib;opengl32.lib;dbghelp.lib;BulletDynamics_Debug.lib;BulletCollision_Debug.lib;LinearMath_Debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\wxWidgets\lib\vc_x64_lib;..\bullet3\install\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
@@ -192,8 +192,8 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>..\wxWidgets\include\msvc;..\wxWidgets\include;lib;lib\gli;lib\nifly\include;lib\nifly\external;lib\TinyXML-2;lib\nlohmannjson\include</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\bullet3\install\include\bullet;..\wxWidgets\include\msvc;..\wxWidgets\include;lib;lib\gli;lib\nifly\include;lib\nifly\external;lib\TinyXML-2;lib\nlohmannjson\include</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;NOMINMAX;USE_BULLET;BT_USE_SSE_IN_API;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>
       </FunctionLevelLinking>
@@ -206,8 +206,8 @@
       <ExternalWarningLevel>Level1</ExternalWarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>glu32.lib;opengl32.lib;dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\wxWidgets\lib\vc_x64_lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>glu32.lib;opengl32.lib;dbghelp.lib;BulletDynamics.lib;BulletCollision.lib;LinearMath.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\wxWidgets\lib\vc_x64_lib;..\bullet3\install\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <IgnoreSpecificDefaultLibraries>
       </IgnoreSpecificDefaultLibraries>
@@ -766,6 +766,32 @@
     <ClInclude Include="src\components\SliderPresets.h" />
     <ClInclude Include="src\components\SliderSet.h" />
     <ClInclude Include="src\components\UndoState.h" />
+    <ClInclude Include="src\physics\NiflyBullet.h" />
+    <ClInclude Include="src\physics\Controller.h" />
+    <ClInclude Include="src\physics\DebugDraw.h" />
+    <ClInclude Include="src\physics\SystemBuilder.h" />
+    <ClInclude Include="src\physics\hdt\XmlReader.h" />
+    <ClInclude Include="src\physics\hdt\hdtAABB.h" />
+    <ClInclude Include="src\physics\hdt\hdtBone.h" />
+    <ClInclude Include="src\physics\hdt\hdtBoneScaleConstraint.h" />
+    <ClInclude Include="src\physics\hdt\hdtBulletHelper.h" />
+    <ClInclude Include="src\physics\hdt\hdtCollider.h" />
+    <ClInclude Include="src\physics\hdt\hdtConeTwistConstraint.h" />
+    <ClInclude Include="src\physics\hdt\hdtConstraintGroup.h" />
+    <ClInclude Include="src\physics\hdt\hdtDispatcher.h" />
+    <ClInclude Include="src\physics\hdt\hdtGeneric6DofConstraint.h" />
+    <ClInclude Include="src\physics\hdt\hdtRefUtils.h" />
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshAlgorithm.h" />
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshBody.h" />
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshBone.h" />
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshShape.h" />
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshSystem.h" />
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshWorld.h" />
+    <ClInclude Include="src\physics\hdt\hdtStiffSpringConstraint.h" />
+    <ClInclude Include="src\physics\hdt\hdtStringUtils.h" />
+    <ClInclude Include="src\physics\hdt\hdtVertex.h" />
+    <ClInclude Include="src\physics\PumpClock.h" />
+    <ClInclude Include="src\files\GameDataStream.h" />
     <ClInclude Include="src\files\MaterialFile.h" />
     <ClInclude Include="src\files\ObjFile.h" />
     <ClInclude Include="src\files\ResourceLoader.h" />
@@ -843,6 +869,24 @@
     <ClCompile Include="src\components\SliderManager.cpp" />
     <ClCompile Include="src\components\SliderPresets.cpp" />
     <ClCompile Include="src\components\SliderSet.cpp" />
+    <ClCompile Include="src\physics\Controller.cpp" />
+    <ClCompile Include="src\physics\DebugDraw.cpp" />
+    <ClCompile Include="src\physics\SystemBuilder.cpp" />
+    <ClCompile Include="src\physics\hdt\XmlReader.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtBoneScaleConstraint.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtCollider.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtConeTwistConstraint.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtDispatcher.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtGeneric6DofConstraint.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshAlgorithm.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshBody.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshBone.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshShape.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshSystem.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshWorld.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtStiffSpringConstraint.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtVertex.cpp" />
+    <ClCompile Include="src\files\GameDataStream.cpp" />
     <ClCompile Include="src\files\MaterialFile.cpp" />
     <ClCompile Include="src\files\ObjFile.cpp" />
     <ClCompile Include="src\files\ResourceLoader.cpp" />

--- a/BodySlide.vcxproj.filters
+++ b/BodySlide.vcxproj.filters
@@ -1,6 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
+    <Filter Include="Physics">
+      <UniqueIdentifier>{a3f1c2d4-9b7e-4f21-8c5a-2d6e0b1f4a37}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Physics\hdt">
+      <UniqueIdentifier>{b4e2d3c5-0c8f-4a32-9d6b-3e7f1c2a5b48}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Resources">
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
@@ -1997,5 +2003,137 @@
     <Xml Include="Config.xml">
       <Filter>Resources</Filter>
     </Xml>
+    <ClInclude Include="src\physics\NiflyBullet.h">
+      <Filter>Physics</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\Controller.h">
+      <Filter>Physics</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\DebugDraw.h">
+      <Filter>Physics</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\SystemBuilder.h">
+      <Filter>Physics</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\XmlReader.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtAABB.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtBone.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtBoneScaleConstraint.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtBulletHelper.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtCollider.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtConeTwistConstraint.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtConstraintGroup.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtDispatcher.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtGeneric6DofConstraint.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtRefUtils.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshAlgorithm.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshBody.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshBone.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshShape.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshSystem.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshWorld.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtStiffSpringConstraint.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtStringUtils.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtVertex.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClCompile Include="src\physics\Controller.cpp">
+      <Filter>Physics</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\DebugDraw.cpp">
+      <Filter>Physics</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\SystemBuilder.cpp">
+      <Filter>Physics</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\XmlReader.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtBoneScaleConstraint.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtCollider.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtConeTwistConstraint.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtDispatcher.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtGeneric6DofConstraint.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshAlgorithm.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshBody.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshBone.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshShape.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshSystem.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshWorld.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtStiffSpringConstraint.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtVertex.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClInclude Include="src\physics\PumpClock.h">
+      <Filter>Physics</Filter>
+    </ClInclude>
+    <ClInclude Include="src\files\GameDataStream.h">
+      <Filter>Files</Filter>
+    </ClInclude>
+    <ClCompile Include="src\files\GameDataStream.cpp">
+      <Filter>Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(MSVC AND NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
 endif()
 
 option(BSOS_ENABLE_FBXSDK "Build Outfit Studio with Autodesk FBX SDK support when available" ON)
-option(BSOS_ENABLE_BULLET "Build Outfit Studio with Bullet physics preview support when available" ON)
+option(BSOS_ENABLE_BULLET "Build with Bullet physics preview support when available" ON)
 option(BSOS_BUILD_TESTS "Build Catch2-based tests" OFF)
 set(BSOS_FBXSDK_ROOT "" CACHE PATH "Root directory of the Autodesk FBX SDK")
 set(BSOS_TEST_MSVC_RUNTIME_LIBRARY "" CACHE STRING "MSVC runtime library override for BSOSTests")
@@ -240,13 +240,38 @@ if(BSOS_ENABLE_BULLET)
 		endforeach()
 		message(STATUS "Bullet found: ${BSOS_BULLET_INCLUDE_DIRS}")
 	else()
-		message(STATUS "Bullet not found; Outfit Studio will build without physics preview support")
+		message(STATUS "Bullet not found; building without physics preview support")
 	endif()
 else()
 	message(STATUS "Bullet physics preview support disabled")
 endif()
 
+# Physics preview sources are always listed; their bodies compile to empty
+# translation units unless USE_BULLET is defined (same convention as
+# FBXWrangler.cpp with USE_FBXSDK), so builds without Bullet stay valid. Both
+# applications preview physics, so they are part of the common sources.
+set(BSOS_PHYSICS_SOURCES
+	src/physics/Controller.cpp
+	src/physics/DebugDraw.cpp
+	src/physics/SystemBuilder.cpp
+	src/physics/hdt/XmlReader.cpp
+	src/physics/hdt/hdtBoneScaleConstraint.cpp
+	src/physics/hdt/hdtCollider.cpp
+	src/physics/hdt/hdtConeTwistConstraint.cpp
+	src/physics/hdt/hdtDispatcher.cpp
+	src/physics/hdt/hdtGeneric6DofConstraint.cpp
+	src/physics/hdt/hdtSkinnedMeshAlgorithm.cpp
+	src/physics/hdt/hdtSkinnedMeshBody.cpp
+	src/physics/hdt/hdtSkinnedMeshBone.cpp
+	src/physics/hdt/hdtSkinnedMeshShape.cpp
+	src/physics/hdt/hdtSkinnedMeshSystem.cpp
+	src/physics/hdt/hdtSkinnedMeshWorld.cpp
+	src/physics/hdt/hdtStiffSpringConstraint.cpp
+	src/physics/hdt/hdtVertex.cpp
+)
+
 set(BSOS_COMMON_SOURCES
+	${BSOS_PHYSICS_SOURCES}
 	lib/FSEngine/FSBSA.cpp
 	lib/FSEngine/FSEngine.cpp
 	lib/FSEngine/FSManager.cpp
@@ -288,6 +313,7 @@ set(BSOS_COMMON_SOURCES
 	src/components/SliderManager.cpp
 	src/components/SliderPresets.cpp
 	src/components/SliderSet.cpp
+	src/files/GameDataStream.cpp
 	src/files/MaterialFile.cpp
 	src/files/ResourceLoader.cpp
 	src/files/TriFile.cpp
@@ -349,30 +375,6 @@ set(BSOS_OUTFIT_STUDIO_SOURCES
 	src/render/GLCanvas.cpp
 	src/render/GLDialog.cpp
 )
-
-# Physics preview sources are always listed; their bodies compile to empty
-# translation units unless USE_BULLET is defined (same convention as
-# FBXWrangler.cpp with USE_FBXSDK), so builds without Bullet stay valid.
-set(BSOS_PHYSICS_SOURCES
-	src/physics/PhysicsController.cpp
-	src/physics/PhysicsDebugDraw.cpp
-	src/physics/PhysicsSystemBuilder.cpp
-	src/physics/hdt/XmlReader.cpp
-	src/physics/hdt/hdtBoneScaleConstraint.cpp
-	src/physics/hdt/hdtCollider.cpp
-	src/physics/hdt/hdtConeTwistConstraint.cpp
-	src/physics/hdt/hdtDispatcher.cpp
-	src/physics/hdt/hdtGeneric6DofConstraint.cpp
-	src/physics/hdt/hdtSkinnedMeshAlgorithm.cpp
-	src/physics/hdt/hdtSkinnedMeshBody.cpp
-	src/physics/hdt/hdtSkinnedMeshBone.cpp
-	src/physics/hdt/hdtSkinnedMeshShape.cpp
-	src/physics/hdt/hdtSkinnedMeshSystem.cpp
-	src/physics/hdt/hdtSkinnedMeshWorld.cpp
-	src/physics/hdt/hdtStiffSpringConstraint.cpp
-	src/physics/hdt/hdtVertex.cpp
-)
-list(APPEND BSOS_OUTFIT_STUDIO_SOURCES ${BSOS_PHYSICS_SOURCES})
 
 set(BSOS_BODYSLIDE_SOURCES
 	${BSOS_COMMON_SOURCES}
@@ -538,8 +540,10 @@ if(BSOS_HAVE_BULLET)
 	# ported physics code uses. It only adds inline members (the storage is
 	# SSE-backed either way), so it does not have to match how the Bullet
 	# libraries themselves were compiled.
-	target_compile_definitions(OutfitStudio PRIVATE USE_BULLET BT_USE_SSE_IN_API)
-	target_include_directories(OutfitStudio SYSTEM PRIVATE ${BSOS_BULLET_INCLUDE_DIRS})
+	foreach(bullet_target OutfitStudio BodySlide)
+		target_compile_definitions(${bullet_target} PRIVATE USE_BULLET BT_USE_SSE_IN_API)
+		target_include_directories(${bullet_target} SYSTEM PRIVATE ${BSOS_BULLET_INCLUDE_DIRS})
+	endforeach()
 
 	# The config package (BulletConfig.cmake) exports bare library names plus
 	# a library directory; the FindBullet module exports full paths and no
@@ -567,9 +571,11 @@ if(BSOS_HAVE_BULLET)
 			endif()
 		endforeach()
 		target_link_directories(OutfitStudio PRIVATE ${BSOS_BULLET_LIBRARY_DIRS})
+		target_link_directories(BodySlide PRIVATE ${BSOS_BULLET_LIBRARY_DIRS})
 	endif()
 
 	target_link_libraries(OutfitStudio PRIVATE ${BSOS_BULLET_LINK_LIBRARIES})
+	target_link_libraries(BodySlide PRIVATE ${BSOS_BULLET_LINK_LIBRARIES})
 endif()
 
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ if(MSVC AND NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
 endif()
 
 option(BSOS_ENABLE_FBXSDK "Build Outfit Studio with Autodesk FBX SDK support when available" ON)
+option(BSOS_ENABLE_BULLET "Build Outfit Studio with Bullet physics preview support when available" ON)
 option(BSOS_BUILD_TESTS "Build Catch2-based tests" OFF)
 set(BSOS_FBXSDK_ROOT "" CACHE PATH "Root directory of the Autodesk FBX SDK")
 set(BSOS_TEST_MSVC_RUNTIME_LIBRARY "" CACHE STRING "MSVC runtime library override for BSOSTests")
@@ -214,6 +215,37 @@ else()
 	message(STATUS "FBX SDK support disabled")
 endif()
 
+set(BSOS_HAVE_BULLET OFF)
+if(BSOS_ENABLE_BULLET)
+	# vcpkg and modern Bullet installs provide a config package; classic
+	# installs (e.g. libbullet-dev) are covered by CMake's FindBullet module.
+	# A Bullet source build installed beside the repository (like the
+	# wxWidgets/FBX SDK convention the vcxproj files use) is found without
+	# any configuration.
+	find_package(Bullet CONFIG QUIET HINTS "${CMAKE_CURRENT_SOURCE_DIR}/../bullet3/install")
+	if(NOT BULLET_FOUND)
+		find_package(Bullet QUIET)
+	endif()
+
+	if(BULLET_FOUND)
+		set(BSOS_HAVE_BULLET ON)
+		# BULLET_INCLUDE_DIRS may be relative to BULLET_ROOT_DIR depending on
+		# how the package was built; normalize to absolute paths.
+		set(BSOS_BULLET_INCLUDE_DIRS)
+		foreach(bullet_include_dir IN LISTS BULLET_INCLUDE_DIRS)
+			if(NOT IS_ABSOLUTE "${bullet_include_dir}" AND DEFINED BULLET_ROOT_DIR)
+				set(bullet_include_dir "${BULLET_ROOT_DIR}/${bullet_include_dir}")
+			endif()
+			list(APPEND BSOS_BULLET_INCLUDE_DIRS "${bullet_include_dir}")
+		endforeach()
+		message(STATUS "Bullet found: ${BSOS_BULLET_INCLUDE_DIRS}")
+	else()
+		message(STATUS "Bullet not found; Outfit Studio will build without physics preview support")
+	endif()
+else()
+	message(STATUS "Bullet physics preview support disabled")
+endif()
+
 set(BSOS_COMMON_SOURCES
 	lib/FSEngine/FSBSA.cpp
 	lib/FSEngine/FSEngine.cpp
@@ -317,6 +349,30 @@ set(BSOS_OUTFIT_STUDIO_SOURCES
 	src/render/GLCanvas.cpp
 	src/render/GLDialog.cpp
 )
+
+# Physics preview sources are always listed; their bodies compile to empty
+# translation units unless USE_BULLET is defined (same convention as
+# FBXWrangler.cpp with USE_FBXSDK), so builds without Bullet stay valid.
+set(BSOS_PHYSICS_SOURCES
+	src/physics/PhysicsController.cpp
+	src/physics/PhysicsDebugDraw.cpp
+	src/physics/PhysicsSystemBuilder.cpp
+	src/physics/hdt/XmlReader.cpp
+	src/physics/hdt/hdtBoneScaleConstraint.cpp
+	src/physics/hdt/hdtCollider.cpp
+	src/physics/hdt/hdtConeTwistConstraint.cpp
+	src/physics/hdt/hdtDispatcher.cpp
+	src/physics/hdt/hdtGeneric6DofConstraint.cpp
+	src/physics/hdt/hdtSkinnedMeshAlgorithm.cpp
+	src/physics/hdt/hdtSkinnedMeshBody.cpp
+	src/physics/hdt/hdtSkinnedMeshBone.cpp
+	src/physics/hdt/hdtSkinnedMeshShape.cpp
+	src/physics/hdt/hdtSkinnedMeshSystem.cpp
+	src/physics/hdt/hdtSkinnedMeshWorld.cpp
+	src/physics/hdt/hdtStiffSpringConstraint.cpp
+	src/physics/hdt/hdtVertex.cpp
+)
+list(APPEND BSOS_OUTFIT_STUDIO_SOURCES ${BSOS_PHYSICS_SOURCES})
 
 set(BSOS_BODYSLIDE_SOURCES
 	${BSOS_COMMON_SOURCES}
@@ -475,6 +531,45 @@ if(BSOS_HAVE_FBXSDK)
 	if(NOT FBXSDK_ZLIB_LIBRARY_DEBUG AND NOT FBXSDK_ZLIB_LIBRARY_RELEASE AND TARGET ZLIB::ZLIB)
 		target_link_libraries(OutfitStudio PRIVATE ZLIB::ZLIB)
 	endif()
+endif()
+
+if(BSOS_HAVE_BULLET)
+	# BT_USE_SSE_IN_API exposes Bullet's SSE-based btVector3 API that the
+	# ported physics code uses. It only adds inline members (the storage is
+	# SSE-backed either way), so it does not have to match how the Bullet
+	# libraries themselves were compiled.
+	target_compile_definitions(OutfitStudio PRIVATE USE_BULLET BT_USE_SSE_IN_API)
+	target_include_directories(OutfitStudio SYSTEM PRIVATE ${BSOS_BULLET_INCLUDE_DIRS})
+
+	# The config package (BulletConfig.cmake) exports bare library names plus
+	# a library directory; the FindBullet module exports full paths and no
+	# directory. Normalize the directory the same way as the include dirs.
+	set(BSOS_BULLET_LINK_LIBRARIES ${BULLET_LIBRARIES})
+
+	if(DEFINED BULLET_LIBRARY_DIRS)
+		set(BSOS_BULLET_LIBRARY_DIRS)
+		foreach(bullet_library_dir IN LISTS BULLET_LIBRARY_DIRS)
+			if(NOT IS_ABSOLUTE "${bullet_library_dir}" AND DEFINED BULLET_ROOT_DIR)
+				set(bullet_library_dir "${BULLET_ROOT_DIR}/${bullet_library_dir}")
+			endif()
+			list(APPEND BSOS_BULLET_LIBRARY_DIRS "${bullet_library_dir}")
+
+			# A Bullet source install keeps "_Debug"-suffixed debug variants
+			# next to the release libraries; they must be picked for Debug
+			# builds so the MSVC runtime (/MTd) matches. vcpkg installs have
+			# no suffix and are handled by its toolchain instead.
+			if(MSVC AND EXISTS "${bullet_library_dir}/BulletDynamics_Debug.lib")
+				set(BSOS_BULLET_LINK_LIBRARIES
+					"$<IF:$<CONFIG:Debug>,BulletDynamics_Debug,BulletDynamics>"
+					"$<IF:$<CONFIG:Debug>,BulletCollision_Debug,BulletCollision>"
+					"$<IF:$<CONFIG:Debug>,LinearMath_Debug,LinearMath>"
+				)
+			endif()
+		endforeach()
+		target_link_directories(OutfitStudio PRIVATE ${BSOS_BULLET_LIBRARY_DIRS})
+	endif()
+
+	target_link_libraries(OutfitStudio PRIVATE ${BSOS_BULLET_LINK_LIBRARIES})
 endif()
 
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,14 +536,29 @@ if(BSOS_HAVE_FBXSDK)
 endif()
 
 if(BSOS_HAVE_BULLET)
-	# BT_USE_SSE_IN_API exposes Bullet's SSE-based btVector3 API that the
-	# ported physics code uses. It only adds inline members (the storage is
-	# SSE-backed either way), so it does not have to match how the Bullet
-	# libraries themselves were compiled.
+	# BT_USE_SSE_IN_API exposes Bullet's SSE-based btVector3 API that the ported
+	# physics code prefers. It only adds inline members (the storage is SSE-backed
+	# either way), so it does not have to match how the Bullet libraries
+	# themselves were compiled. It has no effect unless btScalar.h also turns on
+	# BT_USE_SSE, which it does on Windows and macOS but not on Linux; the port
+	# falls back to explicit conversions there (see hdt::toSimd in
+	# hdtBulletHelper.h).
 	foreach(bullet_target OutfitStudio BodySlide)
 		target_compile_definitions(${bullet_target} PRIVATE USE_BULLET BT_USE_SSE_IN_API)
 		target_include_directories(${bullet_target} SYSTEM PRIVATE ${BSOS_BULLET_INCLUDE_DIRS})
 	endforeach()
+
+	# The port uses SSE4.1 intrinsics throughout, as the MSVC build does through
+	# BT_ALLOW_SSE4. GCC and Clang only accept those with a matching -m flag, and
+	# reject them in always_inline functions otherwise, so raise the instruction
+	# set for the physics sources alone.
+	if(NOT MSVC)
+		include(CheckCXXCompilerFlag)
+		check_cxx_compiler_flag("-msse4.1" BSOS_HAVE_SSE41_FLAG)
+		if(BSOS_HAVE_SSE41_FLAG)
+			set_source_files_properties(${BSOS_PHYSICS_SOURCES} PROPERTIES COMPILE_OPTIONS "-msse4.1")
+		endif()
+	endif()
 
 	# The config package (BulletConfig.cmake) exports bare library names plus
 	# a library directory; the FindBullet module exports full paths and no

--- a/OutfitStudio.vcxproj
+++ b/OutfitStudio.vcxproj
@@ -126,8 +126,8 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\wxWidgets\include\msvc;..\wxWidgets\include;..\FBX SDK\2020.3.7\include;lib;lib\gli;lib\nifly\include;lib\nifly\external;lib\TinyXML-2;lib\fkYAML\include;lib\nlohmannjson\include</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN64;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;NOMINMAX;USE_FBXSDK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\wxWidgets\include\msvc;..\wxWidgets\include;..\FBX SDK\2020.3.7\include;..\bullet3\install\include\bullet;lib;lib\gli;lib\nifly\include;lib\nifly\external;lib\TinyXML-2;lib\fkYAML\include;lib\nlohmannjson\include</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN64;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;NOMINMAX;USE_FBXSDK;USE_BULLET;BT_USE_SSE_IN_API;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -139,8 +139,8 @@
       <ExternalWarningLevel>Level1</ExternalWarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>glu32.lib;opengl32.lib;dbghelp.lib;winmm.lib;libfbxsdk-mt.lib;libxml2-mt.lib;zlib-mt.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\FBX SDK\2020.3.7\lib\x64\debug;..\wxWidgets\lib\vc_x64_lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>glu32.lib;opengl32.lib;dbghelp.lib;winmm.lib;libfbxsdk-mt.lib;libxml2-mt.lib;zlib-mt.lib;BulletDynamics_Debug.lib;BulletCollision_Debug.lib;LinearMath_Debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\FBX SDK\2020.3.7\lib\x64\debug;..\wxWidgets\lib\vc_x64_lib;..\bullet3\install\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
@@ -194,8 +194,8 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>..\wxWidgets\include\msvc;..\wxWidgets\include;..\FBX SDK\2020.3.7\include;lib;lib\gli;lib\nifly\include;lib\nifly\external;lib\TinyXML-2;lib\fkYAML\include;lib\nlohmannjson\include</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;NOMINMAX;USE_FBXSDK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\wxWidgets\include\msvc;..\wxWidgets\include;..\FBX SDK\2020.3.7\include;..\bullet3\install\include\bullet;lib;lib\gli;lib\nifly\include;lib\nifly\external;lib\TinyXML-2;lib\fkYAML\include;lib\nlohmannjson\include</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;NOMINMAX;USE_FBXSDK;USE_BULLET;BT_USE_SSE_IN_API;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>
       </FunctionLevelLinking>
@@ -208,8 +208,8 @@
       <ExternalWarningLevel>Level1</ExternalWarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>glu32.lib;opengl32.lib;dbghelp.lib;winmm.lib;libfbxsdk-mt.lib;libxml2-mt.lib;zlib-mt.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\FBX SDK\2020.3.7\lib\x64\release;..\wxWidgets\lib\vc_x64_lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>glu32.lib;opengl32.lib;dbghelp.lib;winmm.lib;libfbxsdk-mt.lib;libxml2-mt.lib;zlib-mt.lib;BulletDynamics.lib;BulletCollision.lib;LinearMath.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\FBX SDK\2020.3.7\lib\x64\release;..\wxWidgets\lib\vc_x64_lib;..\bullet3\install\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <IgnoreSpecificDefaultLibraries>
       </IgnoreSpecificDefaultLibraries>
@@ -836,6 +836,30 @@
     <ClInclude Include="src\files\TriFile.h" />
     <ClInclude Include="src\files\MaskFile.h" />
     <ClInclude Include="src\files\HkxFile.h" />
+    <ClInclude Include="src\physics\NiflyBullet.h" />
+    <ClInclude Include="src\physics\PhysicsController.h" />
+    <ClInclude Include="src\physics\PhysicsDebugDraw.h" />
+    <ClInclude Include="src\physics\PhysicsSystemBuilder.h" />
+    <ClInclude Include="src\physics\hdt\XmlReader.h" />
+    <ClInclude Include="src\physics\hdt\hdtAABB.h" />
+    <ClInclude Include="src\physics\hdt\hdtBone.h" />
+    <ClInclude Include="src\physics\hdt\hdtBoneScaleConstraint.h" />
+    <ClInclude Include="src\physics\hdt\hdtBulletHelper.h" />
+    <ClInclude Include="src\physics\hdt\hdtCollider.h" />
+    <ClInclude Include="src\physics\hdt\hdtConeTwistConstraint.h" />
+    <ClInclude Include="src\physics\hdt\hdtConstraintGroup.h" />
+    <ClInclude Include="src\physics\hdt\hdtDispatcher.h" />
+    <ClInclude Include="src\physics\hdt\hdtGeneric6DofConstraint.h" />
+    <ClInclude Include="src\physics\hdt\hdtRefUtils.h" />
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshAlgorithm.h" />
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshBody.h" />
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshBone.h" />
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshShape.h" />
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshSystem.h" />
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshWorld.h" />
+    <ClInclude Include="src\physics\hdt\hdtStiffSpringConstraint.h" />
+    <ClInclude Include="src\physics\hdt\hdtStringUtils.h" />
+    <ClInclude Include="src\physics\hdt\hdtVertex.h" />
     <ClInclude Include="src\program\ConvertBodyReferenceDialog.h" />
     <ClInclude Include="src\program\AutomationDialog.h" />
     <ClInclude Include="src\components\Automation.h" />
@@ -935,6 +959,23 @@
     <ClCompile Include="src\files\TriFile.cpp" />
     <ClCompile Include="src\files\MaskFile.cpp" />
     <ClCompile Include="src\files\HkxFile.cpp" />
+    <ClCompile Include="src\physics\PhysicsController.cpp" />
+    <ClCompile Include="src\physics\PhysicsDebugDraw.cpp" />
+    <ClCompile Include="src\physics\PhysicsSystemBuilder.cpp" />
+    <ClCompile Include="src\physics\hdt\XmlReader.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtBoneScaleConstraint.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtCollider.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtConeTwistConstraint.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtDispatcher.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtGeneric6DofConstraint.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshAlgorithm.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshBody.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshBone.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshShape.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshSystem.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshWorld.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtStiffSpringConstraint.cpp" />
+    <ClCompile Include="src\physics\hdt\hdtVertex.cpp" />
     <ClCompile Include="src\program\ConvertBodyReferenceDialog.cpp" />
     <ClCompile Include="src\program\AutomationDialog.cpp" />
     <ClCompile Include="src\program\AutomationDialogExecute.cpp" />

--- a/OutfitStudio.vcxproj
+++ b/OutfitStudio.vcxproj
@@ -825,6 +825,7 @@
     <ClInclude Include="src\components\UndoHistory.h" />
     <ClInclude Include="src\components\WeightNorm.h" />
     <ClInclude Include="src\files\FBXWrangler.h" />
+    <ClInclude Include="src\files\GameDataStream.h" />
     <ClInclude Include="src\files\MaterialFile.h" />
     <ClInclude Include="src\files\SFMaterialDatabase.h" />
     <ClInclude Include="src\files\SFMaterialFile.h" />
@@ -837,9 +838,10 @@
     <ClInclude Include="src\files\MaskFile.h" />
     <ClInclude Include="src\files\HkxFile.h" />
     <ClInclude Include="src\physics\NiflyBullet.h" />
-    <ClInclude Include="src\physics\PhysicsController.h" />
-    <ClInclude Include="src\physics\PhysicsDebugDraw.h" />
-    <ClInclude Include="src\physics\PhysicsSystemBuilder.h" />
+    <ClInclude Include="src\physics\Controller.h" />
+    <ClInclude Include="src\physics\DebugDraw.h" />
+    <ClInclude Include="src\physics\PumpClock.h" />
+    <ClInclude Include="src\physics\SystemBuilder.h" />
     <ClInclude Include="src\physics\hdt\XmlReader.h" />
     <ClInclude Include="src\physics\hdt\hdtAABB.h" />
     <ClInclude Include="src\physics\hdt\hdtBone.h" />
@@ -948,6 +950,7 @@
     <ClCompile Include="src\components\UndoHistory.cpp" />
     <ClCompile Include="src\components\WeightNorm.cpp" />
     <ClCompile Include="src\files\FBXWrangler.cpp" />
+    <ClCompile Include="src\files\GameDataStream.cpp" />
     <ClCompile Include="src\files\MaterialFile.cpp" />
     <ClCompile Include="src\files\SFMaterialDatabase.cpp" />
     <ClCompile Include="src\files\SFMaterialFile.cpp" />
@@ -959,9 +962,9 @@
     <ClCompile Include="src\files\TriFile.cpp" />
     <ClCompile Include="src\files\MaskFile.cpp" />
     <ClCompile Include="src\files\HkxFile.cpp" />
-    <ClCompile Include="src\physics\PhysicsController.cpp" />
-    <ClCompile Include="src\physics\PhysicsDebugDraw.cpp" />
-    <ClCompile Include="src\physics\PhysicsSystemBuilder.cpp" />
+    <ClCompile Include="src\physics\Controller.cpp" />
+    <ClCompile Include="src\physics\DebugDraw.cpp" />
+    <ClCompile Include="src\physics\SystemBuilder.cpp" />
     <ClCompile Include="src\physics\hdt\XmlReader.cpp" />
     <ClCompile Include="src\physics\hdt\hdtBoneScaleConstraint.cpp" />
     <ClCompile Include="src\physics\hdt\hdtCollider.cpp" />

--- a/OutfitStudio.vcxproj.filters
+++ b/OutfitStudio.vcxproj.filters
@@ -35,6 +35,12 @@
     <Filter Include="Components">
       <UniqueIdentifier>{8e852d2f-5f87-416d-be07-c75179e8f57e}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Physics">
+      <UniqueIdentifier>{a3f1c2d4-9b7e-4f21-8c5a-2d6e0b1f4a37}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Physics\hdt">
+      <UniqueIdentifier>{b4e2d3c5-0c8f-4a32-9d6b-3e7f1c2a5b48}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Files">
       <UniqueIdentifier>{782be5c1-aa6f-4e54-acb4-c89dc11d2fcb}</UniqueIdentifier>
     </Filter>
@@ -771,6 +777,78 @@
     </ClInclude>
     <ClInclude Include="src\files\SFResourceHash.h">
       <Filter>Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\NiflyBullet.h">
+      <Filter>Physics</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\PhysicsController.h">
+      <Filter>Physics</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\PhysicsDebugDraw.h">
+      <Filter>Physics</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\PhysicsSystemBuilder.h">
+      <Filter>Physics</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\XmlReader.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtAABB.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtBone.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtBoneScaleConstraint.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtBulletHelper.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtCollider.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtConeTwistConstraint.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtConstraintGroup.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtDispatcher.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtGeneric6DofConstraint.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtRefUtils.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshAlgorithm.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshBody.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshBone.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshShape.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshSystem.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtSkinnedMeshWorld.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtStiffSpringConstraint.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtStringUtils.h">
+      <Filter>Physics\hdt</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\hdt\hdtVertex.h">
+      <Filter>Physics\hdt</Filter>
     </ClInclude>
     <ClInclude Include="src\program\OutfitStudio.h">
       <Filter>Program</Filter>
@@ -2072,6 +2150,57 @@
     </ClCompile>
     <ClCompile Include="src\files\SFResourceHash.cpp">
       <Filter>Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\PhysicsController.cpp">
+      <Filter>Physics</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\PhysicsDebugDraw.cpp">
+      <Filter>Physics</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\PhysicsSystemBuilder.cpp">
+      <Filter>Physics</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\XmlReader.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtBoneScaleConstraint.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtCollider.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtConeTwistConstraint.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtDispatcher.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtGeneric6DofConstraint.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshAlgorithm.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshBody.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshBone.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshShape.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshSystem.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtSkinnedMeshWorld.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtStiffSpringConstraint.cpp">
+      <Filter>Physics\hdt</Filter>
+    </ClCompile>
+    <ClCompile Include="src\physics\hdt\hdtVertex.cpp">
+      <Filter>Physics\hdt</Filter>
     </ClCompile>
     <ClCompile Include="src\program\OutfitStudio.cpp">
       <Filter>Program</Filter>

--- a/OutfitStudio.vcxproj.filters
+++ b/OutfitStudio.vcxproj.filters
@@ -763,6 +763,9 @@
     <ClInclude Include="src\files\FBXWrangler.h">
       <Filter>Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\files\GameDataStream.h">
+      <Filter>Files</Filter>
+    </ClInclude>
     <ClInclude Include="src\files\MaterialFile.h">
       <Filter>Files</Filter>
     </ClInclude>
@@ -781,13 +784,16 @@
     <ClInclude Include="src\physics\NiflyBullet.h">
       <Filter>Physics</Filter>
     </ClInclude>
-    <ClInclude Include="src\physics\PhysicsController.h">
+    <ClInclude Include="src\physics\Controller.h">
       <Filter>Physics</Filter>
     </ClInclude>
-    <ClInclude Include="src\physics\PhysicsDebugDraw.h">
+    <ClInclude Include="src\physics\DebugDraw.h">
       <Filter>Physics</Filter>
     </ClInclude>
-    <ClInclude Include="src\physics\PhysicsSystemBuilder.h">
+    <ClInclude Include="src\physics\PumpClock.h">
+      <Filter>Physics</Filter>
+    </ClInclude>
+    <ClInclude Include="src\physics\SystemBuilder.h">
       <Filter>Physics</Filter>
     </ClInclude>
     <ClInclude Include="src\physics\hdt\XmlReader.h">
@@ -2136,6 +2142,9 @@
     <ClCompile Include="src\files\FBXWrangler.cpp">
       <Filter>Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\files\GameDataStream.cpp">
+      <Filter>Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\files\MaterialFile.cpp">
       <Filter>Files</Filter>
     </ClCompile>
@@ -2151,13 +2160,13 @@
     <ClCompile Include="src\files\SFResourceHash.cpp">
       <Filter>Files</Filter>
     </ClCompile>
-    <ClCompile Include="src\physics\PhysicsController.cpp">
+    <ClCompile Include="src\physics\Controller.cpp">
       <Filter>Physics</Filter>
     </ClCompile>
-    <ClCompile Include="src\physics\PhysicsDebugDraw.cpp">
+    <ClCompile Include="src\physics\DebugDraw.cpp">
       <Filter>Physics</Filter>
     </ClCompile>
-    <ClCompile Include="src\physics\PhysicsSystemBuilder.cpp">
+    <ClCompile Include="src\physics\SystemBuilder.cpp">
       <Filter>Physics</Filter>
     </ClCompile>
     <ClCompile Include="src\physics\hdt\XmlReader.cpp">

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ BodySlide and Outfit Studio, a tool to convert, create, and customize outfits an
 * [nifly](https://github.com/ousnius/nifly): C++ NIF library for the NetImmerse File Format (NetImmerse, Gamebryo, Creation Engine).
 * [NiflySharp](https://github.com/ousnius/NiflySharp): Native C# / .NET version of nifly that uses source generation based on [nifxml](https://github.com/niftools/nifxml).
 * [Faster HDT-SMP (FSMP)](https://github.com/DaymareOn/hdtSMP64): Skinned mesh physics for Skyrim SE/AE/VR, maintained by DaydreamingDay / DaymareOn, forked from [Karonar1](https://github.com/Karonar1/hdtSMP64) and [aers](https://github.com/aers/hdtSMP64), from the original [work](https://github.com/HydrogensaysHDT/hdt-skyrimse-mods) by HydrogensaysHDT.
-  Outfit Studio's physics preview is a port of its `hdtSkinnedMesh` core (GPL-3.0, like this project) so it simulates the same physics XML files with the same behavior. See [src/physics/hdt/README.md](src/physics/hdt/README.md) for the port notes.
+  The physics preview in BodySlide and Outfit Studio is a port of its `hdtSkinnedMesh` core (GPL-3.0, like this project) so it simulates the same physics XML files with the same behavior. See [src/physics/hdt/README.md](src/physics/hdt/README.md) for the port notes.
 
 **Libraries used:**
 * [wxWidgets](https://wxwidgets.org/)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ BodySlide and Outfit Studio, a tool to convert, create, and customize outfits an
 **Relevant work:**
 * [nifly](https://github.com/ousnius/nifly): C++ NIF library for the NetImmerse File Format (NetImmerse, Gamebryo, Creation Engine).
 * [NiflySharp](https://github.com/ousnius/NiflySharp): Native C# / .NET version of nifly that uses source generation based on [nifxml](https://github.com/niftools/nifxml).
+* [Faster HDT-SMP (FSMP)](https://github.com/DaymareOn/hdtSMP64): Skinned mesh physics for Skyrim SE/AE/VR, maintained by DaydreamingDay / DaymareOn, forked from [Karonar1](https://github.com/Karonar1/hdtSMP64) and [aers](https://github.com/aers/hdtSMP64), from the original [work](https://github.com/HydrogensaysHDT/hdt-skyrimse-mods) by HydrogensaysHDT.
+  Outfit Studio's physics preview is a port of its `hdtSkinnedMesh` core (GPL-3.0, like this project) so it simulates the same physics XML files with the same behavior. See [src/physics/hdt/README.md](src/physics/hdt/README.md) for the port notes.
 
 **Libraries used:**
 * [wxWidgets](https://wxwidgets.org/)
@@ -41,4 +43,5 @@ BodySlide and Outfit Studio, a tool to convert, create, and customize outfits an
 * [fkYAML](https://github.com/fktn-k/fkYAML)
 * [Catch2 v3](https://github.com/catchorg/Catch2) (optional tests)
 * FSEngine (BSA/BA2 library)
-* [Autodesk FBX SDK](https://aps.autodesk.com/developer/overview/fbx-sdk)
+* [Autodesk FBX SDK](https://aps.autodesk.com/developer/overview/fbx-sdk) (optional FBX import/export)
+* [Bullet](https://github.com/bulletphysics/bullet3) (optional physics preview)

--- a/res/xrc/OutfitStudio.xrc
+++ b/res/xrc/OutfitStudio.xrc
@@ -1422,6 +1422,78 @@
 																		<option>0</option>
 																		<flag>wxTOP|wxLEFT|wxRIGHT|wxEXPAND</flag>
 																		<border>5</border>
+																		<object class="wxBoxSizer">
+																			<orient>wxHORIZONTAL</orient>
+																			<object class="sizeritem">
+																				<option>0</option>
+																				<flag>wxRIGHT|wxEXPAND</flag>
+																				<border>5</border>
+																				<object class="wxCheckBox" name="cbPhysics">
+																					<label>Physics</label>
+																					<tooltip>Simulate HDT-SMP physics XMLs referenced by the loaded meshes</tooltip>
+																					<checked>0</checked>
+																				</object>
+																			</object>
+																			<object class="sizeritem">
+																				<option>0</option>
+																				<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
+																				<border>5</border>
+																				<object class="wxCheckBox" name="cbPhysicsVis">
+																					<label>Show Colliders</label>
+																					<tooltip>Draw the collision shapes and constraints of the physics simulation</tooltip>
+																					<checked>0</checked>
+																					<enabled>0</enabled>
+																				</object>
+																			</object>
+																		</object>
+																	</object>
+																	<object class="sizeritem">
+																		<option>0</option>
+																		<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
+																		<border>5</border>
+																		<object class="wxBoxSizer">
+																			<orient>wxHORIZONTAL</orient>
+																			<object class="sizeritem">
+																				<option>0</option>
+																				<flag>wxRIGHT|wxALIGN_CENTER_VERTICAL</flag>
+																				<border>5</border>
+																				<object class="wxStaticText" name="physicsWindLabel">
+																					<label>Wind</label>
+																				</object>
+																			</object>
+																			<object class="sizeritem">
+																				<option>1</option>
+																				<flag>wxEXPAND</flag>
+																				<object class="wxSlider" name="physicsWindSlider">
+																					<value>0</value>
+																					<min>0</min>
+																					<max>100</max>
+																					<tooltip>World wind strength for the physics preview (0 = off)</tooltip>
+																				</object>
+																			</object>
+																			<object class="sizeritem">
+																				<option>0</option>
+																				<flag>wxLEFT|wxALIGN_CENTER_VERTICAL</flag>
+																				<border>5</border>
+																				<object class="wxChoice" name="physicsWindDir">
+																					<selection>5</selection>
+																					<content>
+																						<item>Up</item>
+																						<item>Down</item>
+																						<item>Forward</item>
+																						<item>Backward</item>
+																						<item>Left</item>
+																						<item>Right</item>
+																					</content>
+																					<tooltip>Direction the wind blows in, as seen in the viewport. It stays fixed to the mesh while the camera turns.</tooltip>
+																				</object>
+																			</object>
+																		</object>
+																	</object>
+																	<object class="sizeritem">
+																		<option>0</option>
+																		<flag>wxTOP|wxLEFT|wxRIGHT|wxEXPAND</flag>
+																		<border>5</border>
 																		<object class="wxFlexGridSizer">
 																			<rows>0</rows>
 																			<cols>3</cols>

--- a/res/xrc/OutfitStudio.xrc
+++ b/res/xrc/OutfitStudio.xrc
@@ -817,1035 +817,1067 @@
 													<orient>wxVERTICAL</orient>
 													<object class="sizeritem">
 														<option>0</option>
-														<flag>wxALL|wxEXPAND|wxLEFT</flag>
-														<border>2</border>
-														<object class="wxPanel" name="editPanel">
-															<style>wxTAB_TRAVERSAL</style>
+														<flag>wxEXPAND</flag>
+														<border>0</border>
+														<object class="wxScrolledWindow" name="toolScroll">
+															<style>wxVSCROLL|wxTAB_TRAVERSAL</style>
+															<bg>#707070</bg>
+															<scrollrate>0,18</scrollrate>
 															<object class="wxBoxSizer">
 																<orient>wxVERTICAL</orient>
 																<object class="sizeritem">
 																	<option>0</option>
-																	<flag>wxALL|wxEXPAND</flag>
-																	<border>0</border>
-																	<object class="wxBoxSizer">
-																		<orient>wxHORIZONTAL</orient>
-																		<object class="sizeritem">
-																			<option>0</option>
-																			<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
-																			<border>5</border>
-																			<object class="wxStaticText" name="segmentTypeLabel">
-																				<fg>#ffffff</fg>
-																				<label>Type</label>
-																				<hidden>1</hidden>
-																			</object>
-																		</object>
-																		<object class="sizeritem">
-																			<option>1</option>
-																			<flag>wxALL|wxEXPAND</flag>
-																			<border>5</border>
-																			<object class="wxChoice" name="segmentType">
-																				<selection>0</selection>
-																				<content>
-																					<item translate="0">Default</item>
-																					<item translate="0">1 | Head/Hair | 0x86b72980</item>
-																					<item translate="0">1 | Neck | 0x0155094f</item>
-																					<item translate="0">Human 2 | R-Up Arm | 0xb2e2764f</item>
-																					<item translate="0">Human 2 | R-Lo Arm | 0x6fc3fbb2</item>
-																					<item translate="0">Human 4 | L-Up Arm | 0xfc03dc25</item>
-																					<item translate="0">Human 4 | L-Lo Arm | 0x212251d8</item>
-																					<item translate="0">Human 5 | R-Up Thi | 0xbf3a3cc5</item>
-																					<item translate="0">Human 5 | R-Kne-Clf | 0x22324321</item>
-																					<item translate="0">Human 5 | R-Lo Ft.-Ank | 0xc7e6bc92</item>
-																					<item translate="0">Human 6 | L-Up Leg | 0x865d8d9e</item>
-																					<item translate="0">Human 6 | L-Kne-Clf | 0x4630dac2</item>
-																					<item translate="0">Human 6 | L-Lo Ft.-Ank | 0xa3e42571</item>
-																					<item translate="0">Feral Ghoul 2 | R-Up Arm | 0x2a549ee1</item>
-																					<item translate="0">Feral Ghoul 2 | R-Lo Arm | 0xf775131c</item>
-																					<item translate="0">Feral Ghoul 2 | R-Hand | 0x85342e3c</item>
-																					<item translate="0">Feral Ghoul 4 | L-Up Arm | 0x4e560702</item>
-																					<item translate="0">Feral Ghoul 4 | L-Lo Arm | 0x93778aff</item>
-																					<item translate="0">Feral Ghoul 4 | L-Hand | 0x5ae407df</item>
-																					<item translate="0">Death Claw 1 | Neck | 0xc0f43cc3</item>
-																					<item translate="0">Death Claw 2 | R-Up-Arm | 0xf2ba1077</item>
-																					<item translate="0">Death Claw 2 | R-Elbow-4Arm | 0xf4e10d0d</item>
-																					<item translate="0">Death Claw 2 | R-Hand | 0xe2da5319</item>
-																					<item translate="0">Death Claw 4 | L-Up-Arm | 0x17932e95</item>
-																					<item translate="0">Death Claw 4 | L-Elbow-4Arm | 0x0861e2c0</item>
-																					<item translate="0">Death Claw 4 | L-Hand | 0x8beb7000</item>
-																					<item translate="0">Death Claw, Feral Ghoul 5 | R-Up Thi | 0x9af9d18c</item>
-																					<item translate="0">Death Claw, Feral Ghoul 5 | R-Lo Leg | 0x8e0daa93</item>
-																					<item translate="0">Death Claw, Feral Ghoul 5 | R-Lo Ft | 0x6bd95520</item>
-																					<item translate="0">Death Claw, Feral Ghoul 6 | L-Lo Thi | 0xa325b267</item>
-																					<item translate="0">Death Claw, Feral Ghoul 6 | L-Lo Leg | 0x51dd8370</item>
-																					<item translate="0">Death Claw, Feral Ghoul 6 | L-Lo Ft | 0xb4097cc3</item>
-																					<item translate="0">Super Mutant Hound 3 | Fr-Lf Up Leg | 0x99338c09</item>
-																					<item translate="0">Super Mutant Hound 3 | Fr-Lf Lo Leg | 0x7491a630</item>
-																					<item translate="0">Super Mutant Hound 3 | Fr-Lf Foot | 0x8a99ba3f</item>
-																					<item translate="0">Super Mutant Hound 4 | Bk-Lf Thigh | 0xa7860026</item>
-																					<item translate="0">Super Mutant Hound 4 | Bk-Lf Knee | 0xaf6a52d7</item>
-																					<item translate="0">Super Mutant Hound 4 | Bk-Lf Ankle | 0xb42c3610</item>
-																					<item translate="0">Super Mutant Hound 4 | Bk-Lf Foot | 0x6e284ec0</item>
-																					<item translate="0">Super Mutant Hound 5 | Bk-Ri Thigh | 0x0e97871c</item>
-																					<item translate="0">Super Mutant Hound 5 | Bk-Ri Knee | 0x02433b3b</item>
-																					<item translate="0">Super Mutant Hound 5 | Bk-Ri Ankle | 0x1d3db12a</item>
-																					<item translate="0">Super Mutant Hound 5 | Bk-Ri Foot | 0x20c9e4aa</item>
-																					<item translate="0">Super Mutant Hound 6 | Fr-Ri Up Leg | 0x5f96443c</item>
-																					<item translate="0">Super Mutant Hound 6 | Fr-Ri Lo Leg | 0xdd80210a</item>
-																					<item translate="0">Super Mutant Hound 6 | Fr-Ri Foot | 0x4c3c720a</item>
-																					<item translate="0">Mirelurk 2 | Fr-Ri-Up Arm | 0xa5f4be71</item>
-																					<item translate="0">Mirelurk 2 | Fr-Ri-Lo Arm | 0x99eb64eb</item>
-																					<item translate="0">Mirelurk 2 | R Claw | 0x3c9df64f</item>
-																					<item translate="0">Mirelurk 4 | L Shoulder | 0x40f66ca4</item>
-																					<item translate="0">Mirelurk 4 | L-Up Arm | 0xc1f62792</item>
-																					<item translate="0">Mirelurk 4 | L Elbow | 0xf0da47f2</item>
-																					<item translate="0">Mirelurk 4 | L Claw | 0x55acd556</item>
-																					<item translate="0">Mirelurk 5 | Fr-Ri Hip | 0x064f59cd</item>
-																					<item translate="0">Mirelurk 5 | Fr-Ri Thigh | 0x5b033df6</item>
-																					<item translate="0">Mirelurk 5 | Fr-Ri Calf | 0x15fc7bad</item>
-																					<item translate="0">Mirelurk 5 | Fr-Ri Foot | 0xf028841e</item>
-																					<item translate="0">Mirelurk 6 | Fr-Lf Hip-Thigh | 0xf62a541a</item>
-																					<item translate="0">Mirelurk 6 | Fr-Lf Kne-Clf | 0x5b1dd1c7</item>
-																					<item translate="0">Mirelurk 6 | Fr-Lf Foot | 0xbec92e74</item>
-																					<item translate="0">Mirelurk 8 | Bk-Ri Hip-Thigh | 0xfc5546b8</item>
-																					<item translate="0">Mirelurk 8 | Bk-Ri Kne-Clf | 0x24a15449</item>
-																					<item translate="0">Mirelurk 8 | Bk-Ri Foot | 0xc175abfa</item>
-																					<item translate="0">Mirelurk 9 | Bk-Lf Hip-Thigh | 0xb2b4ecd2</item>
-																					<item translate="0">Mirelurk 9 | Bk-Lf Kne-Clf | 0xc1886aab</item>
-																					<item translate="0">Mirelurk 9 | Bk-Lf Foot | 0x245c9518</item>
-																					<item translate="0">Dog 3 | Fr-Lf Knee | 0x5530c47b</item>
-																					<item translate="0">Dog 3 | Fr-Lf Calf | 0xcc3995c1</item>
-																					<item translate="0">Dog 3 | Fr-Lf Heel+Arch | 0xbd2750cf</item>
-																					<item translate="0">Dog 3 | Fr-Lf Paw | 0x77fe1ec8</item>
-																					<item translate="0">Dog 4 | Bk-Lf Knee | 0x52f7244b</item>
-																					<item translate="0">Dog 4 | Bk-Lf Calf | 0xcbfe75f1</item>
-																					<item translate="0">Dog 4 | Bk-Lf Heel+Arch | 0xfe31ace4</item>
-																					<item translate="0">Dog 4 | Bk-Lf Paw | 0x08eb5fa0</item>
-																					<item translate="0">Dog 5 | Bk-Ri Knee | 0x8d270da8</item>
-																					<item translate="0">Dog 5 | Bk-Ri Calf+Heel | 0x142e5c12</item>
-																					<item translate="0">Dog 5 | Bk-Ri Arch | 0x9a333507</item>
-																					<item translate="0">Dog 5 | Bk-Ri Paw | 0x61da7cb9</item>
-																					<item translate="0">Dog 6 | Fr-Ri Knee | 0x8ae0ed98</item>
-																					<item translate="0">Dog 6 | Fr-Ri Calf | 0x13e9bc22</item>
-																					<item translate="0">Dog 6 | Fr-Ri Heel+Arch | 0xd925c92c</item>
-																					<item translate="0">Dog 6 | Fr-Ri Paw | 0x1ecf3dd1</item>
-																					<item translate="0">Behemoth 2 | R-Arm+Elbow | 0x8c5ae189</item>
-																					<item translate="0">Behemoth 2 | R-4 Arm | 0x071dfd97</item>
-																					<item translate="0">Behemoth 2 | R-Hand | 0xded0fadf</item>
-																					<item translate="0">Behemoth 4 | L-Arm+Elbow | 0xc2bb4be3</item>
-																					<item translate="0">Behemoth 4 | L-4 Arm | 0x3e7a4ccc</item>
-																					<item translate="0">Behemoth 4 | L-Hand | 0xe7b74b84</item>
-																					<item translate="0">Behemoth 5 | R-Calf | 0xa411c600</item>
-																					<item translate="0">Behemoth 5 | R-Foot | 0xac900af3</item>
-																					<item translate="0">Behemoth 6 | L-Calf | 0xc0135fe3</item>
-																					<item translate="0">Behemoth 6 | R-Foot | 0x95f7bba8</item>
-																					<item translate="0">Robot 3 | Torso | 0x3d6644aa</item>
-																				</content>
-																				<hidden>1</hidden>
-																				<enabled>0</enabled>
-																			</object>
-																		</object>
-																	</object>
-																</object>
-																<object class="sizeritem">
-																	<option>0</option>
-																	<flag>wxALL|wxEXPAND</flag>
-																	<border>0</border>
-																	<object class="wxBoxSizer">
-																		<orient>wxHORIZONTAL</orient>
-																		<object class="sizeritem">
-																			<option>0</option>
-																			<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
-																			<border>5</border>
-																			<object class="wxStaticText" name="segmentSlotLabel">
-																				<fg>#ffffff</fg>
-																				<label>Slot</label>
-																				<hidden>1</hidden>
-																			</object>
-																		</object>
-																		<object class="sizeritem">
-																			<option>1</option>
-																			<flag>wxALL|wxEXPAND</flag>
-																			<border>5</border>
-																			<object class="wxChoice" name="segmentSlot">
-																				<selection>0</selection>
-																				<content>
-																					<item translate="0">None</item>
-																					<item translate="0">30 - Hair Top</item>
-																					<item translate="0">31 - Hair Long</item>
-																					<item translate="0">32 - Head</item>
-																					<item translate="0">33 - Body</item>
-																					<item translate="0">34 - L Hand</item>
-																					<item translate="0">35 - R Hand</item>
-																					<item translate="0">36 - [U] Torso</item>
-																					<item translate="0">37 - [U] L Arm</item>
-																					<item translate="0">38 - [U] R Arm</item>
-																					<item translate="0">39 - [U] L Leg</item>
-																					<item translate="0">40 - [U] R Leg</item>
-																					<item translate="0">41 - [A] Torso</item>
-																					<item translate="0">42 - [A] L Arm</item>
-																					<item translate="0">43 - [A] R Arm</item>
-																					<item translate="0">44 - [A] L Leg</item>
-																					<item translate="0">45 - [A] R Leg</item>
-																					<item translate="0">46 - Headband</item>
-																					<item translate="0">47 - Eyes</item>
-																					<item translate="0">48 - Beard</item>
-																					<item translate="0">49 - Mouth</item>
-																					<item translate="0">50 - Neck</item>
-																					<item translate="0">51 - Ring</item>
-																					<item translate="0">52 - Scalp</item>
-																					<item translate="0">53 - Decapitation</item>
-																					<item translate="0">54 - Unnamed</item>
-																					<item translate="0">55 - Unnamed</item>
-																					<item translate="0">56 - Unnamed</item>
-																					<item translate="0">57 - Unnamed</item>
-																					<item translate="0">58 - Unnamed</item>
-																					<item translate="0">59 - Shield</item>
-																					<item translate="0">60 - Pipboy</item>
-																					<item translate="0">61 - FX</item>
-																					<item translate="0">65 - Robot</item>
-																					<item translate="0">70 - Robot</item>
-																					<item translate="0">75 - Robot</item>
-																					<item translate="0">80 - Robot</item>
-																					<item translate="0">85 - Robot</item>
-																					<item translate="0">90 - Robot</item>
-																					<item translate="0">95 - Robot</item>
-																					<item translate="0">100 - Gore</item>
-																					<item translate="0">101 - Gore</item>
-																					<item translate="0">102 - Gore</item>
-																					<item translate="0">103 - Gore</item>
-																					<item translate="0">160 - Pipboy Cap</item>
-																				</content>
-																				<hidden>1</hidden>
-																				<enabled>0</enabled>
-																			</object>
-																		</object>
-																	</object>
-																</object>
-																<object class="sizeritem">
-																	<option>0</option>
-																	<flag>wxALL|wxEXPAND</flag>
-																	<border>0</border>
-																	<object class="wxBoxSizer">
-																		<orient>wxHORIZONTAL</orient>
-																		<object class="sizeritem">
-																			<option>0</option>
-																			<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
-																			<border>5</border>
-																			<object class="wxStaticText" name="segmentSSFLabel">
-																				<fg>#ffffff</fg>
-																				<label>SSF File</label>
-																				<hidden>1</hidden>
-																			</object>
-																		</object>
-																		<object class="sizeritem">
-																			<option>1</option>
-																			<flag>wxALL|wxEXPAND</flag>
-																			<border>5</border>
-																			<object class="wxTextCtrl" name="segmentSSF">
-																				<maxlength>255</maxlength>
-																				<hidden>1</hidden>
-																				<enabled>0</enabled>
-																			</object>
-																		</object>
-																		<object class="sizeritem">
-																			<option>0</option>
-																			<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
-																			<border>5</border>
-																			<object class="wxButton" name="segmentSSFEdit">
-																				<size>-1,25</size>
-																				<label>Set</label>
-																				<hidden>1</hidden>
-																			</object>
-																		</object>
-																	</object>
-																</object>
-																<object class="sizeritem">
-																	<option>0</option>
-																	<flag>wxALL|wxEXPAND</flag>
-																	<border>0</border>
-																	<object class="wxBoxSizer">
-																		<orient>wxHORIZONTAL</orient>
-																		<object class="sizeritem">
-																			<option>1</option>
-																			<flag>wxALL|wxEXPAND</flag>
-																			<border>5</border>
-																			<object class="wxButton" name="segmentApply">
-																				<size>-1,25</size>
-																				<label>Apply</label>
-																				<hidden>1</hidden>
-																			</object>
-																		</object>
-																		<object class="sizeritem">
-																			<option>1</option>
-																			<flag>wxALL|wxEXPAND</flag>
-																			<border>5</border>
-																			<object class="wxButton" name="segmentReset">
-																				<size>-1,25</size>
-																				<label>Reset</label>
-																				<hidden>1</hidden>
-																			</object>
-																		</object>
-																	</object>
-																</object>
-																<object class="sizeritem">
-																	<option>0</option>
-																	<flag>wxALL|wxEXPAND</flag>
-																	<border>0</border>
-																	<object class="wxBoxSizer">
-																		<orient>wxHORIZONTAL</orient>
-																		<object class="sizeritem">
-																			<option>0</option>
-																			<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
-																			<border>5</border>
-																			<object class="wxStaticText" name="partitionTypeLabel">
-																				<fg>#ffffff</fg>
-																				<label>Type</label>
-																				<hidden>1</hidden>
-																			</object>
-																		</object>
-																		<object class="sizeritem">
-																			<option>1</option>
-																			<flag>wxALL|wxEXPAND</flag>
-																			<border>5</border>
-																			<object class="wxChoice" name="partitionType">
-																				<selection>0</selection>
-																				<content />
-																				<hidden>1</hidden>
-																				<enabled>0</enabled>
-																			</object>
-																		</object>
-																	</object>
-																</object>
-																<object class="sizeritem">
-																	<option>0</option>
-																	<flag>wxALL|wxEXPAND</flag>
-																	<border>0</border>
-																	<object class="wxBoxSizer">
-																		<orient>wxHORIZONTAL</orient>
-																		<object class="sizeritem">
-																			<option>1</option>
-																			<flag>wxALL|wxEXPAND</flag>
-																			<border>5</border>
-																			<object class="wxButton" name="partitionApply">
-																				<size>-1,25</size>
-																				<label>Apply</label>
-																				<hidden>1</hidden>
-																			</object>
-																		</object>
-																		<object class="sizeritem">
-																			<option>1</option>
-																			<flag>wxALL|wxEXPAND</flag>
-																			<border>5</border>
-																			<object class="wxButton" name="partitionReset">
-																				<size>-1,25</size>
-																				<label>Reset</label>
-																				<hidden>1</hidden>
-																			</object>
-																		</object>
-																	</object>
-																</object>
-																<object class="sizeritem">
-																	<option>0</option>
-																	<flag>wxALL|wxEXPAND</flag>
-																	<border>0</border>
-																	<object class="wxBoxSizer">
-																		<orient>wxHORIZONTAL</orient>
-																		<object class="sizeritem">
-																			<option>0</option>
-																			<flag>wxALL|wxEXPAND</flag>
-																			<border>5</border>
-																			<object class="wxCheckBox" name="selectSliders">
-																				<fg>#ffffff</fg>
-																				<label>De-/Select Sliders</label>
-																				<checked>1</checked>
-																				<enabled>1</enabled>
-																			</object>
-																		</object>
-																		<object class="sizeritem">
-																			<option>1</option>
-																			<flag>wxALL</flag>
-																			<border>0</border>
-																			<object class="unknown" name="sliderFilter" />
-																		</object>
-																	</object>
-																</object>
-																<object class="sizeritem">
-																	<option>0</option>
-																	<flag>wxALL|wxEXPAND</flag>
-																	<border>5</border>
-																	<object class="wxCheckBox" name="cbFixedWeight">
-																		<fg>#ffffff</fg>
-																		<label>Fixed Weight Brush</label>
-																		<checked>0</checked>
-																		<hidden>1</hidden>
-																	</object>
-																</object>
-																<object class="sizeritem">
-																	<option>0</option>
-																	<flag>wxALL|wxEXPAND</flag>
-																	<border>5</border>
-																	<object class="wxCheckBox" name="cbNormalizeWeights">
-																		<fg>#ffffff</fg>
-																		<label>Normalize Weights</label>
-																		<checked>0</checked>
-																		<hidden>1</hidden>
-																	</object>
-																</object>
-																<object class="sizeritem">
-																	<option>0</option>
-																	<flag>wxALL|wxEXPAND</flag>
-																	<border>5</border>
-																	<object class="wxBoxSizer">
-																		<orient>wxHORIZONTAL</orient>
-																		<object class="sizeritem">
-																			<option>0</option>
-																			<flag>wxRIGHT|wxALIGN_CENTER</flag>
-																			<border>15</border>
-																			<object class="wxStaticText" name="xMirrorBoneLabel">
-																				<fg>#ffffff</fg>
-																				<label>X-Mirror Bone</label>
-																				<hidden>1</hidden>
-																			</object>
-																		</object>
-																		<object class="sizeritem">
-																			<option>1</option>
-																			<flag>wxALL|wxEXPAND</flag>
-																			<object class="wxChoice" name="cXMirrorBone">
-																				<selection>0</selection>
-																				<content />
-																				<hidden>1</hidden>
-																			</object>
-																		</object>
-																	</object>
-																</object>
-															</object>
-														</object>
-													</object>
-													<object class="sizeritem">
-														<option>0</option>
-														<flag>wxALL|wxEXPAND|wxLEFT</flag>
-														<border>2</border>
-														<object class="wxCollapsiblePane" name="masksPane">
-															<style>wxCP_DEFAULT_STYLE|wxCP_NO_TLW_RESIZE</style>
-															<collapsed>1</collapsed>
-															<label>Masks</label>
-															<bg>wxSYS_COLOUR_MENU</bg>
-															<hidden>0</hidden>
-															<object class="panewindow">
-																<object class="wxBoxSizer">
-																	<orient>wxVERTICAL</orient>
-																	<object class="sizeritem">
-																		<option>0</option>
-																		<flag>wxALL|wxEXPAND</flag>
-																		<object class="wxBoxSizer">
-																			<orient>wxHORIZONTAL</orient>
-																			<object class="sizeritem">
-																				<option>1</option>
-																				<flag>wxLEFT|wxRIGHT|wxBOTTOM|wxEXPAND</flag>
-																				<border>5</border>
-																				<object class="wxComboBox" name="cMaskName">
-																					<style>wxCB_SORT</style>
-																					<value></value>
-																					<content />
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxBOTTOM|wxEXPAND</flag>
-																				<border>5</border>
-																				<object class="wxButton" name="saveMask">
-																					<size>-1,25</size>
-																					<label>Save</label>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxBOTTOM|wxEXPAND</flag>
-																				<border>5</border>
-																				<object class="wxButton" name="deleteMask">
-																					<size>-1,25</size>
-																					<label>Delete</label>
-																				</object>
-																			</object>
-																		</object>
-																	</object>
-																	<object class="sizeritem">
-																		<option>0</option>
-																		<flag>wxALL|wxEXPAND</flag>
-																		<object class="wxBoxSizer">
-																			<orient>wxHORIZONTAL</orient>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxLEFT|wxBOTTOM|wxEXPAND</flag>
-																				<border>5</border>
-																				<object class="wxButton" name="exportMask">
-																					<size>-1,25</size>
-																					<label>Export...</label>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxLEFT|wxBOTTOM|wxEXPAND</flag>
-																				<border>5</border>
-																				<object class="wxButton" name="importMask">
-																					<size>-1,25</size>
-																					<label>Import...</label>
-																				</object>
-																			</object>
-																		</object>
-																	</object>
-																</object>
-															</object>
-														</object>
-													</object>
-													<object class="sizeritem">
-														<option>0</option>
-														<flag>wxALL|wxEXPAND|wxLEFT</flag>
-														<border>2</border>
-														<object class="wxCollapsiblePane" name="posePane">
-															<style>wxCP_DEFAULT_STYLE|wxCP_NO_TLW_RESIZE</style>
-															<collapsed>1</collapsed>
-															<label>Posing</label>
-															<bg>wxSYS_COLOUR_MENU</bg>
-															<hidden>1</hidden>
-															<object class="panewindow">
-																<object class="wxBoxSizer">
-																	<orient>wxVERTICAL</orient>
-																	<object class="sizeritem">
-																		<option>0</option>
-																		<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
+																	<flag>wxALL|wxEXPAND|wxLEFT</flag>
+																	<border>2</border>
+																	<object class="wxPanel" name="editPanel">
+																		<style>wxTAB_TRAVERSAL</style>
 																		<object class="wxBoxSizer">
 																			<orient>wxVERTICAL</orient>
 																			<object class="sizeritem">
 																				<option>0</option>
-																				<flag>wxEXPAND</flag>
-																				<object class="wxBoxSizer">
-																					<orient>wxHORIZONTAL</orient>
-																					<object class="sizeritem">
-																						<option>1</option>
-																						<flag>wxLEFT|wxRIGHT|wxBOTTOM|wxEXPAND</flag>
-																						<border>5</border>
-																						<object class="wxComboBox" name="cPoseName">
-																							<style>wxCB_SORT</style>
-																							<value></value>
-																							<content />
-																						</object>
-																					</object>
-																					<object class="sizeritem">
-																						<option>0</option>
-																						<flag>wxBOTTOM|wxEXPAND</flag>
-																						<border>5</border>
-																						<object class="wxButton" name="savePose">
-																							<size>-1,25</size>
-																							<label>Save</label>
-																						</object>
-																					</object>
-																					<object class="sizeritem">
-																						<option>0</option>
-																						<flag>wxRIGHT|wxBOTTOM|wxEXPAND</flag>
-																						<border>5</border>
-																						<object class="wxButton" name="deletePose">
-																							<size>-1,25</size>
-																							<label>Delete</label>
-																						</object>
-																					</object>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxLEFT|wxRIGHT|wxBOTTOM|wxEXPAND</flag>
-																				<border>5</border>
-																				<object class="wxBoxSizer">
-																					<orient>wxHORIZONTAL</orient>
-																					<object class="spacer">
-																						<option>1</option>
-																						<flag>wxEXPAND</flag>
-																						<size>0,0</size>
-																					</object>
-																					<object class="sizeritem">
-																						<option>0</option>
-																						<flag>wxRIGHT|wxEXPAND</flag>
-																						<border>5</border>
-																						<object class="wxButton" name="importPoseFile">
-																							<size>-1,25</size>
-																							<label>Import...</label>
-																						</object>
-																					</object>
-																					<object class="sizeritem">
-																						<option>0</option>
-																						<flag>wxRIGHT|wxEXPAND</flag>
-																						<border>5</border>
-																						<object class="wxButton" name="exportPoseFile">
-																							<size>-1,25</size>
-																							<label>Export...</label>
-																						</object>
-																					</object>
-																				</object>
-																			</object>
-																		</object>
-																	</object>
-																	<object class="sizeritem">
-																		<option>0</option>
-																		<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
-																		<border>5</border>
-																		<object class="wxBoxSizer">
-																			<orient>wxHORIZONTAL</orient>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxRIGHT|wxEXPAND</flag>
-																				<border>5</border>
-																				<object class="wxCheckBox" name="cbPose">
-																					<label>Show Pose</label>
-																					<checked>0</checked>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>1</option>
-																				<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
-																				<border>5</border>
-																				<object class="wxChoice" name="cPoseBone">
-																					<selection>0</selection>
-																					<content />
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxLEFT|wxEXPAND</flag>
-																				<object class="wxButton" name="resetBonePose">
-																					<size>-1,25</size>
-																					<label>Reset Bone</label>
-																				</object>
-																			</object>
-																		</object>
-																	</object>
-																	<object class="sizeritem">
-																		<option>0</option>
-																		<flag>wxTOP|wxLEFT|wxRIGHT|wxEXPAND</flag>
-																		<border>5</border>
-																		<object class="wxBoxSizer">
-																			<orient>wxHORIZONTAL</orient>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxRIGHT|wxEXPAND</flag>
-																				<border>5</border>
-																				<object class="wxCheckBox" name="cbPhysics">
-																					<label>Physics</label>
-																					<tooltip>Simulate HDT-SMP physics XMLs referenced by the loaded meshes</tooltip>
-																					<checked>0</checked>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
-																				<border>5</border>
-																				<object class="wxCheckBox" name="cbPhysicsVis">
-																					<label>Show Colliders</label>
-																					<tooltip>Draw the collision shapes and constraints of the physics simulation</tooltip>
-																					<checked>0</checked>
-																					<enabled>0</enabled>
-																				</object>
-																			</object>
-																		</object>
-																	</object>
-																	<object class="sizeritem">
-																		<option>0</option>
-																		<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
-																		<border>5</border>
-																		<object class="wxBoxSizer">
-																			<orient>wxHORIZONTAL</orient>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxRIGHT|wxALIGN_CENTER_VERTICAL</flag>
-																				<border>5</border>
-																				<object class="wxStaticText" name="physicsWindLabel">
-																					<label>Wind</label>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>1</option>
-																				<flag>wxEXPAND</flag>
-																				<object class="wxSlider" name="physicsWindSlider">
-																					<value>0</value>
-																					<min>0</min>
-																					<max>100</max>
-																					<tooltip>World wind strength for the physics preview (0 = off)</tooltip>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxLEFT|wxALIGN_CENTER_VERTICAL</flag>
-																				<border>5</border>
-																				<object class="wxChoice" name="physicsWindDir">
-																					<selection>5</selection>
-																					<content>
-																						<item>Up</item>
-																						<item>Down</item>
-																						<item>Forward</item>
-																						<item>Backward</item>
-																						<item>Left</item>
-																						<item>Right</item>
-																					</content>
-																					<tooltip>Direction the wind blows in, as seen in the viewport. It stays fixed to the mesh while the camera turns.</tooltip>
-																				</object>
-																			</object>
-																		</object>
-																	</object>
-																	<object class="sizeritem">
-																		<option>0</option>
-																		<flag>wxTOP|wxLEFT|wxRIGHT|wxEXPAND</flag>
-																		<border>5</border>
-																		<object class="wxFlexGridSizer">
-																			<rows>0</rows>
-																			<cols>3</cols>
-																			<vgap>0</vgap>
-																			<hgap>0</hgap>
-																			<growablecols>1</growablecols>
-																			<growablerows></growablerows>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxRIGHT|wxALIGN_LEFT</flag>
-																				<object class="wxStaticText" name="rxLabel">
-																					<label>Rotation X</label>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>1</option>
 																				<flag>wxALL|wxEXPAND</flag>
-																				<object class="wxSlider" name="rxPoseSlider">
-																					<style>wxSL_HORIZONTAL</style>
-																					<size>-1,10</size>
-																					<value translate="0">0</value>
-																					<min>-300</min>
-																					<max>300</max>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
-																				<object class="wxTextCtrl" name="rxPoseText">
-																					<style>wxTE_RIGHT|wxSIMPLE_BORDER</style>
-																					<size>40,-1</size>
-																					<value translate="0">0</value>
-																					<maxlength>0</maxlength>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxRIGHT|wxALIGN_LEFT</flag>
-																				<object class="wxStaticText" name="ryLabel">
-																					<label>Rotation Y</label>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>1</option>
-																				<flag>wxALL|wxEXPAND</flag>
-																				<object class="wxSlider" name="ryPoseSlider">
-																					<style>wxSL_HORIZONTAL</style>
-																					<size>-1,10</size>
-																					<value translate="0">0</value>
-																					<min>-300</min>
-																					<max>300</max>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
-																				<object class="wxTextCtrl" name="ryPoseText">
-																					<style>wxTE_RIGHT|wxSIMPLE_BORDER</style>
-																					<size>40,-1</size>
-																					<value translate="0">0</value>
-																					<maxlength>0</maxlength>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxRIGHT|wxALIGN_LEFT</flag>
-																				<object class="wxStaticText" name="rzLabel">
-																					<label>Rotation Z</label>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>1</option>
-																				<flag>wxALL|wxEXPAND</flag>
-																				<object class="wxSlider" name="rzPoseSlider">
-																					<style>wxSL_HORIZONTAL</style>
-																					<size>-1,10</size>
-																					<value translate="0">0</value>
-																					<min>-300</min>
-																					<max>300</max>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
-																				<object class="wxTextCtrl" name="rzPoseText">
-																					<style>wxTE_RIGHT|wxSIMPLE_BORDER</style>
-																					<size>40,-1</size>
-																					<value translate="0">0</value>
-																					<maxlength>0</maxlength>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxRIGHT|wxALIGN_LEFT</flag>
-																				<object class="wxStaticText" name="txLabel">
-																					<label>Offset X</label>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>1</option>
-																				<flag>wxALL|wxEXPAND</flag>
-																				<object class="wxSlider" name="txPoseSlider">
-																					<style>wxSL_HORIZONTAL</style>
-																					<size>-1,10</size>
-																					<value translate="0">0</value>
-																					<min>-1000</min>
-																					<max>1000</max>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
-																				<object class="wxTextCtrl" name="txPoseText">
-																					<style>wxTE_RIGHT|wxSIMPLE_BORDER</style>
-																					<size>40,-1</size>
-																					<value translate="0">0</value>
-																					<maxlength>0</maxlength>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxRIGHT|wxALIGN_LEFT</flag>
-																				<object class="wxStaticText" name="tyLabel">
-																					<label>Offset Y</label>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>1</option>
-																				<flag>wxALL|wxEXPAND</flag>
-																				<object class="wxSlider" name="tyPoseSlider">
-																					<style>wxSL_HORIZONTAL</style>
-																					<size>-1,10</size>
-																					<value translate="0">0</value>
-																					<min>-1000</min>
-																					<max>1000</max>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
-																				<object class="wxTextCtrl" name="tyPoseText">
-																					<style>wxTE_RIGHT|wxSIMPLE_BORDER</style>
-																					<size>40,-1</size>
-																					<value translate="0">0</value>
-																					<maxlength>0</maxlength>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxRIGHT|wxALIGN_LEFT</flag>
-																				<object class="wxStaticText" name="tzLabel">
-																					<label>Offset Z</label>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>1</option>
-																				<flag>wxALL|wxEXPAND</flag>
-																				<object class="wxSlider" name="tzPoseSlider">
-																					<style>wxSL_HORIZONTAL</style>
-																					<size>-1,10</size>
-																					<value translate="0">0</value>
-																					<min>-1000</min>
-																					<max>1000</max>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
-																				<object class="wxTextCtrl" name="tzPoseText">
-																					<style>wxTE_RIGHT|wxSIMPLE_BORDER</style>
-																					<size>40,-1</size>
-																					<value translate="0">0</value>
-																					<maxlength>0</maxlength>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<border>5</border>
-																				<flag>wxBOTTOM|wxALIGN_LEFT</flag>
-																				<object class="wxStaticText" name="scLabel">
-																					<label>Scale</label>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>1</option>
-																				<border>5</border>
-																				<flag>wxBOTTOM|wxEXPAND</flag>
-																				<object class="wxSlider" name="scPoseSlider">
-																					<style>wxSL_HORIZONTAL</style>
-																					<size>-1,10</size>
-																					<value translate="0">0</value>
-																					<min>-1000</min>
-																					<max>1000</max>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<border>5</border>
-																				<flag>wxBOTTOM|wxALIGN_CENTER_VERTICAL</flag>
-																				<object class="wxTextCtrl" name="scPoseText">
-																					<style>wxTE_RIGHT|wxSIMPLE_BORDER</style>
-																					<size>40,-1</size>
-																					<value translate="0">1</value>
-																					<maxlength>0</maxlength>
-																				</object>
-																			</object>
-																		</object>
-																	</object>
-																	<object class="sizeritem">
-																		<option>1</option>
-																		<flag>wxALL|wxEXPAND</flag>
-																		<object class="wxButton" name="resetAllPose">
-																			<size>-1,25</size>
-																			<label>Reset All</label>
-																		</object>
-																	</object>
-																	<object class="sizeritem">
-																		<option>1</option>
-																		<flag>wxALL|wxEXPAND</flag>
-																		<object class="wxButton" name="poseToMesh">
-																			<size>-1,25</size>
-																			<label>Apply to Mesh</label>
-																			<enabled>0</enabled>
-																		</object>
-																	</object>
-																</object>
-															</object>
-														</object>
-													</object>
-													<object class="sizeritem">
-														<option>0</option>
-														<flag>wxALL|wxEXPAND|wxLEFT</flag>
-														<border>2</border>
-														<object class="wxCollapsiblePane" name="animationPane">
-															<style>wxCP_DEFAULT_STYLE|wxCP_NO_TLW_RESIZE</style>
-															<collapsed>1</collapsed>
-															<label>Animation</label>
-															<bg>wxSYS_COLOUR_MENU</bg>
-															<hidden>1</hidden>
-															<object class="panewindow">
-																<object class="wxBoxSizer">
-																	<orient>wxVERTICAL</orient>
-																	<object class="sizeritem">
-																		<option>0</option>
-																		<flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
-																		<border>5</border>
-																		<object class="wxBoxSizer">
-																			<orient>wxVERTICAL</orient>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxEXPAND</flag>
-																				<object class="wxBoxSizer">
-																					<orient>wxHORIZONTAL</orient>
-																					<object class="sizeritem">
-																						<option>1</option>
-																						<flag>wxRIGHT|wxBOTTOM|wxEXPAND</flag>
-																						<border>5</border>
-																						<object class="wxComboBox" name="cAnimationName">
-																							<style>wxCB_READONLY</style>
-																							<value></value>
-																							<content />
-																						</object>
-																					</object>
-																					<object class="sizeritem">
-																						<option>0</option>
-																						<flag>wxBOTTOM|wxEXPAND</flag>
-																						<border>5</border>
-																						<object class="wxButton" name="importAnimationFile">
-																							<size>-1,25</size>
-																							<label>Load...</label>
-																						</object>
-																					</object>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxEXPAND</flag>
+																				<border>0</border>
 																				<object class="wxBoxSizer">
 																					<orient>wxHORIZONTAL</orient>
 																					<object class="sizeritem">
 																						<option>0</option>
-																						<flag>wxRIGHT</flag>
+																						<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
 																						<border>5</border>
-																						<object class="wxButton" name="animPlayPause">
-																							<size>50,25</size>
-																							<label>Play</label>
-																							<enabled>0</enabled>
+																						<object class="wxStaticText" name="segmentTypeLabel">
+																							<fg>#ffffff</fg>
+																							<label>Type</label>
+																							<hidden>1</hidden>
 																						</object>
 																					</object>
 																					<object class="sizeritem">
 																						<option>1</option>
-																						<flag>wxEXPAND</flag>
-																						<object class="wxSlider" name="animFrameSlider">
-																							<style>wxSL_HORIZONTAL</style>
-																							<value translate="0">0</value>
-																							<min>0</min>
-																							<max>1</max>
-																							<enabled>0</enabled>
-																						</object>
-																					</object>
-																				</object>
-																			</object>
-																			<object class="sizeritem">
-																				<option>0</option>
-																				<flag>wxBOTTOM|wxEXPAND</flag>
-																				<border>5</border>
-																				<object class="wxBoxSizer">
-																					<orient>wxHORIZONTAL</orient>
-																					<object class="sizeritem">
-																						<option>0</option>
-																						<flag>wxALIGN_CENTER_VERTICAL</flag>
-																						<object class="wxStaticText" name="animFrameText">
-																							<label translate="0">0 / 0</label>
-																						</object>
-																					</object>
-																					<object class="spacer">
-																						<option>1</option>
-																						<flag>wxEXPAND</flag>
-																						<size>0,0</size>
-																					</object>
-																					<object class="sizeritem">
-																						<option>0</option>
-																						<flag>wxRIGHT|wxALIGN_CENTER_VERTICAL</flag>
-																						<border>10</border>
-																						<object class="wxCheckBox" name="animInterpolate">
-																							<label>Interpolate</label>
-																							<checked>1</checked>
-																							<tooltip>Blend between the animation's frames during playback instead of stepping from one to the next.</tooltip>
-																							<enabled>0</enabled>
-																						</object>
-																					</object>
-																					<object class="sizeritem">
-																						<option>0</option>
-																						<flag>wxRIGHT|wxALIGN_CENTER_VERTICAL</flag>
+																						<flag>wxALL|wxEXPAND</flag>
 																						<border>5</border>
-																						<object class="wxStaticText" name="animSpeedLabel">
-																							<label>Speed</label>
-																						</object>
-																					</object>
-																					<object class="sizeritem">
-																						<option>0</option>
-																						<flag>wxALIGN_CENTER_VERTICAL</flag>
-																						<object class="wxChoice" name="animSpeed">
-																							<selection>2</selection>
+																						<object class="wxChoice" name="segmentType">
+																							<selection>0</selection>
 																							<content>
-																								<item translate="0">0.25x</item>
-																								<item translate="0">0.5x</item>
-																								<item translate="0">1x</item>
-																								<item translate="0">1.5x</item>
-																								<item translate="0">2x</item>
+																								<item translate="0">Default</item>
+																								<item translate="0">1 | Head/Hair | 0x86b72980</item>
+																								<item translate="0">1 | Neck | 0x0155094f</item>
+																								<item translate="0">Human 2 | R-Up Arm | 0xb2e2764f</item>
+																								<item translate="0">Human 2 | R-Lo Arm | 0x6fc3fbb2</item>
+																								<item translate="0">Human 4 | L-Up Arm | 0xfc03dc25</item>
+																								<item translate="0">Human 4 | L-Lo Arm | 0x212251d8</item>
+																								<item translate="0">Human 5 | R-Up Thi | 0xbf3a3cc5</item>
+																								<item translate="0">Human 5 | R-Kne-Clf | 0x22324321</item>
+																								<item translate="0">Human 5 | R-Lo Ft.-Ank | 0xc7e6bc92</item>
+																								<item translate="0">Human 6 | L-Up Leg | 0x865d8d9e</item>
+																								<item translate="0">Human 6 | L-Kne-Clf | 0x4630dac2</item>
+																								<item translate="0">Human 6 | L-Lo Ft.-Ank | 0xa3e42571</item>
+																								<item translate="0">Feral Ghoul 2 | R-Up Arm | 0x2a549ee1</item>
+																								<item translate="0">Feral Ghoul 2 | R-Lo Arm | 0xf775131c</item>
+																								<item translate="0">Feral Ghoul 2 | R-Hand | 0x85342e3c</item>
+																								<item translate="0">Feral Ghoul 4 | L-Up Arm | 0x4e560702</item>
+																								<item translate="0">Feral Ghoul 4 | L-Lo Arm | 0x93778aff</item>
+																								<item translate="0">Feral Ghoul 4 | L-Hand | 0x5ae407df</item>
+																								<item translate="0">Death Claw 1 | Neck | 0xc0f43cc3</item>
+																								<item translate="0">Death Claw 2 | R-Up-Arm | 0xf2ba1077</item>
+																								<item translate="0">Death Claw 2 | R-Elbow-4Arm | 0xf4e10d0d</item>
+																								<item translate="0">Death Claw 2 | R-Hand | 0xe2da5319</item>
+																								<item translate="0">Death Claw 4 | L-Up-Arm | 0x17932e95</item>
+																								<item translate="0">Death Claw 4 | L-Elbow-4Arm | 0x0861e2c0</item>
+																								<item translate="0">Death Claw 4 | L-Hand | 0x8beb7000</item>
+																								<item translate="0">Death Claw, Feral Ghoul 5 | R-Up Thi | 0x9af9d18c</item>
+																								<item translate="0">Death Claw, Feral Ghoul 5 | R-Lo Leg | 0x8e0daa93</item>
+																								<item translate="0">Death Claw, Feral Ghoul 5 | R-Lo Ft | 0x6bd95520</item>
+																								<item translate="0">Death Claw, Feral Ghoul 6 | L-Lo Thi | 0xa325b267</item>
+																								<item translate="0">Death Claw, Feral Ghoul 6 | L-Lo Leg | 0x51dd8370</item>
+																								<item translate="0">Death Claw, Feral Ghoul 6 | L-Lo Ft | 0xb4097cc3</item>
+																								<item translate="0">Super Mutant Hound 3 | Fr-Lf Up Leg | 0x99338c09</item>
+																								<item translate="0">Super Mutant Hound 3 | Fr-Lf Lo Leg | 0x7491a630</item>
+																								<item translate="0">Super Mutant Hound 3 | Fr-Lf Foot | 0x8a99ba3f</item>
+																								<item translate="0">Super Mutant Hound 4 | Bk-Lf Thigh | 0xa7860026</item>
+																								<item translate="0">Super Mutant Hound 4 | Bk-Lf Knee | 0xaf6a52d7</item>
+																								<item translate="0">Super Mutant Hound 4 | Bk-Lf Ankle | 0xb42c3610</item>
+																								<item translate="0">Super Mutant Hound 4 | Bk-Lf Foot | 0x6e284ec0</item>
+																								<item translate="0">Super Mutant Hound 5 | Bk-Ri Thigh | 0x0e97871c</item>
+																								<item translate="0">Super Mutant Hound 5 | Bk-Ri Knee | 0x02433b3b</item>
+																								<item translate="0">Super Mutant Hound 5 | Bk-Ri Ankle | 0x1d3db12a</item>
+																								<item translate="0">Super Mutant Hound 5 | Bk-Ri Foot | 0x20c9e4aa</item>
+																								<item translate="0">Super Mutant Hound 6 | Fr-Ri Up Leg | 0x5f96443c</item>
+																								<item translate="0">Super Mutant Hound 6 | Fr-Ri Lo Leg | 0xdd80210a</item>
+																								<item translate="0">Super Mutant Hound 6 | Fr-Ri Foot | 0x4c3c720a</item>
+																								<item translate="0">Mirelurk 2 | Fr-Ri-Up Arm | 0xa5f4be71</item>
+																								<item translate="0">Mirelurk 2 | Fr-Ri-Lo Arm | 0x99eb64eb</item>
+																								<item translate="0">Mirelurk 2 | R Claw | 0x3c9df64f</item>
+																								<item translate="0">Mirelurk 4 | L Shoulder | 0x40f66ca4</item>
+																								<item translate="0">Mirelurk 4 | L-Up Arm | 0xc1f62792</item>
+																								<item translate="0">Mirelurk 4 | L Elbow | 0xf0da47f2</item>
+																								<item translate="0">Mirelurk 4 | L Claw | 0x55acd556</item>
+																								<item translate="0">Mirelurk 5 | Fr-Ri Hip | 0x064f59cd</item>
+																								<item translate="0">Mirelurk 5 | Fr-Ri Thigh | 0x5b033df6</item>
+																								<item translate="0">Mirelurk 5 | Fr-Ri Calf | 0x15fc7bad</item>
+																								<item translate="0">Mirelurk 5 | Fr-Ri Foot | 0xf028841e</item>
+																								<item translate="0">Mirelurk 6 | Fr-Lf Hip-Thigh | 0xf62a541a</item>
+																								<item translate="0">Mirelurk 6 | Fr-Lf Kne-Clf | 0x5b1dd1c7</item>
+																								<item translate="0">Mirelurk 6 | Fr-Lf Foot | 0xbec92e74</item>
+																								<item translate="0">Mirelurk 8 | Bk-Ri Hip-Thigh | 0xfc5546b8</item>
+																								<item translate="0">Mirelurk 8 | Bk-Ri Kne-Clf | 0x24a15449</item>
+																								<item translate="0">Mirelurk 8 | Bk-Ri Foot | 0xc175abfa</item>
+																								<item translate="0">Mirelurk 9 | Bk-Lf Hip-Thigh | 0xb2b4ecd2</item>
+																								<item translate="0">Mirelurk 9 | Bk-Lf Kne-Clf | 0xc1886aab</item>
+																								<item translate="0">Mirelurk 9 | Bk-Lf Foot | 0x245c9518</item>
+																								<item translate="0">Dog 3 | Fr-Lf Knee | 0x5530c47b</item>
+																								<item translate="0">Dog 3 | Fr-Lf Calf | 0xcc3995c1</item>
+																								<item translate="0">Dog 3 | Fr-Lf Heel+Arch | 0xbd2750cf</item>
+																								<item translate="0">Dog 3 | Fr-Lf Paw | 0x77fe1ec8</item>
+																								<item translate="0">Dog 4 | Bk-Lf Knee | 0x52f7244b</item>
+																								<item translate="0">Dog 4 | Bk-Lf Calf | 0xcbfe75f1</item>
+																								<item translate="0">Dog 4 | Bk-Lf Heel+Arch | 0xfe31ace4</item>
+																								<item translate="0">Dog 4 | Bk-Lf Paw | 0x08eb5fa0</item>
+																								<item translate="0">Dog 5 | Bk-Ri Knee | 0x8d270da8</item>
+																								<item translate="0">Dog 5 | Bk-Ri Calf+Heel | 0x142e5c12</item>
+																								<item translate="0">Dog 5 | Bk-Ri Arch | 0x9a333507</item>
+																								<item translate="0">Dog 5 | Bk-Ri Paw | 0x61da7cb9</item>
+																								<item translate="0">Dog 6 | Fr-Ri Knee | 0x8ae0ed98</item>
+																								<item translate="0">Dog 6 | Fr-Ri Calf | 0x13e9bc22</item>
+																								<item translate="0">Dog 6 | Fr-Ri Heel+Arch | 0xd925c92c</item>
+																								<item translate="0">Dog 6 | Fr-Ri Paw | 0x1ecf3dd1</item>
+																								<item translate="0">Behemoth 2 | R-Arm+Elbow | 0x8c5ae189</item>
+																								<item translate="0">Behemoth 2 | R-4 Arm | 0x071dfd97</item>
+																								<item translate="0">Behemoth 2 | R-Hand | 0xded0fadf</item>
+																								<item translate="0">Behemoth 4 | L-Arm+Elbow | 0xc2bb4be3</item>
+																								<item translate="0">Behemoth 4 | L-4 Arm | 0x3e7a4ccc</item>
+																								<item translate="0">Behemoth 4 | L-Hand | 0xe7b74b84</item>
+																								<item translate="0">Behemoth 5 | R-Calf | 0xa411c600</item>
+																								<item translate="0">Behemoth 5 | R-Foot | 0xac900af3</item>
+																								<item translate="0">Behemoth 6 | L-Calf | 0xc0135fe3</item>
+																								<item translate="0">Behemoth 6 | R-Foot | 0x95f7bba8</item>
+																								<item translate="0">Robot 3 | Torso | 0x3d6644aa</item>
 																							</content>
+																							<hidden>1</hidden>
 																							<enabled>0</enabled>
+																						</object>
+																					</object>
+																				</object>
+																			</object>
+																			<object class="sizeritem">
+																				<option>0</option>
+																				<flag>wxALL|wxEXPAND</flag>
+																				<border>0</border>
+																				<object class="wxBoxSizer">
+																					<orient>wxHORIZONTAL</orient>
+																					<object class="sizeritem">
+																						<option>0</option>
+																						<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
+																						<border>5</border>
+																						<object class="wxStaticText" name="segmentSlotLabel">
+																							<fg>#ffffff</fg>
+																							<label>Slot</label>
+																							<hidden>1</hidden>
+																						</object>
+																					</object>
+																					<object class="sizeritem">
+																						<option>1</option>
+																						<flag>wxALL|wxEXPAND</flag>
+																						<border>5</border>
+																						<object class="wxChoice" name="segmentSlot">
+																							<selection>0</selection>
+																							<content>
+																								<item translate="0">None</item>
+																								<item translate="0">30 - Hair Top</item>
+																								<item translate="0">31 - Hair Long</item>
+																								<item translate="0">32 - Head</item>
+																								<item translate="0">33 - Body</item>
+																								<item translate="0">34 - L Hand</item>
+																								<item translate="0">35 - R Hand</item>
+																								<item translate="0">36 - [U] Torso</item>
+																								<item translate="0">37 - [U] L Arm</item>
+																								<item translate="0">38 - [U] R Arm</item>
+																								<item translate="0">39 - [U] L Leg</item>
+																								<item translate="0">40 - [U] R Leg</item>
+																								<item translate="0">41 - [A] Torso</item>
+																								<item translate="0">42 - [A] L Arm</item>
+																								<item translate="0">43 - [A] R Arm</item>
+																								<item translate="0">44 - [A] L Leg</item>
+																								<item translate="0">45 - [A] R Leg</item>
+																								<item translate="0">46 - Headband</item>
+																								<item translate="0">47 - Eyes</item>
+																								<item translate="0">48 - Beard</item>
+																								<item translate="0">49 - Mouth</item>
+																								<item translate="0">50 - Neck</item>
+																								<item translate="0">51 - Ring</item>
+																								<item translate="0">52 - Scalp</item>
+																								<item translate="0">53 - Decapitation</item>
+																								<item translate="0">54 - Unnamed</item>
+																								<item translate="0">55 - Unnamed</item>
+																								<item translate="0">56 - Unnamed</item>
+																								<item translate="0">57 - Unnamed</item>
+																								<item translate="0">58 - Unnamed</item>
+																								<item translate="0">59 - Shield</item>
+																								<item translate="0">60 - Pipboy</item>
+																								<item translate="0">61 - FX</item>
+																								<item translate="0">65 - Robot</item>
+																								<item translate="0">70 - Robot</item>
+																								<item translate="0">75 - Robot</item>
+																								<item translate="0">80 - Robot</item>
+																								<item translate="0">85 - Robot</item>
+																								<item translate="0">90 - Robot</item>
+																								<item translate="0">95 - Robot</item>
+																								<item translate="0">100 - Gore</item>
+																								<item translate="0">101 - Gore</item>
+																								<item translate="0">102 - Gore</item>
+																								<item translate="0">103 - Gore</item>
+																								<item translate="0">160 - Pipboy Cap</item>
+																							</content>
+																							<hidden>1</hidden>
+																							<enabled>0</enabled>
+																						</object>
+																					</object>
+																				</object>
+																			</object>
+																			<object class="sizeritem">
+																				<option>0</option>
+																				<flag>wxALL|wxEXPAND</flag>
+																				<border>0</border>
+																				<object class="wxBoxSizer">
+																					<orient>wxHORIZONTAL</orient>
+																					<object class="sizeritem">
+																						<option>0</option>
+																						<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
+																						<border>5</border>
+																						<object class="wxStaticText" name="segmentSSFLabel">
+																							<fg>#ffffff</fg>
+																							<label>SSF File</label>
+																							<hidden>1</hidden>
+																						</object>
+																					</object>
+																					<object class="sizeritem">
+																						<option>1</option>
+																						<flag>wxALL|wxEXPAND</flag>
+																						<border>5</border>
+																						<object class="wxTextCtrl" name="segmentSSF">
+																							<maxlength>255</maxlength>
+																							<hidden>1</hidden>
+																							<enabled>0</enabled>
+																						</object>
+																					</object>
+																					<object class="sizeritem">
+																						<option>0</option>
+																						<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
+																						<border>5</border>
+																						<object class="wxButton" name="segmentSSFEdit">
+																							<size>-1,25</size>
+																							<label>Set</label>
+																							<hidden>1</hidden>
+																						</object>
+																					</object>
+																				</object>
+																			</object>
+																			<object class="sizeritem">
+																				<option>0</option>
+																				<flag>wxALL|wxEXPAND</flag>
+																				<border>0</border>
+																				<object class="wxBoxSizer">
+																					<orient>wxHORIZONTAL</orient>
+																					<object class="sizeritem">
+																						<option>1</option>
+																						<flag>wxALL|wxEXPAND</flag>
+																						<border>5</border>
+																						<object class="wxButton" name="segmentApply">
+																							<size>-1,25</size>
+																							<label>Apply</label>
+																							<hidden>1</hidden>
+																						</object>
+																					</object>
+																					<object class="sizeritem">
+																						<option>1</option>
+																						<flag>wxALL|wxEXPAND</flag>
+																						<border>5</border>
+																						<object class="wxButton" name="segmentReset">
+																							<size>-1,25</size>
+																							<label>Reset</label>
+																							<hidden>1</hidden>
+																						</object>
+																					</object>
+																				</object>
+																			</object>
+																			<object class="sizeritem">
+																				<option>0</option>
+																				<flag>wxALL|wxEXPAND</flag>
+																				<border>0</border>
+																				<object class="wxBoxSizer">
+																					<orient>wxHORIZONTAL</orient>
+																					<object class="sizeritem">
+																						<option>0</option>
+																						<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
+																						<border>5</border>
+																						<object class="wxStaticText" name="partitionTypeLabel">
+																							<fg>#ffffff</fg>
+																							<label>Type</label>
+																							<hidden>1</hidden>
+																						</object>
+																					</object>
+																					<object class="sizeritem">
+																						<option>1</option>
+																						<flag>wxALL|wxEXPAND</flag>
+																						<border>5</border>
+																						<object class="wxChoice" name="partitionType">
+																							<selection>0</selection>
+																							<content />
+																							<hidden>1</hidden>
+																							<enabled>0</enabled>
+																						</object>
+																					</object>
+																				</object>
+																			</object>
+																			<object class="sizeritem">
+																				<option>0</option>
+																				<flag>wxALL|wxEXPAND</flag>
+																				<border>0</border>
+																				<object class="wxBoxSizer">
+																					<orient>wxHORIZONTAL</orient>
+																					<object class="sizeritem">
+																						<option>1</option>
+																						<flag>wxALL|wxEXPAND</flag>
+																						<border>5</border>
+																						<object class="wxButton" name="partitionApply">
+																							<size>-1,25</size>
+																							<label>Apply</label>
+																							<hidden>1</hidden>
+																						</object>
+																					</object>
+																					<object class="sizeritem">
+																						<option>1</option>
+																						<flag>wxALL|wxEXPAND</flag>
+																						<border>5</border>
+																						<object class="wxButton" name="partitionReset">
+																							<size>-1,25</size>
+																							<label>Reset</label>
+																							<hidden>1</hidden>
+																						</object>
+																					</object>
+																				</object>
+																			</object>
+																			<object class="sizeritem">
+																				<option>0</option>
+																				<flag>wxALL|wxEXPAND</flag>
+																				<border>0</border>
+																				<object class="wxBoxSizer">
+																					<orient>wxHORIZONTAL</orient>
+																					<object class="sizeritem">
+																						<option>0</option>
+																						<flag>wxALL|wxEXPAND</flag>
+																						<border>5</border>
+																						<object class="wxCheckBox" name="selectSliders">
+																							<fg>#ffffff</fg>
+																							<label>De-/Select Sliders</label>
+																							<checked>1</checked>
+																							<enabled>1</enabled>
+																						</object>
+																					</object>
+																					<object class="sizeritem">
+																						<option>1</option>
+																						<flag>wxALL</flag>
+																						<border>0</border>
+																						<object class="unknown" name="sliderFilter" />
+																					</object>
+																				</object>
+																			</object>
+																			<object class="sizeritem">
+																				<option>0</option>
+																				<flag>wxALL|wxEXPAND</flag>
+																				<border>5</border>
+																				<object class="wxCheckBox" name="cbFixedWeight">
+																					<fg>#ffffff</fg>
+																					<label>Fixed Weight Brush</label>
+																					<checked>0</checked>
+																					<hidden>1</hidden>
+																				</object>
+																			</object>
+																			<object class="sizeritem">
+																				<option>0</option>
+																				<flag>wxALL|wxEXPAND</flag>
+																				<border>5</border>
+																				<object class="wxCheckBox" name="cbNormalizeWeights">
+																					<fg>#ffffff</fg>
+																					<label>Normalize Weights</label>
+																					<checked>0</checked>
+																					<hidden>1</hidden>
+																				</object>
+																			</object>
+																			<object class="sizeritem">
+																				<option>0</option>
+																				<flag>wxALL|wxEXPAND</flag>
+																				<border>5</border>
+																				<object class="wxBoxSizer">
+																					<orient>wxHORIZONTAL</orient>
+																					<object class="sizeritem">
+																						<option>0</option>
+																						<flag>wxRIGHT|wxALIGN_CENTER</flag>
+																						<border>15</border>
+																						<object class="wxStaticText" name="xMirrorBoneLabel">
+																							<fg>#ffffff</fg>
+																							<label>X-Mirror Bone</label>
+																							<hidden>1</hidden>
+																						</object>
+																					</object>
+																					<object class="sizeritem">
+																						<option>1</option>
+																						<flag>wxALL|wxEXPAND</flag>
+																						<object class="wxChoice" name="cXMirrorBone">
+																							<selection>0</selection>
+																							<content />
+																							<hidden>1</hidden>
+																						</object>
+																					</object>
+																				</object>
+																			</object>
+																		</object>
+																	</object>
+																</object>
+																<object class="sizeritem">
+																	<option>0</option>
+																	<flag>wxALL|wxEXPAND|wxLEFT</flag>
+																	<border>2</border>
+																	<object class="wxCollapsiblePane" name="masksPane">
+																		<style>wxCP_DEFAULT_STYLE|wxCP_NO_TLW_RESIZE</style>
+																		<collapsed>1</collapsed>
+																		<label>Masks</label>
+																		<bg>wxSYS_COLOUR_MENU</bg>
+																		<hidden>0</hidden>
+																		<object class="panewindow">
+																			<object class="wxBoxSizer">
+																				<orient>wxVERTICAL</orient>
+																				<object class="sizeritem">
+																					<option>0</option>
+																					<flag>wxALL|wxEXPAND</flag>
+																					<object class="wxBoxSizer">
+																						<orient>wxHORIZONTAL</orient>
+																						<object class="sizeritem">
+																							<option>1</option>
+																							<flag>wxLEFT|wxRIGHT|wxBOTTOM|wxEXPAND</flag>
+																							<border>5</border>
+																							<object class="wxComboBox" name="cMaskName">
+																								<style>wxCB_SORT</style>
+																								<value></value>
+																								<content />
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxBOTTOM|wxEXPAND</flag>
+																							<border>5</border>
+																							<object class="wxButton" name="saveMask">
+																								<size>-1,25</size>
+																								<label>Save</label>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxBOTTOM|wxEXPAND</flag>
+																							<border>5</border>
+																							<object class="wxButton" name="deleteMask">
+																								<size>-1,25</size>
+																								<label>Delete</label>
+																							</object>
+																						</object>
+																					</object>
+																				</object>
+																				<object class="sizeritem">
+																					<option>0</option>
+																					<flag>wxALL|wxEXPAND</flag>
+																					<object class="wxBoxSizer">
+																						<orient>wxHORIZONTAL</orient>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxLEFT|wxBOTTOM|wxEXPAND</flag>
+																							<border>5</border>
+																							<object class="wxButton" name="exportMask">
+																								<size>-1,25</size>
+																								<label>Export...</label>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxLEFT|wxBOTTOM|wxEXPAND</flag>
+																							<border>5</border>
+																							<object class="wxButton" name="importMask">
+																								<size>-1,25</size>
+																								<label>Import...</label>
+																							</object>
+																						</object>
+																					</object>
+																				</object>
+																			</object>
+																		</object>
+																	</object>
+																</object>
+																<object class="sizeritem">
+																	<option>0</option>
+																	<flag>wxALL|wxEXPAND|wxLEFT</flag>
+																	<border>2</border>
+																	<object class="wxCollapsiblePane" name="posePane">
+																		<style>wxCP_DEFAULT_STYLE|wxCP_NO_TLW_RESIZE</style>
+																		<collapsed>1</collapsed>
+																		<label>Posing</label>
+																		<bg>wxSYS_COLOUR_MENU</bg>
+																		<hidden>1</hidden>
+																		<object class="panewindow">
+																			<object class="wxBoxSizer">
+																				<orient>wxVERTICAL</orient>
+																				<object class="sizeritem">
+																					<option>0</option>
+																					<flag>wxLEFT|wxRIGHT|wxBOTTOM|wxEXPAND</flag>
+																					<border>5</border>
+																					<object class="wxBoxSizer">
+																						<orient>wxHORIZONTAL</orient>
+																						<object class="sizeritem">
+																							<option>1</option>
+																							<flag>wxRIGHT|wxEXPAND</flag>
+																							<border>5</border>
+																							<object class="wxComboBox" name="cPoseName">
+																								<style>wxCB_SORT</style>
+																								<value></value>
+																								<content />
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxRIGHT|wxEXPAND</flag>
+																							<border>5</border>
+																							<object class="wxButton" name="savePose">
+																								<size>-1,25</size>
+																								<label>Save</label>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxEXPAND</flag>
+																							<object class="wxButton" name="deletePose">
+																								<size>-1,25</size>
+																								<label>Delete</label>
+																							</object>
+																						</object>
+																					</object>
+																				</object>
+																				<object class="sizeritem">
+																					<option>0</option>
+																					<flag>wxLEFT|wxRIGHT|wxBOTTOM|wxEXPAND</flag>
+																					<border>5</border>
+																					<object class="wxBoxSizer">
+																						<orient>wxHORIZONTAL</orient>
+																						<object class="spacer">
+																							<option>1</option>
+																							<flag>wxEXPAND</flag>
+																							<size>0,0</size>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxRIGHT|wxEXPAND</flag>
+																							<border>5</border>
+																							<object class="wxButton" name="importPoseFile">
+																								<size>-1,25</size>
+																								<label>Import...</label>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxEXPAND</flag>
+																							<object class="wxButton" name="exportPoseFile">
+																								<size>-1,25</size>
+																								<label>Export...</label>
+																							</object>
+																						</object>
+																					</object>
+																				</object>
+																				<object class="sizeritem">
+																					<option>0</option>
+																					<flag>wxLEFT|wxRIGHT|wxBOTTOM|wxEXPAND</flag>
+																					<border>5</border>
+																					<object class="wxStaticLine" name="poseSeparator">
+																						<style>wxLI_HORIZONTAL</style>
+																					</object>
+																				</object>
+																				<object class="sizeritem">
+																					<option>0</option>
+																					<flag>wxLEFT|wxRIGHT|wxBOTTOM|wxEXPAND</flag>
+																					<border>5</border>
+																					<object class="wxBoxSizer">
+																						<orient>wxHORIZONTAL</orient>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxRIGHT|wxALIGN_CENTER_VERTICAL</flag>
+																							<border>5</border>
+																							<object class="wxCheckBox" name="cbPose">
+																								<label>Show Pose</label>
+																								<tooltip>Display the meshes with the pose below applied</tooltip>
+																								<checked>0</checked>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>1</option>
+																							<flag>wxRIGHT|wxEXPAND</flag>
+																							<border>5</border>
+																							<object class="wxChoice" name="cPoseBone">
+																								<selection>0</selection>
+																								<content />
+																								<tooltip>Bone the transform below applies to</tooltip>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxEXPAND</flag>
+																							<object class="wxButton" name="resetBonePose">
+																								<size>-1,25</size>
+																								<label>Reset Bone</label>
+																							</object>
+																						</object>
+																					</object>
+																				</object>
+																				<object class="sizeritem">
+																					<option>0</option>
+																					<flag>wxLEFT|wxRIGHT|wxBOTTOM|wxEXPAND</flag>
+																					<border>5</border>
+																					<object class="wxFlexGridSizer">
+																						<rows>0</rows>
+																						<cols>3</cols>
+																						<vgap>2</vgap>
+																						<hgap>5</hgap>
+																						<growablecols>1</growablecols>
+																						<growablerows></growablerows>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxStaticText" name="rxLabel">
+																								<label>Rotation X</label>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>1</option>
+																							<flag>wxEXPAND</flag>
+																							<object class="wxSlider" name="rxPoseSlider">
+																								<style>wxSL_HORIZONTAL</style>
+																								<size>-1,10</size>
+																								<value translate="0">0</value>
+																								<min>-300</min>
+																								<max>300</max>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxTextCtrl" name="rxPoseText">
+																								<style>wxTE_RIGHT|wxSIMPLE_BORDER</style>
+																								<size>55,-1</size>
+																								<value translate="0">0</value>
+																								<maxlength>0</maxlength>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxStaticText" name="ryLabel">
+																								<label>Rotation Y</label>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>1</option>
+																							<flag>wxEXPAND</flag>
+																							<object class="wxSlider" name="ryPoseSlider">
+																								<style>wxSL_HORIZONTAL</style>
+																								<size>-1,10</size>
+																								<value translate="0">0</value>
+																								<min>-300</min>
+																								<max>300</max>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxTextCtrl" name="ryPoseText">
+																								<style>wxTE_RIGHT|wxSIMPLE_BORDER</style>
+																								<size>55,-1</size>
+																								<value translate="0">0</value>
+																								<maxlength>0</maxlength>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxStaticText" name="rzLabel">
+																								<label>Rotation Z</label>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>1</option>
+																							<flag>wxEXPAND</flag>
+																							<object class="wxSlider" name="rzPoseSlider">
+																								<style>wxSL_HORIZONTAL</style>
+																								<size>-1,10</size>
+																								<value translate="0">0</value>
+																								<min>-300</min>
+																								<max>300</max>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxTextCtrl" name="rzPoseText">
+																								<style>wxTE_RIGHT|wxSIMPLE_BORDER</style>
+																								<size>55,-1</size>
+																								<value translate="0">0</value>
+																								<maxlength>0</maxlength>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxStaticText" name="txLabel">
+																								<label>Offset X</label>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>1</option>
+																							<flag>wxEXPAND</flag>
+																							<object class="wxSlider" name="txPoseSlider">
+																								<style>wxSL_HORIZONTAL</style>
+																								<size>-1,10</size>
+																								<value translate="0">0</value>
+																								<min>-1000</min>
+																								<max>1000</max>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxTextCtrl" name="txPoseText">
+																								<style>wxTE_RIGHT|wxSIMPLE_BORDER</style>
+																								<size>55,-1</size>
+																								<value translate="0">0</value>
+																								<maxlength>0</maxlength>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxStaticText" name="tyLabel">
+																								<label>Offset Y</label>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>1</option>
+																							<flag>wxEXPAND</flag>
+																							<object class="wxSlider" name="tyPoseSlider">
+																								<style>wxSL_HORIZONTAL</style>
+																								<size>-1,10</size>
+																								<value translate="0">0</value>
+																								<min>-1000</min>
+																								<max>1000</max>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxTextCtrl" name="tyPoseText">
+																								<style>wxTE_RIGHT|wxSIMPLE_BORDER</style>
+																								<size>55,-1</size>
+																								<value translate="0">0</value>
+																								<maxlength>0</maxlength>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxStaticText" name="tzLabel">
+																								<label>Offset Z</label>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>1</option>
+																							<flag>wxEXPAND</flag>
+																							<object class="wxSlider" name="tzPoseSlider">
+																								<style>wxSL_HORIZONTAL</style>
+																								<size>-1,10</size>
+																								<value translate="0">0</value>
+																								<min>-1000</min>
+																								<max>1000</max>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxTextCtrl" name="tzPoseText">
+																								<style>wxTE_RIGHT|wxSIMPLE_BORDER</style>
+																								<size>55,-1</size>
+																								<value translate="0">0</value>
+																								<maxlength>0</maxlength>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxStaticText" name="scLabel">
+																								<label>Scale</label>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>1</option>
+																							<flag>wxEXPAND</flag>
+																							<object class="wxSlider" name="scPoseSlider">
+																								<style>wxSL_HORIZONTAL</style>
+																								<size>-1,10</size>
+																								<value translate="0">0</value>
+																								<min>-1000</min>
+																								<max>1000</max>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxTextCtrl" name="scPoseText">
+																								<style>wxTE_RIGHT|wxSIMPLE_BORDER</style>
+																								<size>55,-1</size>
+																								<value translate="0">1</value>
+																								<maxlength>0</maxlength>
+																							</object>
+																						</object>
+																					</object>
+																				</object>
+																				<object class="sizeritem">
+																					<option>0</option>
+																					<flag>wxLEFT|wxRIGHT|wxBOTTOM|wxEXPAND</flag>
+																					<border>5</border>
+																					<object class="wxBoxSizer">
+																						<orient>wxHORIZONTAL</orient>
+																						<object class="sizeritem">
+																							<option>1</option>
+																							<flag>wxRIGHT|wxEXPAND</flag>
+																							<border>5</border>
+																							<object class="wxButton" name="resetAllPose">
+																								<size>-1,25</size>
+																								<label>Reset All</label>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>1</option>
+																							<flag>wxEXPAND</flag>
+																							<object class="wxButton" name="poseToMesh">
+																								<size>-1,25</size>
+																								<label>Apply to Mesh</label>
+																								<enabled>0</enabled>
+																							</object>
+																						</object>
+																					</object>
+																				</object>
+																			</object>
+																		</object>
+																	</object>
+																</object>
+																<object class="sizeritem">
+																	<option>0</option>
+																	<flag>wxALL|wxEXPAND|wxLEFT</flag>
+																	<border>2</border>
+																	<object class="wxCollapsiblePane" name="physicsPane">
+																		<style>wxCP_DEFAULT_STYLE|wxCP_NO_TLW_RESIZE</style>
+																		<collapsed>1</collapsed>
+																		<label>Physics</label>
+																		<bg>wxSYS_COLOUR_MENU</bg>
+																		<hidden>1</hidden>
+																		<object class="panewindow">
+																			<object class="wxBoxSizer">
+																				<orient>wxVERTICAL</orient>
+																				<object class="sizeritem">
+																					<option>0</option>
+																					<flag>wxLEFT|wxRIGHT|wxBOTTOM|wxEXPAND</flag>
+																					<border>5</border>
+																					<object class="wxBoxSizer">
+																						<orient>wxHORIZONTAL</orient>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxRIGHT|wxALIGN_CENTER_VERTICAL</flag>
+																							<border>10</border>
+																							<object class="wxCheckBox" name="cbPhysics">
+																								<label>Simulate</label>
+																								<tooltip>Simulate HDT-SMP physics XMLs referenced by the loaded meshes</tooltip>
+																								<checked>0</checked>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxCheckBox" name="cbPhysicsVis">
+																								<label>Show Colliders</label>
+																								<tooltip>Draw the collision shapes and constraints of the physics simulation</tooltip>
+																								<checked>0</checked>
+																								<enabled>0</enabled>
+																							</object>
+																						</object>
+																					</object>
+																				</object>
+																				<object class="sizeritem">
+																					<option>0</option>
+																					<flag>wxLEFT|wxRIGHT|wxBOTTOM|wxEXPAND</flag>
+																					<border>5</border>
+																					<object class="wxBoxSizer">
+																						<orient>wxHORIZONTAL</orient>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxRIGHT|wxALIGN_CENTER_VERTICAL</flag>
+																							<border>5</border>
+																							<object class="wxStaticText" name="physicsWindLabel">
+																								<label>Wind</label>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>1</option>
+																							<flag>wxRIGHT|wxALIGN_CENTER_VERTICAL</flag>
+																							<border>5</border>
+																							<object class="wxSlider" name="physicsWindSlider">
+																								<value>0</value>
+																								<min>0</min>
+																								<max>100</max>
+																								<tooltip>World wind strength for the physics preview (0 = off)</tooltip>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxChoice" name="physicsWindDir">
+																								<selection>5</selection>
+																								<content>
+																									<item>Up</item>
+																									<item>Down</item>
+																									<item>Forward</item>
+																									<item>Backward</item>
+																									<item>Left</item>
+																									<item>Right</item>
+																								</content>
+																								<tooltip>Direction the wind blows in, as seen in the viewport. It stays fixed to the mesh while the camera turns.</tooltip>
+																							</object>
+																						</object>
+																					</object>
+																				</object>
+																			</object>
+																		</object>
+																	</object>
+																</object>
+																<object class="sizeritem">
+																	<option>0</option>
+																	<flag>wxALL|wxEXPAND|wxLEFT</flag>
+																	<border>2</border>
+																	<object class="wxCollapsiblePane" name="animationPane">
+																		<style>wxCP_DEFAULT_STYLE|wxCP_NO_TLW_RESIZE</style>
+																		<collapsed>1</collapsed>
+																		<label>Animation</label>
+																		<bg>wxSYS_COLOUR_MENU</bg>
+																		<hidden>1</hidden>
+																		<object class="panewindow">
+																			<object class="wxBoxSizer">
+																				<orient>wxVERTICAL</orient>
+																				<object class="sizeritem">
+																					<option>0</option>
+																					<flag>wxLEFT|wxRIGHT|wxBOTTOM|wxEXPAND</flag>
+																					<border>5</border>
+																					<object class="wxBoxSizer">
+																						<orient>wxHORIZONTAL</orient>
+																						<object class="sizeritem">
+																							<option>1</option>
+																							<flag>wxRIGHT|wxEXPAND</flag>
+																							<border>5</border>
+																							<object class="wxComboBox" name="cAnimationName">
+																								<style>wxCB_READONLY</style>
+																								<value></value>
+																								<content />
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxEXPAND</flag>
+																							<object class="wxButton" name="importAnimationFile">
+																								<size>-1,25</size>
+																								<label>Load...</label>
+																							</object>
+																						</object>
+																					</object>
+																				</object>
+																				<object class="sizeritem">
+																					<option>0</option>
+																					<flag>wxLEFT|wxRIGHT|wxBOTTOM|wxEXPAND</flag>
+																					<border>5</border>
+																					<object class="wxBoxSizer">
+																						<orient>wxHORIZONTAL</orient>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxRIGHT|wxALIGN_CENTER_VERTICAL</flag>
+																							<border>5</border>
+																							<object class="wxButton" name="animPlayPause">
+																								<size>55,25</size>
+																								<label>Play</label>
+																								<enabled>0</enabled>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>1</option>
+																							<flag>wxRIGHT|wxALIGN_CENTER_VERTICAL</flag>
+																							<border>5</border>
+																							<object class="wxSlider" name="animFrameSlider">
+																								<style>wxSL_HORIZONTAL</style>
+																								<value translate="0">0</value>
+																								<min>0</min>
+																								<max>1</max>
+																								<enabled>0</enabled>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxStaticText" name="animFrameText">
+																								<style>wxALIGN_RIGHT</style>
+																								<size>55,-1</size>
+																								<label translate="0">0 / 0</label>
+																							</object>
+																						</object>
+																					</object>
+																				</object>
+																				<object class="sizeritem">
+																					<option>0</option>
+																					<flag>wxLEFT|wxRIGHT|wxBOTTOM|wxEXPAND</flag>
+																					<border>5</border>
+																					<object class="wxBoxSizer">
+																						<orient>wxHORIZONTAL</orient>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxCheckBox" name="animInterpolate">
+																								<label>Interpolate</label>
+																								<checked>1</checked>
+																								<tooltip>Blend between the animation's frames during playback instead of stepping from one to the next.</tooltip>
+																								<enabled>0</enabled>
+																							</object>
+																						</object>
+																						<object class="spacer">
+																							<option>1</option>
+																							<flag>wxEXPAND</flag>
+																							<size>0,0</size>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxRIGHT|wxALIGN_CENTER_VERTICAL</flag>
+																							<border>5</border>
+																							<object class="wxStaticText" name="animSpeedLabel">
+																								<label>Speed</label>
+																							</object>
+																						</object>
+																						<object class="sizeritem">
+																							<option>0</option>
+																							<flag>wxALIGN_CENTER_VERTICAL</flag>
+																							<object class="wxChoice" name="animSpeed">
+																								<selection>2</selection>
+																								<content>
+																									<item translate="0">0.25x</item>
+																									<item translate="0">0.5x</item>
+																									<item translate="0">1x</item>
+																									<item translate="0">1.5x</item>
+																									<item translate="0">2x</item>
+																								</content>
+																								<enabled>0</enabled>
+																							</object>
 																						</object>
 																					</object>
 																				</object>

--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -7,6 +7,7 @@ See the included LICENSE file
 #include "NifUtil.hpp"
 #include "../utils/StringStuff.h"
 #include <unordered_set>
+#include <wx/filename.h>
 #include <wx/log.h>
 #include <wx/msgdlg.h>
 
@@ -1103,6 +1104,14 @@ bool AnimBone::IsFullyUnposed() {
 		p = p->parent;
 	}
 	return IsUnposed();
+}
+
+int LoadDefaultSkeletonReference() {
+	std::string defSkelFile = Config["Anim/DefaultSkeletonReference"];
+	if (wxFileName(wxString::FromUTF8(defSkelFile)).IsRelative())
+		return AnimSkeleton::getInstance().LoadFromNif(Config["AppDir"] + PathSepStr + defSkelFile);
+
+	return AnimSkeleton::getInstance().LoadFromNif(defSkelFile);
 }
 
 void ApplySkinningToVerts(AnimInfo& anim, NiShape* shape, bool isSF, const AnimPoseOverrideMap* poseOverrides, std::vector<Vector3>& verts) {

--- a/src/components/Anim.cpp
+++ b/src/components/Anim.cpp
@@ -1104,3 +1104,57 @@ bool AnimBone::IsFullyUnposed() {
 	}
 	return IsUnposed();
 }
+
+void ApplySkinningToVerts(AnimInfo& anim, NiShape* shape, bool isSF, const AnimPoseOverrideMap* poseOverrides, std::vector<Vector3>& verts) {
+	size_t nv = verts.size();
+	std::vector<Vector3> pv(nv);
+	std::vector<float> wv(nv, 0.0f);
+	AnimSkin& animSkin = anim.shapeSkinning[shape->name.get()];
+	MatTransform globalToSkin = anim.GetTransformGlobalToShape(shape);
+
+	for (auto& boneNamesIt : animSkin.boneNames) {
+		AnimBone* animB = AnimSkeleton::getInstance().GetBonePtr(boneNamesIt.first);
+		if (animB) {
+			AnimWeight& animW = animSkin.boneWeights[boneNamesIt.second];
+
+			const MatTransform* poseToGlobal = &animB->xformPoseToGlobal;
+			if (poseOverrides) {
+				auto overrideIt = poseOverrides->find(boneNamesIt.first);
+				if (overrideIt != poseOverrides->end())
+					poseToGlobal = &overrideIt->second;
+			}
+
+			// Compose transform: skin -> (posed) bone -> global -> skin
+			MatTransform transform = globalToSkin.ComposeTransforms(poseToGlobal->ComposeTransforms(animW.xformSkinToBone));
+
+			if (isSF)
+				transform.translation *= sfHavokScale;
+
+			if (transform.IsNearlyEqualTo(MatTransform()))
+				transform.Clear();
+
+			// Add weighted contributions to vertex for this bone
+			for (auto& wIt : animW.weights) {
+				int ind = wIt.first;
+				float w = wIt.second;
+				pv[ind] += w * transform.ApplyTransform(verts[ind]);
+				wv[ind] += w;
+			}
+		}
+	}
+
+	// Check if total weight for each vertex was 1
+	for (size_t ind = 0; ind < nv; ++ind) {
+		if (wv[ind] < EPSILON) // If weights are missing for this vertex
+			pv[ind] = verts[ind];
+		else if (std::fabs(wv[ind] - 1.0f) >= EPSILON) // If weights are bad for this vertex
+			pv[ind] /= wv[ind];
+		// else do nothing because weights totaled 1.
+
+		// New position is nearly equal to old position (reduce noise)
+		if (pv[ind].IsNearlyEqualTo(verts[ind]))
+			pv[ind] = verts[ind];
+	}
+
+	verts.swap(pv);
+}

--- a/src/components/Anim.h
+++ b/src/components/Anim.h
@@ -241,3 +241,13 @@ public:
 	size_t GetBoneNames(std::vector<std::string>& outBoneNames) const;
 	void DisableCustomTransforms();
 };
+
+// Bone name -> replacement pose-to-global transform, e.g. produced by the
+// physics preview simulation.
+using AnimPoseOverrideMap = std::unordered_map<std::string, nifly::MatTransform>;
+
+// Applies CPU linear-blend skinning with the current pose to the given
+// shape-space vertices of the shape. Bones present in poseOverrides use the
+// override transform instead of their AnimBone::xformPoseToGlobal.
+void ApplySkinningToVerts(
+	AnimInfo& anim, nifly::NiShape* shape, bool isSF, const AnimPoseOverrideMap* poseOverrides, std::vector<nifly::Vector3>& verts);

--- a/src/components/Anim.h
+++ b/src/components/Anim.h
@@ -242,6 +242,11 @@ public:
 	void DisableCustomTransforms();
 };
 
+// Loads the skeleton configured as "Anim/DefaultSkeletonReference" into the
+// AnimSkeleton singleton, resolving a relative path against the application
+// directory. Returns 0 on success.
+int LoadDefaultSkeletonReference();
+
 // Bone name -> replacement pose-to-global transform, e.g. produced by the
 // physics preview simulation.
 using AnimPoseOverrideMap = std::unordered_map<std::string, nifly::MatTransform>;

--- a/src/components/UndoState.h
+++ b/src/components/UndoState.h
@@ -110,6 +110,7 @@ struct UndoStateShapeDelete {
 	std::vector<UndoStateShapeSliderDiff> sliderDiffs;
 	std::vector<std::string> textures;
 	std::optional<MaterialFile> materialFile;
+	std::vector<std::string> physicsFiles;
 	// Reference info captured when wasBaseShape, restored on undo
 	std::string refProjectFile;
 	std::string refProjectName;

--- a/src/files/GameDataStream.cpp
+++ b/src/files/GameDataStream.cpp
@@ -1,0 +1,100 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#include "GameDataStream.h"
+
+#include "../utils/ConfigurationManager.h"
+#include "../utils/PlatformUtil.h"
+#include "../utils/StringStuff.h"
+
+#include "FSEngine/FSEngine.h"
+#include "FSEngine/FSManager.h"
+
+#include <fstream>
+#include <regex>
+#include <sstream>
+
+#include <wx/buffer.h>
+
+extern ConfigurationManager Config;
+
+namespace GameDataStream {
+std::unique_ptr<std::istream> OpenLoose(const std::string& fullPath) {
+	if (!PlatformUtil::FileExists(fullPath))
+		return nullptr;
+
+	auto fs = std::make_unique<std::fstream>();
+	PlatformUtil::OpenFileStream(*fs, fullPath, std::ios::in | std::ios::binary);
+	if (!fs->fail())
+		return fs;
+
+	return nullptr;
+}
+
+std::unique_ptr<std::istream> OpenArchive(const std::string& relPath) {
+	for (FSArchiveFile* archive : FSManager::archiveList()) {
+		if (!archive || !archive->hasFile(relPath))
+			continue;
+
+		wxMemoryBuffer outData;
+		archive->fileContents(relPath, outData);
+		if (outData.IsEmpty())
+			continue;
+
+		auto contentStream = std::make_unique<std::istringstream>(
+			std::string(static_cast<char*>(outData.GetData()), outData.GetDataLen()), std::istringstream::binary);
+		if (!contentStream->fail())
+			return contentStream;
+	}
+
+	return nullptr;
+}
+
+std::unique_ptr<std::istream> OpenPhysicsXml(const std::string& xmlPath, const std::string& nifFilePath) {
+	// The paths are relative to the game data folder, but the game's resource
+	// system also accepts a leading "Data\" prefix ("Data\meshes\...") and mods
+	// in the wild use both spellings, so strip it before resolving.
+	std::string relPath = std::regex_replace(xmlPath, std::regex("\\\\+"), "/");
+	relPath = std::regex_replace(relPath, std::regex("^/+"), "");
+	if (ToLower(relPath).rfind("data/", 0) == 0)
+		relPath = relPath.substr(5);
+	if (relPath.empty())
+		return nullptr;
+
+	// 1) Loose file in GameDataPath
+	if (auto stream = OpenLoose(Config["GameDataPath"] + relPath))
+		return stream;
+
+	// 2) Relative to the NIF the link came from: its "meshes" anchor points at
+	// the mod's data root, where SKSE/Plugins/... lives for loose mod folders
+	if (!nifFilePath.empty()) {
+		std::string nifDir = std::regex_replace(nifFilePath, std::regex("\\\\+"), "/");
+		std::string nifDirLower = ToLower(nifDir);
+
+		auto meshesPos = nifDirLower.rfind("/meshes/");
+		if (meshesPos != std::string::npos) {
+			if (auto stream = OpenLoose(nifDir.substr(0, meshesPos + 1) + relPath))
+				return stream;
+		}
+
+		auto lastSlash = nifDir.rfind('/');
+		if (lastSlash != std::string::npos) {
+			// Also try directly beside the NIF (both the full relative path and
+			// just the file name), for standalone test setups
+			if (auto stream = OpenLoose(nifDir.substr(0, lastSlash + 1) + relPath))
+				return stream;
+
+			auto fileNamePos = relPath.rfind('/');
+			if (fileNamePos != std::string::npos) {
+				if (auto stream = OpenLoose(nifDir.substr(0, lastSlash + 1) + relPath.substr(fileNamePos + 1)))
+					return stream;
+			}
+		}
+	}
+
+	// 3) Search in archives
+	return OpenArchive(relPath);
+}
+}

--- a/src/files/GameDataStream.h
+++ b/src/files/GameDataStream.h
@@ -1,0 +1,30 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#pragma once
+
+#include <istream>
+#include <memory>
+#include <string>
+
+// Opening game asset files the way the game's resource system does: loose files
+// under the configured data folder first, then the loaded BSA/BA2 archives.
+// Shared by BodySlide and Outfit Studio.
+namespace GameDataStream {
+// Opens a file at an absolute or working-directory relative path.
+std::unique_ptr<std::istream> OpenLoose(const std::string& fullPath);
+
+// Opens a data folder relative path ("meshes/actors/...") in one of the loaded
+// archives.
+std::unique_ptr<std::istream> OpenArchive(const std::string& relPath);
+
+// Resolves a physics XML path as referenced by a "HDT Skinned Mesh Physics
+// Object" NiStringExtraData, e.g.
+// "SKSE\Plugins\hdtSkinnedMeshConfigs\outfit.xml". Looks for a loose file under
+// the game data folder, then relative to "nifFilePath" (the NIF the link came
+// from, for mods previewed straight out of their own folder), then in the
+// archives. Returns nullptr when it cannot be found.
+std::unique_ptr<std::istream> OpenPhysicsXml(const std::string& xmlPath, const std::string& nifFilePath);
+}

--- a/src/physics/Controller.cpp
+++ b/src/physics/Controller.cpp
@@ -3,13 +3,32 @@ BodySlide and Outfit Studio
 See the included LICENSE file
 */
 
-#include "PhysicsController.h"
+#include "Controller.h"
+
+// The wind direction list is part of the interface both applications build
+// their controls from, so it exists with or without Bullet.
+namespace Physics {
+const std::vector<std::string>& WindDirectionNames() {
+	static const std::vector<std::string> names{"Up", "Down", "Forward", "Backward", "Left", "Right"};
+	return names;
+}
+
+WindDirection WindDirectionFromIndex(int index) {
+	static const WindDirection directions[]
+		= {WindDirection::Up, WindDirection::Down, WindDirection::Forward, WindDirection::Backward, WindDirection::Left, WindDirection::Right};
+
+	if (index < 0 || index >= static_cast<int>(sizeof(directions) / sizeof(directions[0])))
+		return WindDirection::Right;
+
+	return directions[index];
+}
+}
 
 #ifdef USE_BULLET
 
 #include "NiflyBullet.h"
-#include "PhysicsDebugDraw.h"
-#include "PhysicsSystemBuilder.h"
+#include "DebugDraw.h"
+#include "SystemBuilder.h"
 #include "hdt/hdtSkinnedMeshWorld.h"
 
 #include "../components/Anim.h"
@@ -22,7 +41,7 @@ See the included LICENSE file
 #include <sstream>
 #include <type_traits>
 
-namespace bsos {
+namespace Physics {
 // The skinning code takes the override map through Anim.h, which cannot depend
 // on this module; keep the two spellings of the type interchangeable.
 static_assert(std::is_same<PoseOverrideMap, AnimPoseOverrideMap>::value, "PoseOverrideMap must match AnimPoseOverrideMap");
@@ -61,9 +80,9 @@ namespace {
 	// Thin subclass so the controller can drive the protected per-frame hooks
 	// in the same order hdtSMP64's SkyrimPhysicsWorld did, and set the same
 	// default gravity (hdtSkyrimPhysicsWorld.cpp: (0, 0, -9.8 * scaleSkyrim)).
-	class BSOSWorld : public hdt::SkinnedMeshWorld {
+	class PreviewWorld : public hdt::SkinnedMeshWorld {
 	public:
-		BSOSWorld() { setGravity(btVector3(0, 0, -9.8f * scaleSkyrim)); }
+		PreviewWorld() { setGravity(btVector3(0, 0, -9.8f * scaleSkyrim)); }
 
 		using hdt::SkinnedMeshWorld::readTransform;
 		using hdt::SkinnedMeshWorld::writeTransform;
@@ -103,6 +122,13 @@ namespace {
 		}
 	};
 
+	// One system per distinct XML path, applied to the union of the shapes it
+	// was found on.
+	struct XmlEntry {
+		std::string path; // first-seen spelling
+		std::vector<nifly::NiShape*> shapes;
+	};
+
 	// Collects the physics XML paths attached to a block via NiStringExtraData
 	// named "HDT Skinned Mesh Physics Object".
 	std::vector<std::string> GetPhysicsXmlPaths(nifly::NifFile* nif, nifly::NiObjectNET* obj) {
@@ -123,14 +149,107 @@ namespace {
 
 		return result;
 	}
+
+	// Extra data on a shape applies to that shape; extra data on a NiNode
+	// applies to all shapes under that node. "shapePhysicsFiles" adds the links
+	// captured when each NIF was loaded: Outfit Studio merges the shapes of
+	// every file after the first into one work NIF, dropping the root nodes the
+	// links live on, so those shapes are only covered by that map.
+	std::vector<XmlEntry> CollectPhysicsXmlEntries(nifly::NifFile* nif, const ShapePhysicsFileMap& shapePhysicsFiles) {
+		std::vector<XmlEntry> entries;
+		if (!nif)
+			return entries;
+
+		auto addEntry = [&entries](const std::string& path, nifly::NiShape* shape) {
+			const hdt::IDStr pathId(path);
+			for (auto& e : entries) {
+				if (hdt::IDStr(e.path) == pathId) {
+					if (std::find(e.shapes.begin(), e.shapes.end(), shape) == e.shapes.end())
+						e.shapes.push_back(shape);
+					return;
+				}
+			}
+			entries.push_back({path, {shape}});
+		};
+
+		const auto shapes = nif->GetShapes();
+
+		for (auto* shape : shapes) {
+			for (const auto& xmlPath : GetPhysicsXmlPaths(nif, shape))
+				addEntry(xmlPath, shape);
+		}
+
+		for (auto* node : nif->GetNodes()) {
+			const auto xmlPaths = GetPhysicsXmlPaths(nif, node);
+			if (xmlPaths.empty())
+				continue;
+
+			for (auto* shape : shapes) {
+				bool underNode = false;
+				for (nifly::NiNode* p = nif->GetParentNode(shape); p; p = nif->GetParentNode(p)) {
+					if (p == node) {
+						underNode = true;
+						break;
+					}
+				}
+
+				if (underNode) {
+					for (const auto& xmlPath : xmlPaths)
+						addEntry(xmlPath, shape);
+				}
+			}
+		}
+
+		for (auto& shapePhysicsFile : shapePhysicsFiles) {
+			auto* shape = nif->FindBlockByName<nifly::NiShape>(shapePhysicsFile.first);
+			if (!shape)
+				continue;
+
+			for (const auto& xmlPath : shapePhysicsFile.second)
+				addEntry(xmlPath, shape);
+		}
+
+		return entries;
+	}
 }
 
-struct PhysicsController::Impl {
-	BSOSWorld world;
-	std::vector<hdt::Ref<BSOSSystem>> systems;
+bool HasPhysicsLinks(nifly::NifFile* nif, const ShapePhysicsFileMap& shapePhysicsFiles) {
+	if (!nif)
+		return false;
+
+	for (auto& shapePhysicsFile : shapePhysicsFiles) {
+		if (!shapePhysicsFile.second.empty() && nif->FindBlockByName<nifly::NiShape>(shapePhysicsFile.first))
+			return true;
+	}
+
+	// Answering "is there anything at all" does not need the shape sets
+	// CollectPhysicsXmlEntries builds, which is what makes this cheap enough to
+	// call whenever the loaded meshes change. A link on a node with no shapes
+	// under it counts here but builds nothing - it does not exist in practice,
+	// since the game only reads the link from the model root.
+	const auto shapes = nif->GetShapes();
+	if (shapes.empty())
+		return false;
+
+	for (auto* shape : shapes) {
+		if (!GetPhysicsXmlPaths(nif, shape).empty())
+			return true;
+	}
+
+	for (auto* node : nif->GetNodes()) {
+		if (!GetPhysicsXmlPaths(nif, node).empty())
+			return true;
+	}
+
+	return false;
+}
+
+struct Controller::Impl {
+	PreviewWorld world;
+	std::vector<hdt::Ref<PreviewSystem>> systems;
 	PoseOverrideMap poseOverrides;
 	std::unordered_set<std::string> affectedShapes;
-	PhysicsDebugVis debugVis;
+	DebugVis debugVis;
 	float rootYawRad = 0.0f;
 	// Wall-clock time that has not been simulated yet, kept below one tick
 	float leftoverTime = 0.0f;
@@ -150,14 +269,14 @@ struct PhysicsController::Impl {
 	}
 };
 
-PhysicsController::PhysicsController()
+Controller::Controller()
 	: impl(std::make_unique<Impl>()) {}
 
-PhysicsController::~PhysicsController() {
+Controller::~Controller() {
 	Clear();
 }
 
-size_t PhysicsController::BuildFromNif(nifly::NifFile* nif,
+size_t Controller::BuildFromNif(nifly::NifFile* nif,
 									   AnimInfo* anim,
 									   const XmlStreamResolver& resolver,
 									   const ShapePhysicsFileMap& shapePhysicsFiles,
@@ -167,68 +286,7 @@ size_t PhysicsController::BuildFromNif(nifly::NifFile* nif,
 	if (!nif || !anim || !resolver)
 		return 0;
 
-	// One system per distinct XML path, applied to the union of the shapes it
-	// was found on. Extra data on a shape applies to that shape; extra data on
-	// a NiNode applies to all shapes under that node.
-	struct XmlEntry {
-		std::string path; // first-seen spelling
-		std::vector<nifly::NiShape*> shapes;
-	};
-	std::vector<XmlEntry> entries;
-
-	auto addEntry = [&entries](const std::string& path, nifly::NiShape* shape) {
-		const hdt::IDStr pathId(path);
-		for (auto& e : entries) {
-			if (hdt::IDStr(e.path) == pathId) {
-				if (std::find(e.shapes.begin(), e.shapes.end(), shape) == e.shapes.end())
-					e.shapes.push_back(shape);
-				return;
-			}
-		}
-		entries.push_back({path, {shape}});
-	};
-
-	const auto shapes = nif->GetShapes();
-
-	for (auto* shape : shapes) {
-		for (const auto& xmlPath : GetPhysicsXmlPaths(nif, shape))
-			addEntry(xmlPath, shape);
-	}
-
-	for (auto* node : nif->GetNodes()) {
-		const auto xmlPaths = GetPhysicsXmlPaths(nif, node);
-		if (xmlPaths.empty())
-			continue;
-
-		for (auto* shape : shapes) {
-			bool underNode = false;
-			for (nifly::NiNode* p = nif->GetParentNode(shape); p; p = nif->GetParentNode(p)) {
-				if (p == node) {
-					underNode = true;
-					break;
-				}
-			}
-
-			if (underNode) {
-				for (const auto& xmlPath : xmlPaths)
-					addEntry(xmlPath, shape);
-			}
-		}
-	}
-
-	// Links captured when each NIF was loaded. Outfit Studio merges shapes of
-	// every file after the first into one work NIF, dropping the root nodes
-	// the links live on, so those shapes are only covered by this map.
-	for (auto& shapePhysicsFile : shapePhysicsFiles) {
-		auto* shape = nif->FindBlockByName<nifly::NiShape>(shapePhysicsFile.first);
-		if (!shape)
-			continue;
-
-		for (const auto& xmlPath : shapePhysicsFile.second)
-			addEntry(xmlPath, shape);
-	}
-
-	for (auto& entry : entries) {
+	for (auto& entry : CollectPhysicsXmlEntries(nif, shapePhysicsFiles)) {
 		auto stream = resolver(entry.path);
 		if (!stream) {
 			outWarnings.push_back("physics XML not found: " + entry.path);
@@ -239,14 +297,14 @@ size_t PhysicsController::BuildFromNif(nifly::NifFile* nif,
 		contents << stream->rdbuf();
 		const std::string xmlData = contents.str();
 
-		PhysicsBuildInput input;
+		BuildInput input;
 		input.xmlData = &xmlData;
 		input.xmlName = entry.path;
 		input.nif = nif;
 		input.anim = anim;
 		input.shapes = entry.shapes;
 
-		PhysicsSystemBuilder builder;
+		SystemBuilder builder;
 		auto system = builder.Build(input, outWarnings);
 		if (!system)
 			continue;
@@ -284,7 +342,7 @@ size_t PhysicsController::BuildFromNif(nifly::NifFile* nif,
 	return impl->systems.size();
 }
 
-void PhysicsController::Clear() {
+void Controller::Clear() {
 	if (!impl)
 		return;
 
@@ -298,11 +356,11 @@ void PhysicsController::Clear() {
 	impl->leftoverTime = 0.0f;
 }
 
-bool PhysicsController::IsActive() const {
+bool Controller::IsActive() const {
 	return impl && !impl->systems.empty();
 }
 
-void PhysicsController::ResetDynamics() {
+void Controller::ResetDynamics() {
 	if (!IsActive())
 		return;
 
@@ -314,7 +372,7 @@ void PhysicsController::ResetDynamics() {
 	impl->leftoverTime = 0.0f;
 }
 
-void PhysicsController::Step(float dtSeconds) {
+void Controller::Step(float dtSeconds) {
 	if (!IsActive())
 		return;
 
@@ -359,7 +417,7 @@ void PhysicsController::Step(float dtSeconds) {
 	}
 }
 
-void PhysicsController::InjectCameraYaw(float deltaDegrees) {
+void Controller::InjectCameraYaw(float deltaDegrees) {
 	if (!IsActive())
 		return;
 
@@ -374,25 +432,25 @@ void PhysicsController::InjectCameraYaw(float deltaDegrees) {
 	impl->rootYawRad = std::fmod(impl->rootYawRad, twoPi);
 }
 
-void PhysicsController::SetWindStrength(float strength) {
+void Controller::SetWindStrength(float strength) {
 	impl->windStrength = std::max(0.0f, std::min(strength, 1.0f));
 	impl->applyWind();
 }
 
-void PhysicsController::SetWindDirection(WindDirection direction) {
+void Controller::SetWindDirection(WindDirection direction) {
 	impl->windDirection = direction;
 	impl->applyWind();
 }
 
-const PoseOverrideMap& PhysicsController::PoseOverrides() const {
+const PoseOverrideMap& Controller::PoseOverrides() const {
 	return impl->poseOverrides;
 }
 
-const std::unordered_set<std::string>& PhysicsController::AffectedShapes() const {
+const std::unordered_set<std::string>& Controller::AffectedShapes() const {
 	return impl->affectedShapes;
 }
 
-void PhysicsController::UpdateDebugVis(GLSurface& gls, bool enabled) {
+void Controller::UpdateDebugVis(GLSurface& gls, bool enabled) {
 	if (enabled && IsActive())
 		impl->debugVis.Update(gls, impl->systems);
 	else
@@ -403,39 +461,45 @@ void PhysicsController::UpdateDebugVis(GLSurface& gls, bool enabled) {
 #else  // USE_BULLET
 
 // Inert stubs keep call sites valid in builds without Bullet.
-namespace bsos {
-struct PhysicsController::Impl {};
-
-PhysicsController::PhysicsController() = default;
-PhysicsController::~PhysicsController() = default;
-
-size_t PhysicsController::BuildFromNif(nifly::NifFile*, AnimInfo*, const XmlStreamResolver&, const ShapePhysicsFileMap&, std::vector<std::string>&) {
-	return 0;
-}
-
-void PhysicsController::Clear() {}
-
-bool PhysicsController::IsActive() const {
+namespace Physics {
+// Nothing can be simulated, so the applications keep their physics controls
+// hidden.
+bool HasPhysicsLinks(nifly::NifFile*, const ShapePhysicsFileMap&) {
 	return false;
 }
 
-void PhysicsController::ResetDynamics() {}
-void PhysicsController::Step(float) {}
-void PhysicsController::InjectCameraYaw(float) {}
-void PhysicsController::SetWindStrength(float) {}
-void PhysicsController::SetWindDirection(WindDirection) {}
+struct Controller::Impl {};
 
-const PoseOverrideMap& PhysicsController::PoseOverrides() const {
+Controller::Controller() = default;
+Controller::~Controller() = default;
+
+size_t Controller::BuildFromNif(nifly::NifFile*, AnimInfo*, const XmlStreamResolver&, const ShapePhysicsFileMap&, std::vector<std::string>&) {
+	return 0;
+}
+
+void Controller::Clear() {}
+
+bool Controller::IsActive() const {
+	return false;
+}
+
+void Controller::ResetDynamics() {}
+void Controller::Step(float) {}
+void Controller::InjectCameraYaw(float) {}
+void Controller::SetWindStrength(float) {}
+void Controller::SetWindDirection(WindDirection) {}
+
+const PoseOverrideMap& Controller::PoseOverrides() const {
 	static const PoseOverrideMap empty;
 	return empty;
 }
 
-const std::unordered_set<std::string>& PhysicsController::AffectedShapes() const {
+const std::unordered_set<std::string>& Controller::AffectedShapes() const {
 	static const std::unordered_set<std::string> empty;
 	return empty;
 }
 
-void PhysicsController::UpdateDebugVis(GLSurface&, bool) {}
+void Controller::UpdateDebugVis(GLSurface&, bool) {}
 }
 
 #endif	// USE_BULLET

--- a/src/physics/Controller.h
+++ b/src/physics/Controller.h
@@ -22,7 +22,7 @@ namespace nifly {
 class NifFile;
 }
 
-namespace bsos {
+namespace Physics {
 // Resolves a physics XML path as referenced by a NiStringExtraData (e.g.
 // "SKSE\Plugins\hdtSkinnedMeshConfigs\outfit.xml") to a readable stream, or
 // nullptr when it cannot be found.
@@ -32,7 +32,7 @@ using XmlStreamResolver = std::function<std::unique_ptr<std::istream>(const std:
 // simulation, consumed by the skinning code instead of
 // AnimBone::xformPoseToGlobal for bones driven by physics. Spelled out again
 // instead of including Anim.h, which would pull the application skeleton into
-// every user of this header; PhysicsController.cpp asserts that this stays the
+// every user of this header; Controller.cpp asserts that this stays the
 // same type as AnimPoseOverrideMap.
 using PoseOverrideMap = std::unordered_map<std::string, nifly::MatTransform>;
 
@@ -47,6 +47,17 @@ using ShapePhysicsFileMap = std::unordered_map<std::string, std::vector<std::str
 // inside the physics world.
 enum class WindDirection { Up, Down, Forward, Backward, Left, Right };
 
+// The wind directions in the order both applications list them in their
+// controls, so a selection index means the same thing in either.
+const std::vector<std::string>& WindDirectionNames();
+WindDirection WindDirectionFromIndex(int index);
+
+// True when "nif" or "shapePhysicsFiles" reference at least one physics XML,
+// i.e. when a physics preview has anything to simulate. Only looks at extra
+// data, so it is cheap enough to call whenever the loaded meshes change; the
+// XMLs are neither resolved nor parsed. Always false without Bullet.
+bool HasPhysicsLinks(nifly::NifFile* nif, const ShapePhysicsFileMap& shapePhysicsFiles);
+
 /*
 App-facing facade over the physics core ported from Faster HDT-SMP (see
 src/physics/hdt/README.md for its origin, license and the port notes). Owns
@@ -57,13 +68,13 @@ Bullet, never on OutfitProject or any UI type.
 Without USE_BULLET every method is an inert stub so call sites stay valid in
 builds without Bullet.
 */
-class PhysicsController {
+class Controller {
 public:
-	PhysicsController();
-	~PhysicsController();
+	Controller();
+	~Controller();
 
-	PhysicsController(const PhysicsController&) = delete;
-	PhysicsController& operator=(const PhysicsController&) = delete;
+	Controller(const Controller&) = delete;
+	Controller& operator=(const Controller&) = delete;
 
 	// Scans all shapes and nodes of the NIF for NiStringExtraData named
 	// "HDT Skinned Mesh Physics Object" and adds the links of

--- a/src/physics/DebugDraw.cpp
+++ b/src/physics/DebugDraw.cpp
@@ -5,7 +5,7 @@ See the included LICENSE file
 
 #ifdef USE_BULLET
 
-#include "PhysicsDebugDraw.h"
+#include "DebugDraw.h"
 
 #include "NiflyBullet.h"
 
@@ -17,7 +17,7 @@ See the included LICENSE file
 #include <BulletCollision/CollisionShapes/btCompoundShape.h>
 #include <BulletCollision/CollisionShapes/btSphereShape.h>
 
-namespace bsos {
+namespace Physics {
 namespace {
 	constexpr float meshScale = 0.1f; // NIF units -> mesh units
 
@@ -32,7 +32,7 @@ namespace {
 // Draws one bullet collision shape at the given physics-world transform.
 // Compound shapes recurse; unsupported shapes fall back to a sphere of their
 // bounding radius.
-void PhysicsDebugVis::drawShape(GLSurface& gls, const btCollisionShape* shape, const btTransform& transform, const nifly::Vector3& color) {
+void DebugVis::drawShape(GLSurface& gls, const btCollisionShape* shape, const btTransform& transform, const nifly::Vector3& color) {
 	if (!shape)
 		return;
 
@@ -109,7 +109,7 @@ void PhysicsDebugVis::drawShape(GLSurface& gls, const btCollisionShape* shape, c
 	}
 }
 
-void PhysicsDebugVis::drawConstraint(GLSurface& gls, const btTypedConstraint* constraint, const btTransform& rootMotionInv) {
+void DebugVis::drawConstraint(GLSurface& gls, const btTypedConstraint* constraint, const btTransform& rootMotionInv) {
 	if (!constraint)
 		return;
 
@@ -120,7 +120,7 @@ void PhysicsDebugVis::drawConstraint(GLSurface& gls, const btTypedConstraint* co
 	gls.AddVisSeg(ToMeshPos(a), ToMeshPos(b), visNames.back());
 }
 
-void PhysicsDebugVis::Update(GLSurface& gls, const std::vector<hdt::Ref<BSOSSystem>>& systems) {
+void DebugVis::Update(GLSurface& gls, const std::vector<hdt::Ref<PreviewSystem>>& systems) {
 	Clear(gls);
 
 	for (auto& system : systems) {
@@ -143,7 +143,7 @@ void PhysicsDebugVis::Update(GLSurface& gls, const std::vector<hdt::Ref<BSOSSyst
 	}
 }
 
-void PhysicsDebugVis::Clear(GLSurface& gls) {
+void DebugVis::Clear(GLSurface& gls) {
 	for (auto& name : visNames)
 		gls.DeleteOverlay(name);
 

--- a/src/physics/DebugDraw.h
+++ b/src/physics/DebugDraw.h
@@ -7,22 +7,22 @@ See the included LICENSE file
 
 #ifdef USE_BULLET
 
-#include "PhysicsSystemBuilder.h"
+#include "SystemBuilder.h"
 
 #include <string>
 #include <vector>
 
 class GLSurface;
 
-namespace bsos {
+namespace Physics {
 // Draws the bone collision shapes and constraints of a set of physics systems
 // as named overlay primitives on a surface. Owns the names it drew so it can
 // replace or remove them again. Per-vertex/per-triangle collider clouds are
 // not drawn individually (they would be one overlay mesh per collider).
-class PhysicsDebugVis {
+class DebugVis {
 public:
 	// Replaces everything drawn by the previous call.
-	void Update(GLSurface& gls, const std::vector<hdt::Ref<BSOSSystem>>& systems);
+	void Update(GLSurface& gls, const std::vector<hdt::Ref<PreviewSystem>>& systems);
 
 	// Removes all overlays of the previous Update.
 	void Clear(GLSurface& gls);

--- a/src/physics/NiflyBullet.h
+++ b/src/physics/NiflyBullet.h
@@ -1,0 +1,56 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#pragma once
+
+#ifdef USE_BULLET
+
+#include <Object3d.hpp>
+
+#include <LinearMath/btTransform.h>
+#include <LinearMath/btVector3.h>
+
+// Conversions between nifly math types and Bullet math types. The physics
+// simulation runs in NIF global space (the same space as
+// AnimBone::xformPoseToGlobal), so no axis swaps or unit scaling happen here.
+// MatTransform scale is intentionally dropped: physics bones are treated as
+// scale 1 (the builder warns when a posed bone is scaled).
+namespace bsos {
+inline btVector3 ToBt(const nifly::Vector3& v) {
+	return btVector3(v.x, v.y, v.z);
+}
+
+inline nifly::Vector3 FromBt(const btVector3& v) {
+	return nifly::Vector3(v.x(), v.y(), v.z());
+}
+
+inline btMatrix3x3 ToBt(const nifly::Matrix3& m) {
+	return btMatrix3x3(m[0].x, m[0].y, m[0].z, m[1].x, m[1].y, m[1].z, m[2].x, m[2].y, m[2].z);
+}
+
+inline nifly::Matrix3 FromBt(const btMatrix3x3& m) {
+	nifly::Matrix3 r;
+	for (int i = 0; i < 3; ++i) {
+		r[i].x = m[i].x();
+		r[i].y = m[i].y();
+		r[i].z = m[i].z();
+	}
+	return r;
+}
+
+inline btTransform ToBt(const nifly::MatTransform& t) {
+	return btTransform(ToBt(t.rotation), ToBt(t.translation));
+}
+
+inline nifly::MatTransform FromBt(const btTransform& t) {
+	nifly::MatTransform r;
+	r.rotation = FromBt(t.getBasis());
+	r.translation = FromBt(t.getOrigin());
+	r.scale = 1.0f;
+	return r;
+}
+}
+
+#endif	// USE_BULLET

--- a/src/physics/NiflyBullet.h
+++ b/src/physics/NiflyBullet.h
@@ -17,7 +17,7 @@ See the included LICENSE file
 // AnimBone::xformPoseToGlobal), so no axis swaps or unit scaling happen here.
 // MatTransform scale is intentionally dropped: physics bones are treated as
 // scale 1 (the builder warns when a posed bone is scaled).
-namespace bsos {
+namespace Physics {
 inline btVector3 ToBt(const nifly::Vector3& v) {
 	return btVector3(v.x, v.y, v.z);
 }

--- a/src/physics/PhysicsController.cpp
+++ b/src/physics/PhysicsController.cpp
@@ -1,0 +1,441 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#include "PhysicsController.h"
+
+#ifdef USE_BULLET
+
+#include "NiflyBullet.h"
+#include "PhysicsDebugDraw.h"
+#include "PhysicsSystemBuilder.h"
+#include "hdt/hdtSkinnedMeshWorld.h"
+
+#include "../components/Anim.h"
+
+#include <ExtraData.hpp>
+#include <NifFile.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <sstream>
+#include <type_traits>
+
+namespace bsos {
+// The skinning code takes the override map through Anim.h, which cannot depend
+// on this module; keep the two spellings of the type interchangeable.
+static_assert(std::is_same<PoseOverrideMap, AnimPoseOverrideMap>::value, "PoseOverrideMap must match AnimPoseOverrideMap");
+
+namespace {
+	// The NiStringExtraData name the game scans for (case-insensitive, like
+	// BSFixedString comparison in hdtSMP64's DefaultBBP scan).
+	const hdt::IDStr physicsExtraDataName("HDT Skinned Mesh Physics Object");
+
+	// Same world units as hdtConvertNi.h upstream
+	constexpr float scaleRealWorld = 0.01425f;
+	constexpr float scaleSkyrim = 1.0f / scaleRealWorld;
+
+	// Wind strength 1 is well past the strongest vanilla weather wind (which
+	// is scaleSkyrim): exaggerated wind is the point of a test tool, and the
+	// in-game maximum barely moves stiffer setups.
+	constexpr float maxWindScale = 3.0f;
+
+	// NIF axes: +X is the mesh's own right, +Y forward, +Z up. Left and right
+	// are swapped against that because the viewport looks at the mesh from the
+	// front, where its right side is on the viewer's left - the labels name
+	// what the user sees, not the mesh's anatomy.
+	btVector3 WindDirectionVector(WindDirection direction) {
+		switch (direction) {
+			case WindDirection::Up: return btVector3(0, 0, 1);
+			case WindDirection::Down: return btVector3(0, 0, -1);
+			case WindDirection::Forward: return btVector3(0, 1, 0);
+			case WindDirection::Backward: return btVector3(0, -1, 0);
+			case WindDirection::Left: return btVector3(1, 0, 0);
+			case WindDirection::Right: return btVector3(-1, 0, 0);
+		}
+
+		return btVector3(-1, 0, 0);
+	}
+
+	// Thin subclass so the controller can drive the protected per-frame hooks
+	// in the same order hdtSMP64's SkyrimPhysicsWorld did, and set the same
+	// default gravity (hdtSkyrimPhysicsWorld.cpp: (0, 0, -9.8 * scaleSkyrim)).
+	class BSOSWorld : public hdt::SkinnedMeshWorld {
+	public:
+		BSOSWorld() { setGravity(btVector3(0, 0, -9.8f * scaleSkyrim)); }
+
+		using hdt::SkinnedMeshWorld::readTransform;
+		using hdt::SkinnedMeshWorld::writeTransform;
+
+		// Ports of SkyrimPhysicsWorld::applyTranslationOffset /
+		// restoreTranslationOffset: recenter all rigid bodies around their
+		// average position during the step to keep float precision stable.
+		btVector3 applyTranslationOffset() {
+			btVector3 center;
+			center.setZero();
+			int count = 0;
+			for (int i = 0; i < m_collisionObjects.size(); ++i) {
+				auto rig = btRigidBody::upcast(m_collisionObjects[i]);
+				if (rig) {
+					center += rig->getWorldTransform().getOrigin();
+					++count;
+				}
+			}
+
+			if (count > 0) {
+				center /= static_cast<btScalar>(count);
+				for (int i = 0; i < m_collisionObjects.size(); ++i) {
+					auto rig = btRigidBody::upcast(m_collisionObjects[i]);
+					if (rig)
+						rig->getWorldTransform().getOrigin() -= center;
+				}
+			}
+			return center;
+		}
+
+		void restoreTranslationOffset(const btVector3& offset) {
+			for (int i = 0; i < m_collisionObjects.size(); ++i) {
+				auto rig = btRigidBody::upcast(m_collisionObjects[i]);
+				if (rig)
+					rig->getWorldTransform().getOrigin() += offset;
+			}
+		}
+	};
+
+	// Collects the physics XML paths attached to a block via NiStringExtraData
+	// named "HDT Skinned Mesh Physics Object".
+	std::vector<std::string> GetPhysicsXmlPaths(nifly::NifFile* nif, nifly::NiObjectNET* obj) {
+		std::vector<std::string> result;
+
+		for (auto& extraDataRef : obj->extraDataRefs) {
+			auto stringExtraData = nif->GetHeader().GetBlock<nifly::NiStringExtraData>(extraDataRef);
+			if (!stringExtraData)
+				continue;
+
+			if (hdt::IDStr(stringExtraData->name.get()) != physicsExtraDataName)
+				continue;
+
+			const std::string& xmlPath = stringExtraData->stringData.get();
+			if (!xmlPath.empty())
+				result.push_back(xmlPath);
+		}
+
+		return result;
+	}
+}
+
+struct PhysicsController::Impl {
+	BSOSWorld world;
+	std::vector<hdt::Ref<BSOSSystem>> systems;
+	PoseOverrideMap poseOverrides;
+	std::unordered_set<std::string> affectedShapes;
+	PhysicsDebugVis debugVis;
+	float rootYawRad = 0.0f;
+	// Wall-clock time that has not been simulated yet, kept below one tick
+	float leftoverTime = 0.0f;
+	float windStrength = 0.0f;
+	WindDirection windDirection = WindDirection::Right;
+
+	// The root motion turns the mesh inside the physics world, so a wind
+	// vector fixed in world space would blow at a different side of the mesh
+	// after every camera turn. Turning it along with the mesh keeps it where
+	// the user aimed it. Call after anything that changes yaw, strength or
+	// direction.
+	void applyWind() {
+		const btVector3 direction = btMatrix3x3(btQuaternion(btVector3(0, 0, 1), rootYawRad)) * WindDirectionVector(windDirection);
+
+		world.m_enableWind = windStrength > 0.0f;
+		world.getWind() = direction * (windStrength * maxWindScale * scaleSkyrim);
+	}
+};
+
+PhysicsController::PhysicsController()
+	: impl(std::make_unique<Impl>()) {}
+
+PhysicsController::~PhysicsController() {
+	Clear();
+}
+
+size_t PhysicsController::BuildFromNif(nifly::NifFile* nif,
+									   AnimInfo* anim,
+									   const XmlStreamResolver& resolver,
+									   const ShapePhysicsFileMap& shapePhysicsFiles,
+									   std::vector<std::string>& outWarnings) {
+	Clear();
+
+	if (!nif || !anim || !resolver)
+		return 0;
+
+	// One system per distinct XML path, applied to the union of the shapes it
+	// was found on. Extra data on a shape applies to that shape; extra data on
+	// a NiNode applies to all shapes under that node.
+	struct XmlEntry {
+		std::string path; // first-seen spelling
+		std::vector<nifly::NiShape*> shapes;
+	};
+	std::vector<XmlEntry> entries;
+
+	auto addEntry = [&entries](const std::string& path, nifly::NiShape* shape) {
+		const hdt::IDStr pathId(path);
+		for (auto& e : entries) {
+			if (hdt::IDStr(e.path) == pathId) {
+				if (std::find(e.shapes.begin(), e.shapes.end(), shape) == e.shapes.end())
+					e.shapes.push_back(shape);
+				return;
+			}
+		}
+		entries.push_back({path, {shape}});
+	};
+
+	const auto shapes = nif->GetShapes();
+
+	for (auto* shape : shapes) {
+		for (const auto& xmlPath : GetPhysicsXmlPaths(nif, shape))
+			addEntry(xmlPath, shape);
+	}
+
+	for (auto* node : nif->GetNodes()) {
+		const auto xmlPaths = GetPhysicsXmlPaths(nif, node);
+		if (xmlPaths.empty())
+			continue;
+
+		for (auto* shape : shapes) {
+			bool underNode = false;
+			for (nifly::NiNode* p = nif->GetParentNode(shape); p; p = nif->GetParentNode(p)) {
+				if (p == node) {
+					underNode = true;
+					break;
+				}
+			}
+
+			if (underNode) {
+				for (const auto& xmlPath : xmlPaths)
+					addEntry(xmlPath, shape);
+			}
+		}
+	}
+
+	// Links captured when each NIF was loaded. Outfit Studio merges shapes of
+	// every file after the first into one work NIF, dropping the root nodes
+	// the links live on, so those shapes are only covered by this map.
+	for (auto& shapePhysicsFile : shapePhysicsFiles) {
+		auto* shape = nif->FindBlockByName<nifly::NiShape>(shapePhysicsFile.first);
+		if (!shape)
+			continue;
+
+		for (const auto& xmlPath : shapePhysicsFile.second)
+			addEntry(xmlPath, shape);
+	}
+
+	for (auto& entry : entries) {
+		auto stream = resolver(entry.path);
+		if (!stream) {
+			outWarnings.push_back("physics XML not found: " + entry.path);
+			continue;
+		}
+
+		std::ostringstream contents;
+		contents << stream->rdbuf();
+		const std::string xmlData = contents.str();
+
+		PhysicsBuildInput input;
+		input.xmlData = &xmlData;
+		input.xmlName = entry.path;
+		input.nif = nif;
+		input.anim = anim;
+		input.shapes = entry.shapes;
+
+		PhysicsSystemBuilder builder;
+		auto system = builder.Build(input, outWarnings);
+		if (!system)
+			continue;
+
+		system->m_poseOverrides = &impl->poseOverrides;
+		impl->world.addSkinnedMeshSystem(system.get());
+		impl->systems.push_back(system);
+
+		// A shape needs re-skinning against pose overrides when its skin
+		// references at least one dynamic (non-kinematic) bone of the system.
+		for (auto* shape : entry.shapes) {
+			const std::string shapeName = shape->name.get();
+			auto skinIt = anim->shapeSkinning.find(shapeName);
+			if (skinIt == anim->shapeSkinning.end())
+				continue;
+
+			bool affected = false;
+			for (const auto& bn : skinIt->second.boneNames) {
+				const hdt::IDStr boneName(bn.first);
+				for (const auto& bone : system->getBones()) {
+					if (bone->m_name == boneName && !bone->m_rig.isStaticOrKinematicObject()) {
+						affected = true;
+						break;
+					}
+				}
+				if (affected)
+					break;
+			}
+
+			if (affected)
+				impl->affectedShapes.insert(shapeName);
+		}
+	}
+
+	return impl->systems.size();
+}
+
+void PhysicsController::Clear() {
+	if (!impl)
+		return;
+
+	for (auto& system : impl->systems)
+		impl->world.removeSkinnedMeshSystem(system.get());
+
+	impl->systems.clear();
+	impl->poseOverrides.clear();
+	impl->affectedShapes.clear();
+	impl->rootYawRad = 0.0f;
+	impl->leftoverTime = 0.0f;
+}
+
+bool PhysicsController::IsActive() const {
+	return impl && !impl->systems.empty();
+}
+
+void PhysicsController::ResetDynamics() {
+	if (!IsActive())
+		return;
+
+	// Mirrors hdtSMP64 SkyrimPhysicsWorld::resetSystems (and the reset call in
+	// SkinnedMeshWorld::addSkinnedMeshSystem).
+	for (auto& system : impl->systems)
+		system->readTransform(system->prepareForRead(hdt::RESET_PHYSICS));
+
+	impl->leftoverTime = 0.0f;
+}
+
+void PhysicsController::Step(float dtSeconds) {
+	if (!IsActive())
+		return;
+
+	// Like hdtSMP64's SkyrimPhysicsWorld::doUpdate, the simulation only ever
+	// advances in whole ticks of a fixed length, so its behavior does not
+	// depend on the frame rate. Time that does not fill a tick is carried over
+	// to the next call; time beyond maxTicksPerStep is dropped so a stall
+	// (breakpoint, window drag) cannot turn into a burst of catch-up steps.
+	constexpr float fixedTimeStep = 1.0f / 60.0f;
+	constexpr int maxTicksPerStep = 3;
+
+	if (dtSeconds > 0.0f)
+		impl->leftoverTime += dtSeconds;
+
+	int ticks = static_cast<int>(impl->leftoverTime / fixedTimeStep);
+	if (ticks <= 0)
+		return;
+
+	impl->leftoverTime -= ticks * fixedTimeStep;
+	ticks = std::min(ticks, maxTicksPerStep);
+
+	// Root motion from the accumulated camera yaw: rotate the character about
+	// the world Z axis under a fixed camera.
+	const btTransform rootMotion(btQuaternion(btVector3(0, 0, 1), impl->rootYawRad));
+	for (auto& system : impl->systems)
+		system->m_rootMotion = rootMotion;
+
+	// Keep the wind aimed at the same side of the mesh as it turns
+	impl->applyWind();
+
+	// Same call order as hdtSMP64's SkyrimPhysicsWorld::doUpdate /
+	// doUpdate2ndStep: readTransform (which runs prepareForRead per system) ->
+	// translation offset -> stepSimulation -> restore offset ->
+	// writeTransform. SkinnedMeshWorld::stepSimulation does not call
+	// readTransform/writeTransform itself.
+	for (int i = 0; i < ticks; ++i) {
+		impl->world.readTransform(fixedTimeStep);
+		const btVector3 offset = impl->world.applyTranslationOffset();
+		impl->world.stepSimulation(fixedTimeStep, 1, fixedTimeStep);
+		impl->world.restoreTranslationOffset(offset);
+		impl->world.writeTransform();
+	}
+}
+
+void PhysicsController::InjectCameraYaw(float deltaDegrees) {
+	if (!IsActive())
+		return;
+
+	// The camera orbits the mesh, so the mesh turns with the camera rather
+	// than against it: same sign, or the cloth swings the wrong way.
+	constexpr float degToRad = 3.14159265358979323846f / 180.0f;
+	impl->rootYawRad += deltaDegrees * degToRad;
+
+	// Only ever used as a rotation, so wrapping is exact and prevents float
+	// precision loss from unbounded accumulation.
+	constexpr float twoPi = 2.0f * 3.14159265358979323846f;
+	impl->rootYawRad = std::fmod(impl->rootYawRad, twoPi);
+}
+
+void PhysicsController::SetWindStrength(float strength) {
+	impl->windStrength = std::max(0.0f, std::min(strength, 1.0f));
+	impl->applyWind();
+}
+
+void PhysicsController::SetWindDirection(WindDirection direction) {
+	impl->windDirection = direction;
+	impl->applyWind();
+}
+
+const PoseOverrideMap& PhysicsController::PoseOverrides() const {
+	return impl->poseOverrides;
+}
+
+const std::unordered_set<std::string>& PhysicsController::AffectedShapes() const {
+	return impl->affectedShapes;
+}
+
+void PhysicsController::UpdateDebugVis(GLSurface& gls, bool enabled) {
+	if (enabled && IsActive())
+		impl->debugVis.Update(gls, impl->systems);
+	else
+		impl->debugVis.Clear(gls);
+}
+}
+
+#else  // USE_BULLET
+
+// Inert stubs keep call sites valid in builds without Bullet.
+namespace bsos {
+struct PhysicsController::Impl {};
+
+PhysicsController::PhysicsController() = default;
+PhysicsController::~PhysicsController() = default;
+
+size_t PhysicsController::BuildFromNif(nifly::NifFile*, AnimInfo*, const XmlStreamResolver&, const ShapePhysicsFileMap&, std::vector<std::string>&) {
+	return 0;
+}
+
+void PhysicsController::Clear() {}
+
+bool PhysicsController::IsActive() const {
+	return false;
+}
+
+void PhysicsController::ResetDynamics() {}
+void PhysicsController::Step(float) {}
+void PhysicsController::InjectCameraYaw(float) {}
+void PhysicsController::SetWindStrength(float) {}
+void PhysicsController::SetWindDirection(WindDirection) {}
+
+const PoseOverrideMap& PhysicsController::PoseOverrides() const {
+	static const PoseOverrideMap empty;
+	return empty;
+}
+
+const std::unordered_set<std::string>& PhysicsController::AffectedShapes() const {
+	static const std::unordered_set<std::string> empty;
+	return empty;
+}
+
+void PhysicsController::UpdateDebugVis(GLSurface&, bool) {}
+}
+
+#endif	// USE_BULLET

--- a/src/physics/PhysicsController.h
+++ b/src/physics/PhysicsController.h
@@ -1,0 +1,124 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#pragma once
+
+#include <Object3d.hpp>
+
+#include <functional>
+#include <istream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+class AnimInfo;
+class GLSurface;
+
+namespace nifly {
+class NifFile;
+}
+
+namespace bsos {
+// Resolves a physics XML path as referenced by a NiStringExtraData (e.g.
+// "SKSE\Plugins\hdtSkinnedMeshConfigs\outfit.xml") to a readable stream, or
+// nullptr when it cannot be found.
+using XmlStreamResolver = std::function<std::unique_ptr<std::istream>(const std::string& xmlPath)>;
+
+// Bone name -> replacement pose-to-global transform produced by the
+// simulation, consumed by the skinning code instead of
+// AnimBone::xformPoseToGlobal for bones driven by physics. Spelled out again
+// instead of including Anim.h, which would pull the application skeleton into
+// every user of this header; PhysicsController.cpp asserts that this stays the
+// same type as AnimPoseOverrideMap.
+using PoseOverrideMap = std::unordered_map<std::string, nifly::MatTransform>;
+
+// Shape name -> physics XML paths linked to that shape by the NIF it was
+// loaded from, for shapes merged into a work NIF that no longer holds the
+// node hierarchy the link came from.
+using ShapePhysicsFileMap = std::unordered_map<std::string, std::vector<std::string>>;
+
+// Direction the wind blows in. Named as the viewport shows it, which looks
+// at the mesh from the front, but anchored to the mesh: the wind keeps
+// blowing at the same side of it no matter how far the camera has turned it
+// inside the physics world.
+enum class WindDirection { Up, Down, Forward, Backward, Left, Right };
+
+/*
+App-facing facade over the physics core ported from Faster HDT-SMP (see
+src/physics/hdt/README.md for its origin, license and the port notes). Owns
+the Bullet world and all physics systems built from the XMLs referenced by a
+NIF's shapes. App-agnostic: depends only on nifly, AnimInfo/AnimSkeleton and
+Bullet, never on OutfitProject or any UI type.
+
+Without USE_BULLET every method is an inert stub so call sites stay valid in
+builds without Bullet.
+*/
+class PhysicsController {
+public:
+	PhysicsController();
+	~PhysicsController();
+
+	PhysicsController(const PhysicsController&) = delete;
+	PhysicsController& operator=(const PhysicsController&) = delete;
+
+	// Scans all shapes and nodes of the NIF for NiStringExtraData named
+	// "HDT Skinned Mesh Physics Object" and adds the links of
+	// "shapePhysicsFiles", which cover shapes whose original node hierarchy
+	// is not part of this NIF. Resolves each XML through "resolver" and
+	// builds one physics system per (xml, shape set).
+	// Bones referenced by an XML but missing from the skeleton and the NIF
+	// are reported in "outWarnings" and skipped.
+	// Returns the number of systems built.
+	size_t BuildFromNif(nifly::NifFile* nif,
+						AnimInfo* anim,
+						const XmlStreamResolver& resolver,
+						const ShapePhysicsFileMap& shapePhysicsFiles,
+						std::vector<std::string>& outWarnings);
+
+	// Tears down all systems and the physics world.
+	void Clear();
+
+	// True when at least one system was built.
+	bool IsActive() const;
+
+	// Re-seats all dynamic bodies on the current kinematic pose. Call after
+	// enabling physics, seeking an animation or any other teleport.
+	void ResetDynamics();
+
+	// Advances the simulation by the given wall-clock time. Simulates whole
+	// 1/60 ticks only and carries the remainder over to the next call, so the
+	// result does not depend on the rate this is called at. Time beyond a few
+	// ticks is dropped rather than simulated, so a stall cannot explode the
+	// simulation.
+	void Step(float dtSeconds);
+
+	// Reports a horizontal camera turntable rotation in degrees. Accumulated
+	// into a root yaw offset so cloth/hair reacts as if the character turned
+	// under a fixed camera.
+	void InjectCameraYaw(float deltaDegrees);
+
+	// World wind strength, 0 (off) to 1. Per-bone and per-system wind factors
+	// from the XMLs still apply.
+	void SetWindStrength(float strength);
+
+	// Direction the wind blows in, relative to the mesh.
+	void SetWindDirection(WindDirection direction);
+
+	// Simulated replacement transforms for physics-driven bones.
+	const PoseOverrideMap& PoseOverrides() const;
+
+	// Names of shapes whose skinning uses at least one physics-driven bone.
+	const std::unordered_set<std::string>& AffectedShapes() const;
+
+	// Draws (or removes, when disabled) collider and constraint overlays.
+	void UpdateDebugVis(GLSurface& gls, bool enabled);
+
+private:
+	struct Impl;
+	std::unique_ptr<Impl> impl;
+};
+}

--- a/src/physics/PhysicsDebugDraw.cpp
+++ b/src/physics/PhysicsDebugDraw.cpp
@@ -1,0 +1,154 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#ifdef USE_BULLET
+
+#include "PhysicsDebugDraw.h"
+
+#include "NiflyBullet.h"
+
+#include "../components/Mesh.h"
+#include "../render/GLSurface.h"
+
+#include <BulletCollision/CollisionShapes/btBoxShape.h>
+#include <BulletCollision/CollisionShapes/btCapsuleShape.h>
+#include <BulletCollision/CollisionShapes/btCompoundShape.h>
+#include <BulletCollision/CollisionShapes/btSphereShape.h>
+
+namespace bsos {
+namespace {
+	constexpr float meshScale = 0.1f; // NIF units -> mesh units
+
+	const nifly::Vector3 colorKinematic(0.3f, 0.5f, 1.0f);
+	const nifly::Vector3 colorDynamic(0.2f, 1.0f, 0.3f);
+
+	nifly::Vector3 ToMeshPos(const btVector3& worldPos) {
+		return Mesh::TransformPosNifToMesh(FromBt(worldPos));
+	}
+}
+
+// Draws one bullet collision shape at the given physics-world transform.
+// Compound shapes recurse; unsupported shapes fall back to a sphere of their
+// bounding radius.
+void PhysicsDebugVis::drawShape(GLSurface& gls, const btCollisionShape* shape, const btTransform& transform, const nifly::Vector3& color) {
+	if (!shape)
+		return;
+
+	switch (shape->getShapeType()) {
+		case EMPTY_SHAPE_PROXYTYPE: return;
+
+		case COMPOUND_SHAPE_PROXYTYPE: {
+			auto compound = static_cast<const btCompoundShape*>(shape);
+			for (int i = 0; i < compound->getNumChildShapes(); ++i)
+				drawShape(gls, compound->getChildShape(i), transform * compound->getChildTransform(i), color);
+			return;
+		}
+
+		case SPHERE_SHAPE_PROXYTYPE: {
+			auto sphere = static_cast<const btSphereShape*>(shape);
+			visNames.push_back(nextName());
+			gls.AddVis3dSphere(ToMeshPos(transform.getOrigin()), sphere->getRadius() * meshScale, color, visNames.back());
+			return;
+		}
+
+		case CAPSULE_SHAPE_PROXYTYPE: {
+			auto capsule = static_cast<const btCapsuleShape*>(shape);
+			const int axis = capsule->getUpAxis();
+			btVector3 axisDir(0, 0, 0);
+			axisDir[axis] = capsule->getHalfHeight();
+
+			const btVector3 p1 = transform * axisDir;
+			const btVector3 p2 = transform * -axisDir;
+			const float radius = capsule->getRadius() * meshScale;
+
+			visNames.push_back(nextName());
+			gls.AddVis3dSphere(ToMeshPos(p1), radius, color, visNames.back());
+			visNames.push_back(nextName());
+			gls.AddVis3dSphere(ToMeshPos(p2), radius, color, visNames.back());
+			visNames.push_back(nextName());
+			gls.AddVisSeg(ToMeshPos(p1), ToMeshPos(p2), visNames.back());
+			return;
+		}
+
+		case BOX_SHAPE_PROXYTYPE: {
+			auto box = static_cast<const btBoxShape*>(shape);
+			const btVector3 he = box->getHalfExtentsWithMargin();
+
+			// Wireframe box from its 12 edges
+			const btVector3 corners[8] = {
+				{-he.x(), -he.y(), -he.z()},
+				{he.x(), -he.y(), -he.z()},
+				{he.x(), he.y(), -he.z()},
+				{-he.x(), he.y(), -he.z()},
+				{-he.x(), -he.y(), he.z()},
+				{he.x(), -he.y(), he.z()},
+				{he.x(), he.y(), he.z()},
+				{-he.x(), he.y(), he.z()},
+			};
+			static const int edges[12][2] = {{0, 1}, {1, 2}, {2, 3}, {3, 0}, {4, 5}, {5, 6}, {6, 7}, {7, 4}, {0, 4}, {1, 5}, {2, 6}, {3, 7}};
+
+			for (auto& edge : edges) {
+				visNames.push_back(nextName());
+				gls.AddVisSeg(ToMeshPos(transform * corners[edge[0]]), ToMeshPos(transform * corners[edge[1]]), visNames.back());
+			}
+			return;
+		}
+
+		default: {
+			// Convex hulls, cylinders etc.: bounding sphere approximation
+			btVector3 center;
+			btScalar radius = 0.0f;
+			shape->getBoundingSphere(center, radius);
+
+			visNames.push_back(nextName());
+			gls.AddVis3dSphere(ToMeshPos(transform * center), radius * meshScale, color, visNames.back());
+			return;
+		}
+	}
+}
+
+void PhysicsDebugVis::drawConstraint(GLSurface& gls, const btTypedConstraint* constraint, const btTransform& rootMotionInv) {
+	if (!constraint)
+		return;
+
+	const btVector3 a = rootMotionInv * constraint->getRigidBodyA().getWorldTransform().getOrigin();
+	const btVector3 b = rootMotionInv * constraint->getRigidBodyB().getWorldTransform().getOrigin();
+
+	visNames.push_back(nextName());
+	gls.AddVisSeg(ToMeshPos(a), ToMeshPos(b), visNames.back());
+}
+
+void PhysicsDebugVis::Update(GLSurface& gls, const std::vector<hdt::Ref<BSOSSystem>>& systems) {
+	Clear(gls);
+
+	for (auto& system : systems) {
+		// The simulation runs in root-motion space (camera yaw); overlays must
+		// come back to render space.
+		const btTransform rootMotionInv = system->m_rootMotion.inverse();
+
+		for (auto& bone : system->getBones()) {
+			const bool kinematic = bone->m_rig.isStaticOrKinematicObject();
+			const btTransform transform = rootMotionInv * bone->m_rig.getWorldTransform();
+			drawShape(gls, bone->m_rig.getCollisionShape(), transform, kinematic ? colorKinematic : colorDynamic);
+		}
+
+		for (auto& constraint : system->constraints())
+			drawConstraint(gls, constraint->getConstraint(), rootMotionInv);
+
+		for (auto& group : system->constraintGroups())
+			for (auto& constraint : group->m_constraints)
+				drawConstraint(gls, constraint->getConstraint(), rootMotionInv);
+	}
+}
+
+void PhysicsDebugVis::Clear(GLSurface& gls) {
+	for (auto& name : visNames)
+		gls.DeleteOverlay(name);
+
+	visNames.clear();
+}
+}
+
+#endif	// USE_BULLET

--- a/src/physics/PhysicsDebugDraw.h
+++ b/src/physics/PhysicsDebugDraw.h
@@ -1,0 +1,40 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#pragma once
+
+#ifdef USE_BULLET
+
+#include "PhysicsSystemBuilder.h"
+
+#include <string>
+#include <vector>
+
+class GLSurface;
+
+namespace bsos {
+// Draws the bone collision shapes and constraints of a set of physics systems
+// as named overlay primitives on a surface. Owns the names it drew so it can
+// replace or remove them again. Per-vertex/per-triangle collider clouds are
+// not drawn individually (they would be one overlay mesh per collider).
+class PhysicsDebugVis {
+public:
+	// Replaces everything drawn by the previous call.
+	void Update(GLSurface& gls, const std::vector<hdt::Ref<BSOSSystem>>& systems);
+
+	// Removes all overlays of the previous Update.
+	void Clear(GLSurface& gls);
+
+private:
+	std::string nextName() { return "physvis_" + std::to_string(visNames.size()); }
+
+	void drawShape(GLSurface& gls, const btCollisionShape* shape, const btTransform& transform, const nifly::Vector3& color);
+	void drawConstraint(GLSurface& gls, const btTypedConstraint* constraint, const btTransform& rootMotionInv);
+
+	std::vector<std::string> visNames;
+};
+}
+
+#endif	// USE_BULLET

--- a/src/physics/PhysicsSystemBuilder.cpp
+++ b/src/physics/PhysicsSystemBuilder.cpp
@@ -1,0 +1,1497 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+
+Port of hdtSMP64's hdtSkyrimSystem.cpp / hdtSkyrimBone.cpp / hdtSkyrimBody.cpp
+(SkyrimSystemCreator, SkyrimSystem, SkyrimBone, SkyrimBody). Game-engine data
+sources are replaced: mesh/skin data comes from nifly + AnimInfo, bones bind to
+AnimSkeleton's AnimBone instead of NiNode, and logging goes to a warning list.
+The XML parsing semantics are kept identical to upstream.
+*/
+
+#ifdef USE_BULLET
+
+#include "PhysicsSystemBuilder.h"
+
+#include "NiflyBullet.h"
+#include "hdt/XmlReader.h"
+#include "hdt/hdtSkinnedMeshShape.h"
+
+#include "../components/Anim.h"
+
+#include <NifFile.hpp>
+
+#include <algorithm>
+#include <cfloat>
+
+namespace bsos {
+using hdt::btQsTransform;
+using hdt::IDStr;
+using hdt::RESET_PHYSICS;
+
+// nifly rotation matrix -> Bullet quaternion (via btMatrix3x3)
+static btQuaternion ToBtQuaternion(const nifly::Matrix3& m) {
+	btQuaternion q;
+	ToBt(m).getRotation(q);
+	return q;
+}
+
+// Replacement for upstream's convertNi(RE::NiTransform): nifly MatTransform ->
+// btQsTransform with an explicit scale slot.
+static btQsTransform ToBtQs(const nifly::MatTransform& t, float scaleOverride) {
+	if (!(scaleOverride > FLT_EPSILON))
+		scaleOverride = 1.0f;
+	return btQsTransform(ToBtQuaternion(t.rotation), ToBt(t.translation), scaleOverride);
+}
+
+btEmptyShape PhysicsSystemBuilder::BoneTemplate::emptyShape[1];
+
+// ---------------------------------------------------------------- BSOSBone
+
+BSOSBone::BSOSBone(const IDStr& name, AnimBone* animBone, BSOSSystem* system, btRigidBody::btRigidBodyConstructionInfo& ci)
+	: hdt::SkinnedMeshBone(name, ci)
+	, m_animBone(animBone)
+	, m_system(system) {
+	if (ci.m_mass)
+		m_rig.setCollisionFlags(0);
+	else
+		m_rig.setCollisionFlags(btCollisionObject::CF_KINEMATIC_OBJECT);
+
+	m_depth = 0;
+	for (auto i = animBone; i; i = i->parent)
+		++m_depth;
+}
+
+void BSOSBone::readTransform(float timeStep) {
+	// Upstream read the NiNode's world transform here. The kinematic input is
+	// now the pose-to-global transform of the AnimBone, shifted by the
+	// controller's root motion. Scale is treated as a constant 1 (poseScale
+	// is ignored), so upstream's scale-changed branch is dropped entirely.
+	m_currentTransform = btQsTransform(m_system->m_rootMotion * ToBt(m_animBone->xformPoseToGlobal), 1.0f);
+
+	auto current = m_rig.getWorldTransform();
+	auto isStaticOrKinematic = m_rig.isStaticOrKinematicObject();
+
+	auto dest = m_currentTransform.asTransform() * m_localToRig;
+	if (timeStep <= RESET_PHYSICS) {
+		static const btVector3 zero(0, 0, 0);
+		m_rig.setWorldTransform(dest);
+		m_rig.setInterpolationWorldTransform(dest);
+		m_rig.setLinearVelocity(zero);
+		m_rig.setAngularVelocity(zero);
+		m_rig.setInterpolationLinearVelocity(zero);
+		m_rig.setInterpolationAngularVelocity(zero);
+		m_rig.updateInertiaTensor();
+	}
+	else if (isStaticOrKinematic) {
+		btVector3 linVel, angVel;
+		btTransformUtil::calculateVelocity(current, dest, timeStep, linVel, angVel);
+		m_rig.setLinearVelocity(linVel);
+		m_rig.setAngularVelocity(angVel);
+		m_rig.setInterpolationLinearVelocity(linVel);
+		m_rig.setInterpolationAngularVelocity(angVel);
+	}
+}
+
+void BSOSBone::writeTransform() {
+	auto transform = m_rig.getWorldTransform() * m_rigToLocal;
+
+	m_currentTransform.setBasis(transform.getBasis());
+	m_currentTransform.setOrigin(transform.getOrigin());
+
+	// Upstream wrote the NiNode's world transform. Here the simulated pose is
+	// published to the controller's override map, expressed without the root
+	// motion so the skinning code can use it in place of xformPoseToGlobal.
+	// Kinematic bones write nothing (the caller skips them too).
+	if (m_rig.isKinematicObject())
+		return;
+
+	auto* overrides = m_system->m_poseOverrides;
+	if (overrides)
+		(*overrides)[m_animBone->boneName] = FromBt(m_system->m_rootMotion.inverseTimes(transform));
+}
+
+// ---------------------------------------------------------------- BSOSBody
+
+bool BSOSBody::canCollideWith(const hdt::SkinnedMeshBody* rhs) const {
+	auto body = (BSOSBody*)rhs;
+	if (m_disabled || body->m_disabled)
+		return false;
+
+	// The preview simulates a single actor, so every system shares the same
+	// skeleton: "internal" always passes and "external" never does.
+	switch (m_shared) {
+		case SharedType::SHARED_PUBLIC: break;
+		case SharedType::SHARED_INTERNAL: break;
+		case SharedType::SHARED_EXTERNAL: return false;
+		case SharedType::SHARED_PRIVATE:
+			if (m_mesh != body->m_mesh)
+				return false;
+			break;
+		default: return false;
+	}
+
+	return hdt::SkinnedMeshBody::canCollideWith(rhs);
+}
+
+void BSOSBody::internalUpdate() {
+	if (m_disabled)
+		return;
+	hdt::SkinnedMeshBody::internalUpdate();
+}
+
+// -------------------------------------------------------------- BSOSSystem
+
+hdt::SkinnedMeshBone* BSOSSystem::findBone(const IDStr& name) {
+	for (auto i : m_bones) {
+		if (i->m_name == name)
+			return i.get();
+	}
+
+	return nullptr;
+}
+
+hdt::SkinnedMeshBody* BSOSSystem::findBody(const IDStr& name) {
+	for (auto i : m_meshes) {
+		if (i->m_name == name)
+			return i.get();
+	}
+
+	return nullptr;
+}
+
+int BSOSSystem::findBoneIdx(const IDStr& name) {
+	for (size_t i = 0; i < m_bones.size(); ++i) {
+		if (m_bones[i]->m_name == name)
+			return static_cast<int>(i);
+	}
+
+	return -1;
+}
+
+float BSOSSystem::prepareForRead(float timeStep) {
+	// Port of SkyrimSystem::prepareForRead. The game watched the skeleton
+	// root's world rotation and damped fast rotation to keep the simulation
+	// from exploding; here m_rootMotion (the camera turntable yaw) is the only
+	// root movement, so the damper acts on its rotation delta instead. The
+	// game-only branches (skeleton reparenting, player camera state) are gone.
+	if (!m_initialized) {
+		timeStep = RESET_PHYSICS;
+		m_initialized = true;
+	}
+
+	if (timeStep <= RESET_PHYSICS) {
+		m_lastRootRotation = m_rootMotion.getRotation();
+	}
+	else {
+		btQuaternion newRot = m_rootMotion.getRotation();
+		btVector3 rotAxis;
+		float rotAngle;
+		btTransformUtil::calculateDiffAxisAngleQuaternion(m_lastRootRotation, newRot, rotAxis, rotAngle);
+
+		if (m_clampRotations) {
+			float limit = m_rotationSpeedLimit * timeStep;
+
+			if (rotAngle < -limit || rotAngle > limit) {
+				rotAngle = btClamped(rotAngle, -limit, limit);
+				btQuaternion clampedRot(rotAxis, rotAngle);
+				m_lastRootRotation = clampedRot * m_lastRootRotation;
+				// Upstream wrote the damped rotation back into the skeleton
+				// root; the equivalent here is damping the root motion itself.
+				m_rootMotion.setRotation(m_lastRootRotation);
+			}
+			else
+				m_lastRootRotation = newRot;
+		}
+		else if (m_unclampedResets) {
+			float limit = m_unclampedResetAngle * timeStep;
+
+			if (rotAngle < -limit || rotAngle > limit)
+				timeStep = RESET_PHYSICS;
+
+			m_lastRootRotation = newRot;
+		}
+		else
+			m_lastRootRotation = newRot;
+	}
+
+	return timeStep;
+}
+
+// ---------------------------------------------------- PhysicsSystemBuilder
+
+void PhysicsSystemBuilder::warn(const std::string& msg) {
+	if (m_warnings)
+		m_warnings->push_back(m_filePath + ": " + msg);
+}
+
+void PhysicsSystemBuilder::indexBone(BSOSBone* bone) {
+	m_boneIndex.emplace(bone->m_name, bone);
+}
+
+BSOSBone* PhysicsSystemBuilder::findBoneFromIndex(const IDStr& name) const {
+	auto it = m_boneIndex.find(name);
+	return it != m_boneIndex.end() ? it->second : nullptr;
+}
+
+// Replacement for upstream's findObjectByName: resolves a bone name to an
+// AnimBone of the application skeleton. Falls back to loading the node from
+// the NIF as a custom bone; the initial lookup retries with the NIF node's
+// exact spelling because AnimSkeleton is case-sensitive while SMP names
+// (BSFixedString upstream, IDStr here) are not.
+AnimBone* PhysicsSystemBuilder::findAnimBone(const IDStr& name) {
+	auto& skel = AnimSkeleton::getInstance();
+
+	AnimBone* bone = skel.GetBonePtr(name.str(), true);
+	if (bone)
+		return bone;
+
+	std::string nodeName = name.str();
+	if (m_nif) {
+		for (auto* node : m_nif->GetNodes()) {
+			if (IDStr(node->name.get()) == name) {
+				nodeName = node->name.get();
+				break;
+			}
+		}
+	}
+
+	bone = skel.GetBonePtr(nodeName, true);
+	if (!bone && m_nif)
+		bone = skel.LoadCustomBoneFromNif(m_nif, nodeName);
+
+	return bone;
+}
+
+BSOSBone* PhysicsSystemBuilder::getOrCreateBone(const IDStr& name) {
+	auto bone = findBoneFromIndex(name);
+	if (bone)
+		return bone;
+
+	warn("Bone " + name.str() + " used before being created, trying to create it with current default values");
+	return createBoneFromNodeName(name);
+}
+
+hdt::Ref<BSOSSystem> PhysicsSystemBuilder::Build(const PhysicsBuildInput& input, std::vector<std::string>& outWarnings) {
+	m_warnings = &outWarnings;
+	m_filePath = input.xmlName;
+
+	if (!input.xmlData || input.xmlData->empty() || !input.nif || !input.anim)
+		return nullptr;
+
+	m_nif = input.nif;
+	m_anim = input.anim;
+	m_nifShapes = &input.shapes;
+
+	hdt::XMLReader reader(reinterpret_cast<const uint8_t*>(input.xmlData->data()), input.xmlData->size());
+	m_reader = &reader;
+
+	auto system = readSystem();
+
+	// The reader only lives for this call
+	m_reader = nullptr;
+	return system;
+}
+
+hdt::Ref<BSOSSystem> PhysicsSystemBuilder::readSystem() {
+	// The whole document is parsed up front, so a malformed file is reported
+	// as such instead of as a missing <system> element.
+	if (m_reader->HasError()) {
+		warn(std::string("xml parse error - ") + m_reader->GetErrorMessage());
+		return nullptr;
+	}
+
+	m_reader->nextStartElement();
+	if (m_reader->GetName() != "system") {
+		warn("root element is not <system>");
+		return nullptr;
+	}
+
+	m_mesh = hdt::make_ref(new BSOSSystem);
+	m_boneIndex.clear();
+
+	try {
+		while (m_reader->Inspect()) {
+			if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
+				const auto name = m_reader->GetName();
+				if (name == "bone") {
+					readOrUpdateBone();
+				}
+				else if (name == "bone-default") {
+					auto clsname = m_reader->getAttribute("name", "");
+					auto extends = m_reader->getAttribute("extends", "");
+					auto defaultBoneInfo = getBoneTemplate(extends);
+					readBoneTemplate(defaultBoneInfo);
+					m_boneTemplates[clsname] = defaultBoneInfo;
+				}
+				else if (name == "per-vertex-shape") {
+					auto shape = readPerVertexShape();
+					if (shape && shape->m_vertices.size()) {
+						m_mesh->m_meshes.push_back(shape);
+						shape->m_mesh = m_mesh.get();
+					}
+				}
+				else if (name == "per-triangle-shape") {
+					auto shape = readPerTriangleShape();
+					if (shape && shape->m_vertices.size()) {
+						m_mesh->m_meshes.push_back(shape);
+						shape->m_mesh = m_mesh.get();
+					}
+				}
+				else if (name == "constraint-group") {
+					auto constraint = readConstraintGroup();
+					if (constraint)
+						m_mesh->m_constraintGroups.push_back(constraint);
+				}
+				else if (name == "generic-constraint") {
+					auto constraint = readGenericConstraint();
+					if (constraint)
+						m_mesh->m_constraints.push_back(constraint);
+				}
+				else if (name == "stiffspring-constraint") {
+					auto constraint = readStiffSpringConstraint();
+					if (constraint)
+						m_mesh->m_constraints.push_back(constraint);
+				}
+				else if (name == "conetwist-constraint") {
+					auto constraint = readConeTwistConstraint();
+					if (constraint)
+						m_mesh->m_constraints.push_back(constraint);
+				}
+				else if (name == "generic-constraint-default") {
+					auto clsname = m_reader->getAttribute("name", "");
+					auto extends = m_reader->getAttribute("extends", "");
+					auto defaultGenericConstraintTemplate = getGenericConstraintTemplate(extends);
+					readGenericConstraintTemplate(defaultGenericConstraintTemplate);
+					m_genericConstraintTemplates[clsname] = defaultGenericConstraintTemplate;
+				}
+				else if (name == "stiffspring-constraint-default") {
+					auto clsname = m_reader->getAttribute("name", "");
+					auto extends = m_reader->getAttribute("extends", "");
+					auto defaultStiffSpringConstraintTemplate = getStiffSpringConstraintTemplate(extends);
+					readStiffSpringConstraintTemplate(defaultStiffSpringConstraintTemplate);
+					m_stiffSpringConstraintTemplates[clsname] = defaultStiffSpringConstraintTemplate;
+				}
+				else if (name == "conetwist-constraint-default") {
+					auto clsname = m_reader->getAttribute("name", "");
+					auto extends = m_reader->getAttribute("extends", "");
+					auto defaultConeTwistConstraintTemplate = getConeTwistConstraintTemplate(extends);
+					readConeTwistConstraintTemplate(defaultConeTwistConstraintTemplate);
+					m_coneTwistConstraintTemplates[clsname] = defaultConeTwistConstraintTemplate;
+				}
+				else if (name == "shape") {
+					auto attrName = m_reader->getAttribute("name");
+					auto shape = readShape();
+					if (shape) {
+						m_shapeRefs.push_back(shape);
+						m_shapes.insert(std::make_pair(attrName, shape));
+					}
+				}
+				else {
+					warn("unknown element - " + name);
+					m_reader->skipCurrentElement();
+				}
+			}
+			else if (m_reader->GetInspected() == hdt::XMLReader::Inspected::EndTag)
+				break;
+		}
+	}
+	catch (const std::string& err) {
+		warn("xml parse error - " + err);
+		return nullptr;
+	}
+
+	// Upstream ran this over TBB above a size threshold and serially below it;
+	// hdt::par::for_each is serial, so there is only one path left.
+	hdt::par::for_each(m_deferredBuilds.begin(), m_deferredBuilds.end(), [](const DeferredBuild& db) {
+		if (db.vertexShape)
+			db.vertexShape->autoGen();
+		db.body->finishBuild();
+	});
+
+	m_deferredBuilds.clear();
+
+	m_mesh->m_shapeRefs.swap(m_shapeRefs);
+	std::sort(m_mesh->m_bones.begin(), m_mesh->m_bones.end(), [](const auto& a, const auto& b) {
+		return static_cast<BSOSBone*>(a.get())->m_depth < static_cast<BSOSBone*>(b.get())->m_depth;
+	});
+
+	return m_mesh->valid() ? m_mesh : nullptr;
+}
+
+hdt::Ref<hdt::ConstraintGroup> PhysicsSystemBuilder::readConstraintGroup() {
+	hdt::Ref<hdt::ConstraintGroup> ret = hdt::make_ref(new hdt::ConstraintGroup);
+
+	while (m_reader->Inspect()) {
+		if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
+			auto name = m_reader->GetName();
+
+			if (name == "generic-constraint") {
+				auto constraint = readGenericConstraint();
+				if (constraint)
+					ret->m_constraints.push_back(constraint);
+			}
+			else if (name == "stiffspring-constraint") {
+				auto constraint = readStiffSpringConstraint();
+				if (constraint)
+					ret->m_constraints.push_back(constraint);
+			}
+			else if (name == "conetwist-constraint") {
+				auto constraint = readConeTwistConstraint();
+				if (constraint)
+					ret->m_constraints.push_back(constraint);
+			}
+			else if (name == "generic-constraint-default") {
+				auto clsname = m_reader->getAttribute("name", "");
+				auto extends = m_reader->getAttribute("extends", "");
+				auto defaultGenericConstraintTemplate = getGenericConstraintTemplate(extends);
+				readGenericConstraintTemplate(defaultGenericConstraintTemplate);
+				m_genericConstraintTemplates[clsname] = defaultGenericConstraintTemplate;
+			}
+			else if (name == "stiffspring-constraint-default") {
+				auto clsname = m_reader->getAttribute("name", "");
+				auto extends = m_reader->getAttribute("extends", "");
+				auto defaultStiffSpringConstraintTemplate = getStiffSpringConstraintTemplate(extends);
+				readStiffSpringConstraintTemplate(defaultStiffSpringConstraintTemplate);
+				m_stiffSpringConstraintTemplates[clsname] = defaultStiffSpringConstraintTemplate;
+			}
+			else if (name == "conetwist-constraint-default") {
+				auto clsname = m_reader->getAttribute("name", "");
+				auto extends = m_reader->getAttribute("extends", "");
+				auto defaultConeTwistConstraintTemplate = getConeTwistConstraintTemplate(extends);
+				readConeTwistConstraintTemplate(defaultConeTwistConstraintTemplate);
+				m_coneTwistConstraintTemplates[clsname] = defaultConeTwistConstraintTemplate;
+			}
+			else {
+				warn("unknown element - " + name);
+				m_reader->skipCurrentElement();
+			}
+		}
+		else if (m_reader->GetInspected() == hdt::XMLReader::Inspected::EndTag)
+			break;
+	}
+	return ret;
+}
+
+void PhysicsSystemBuilder::readBoneTemplate(BoneTemplate& cinfo) {
+	bool clearCollide = true;
+	while (m_reader->Inspect()) {
+		if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
+			auto name = m_reader->GetName();
+			if (name == "mass")
+				cinfo.m_mass = m_reader->readFloat();
+			else if (name == "inertia")
+				cinfo.m_localInertia = m_reader->readVector3();
+			else if (name == "centerOfMassTransform")
+				cinfo.m_centerOfMassTransform = m_reader->readTransform();
+			else if (name == "linearDamping")
+				cinfo.m_linearDamping = m_reader->readFloat();
+			else if (name == "angularDamping")
+				cinfo.m_angularDamping = m_reader->readFloat();
+			else if (name == "friction")
+				cinfo.m_friction = m_reader->readFloat();
+			else if (name == "rollingFriction")
+				cinfo.m_rollingFriction = m_reader->readFloat();
+			else if (name == "restitution")
+				cinfo.m_restitution = m_reader->readFloat();
+			else if (name == "margin-multiplier")
+				cinfo.m_marginMultipler = m_reader->readFloat();
+			else if (name == "shape") {
+				auto shape = readShape();
+				if (shape) {
+					m_shapeRefs.push_back(shape);
+					cinfo.m_collisionShape = shape.get();
+				}
+				else
+					cinfo.m_collisionShape = BoneTemplate::emptyShape;
+			}
+			else if (name == "collision-filter")
+				cinfo.m_collisionFilter = m_reader->readInt();
+			else if (name == "can-collide-with-bone") {
+				if (clearCollide) {
+					cinfo.m_canCollideWithBone.clear();
+					cinfo.m_noCollideWithBone.clear();
+					clearCollide = false;
+				}
+				cinfo.m_canCollideWithBone.push_back(m_reader->readText());
+			}
+			else if (name == "no-collide-with-bone") {
+				if (clearCollide) {
+					cinfo.m_canCollideWithBone.clear();
+					cinfo.m_noCollideWithBone.clear();
+					clearCollide = false;
+				}
+				cinfo.m_noCollideWithBone.push_back(m_reader->readText());
+			}
+			else if (name == "gravity-factor") {
+				cinfo.m_gravityFactor = btClamped(m_reader->readFloat(), 0.0f, 1.0f);
+			}
+			else if (name == "wind-factor") {
+				cinfo.m_windFactor = std::max(m_reader->readFloat(), 0.0f);
+			}
+			else {
+				warn("unknown element - " + name);
+				m_reader->skipCurrentElement();
+			}
+		}
+		else if (m_reader->GetInspected() == hdt::XMLReader::Inspected::EndTag)
+			break;
+	}
+}
+
+std::shared_ptr<btCollisionShape> PhysicsSystemBuilder::readShape() {
+	auto typeStr = m_reader->getAttribute("type");
+	if (typeStr == "ref") {
+		auto shapeName = m_reader->getAttribute("name");
+		m_reader->skipCurrentElement();
+		auto iter = m_shapes.find(shapeName);
+		if (iter != m_shapes.end())
+			return iter->second;
+		warn("unknown shape - " + shapeName);
+		return nullptr;
+	}
+	if (typeStr == "box") {
+		btVector3 halfExtend(0, 0, 0);
+		float margin = 0;
+		while (m_reader->Inspect()) {
+			if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
+				auto name = m_reader->GetName();
+				if (name == "halfExtend")
+					halfExtend = m_reader->readVector3();
+				else if (name == "margin")
+					margin = m_reader->readFloat();
+				else {
+					warn("unknown element - " + name);
+					m_reader->skipCurrentElement();
+				}
+			}
+			else if (m_reader->GetInspected() == hdt::XMLReader::Inspected::EndTag)
+				break;
+		}
+		auto ret = std::make_shared<btBoxShape>(halfExtend);
+		ret->setMargin(margin);
+		return ret;
+	}
+	if (typeStr == "sphere") {
+		float radius = 0;
+		while (m_reader->Inspect()) {
+			if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
+				auto name = m_reader->GetName();
+				if (name == "radius")
+					radius = m_reader->readFloat();
+				else {
+					warn("unknown element - " + name);
+					m_reader->skipCurrentElement();
+				}
+			}
+			else if (m_reader->GetInspected() == hdt::XMLReader::Inspected::EndTag)
+				break;
+		}
+		return std::make_shared<btSphereShape>(radius);
+	}
+	if (typeStr == "capsule") {
+		float radius = 0;
+		float height = 0;
+		while (m_reader->Inspect()) {
+			if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
+				auto name = m_reader->GetName();
+				if (name == "radius")
+					radius = m_reader->readFloat();
+				else if (name == "height")
+					height = m_reader->readFloat();
+				else {
+					warn("unknown element - " + name);
+					m_reader->skipCurrentElement();
+				}
+			}
+			else if (m_reader->GetInspected() == hdt::XMLReader::Inspected::EndTag)
+				break;
+		}
+		return std::make_shared<btCapsuleShape>(radius, height);
+	}
+	if (typeStr == "hull") {
+		float margin = 0;
+		auto ret = std::make_shared<btConvexHullShape>();
+		while (m_reader->Inspect()) {
+			if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
+				auto name = m_reader->GetName();
+				if (name == "point")
+					ret->addPoint(m_reader->readVector3(), false);
+				else if (name == "margin")
+					margin = m_reader->readFloat();
+				else {
+					warn("unknown element - " + name);
+					m_reader->skipCurrentElement();
+				}
+			}
+			else if (m_reader->GetInspected() == hdt::XMLReader::Inspected::EndTag)
+				break;
+		}
+		(void)margin; // never applied upstream either
+		ret->recalcLocalAabb();
+		return ret->getNumPoints() ? ret : nullptr;
+	}
+	if (typeStr == "cylinder") {
+		float height = 0;
+		float radius = 0;
+		float margin = 0;
+		while (m_reader->Inspect()) {
+			if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
+				auto name = m_reader->GetName();
+				if (name == "height")
+					height = m_reader->readFloat();
+				else if (name == "radius")
+					radius = m_reader->readFloat();
+				else if (name == "margin")
+					margin = m_reader->readFloat();
+				else {
+					warn("unknown element - " + name);
+					m_reader->skipCurrentElement();
+				}
+			}
+			else if (m_reader->GetInspected() == hdt::XMLReader::Inspected::EndTag)
+				break;
+		}
+
+		if (radius >= 0 && height >= 0) {
+			auto ret = std::make_shared<btCylinderShape>(btVector3(radius, height, radius));
+			ret->setMargin(margin);
+			return ret;
+		}
+		return nullptr;
+	}
+	if (typeStr == "compound") {
+		auto ret = std::make_shared<btCompoundShape>();
+		while (m_reader->Inspect()) {
+			if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
+				if (m_reader->GetName() == "child") {
+					btTransform tr;
+					std::shared_ptr<btCollisionShape> shape;
+
+					while (m_reader->Inspect()) {
+						if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
+							if (m_reader->GetName() == "transform") {
+								tr = m_reader->readTransform();
+							}
+							else if (m_reader->GetName() == "shape") {
+								shape = readShape();
+							}
+							else {
+								warn("unknown element - " + m_reader->GetName());
+								m_reader->skipCurrentElement();
+							}
+						}
+						else if (m_reader->GetInspected() == hdt::XMLReader::Inspected::EndTag)
+							break;
+					}
+
+					if (shape) {
+						ret->addChildShape(tr, shape.get());
+						m_shapeRefs.push_back(shape);
+					}
+				}
+			}
+			else if (m_reader->GetInspected() == hdt::XMLReader::Inspected::EndTag)
+				break;
+		}
+		return ret->getNumChildShapes() ? ret : nullptr;
+	}
+	warn("Unknown shape type " + typeStr);
+	return nullptr;
+}
+
+void PhysicsSystemBuilder::readOrUpdateBone() {
+	IDStr name = m_reader->getAttribute("name");
+	if (findBoneFromIndex(name)) {
+		warn("Bone " + name.str() + " already exists, skipped");
+		m_reader->skipCurrentElement();
+		return;
+	}
+
+	IDStr cls = m_reader->getAttribute("template", "");
+	if (!createBoneFromNodeName(name, cls, true))
+		m_reader->skipCurrentElement();
+}
+
+BSOSBone* PhysicsSystemBuilder::createBoneFromNodeName(const IDStr& bodyName, const IDStr& templateName, const bool readTemplate) {
+	auto animBone = findAnimBone(bodyName);
+	if (animBone) {
+		auto boneTemplate = getBoneTemplate(templateName);
+		if (readTemplate)
+			readBoneTemplate(boneTemplate);
+		auto bone = new BSOSBone(animBone->boneName, animBone, m_mesh.get(), boneTemplate);
+		bone->m_localToRig = boneTemplate.m_centerOfMassTransform;
+		bone->m_rigToLocal = boneTemplate.m_centerOfMassTransform.inverse();
+		bone->m_marginMultipler = boneTemplate.m_marginMultipler;
+		bone->m_gravityFactor = boneTemplate.m_gravityFactor;
+		bone->m_windFactor = boneTemplate.m_windFactor;
+
+		bone->readTransform(RESET_PHYSICS);
+
+		m_mesh->m_bones.push_back(bone);
+		indexBone(bone);
+		return bone;
+	}
+	warn("Node named " + bodyName.str() + " doesn't exist, skipped, no bone created");
+	return nullptr;
+}
+
+std::pair<hdt::Ref<BSOSBody>, PhysicsSystemBuilder::VertexOffsetMap> PhysicsSystemBuilder::generateMeshBody(const std::string& name) {
+	hdt::Ref<BSOSBody> body = hdt::make_ref(new BSOSBody);
+	body->m_name = name;
+
+	int vertexStart = 0;
+	int boneStart = 0;
+
+	VertexOffsetMap vertexOffsetMap;
+
+	const IDStr nameId(name);
+	for (auto* shape : *m_nifShapes) {
+		if (IDStr(shape->name.get()) != nameId)
+			continue;
+
+		// Upstream skipped meshes without a skin instance
+		auto skinIt = m_anim->shapeSkinning.find(shape->name.get());
+		if (skinIt == m_anim->shapeSkinning.end())
+			continue;
+		auto& skin = skinIt->second;
+
+		std::vector<nifly::Vector3> verts;
+		if (!m_nif->GetVertsForShape(shape, verts) || verts.empty())
+			continue;
+
+		// Skin bones ordered by their skin bone index, so per-vertex bone
+		// indices keep the same meaning as in the NIF vertex data upstream.
+		int numBones = 0;
+		for (auto& bn : skin.boneNames)
+			numBones = std::max(numBones, bn.second + 1);
+
+		std::vector<const std::string*> boneNamesByIdx(static_cast<size_t>(numBones), nullptr);
+		for (auto& bn : skin.boneNames)
+			if (bn.second >= 0 && bn.second < numBones)
+				boneNamesByIdx[bn.second] = &bn.first;
+
+		const size_t skinnedBonesBefore = body->m_skinnedBones.size();
+		bool boneFailed = false;
+
+		for (int boneIdx = 0; boneIdx < numBones && !boneFailed; ++boneIdx) {
+			if (!boneNamesByIdx[boneIdx]) {
+				warn("Shape " + std::string(shape->name.get()) + " has a gap in its skin bone indices, skipped");
+				boneFailed = true;
+				break;
+			}
+			const std::string& boneName = *boneNamesByIdx[boneIdx];
+
+			auto bone = static_cast<hdt::SkinnedMeshBone*>(findBoneFromIndex(boneName));
+			if (!bone) {
+				auto defaultBoneInfo = getBoneTemplate(IDStr(""));
+				auto animBone = findAnimBone(boneName);
+				if (!animBone) {
+					// Preserving the vertex bone indices requires every skin
+					// bone, so a missing node drops the whole mesh.
+					warn("Bone node " + boneName + " of shape " + std::string(shape->name.get()) + " doesn't exist, shape skipped");
+					boneFailed = true;
+					break;
+				}
+				auto newBone = new BSOSBone(animBone->boneName, animBone, m_mesh.get(), defaultBoneInfo);
+				// Upstream left the rig at identity here; seating it on the
+				// pose keeps constraint frames correct for skin-created bones.
+				newBone->readTransform(RESET_PHYSICS);
+				m_mesh->m_bones.push_back(newBone);
+				indexBone(newBone);
+				bone = newBone;
+				warn("Created bone " + boneName + " added to body " + name + ", created without default values");
+			}
+
+			btQsTransform skinToBone = btQsTransform::getIdentity();
+			hdt::BoundingSphere boundingSphere(btVector3(0, 0, 0), 0.0f);
+			auto awIt = skin.boneWeights.find(boneIdx);
+			if (awIt != skin.boneWeights.end()) {
+				const AnimWeight& aw = awIt->second;
+				skinToBone = ToBtQs(aw.xformSkinToBone, aw.xformSkinToBone.scale);
+				boundingSphere = hdt::BoundingSphere(ToBt(aw.bounds.center), aw.bounds.radius);
+			}
+
+			body->addBone(bone, skinToBone, boundingSphere);
+		}
+
+		if (boneFailed) {
+			body->m_skinnedBones.resize(skinnedBonesBefore);
+			continue;
+		}
+
+		body->m_vertices.resize(vertexStart + verts.size());
+
+		for (size_t j = 0; j < verts.size(); ++j)
+			body->m_vertices[vertexStart + j].m_skinPos = ToBt(verts[j]);
+
+		// Distribute the bone weights over the 4 slots of each vertex,
+		// keeping the 4 largest weights (upstream read the NIF's 4 weight
+		// slots directly; AnimSkin stores weights per bone instead).
+		for (int boneIdx = 0; boneIdx < numBones; ++boneIdx) {
+			auto awIt = skin.boneWeights.find(boneIdx);
+			if (awIt == skin.boneWeights.end())
+				continue;
+
+			for (const auto& vw : awIt->second.weights) {
+				if (vw.first >= verts.size())
+					continue;
+
+				auto& v = body->m_vertices[vertexStart + vw.first];
+				int minSlot = 0;
+				for (int k = 1; k < 4; ++k)
+					if (v.m_weight[k] < v.m_weight[minSlot])
+						minSlot = k;
+
+				if (vw.second > v.m_weight[minSlot]) {
+					v.m_weight[minSlot] = vw.second;
+					v.setBoneIdx(minSlot, static_cast<hdt::U32>(boneStart + boneIdx));
+				}
+			}
+		}
+
+		vertexOffsetMap.emplace_back(shape, vertexStart);
+		boneStart = static_cast<int>(body->m_skinnedBones.size());
+		vertexStart = static_cast<int>(body->m_vertices.size());
+	}
+
+	if (0 == vertexStart) {
+		m_reader->skipCurrentElement();
+		return {nullptr, {}};
+	}
+
+	for (auto& i : body->m_vertices)
+		i.sortWeight();
+
+	return {body, vertexOffsetMap};
+}
+
+hdt::Ref<BSOSBody> PhysicsSystemBuilder::readPerVertexShape() {
+	auto name = m_reader->getAttribute("name");
+
+	auto body = generateMeshBody(name).first;
+	if (!body)
+		return nullptr;
+
+	auto shape = hdt::make_ref(new hdt::PerVertexShape(body.get()));
+
+	while (m_reader->Inspect()) {
+		if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
+			auto nodeName = m_reader->GetName();
+			if (nodeName == "priority") {
+				warn("priority is deprecated and no longer used");
+				m_reader->skipCurrentElement();
+			}
+			else if (nodeName == "margin") {
+				shape->m_shapeProp.margin = m_reader->readFloat();
+			}
+			else if (nodeName == "shared") {
+				auto str = m_reader->readText();
+				if (str == "public") {
+					body->m_shared = BSOSBody::SharedType::SHARED_PUBLIC;
+				}
+				else if (str == "internal") {
+					body->m_shared = BSOSBody::SharedType::SHARED_INTERNAL;
+				}
+				else if (str == "external") {
+					body->m_shared = BSOSBody::SharedType::SHARED_EXTERNAL;
+				}
+				else if (str == "private") {
+					body->m_shared = BSOSBody::SharedType::SHARED_PRIVATE;
+				}
+				else {
+					warn("unknown shared value, use default value \"public\"");
+					body->m_shared = BSOSBody::SharedType::SHARED_PUBLIC;
+				}
+			}
+			else if (nodeName == "tag") {
+				body->m_tags.push_back(m_reader->readText());
+			}
+			else if (nodeName == "can-collide-with-tag") {
+				body->m_canCollideWithTags.insert(m_reader->readText());
+			}
+			else if (nodeName == "no-collide-with-tag") {
+				body->m_noCollideWithTags.insert(m_reader->readText());
+			}
+			else if (nodeName == "can-collide-with-bone") {
+				auto bone = getOrCreateBone(m_reader->readText());
+				if (bone)
+					body->m_canCollideWithBones.insert(bone);
+			}
+			else if (nodeName == "no-collide-with-bone") {
+				auto bone = getOrCreateBone(m_reader->readText());
+				if (bone)
+					body->m_noCollideWithBones.insert(bone);
+			}
+			else if (nodeName == "weight-threshold") {
+				auto boneName = m_reader->getAttribute("bone");
+				float wt = m_reader->readFloat();
+				for (size_t i = 0; i < body->m_skinnedBones.size(); ++i) {
+					if (body->m_skinnedBones[i].ptr->m_name == IDStr(boneName)) {
+						body->m_skinnedBones[i].weightThreshold = wt;
+						break;
+					}
+				}
+			}
+			else if (nodeName == "disable-tag") {
+				body->m_disableTag = m_reader->readText();
+			}
+			else if (nodeName == "disable-priority") {
+				body->m_disablePriority = m_reader->readInt();
+			}
+			else {
+				warn("unknown element - " + nodeName);
+				m_reader->skipCurrentElement();
+			}
+		}
+		else if (m_reader->GetInspected() == hdt::XMLReader::Inspected::EndTag) {
+			break;
+		}
+	}
+
+	m_deferredBuilds.push_back({body.get(), shape.get()});
+
+	return body;
+}
+
+hdt::Ref<BSOSBody> PhysicsSystemBuilder::readPerTriangleShape() {
+	auto name = m_reader->getAttribute("name");
+
+	auto bodyData = generateMeshBody(name);
+	auto body = bodyData.first;
+	auto vertexOffsetMap = bodyData.second;
+	if (!body)
+		return nullptr;
+
+	auto shape = hdt::make_ref(new hdt::PerTriangleShape(body.get()));
+
+	for (auto& entry : vertexOffsetMap) {
+		int offset = entry.second;
+
+		std::vector<nifly::Triangle> tris;
+		if (!entry.first->GetTriangles(tris)) {
+			warn("Shape " + std::string(entry.first->name.get()) + " has no triangle data, skipped");
+			return nullptr;
+		}
+
+		for (const auto& t : tris)
+			shape->addTriangle(t.p1 + offset, t.p2 + offset, t.p3 + offset);
+	}
+
+	while (m_reader->Inspect()) {
+		if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
+			auto nodeName = m_reader->GetName();
+			if (nodeName == "priority") {
+				warn("priority is deprecated and no longer used");
+				m_reader->skipCurrentElement();
+			}
+			else if (nodeName == "margin") {
+				shape->m_shapeProp.margin = m_reader->readFloat();
+			}
+			else if (nodeName == "shared") {
+				auto str = m_reader->readText();
+				if (str == "public") {
+					body->m_shared = BSOSBody::SharedType::SHARED_PUBLIC;
+				}
+				else if (str == "internal") {
+					body->m_shared = BSOSBody::SharedType::SHARED_INTERNAL;
+				}
+				else if (str == "external") {
+					body->m_shared = BSOSBody::SharedType::SHARED_EXTERNAL;
+				}
+				else if (str == "private") {
+					body->m_shared = BSOSBody::SharedType::SHARED_PRIVATE;
+				}
+				else {
+					warn("unknown shared value, use default value \"public\"");
+					body->m_shared = BSOSBody::SharedType::SHARED_PUBLIC;
+				}
+			}
+			else if (nodeName == "prenetration" || nodeName == "penetration") {
+				shape->m_shapeProp.penetration = m_reader->readFloat();
+			}
+			else if (nodeName == "tag") {
+				body->m_tags.push_back(m_reader->readText());
+			}
+			else if (nodeName == "no-collide-with-tag") {
+				body->m_noCollideWithTags.insert(m_reader->readText());
+			}
+			else if (nodeName == "can-collide-with-tag") {
+				body->m_canCollideWithTags.insert(m_reader->readText());
+			}
+			else if (nodeName == "can-collide-with-bone") {
+				auto bone = getOrCreateBone(m_reader->readText());
+				if (bone)
+					body->m_canCollideWithBones.insert(bone);
+			}
+			else if (nodeName == "no-collide-with-bone") {
+				auto bone = getOrCreateBone(m_reader->readText());
+				if (bone)
+					body->m_noCollideWithBones.insert(bone);
+			}
+			else if (nodeName == "weight-threshold") {
+				auto boneName = m_reader->getAttribute("bone");
+				float wt = m_reader->readFloat();
+				for (size_t i = 0; i < body->m_skinnedBones.size(); ++i) {
+					if (body->m_skinnedBones[i].ptr->m_name == IDStr(boneName)) {
+						body->m_skinnedBones[i].weightThreshold = wt;
+					}
+				}
+			}
+			else if (nodeName == "disable-tag") {
+				body->m_disableTag = m_reader->readText();
+			}
+			else if (nodeName == "disable-priority") {
+				body->m_disablePriority = m_reader->readInt();
+			}
+			else {
+				warn("unknown element - " + nodeName);
+				m_reader->skipCurrentElement();
+			}
+		}
+		else if (m_reader->GetInspected() == hdt::XMLReader::Inspected::EndTag) {
+			break;
+		}
+	}
+
+	m_deferredBuilds.push_back({body.get(), nullptr});
+
+	return body;
+}
+
+void PhysicsSystemBuilder::readFrameLerp(btTransform& tr) {
+	tr.setIdentity();
+	while (m_reader->Inspect()) {
+		if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
+			auto name = m_reader->GetName();
+			if (name == "translationLerp")
+				tr.getOrigin().setX(m_reader->readFloat());
+			else if (name == "rotationLerp")
+				tr.getOrigin().setY(m_reader->readFloat());
+			else {
+				warn("unknown element - " + name);
+				m_reader->skipCurrentElement();
+			}
+		}
+		else if (m_reader->GetInspected() == hdt::XMLReader::Inspected::EndTag)
+			break;
+	}
+}
+
+bool PhysicsSystemBuilder::parseFrameType(const std::string& name, FrameType& frameType, btTransform& frame) {
+	if (name == "frameInA") {
+		frameType = FrameInA;
+		frame = m_reader->readTransform();
+	}
+	else if (name == "frameInB") {
+		frameType = FrameInB;
+		frame = m_reader->readTransform();
+	}
+	else if (name == "frameInLerp") {
+		frameType = FrameInLerp;
+		readFrameLerp(frame);
+	}
+	else
+		return false;
+	return true;
+}
+
+void PhysicsSystemBuilder::readGenericConstraintTemplate(GenericConstraintTemplate& dest) {
+	while (m_reader->Inspect()) {
+		if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
+			auto name = m_reader->GetName();
+			if (parseFrameType(name, dest.frameType, dest.frame))
+				;
+			else if (name == "enableLinearSprings")
+				dest.enableLinearSprings = m_reader->readBool();
+			else if (name == "enableAngularSprings")
+				dest.enableAngularSprings = m_reader->readBool();
+			else if (name == "linearStiffnessLimited")
+				dest.linearStiffnessLimited = m_reader->readBool();
+			else if (name == "angularStiffnessLimited")
+				dest.angularStiffnessLimited = m_reader->readBool();
+
+			else if (name == "springDampingLimited")
+				dest.springDampingLimited = m_reader->readBool();
+			else if (name == "linearNonHookeanDamping")
+				dest.linearNonHookeanDamping = m_reader->readVector3();
+			else if (name == "angularNonHookeanDamping")
+				dest.angularNonHookeanDamping = m_reader->readVector3();
+			else if (name == "linearNonHookeanStiffness")
+				dest.linearNonHookeanStiffness = m_reader->readVector3();
+			else if (name == "angularNonHookeanStiffness")
+				dest.angularNonHookeanStiffness = m_reader->readVector3();
+
+			else if (name == "linearMotors")
+				dest.linearMotors = m_reader->readBool();
+			else if (name == "angularMotors")
+				dest.angularMotors = m_reader->readBool();
+			else if (name == "linearServoMotors")
+				dest.linearServoMotors = m_reader->readBool();
+			else if (name == "angularServoMotors")
+				dest.angularServoMotors = m_reader->readBool();
+			else if (name == "linearTargetVelocity")
+				dest.linearTargetVelocity = m_reader->readVector3();
+			else if (name == "angularTargetVelocity")
+				dest.angularTargetVelocity = m_reader->readVector3();
+			else if (name == "linearMaxMotorForce")
+				dest.linearMaxMotorForce = m_reader->readVector3();
+			else if (name == "angularMaxMotorForce")
+				dest.angularMaxMotorForce = m_reader->readVector3();
+
+			else if (name == "stopERP")
+				dest.stopERP = m_reader->readFloat();
+			else if (name == "stopCFM")
+				dest.stopCFM = m_reader->readFloat();
+			else if (name == "motorERP")
+				dest.motorERP = m_reader->readFloat();
+			else if (name == "motorCFM")
+				dest.motorCFM = m_reader->readFloat();
+
+			else if (name == "useLinearReferenceFrameA")
+				dest.useLinearReferenceFrameA = m_reader->readBool();
+			else if (name == "linearLowerLimit")
+				dest.linearLowerLimit = m_reader->readVector3();
+			else if (name == "linearUpperLimit")
+				dest.linearUpperLimit = m_reader->readVector3();
+			else if (name == "angularLowerLimit")
+				dest.angularLowerLimit = m_reader->readVector3();
+			else if (name == "angularUpperLimit")
+				dest.angularUpperLimit = m_reader->readVector3();
+			else if (name == "linearStiffness")
+				dest.linearStiffness = m_reader->readVector3();
+			else if (name == "angularStiffness")
+				dest.angularStiffness = m_reader->readVector3();
+			else if (name == "linearDamping")
+				dest.linearDamping = m_reader->readVector3();
+			else if (name == "angularDamping")
+				dest.angularDamping = m_reader->readVector3();
+			else if (name == "linearEquilibrium")
+				dest.linearEquilibrium = m_reader->readVector3();
+			else if (name == "angularEquilibrium")
+				dest.angularEquilibrium = m_reader->readVector3();
+			else if (name == "linearBounce")
+				dest.linearBounce = m_reader->readVector3();
+			else if (name == "angularBounce")
+				dest.angularBounce = m_reader->readVector3();
+			else {
+				warn("unknown element - " + name);
+				m_reader->skipCurrentElement();
+			}
+		}
+		else if (m_reader->GetInspected() == hdt::XMLReader::Inspected::EndTag)
+			break;
+	}
+}
+
+bool PhysicsSystemBuilder::findBones(const IDStr& bodyAName, const IDStr& bodyBName, BSOSBone*& bodyA, BSOSBone*& bodyB) {
+	bodyA = findBoneFromIndex(bodyAName);
+	bodyB = findBoneFromIndex(bodyBName);
+
+	if (!bodyA) {
+		warn("constraint " + bodyAName.str() + " <-> " + bodyBName.str() + " : bone for bodyA doesn't exist, will try to create it");
+		bodyA = createBoneFromNodeName(bodyAName);
+		if (!bodyA) {
+			m_reader->skipCurrentElement();
+			return false;
+		}
+	}
+	if (!bodyB) {
+		warn("constraint " + bodyAName.str() + " <-> " + bodyBName.str() + " : bone for bodyB doesn't exist, will try to create it");
+		bodyB = createBoneFromNodeName(bodyBName);
+		if (!bodyB) {
+			m_reader->skipCurrentElement();
+			return false;
+		}
+	}
+	if (bodyA == bodyB) {
+		warn("constraint between same object " + bodyAName.str() + " <-> " + bodyBName.str() + ", skipped");
+		m_reader->skipCurrentElement();
+		return false;
+	}
+
+	if (bodyA->m_rig.isKinematicObject() && bodyB->m_rig.isKinematicObject()) {
+		warn("constraint between two kinematic object " + bodyAName.str() + " <-> " + bodyBName.str() + ", skipped");
+		m_reader->skipCurrentElement();
+		return false;
+	}
+
+	return true;
+}
+
+static btQuaternion rotFromAtoB(const btVector3& a, const btVector3& b) {
+	auto axis = a.cross(b);
+	if (axis.fuzzyZero())
+		return btQuaternion::getIdentity();
+	float sinA = axis.length();
+	float cosA = a.dot(b);
+	float angle = btAtan2(cosA, sinA);
+	return btQuaternion(axis, angle);
+}
+
+void PhysicsSystemBuilder::calcFrame(FrameType type, const btTransform& frame, const btQsTransform& trA, const btQsTransform& trB, btTransform& frameA, btTransform& frameB) {
+	btQsTransform frameInWorld;
+	switch (type) {
+		case FrameInA:
+			frameA = frame;
+			frameInWorld = trA * frame;
+			frameB = (trB.inverse() * frameInWorld).asTransform();
+			break;
+		case FrameInB:
+			frameB = frame;
+			frameInWorld = trB * frameB;
+			frameA = (trA.inverse() * frameInWorld).asTransform();
+			break;
+		case FrameInLerp: {
+			auto trans = trA.getOrigin().lerp(trB.getOrigin(), frame.getOrigin().x());
+			auto rot = trA.getBasis().slerp(trB.getBasis(), frame.getOrigin().y());
+			frameInWorld = btQsTransform(rot, trans);
+			frameA = (trA.inverse() * frameInWorld).asTransform();
+			frameB = (trB.inverse() * frameInWorld).asTransform();
+			break;
+		}
+		case AWithXPointToB: {
+			btMatrix3x3 matr(trA.getBasis());
+			frameInWorld = trA;
+			auto old = matr.getColumn(0).normalized();
+			auto a2b = (trB.getOrigin() - trA.getOrigin()).normalized();
+			auto q = rotFromAtoB(old, a2b);
+			frameInWorld.getBasis() *= q;
+			frameA = (trA.inverse() * frameInWorld).asTransform();
+			frameB = (trB.inverse() * frameInWorld).asTransform();
+			break;
+		}
+		case AWithYPointToB: {
+			btMatrix3x3 matr(trA.getBasis());
+			frameInWorld = trA;
+			auto old = matr.getColumn(1).normalized();
+			auto a2b = (trB.getOrigin() - trA.getOrigin()).normalized();
+			auto q = rotFromAtoB(old, a2b);
+			frameInWorld.getBasis() *= q;
+			frameA = (trA.inverse() * frameInWorld).asTransform();
+			frameB = (trB.inverse() * frameInWorld).asTransform();
+			break;
+		}
+		case AWithZPointToB: {
+			btMatrix3x3 matr(trA.getBasis());
+			frameInWorld = trA;
+			auto old = matr.getColumn(2).normalized();
+			auto a2b = (trB.getOrigin() - trA.getOrigin()).normalized();
+			auto q = rotFromAtoB(old, a2b);
+			frameInWorld.getBasis() *= q;
+			frameA = (trA.inverse() * frameInWorld).asTransform();
+			frameB = (trB.inverse() * frameInWorld).asTransform();
+			break;
+		}
+	}
+}
+
+hdt::Ref<hdt::Generic6DofConstraint> PhysicsSystemBuilder::readGenericConstraint() {
+	auto bodyAName = IDStr(m_reader->getAttribute("bodyA"));
+	auto bodyBName = IDStr(m_reader->getAttribute("bodyB"));
+	auto clsname = IDStr(m_reader->getAttribute("template", ""));
+
+	BSOSBone *bodyA, *bodyB;
+	if (!findBones(bodyAName, bodyBName, bodyA, bodyB))
+		return nullptr;
+
+	auto trA = bodyA->m_currentTransform;
+	auto trB = bodyB->m_currentTransform;
+
+	auto cinfo = getGenericConstraintTemplate(clsname);
+	readGenericConstraintTemplate(cinfo);
+	btTransform frameA, frameB;
+	calcFrame(cinfo.frameType, cinfo.frame, trA, trB, frameA, frameB);
+
+	if (!cinfo.linearNonHookeanDamping.isZero() || !cinfo.angularNonHookeanDamping.isZero() || !cinfo.linearNonHookeanStiffness.isZero()
+		|| !cinfo.angularNonHookeanStiffness.isZero())
+		warn("constraint " + bodyAName.str() + " <-> " + bodyBName.str() + " : non-Hookean spring parameters need hdtSMP64's Bullet fork, ignored");
+
+	hdt::Ref<hdt::Generic6DofConstraint> constraint;
+	if (cinfo.useLinearReferenceFrameA) {
+		constraint = hdt::make_ref(new hdt::Generic6DofConstraint(bodyB, bodyA, frameB, frameA));
+	}
+	else {
+		constraint = hdt::make_ref(new hdt::Generic6DofConstraint(bodyA, bodyB, frameA, frameB));
+	}
+
+	constraint->setLinearLowerLimit(cinfo.linearLowerLimit);
+	constraint->setLinearUpperLimit(cinfo.linearUpperLimit);
+	constraint->setAngularLowerLimit(cinfo.angularLowerLimit);
+	constraint->setAngularUpperLimit(cinfo.angularUpperLimit);
+	for (int i = 0; i < 3; ++i) {
+		constraint->setStiffness(i, cinfo.linearStiffness[i], cinfo.linearStiffnessLimited);
+		constraint->setStiffness(i + 3, cinfo.angularStiffness[i], cinfo.angularStiffnessLimited);
+		constraint->setDamping(i, cinfo.linearDamping[i], cinfo.springDampingLimited);
+		constraint->setDamping(i + 3, cinfo.angularDamping[i], cinfo.springDampingLimited);
+
+		constraint->setEquilibriumPoint(i, cinfo.linearEquilibrium[i]);
+		constraint->setEquilibriumPoint(i + 3, cinfo.angularEquilibrium[i]);
+
+		// Non-Hookean spring terms are an hdtSMP64 extension of Bullet's
+		// btGeneric6DofSpring2Constraint; vanilla Bullet has no equivalent.
+		// The XML values are still parsed (see the template) but not applied.
+
+		constraint->enableSpring(i, cinfo.enableLinearSprings);
+		constraint->enableSpring(i + 3, cinfo.enableAngularSprings);
+
+		constraint->enableMotor(i, cinfo.linearMotors);
+		constraint->enableMotor(i + 3, cinfo.angularMotors);
+		constraint->setServo(i, cinfo.linearServoMotors);
+		constraint->setServo(i + 3, cinfo.angularServoMotors);
+		// TODO: Test if servo motors go to [0, 0, 0], or whatever equilibrium is. Provide option to set servo motor target. Hard coded to equilibrium right now.
+		constraint->setServoTarget(i, cinfo.linearEquilibrium[i]);
+		constraint->setServoTarget(i + 3, cinfo.angularEquilibrium[i]);
+		constraint->setTargetVelocity(i, cinfo.linearTargetVelocity[i]);
+		constraint->setTargetVelocity(i + 3, cinfo.angularTargetVelocity[i]);
+		constraint->setMaxMotorForce(i, cinfo.linearMaxMotorForce[i]);
+		constraint->setMaxMotorForce(i + 3, cinfo.angularMaxMotorForce[i]);
+
+		constraint->setParam(BT_CONSTRAINT_ERP, cinfo.motorERP, i);
+		constraint->setParam(BT_CONSTRAINT_CFM, cinfo.motorCFM, i);
+		constraint->setParam(BT_CONSTRAINT_STOP_ERP, cinfo.stopERP, i);
+		constraint->setParam(BT_CONSTRAINT_STOP_CFM, cinfo.stopCFM, i);
+
+		auto rotMotor = constraint->getRotationalLimitMotor(i);
+		if (rotMotor) {
+			rotMotor->m_motorERP = cinfo.motorERP;
+			rotMotor->m_motorCFM = cinfo.motorCFM;
+			rotMotor->m_stopERP = cinfo.stopERP;
+			rotMotor->m_stopCFM = cinfo.stopCFM;
+		}
+	}
+	constraint->getTranslationalLimitMotor()->m_bounce = cinfo.linearBounce;
+	constraint->getRotationalLimitMotor(0)->m_bounce = cinfo.angularBounce[0];
+	constraint->getRotationalLimitMotor(1)->m_bounce = cinfo.angularBounce[1];
+	constraint->getRotationalLimitMotor(2)->m_bounce = cinfo.angularBounce[2];
+
+	return constraint;
+}
+
+void PhysicsSystemBuilder::readStiffSpringConstraintTemplate(StiffSpringConstraintTemplate& dest) {
+	while (m_reader->Inspect()) {
+		if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
+			auto name = m_reader->GetName();
+			if (name == "minDistanceFactor")
+				dest.minDistanceFactor = std::max(m_reader->readFloat(), 0.0f);
+			else if (name == "maxDistanceFactor")
+				dest.maxDistanceFactor = std::max(m_reader->readFloat(), 0.0f);
+			else if (name == "stiffness")
+				dest.stiffness = std::max(m_reader->readFloat(), 0.0f);
+			else if (name == "damping")
+				dest.damping = std::max(m_reader->readFloat(), 0.0f);
+			else if (name == "equilibrium")
+				dest.equilibriumFactor = btClamped(m_reader->readFloat(), 0.0f, 1.0f);
+			else {
+				warn("unknown element - " + name);
+				m_reader->skipCurrentElement();
+			}
+		}
+		else if (m_reader->GetInspected() == hdt::XMLReader::Inspected::EndTag)
+			break;
+	}
+}
+
+void PhysicsSystemBuilder::readConeTwistConstraintTemplate(ConeTwistConstraintTemplate& dest) {
+	while (m_reader->Inspect()) {
+		if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
+			auto name = m_reader->GetName();
+			if (parseFrameType(name, dest.frameType, dest.frame))
+				;
+			else if (name == "swingSpan1" || name == "coneLimit" || name == "limitZ")
+				dest.swingSpan1 = std::max(m_reader->readFloat(), 0.f);
+			else if (name == "swingSpan2" || name == "planeLimit" || name == "limitY")
+				dest.swingSpan2 = std::max(m_reader->readFloat(), 0.f);
+			else if (name == "twistSpan" || name == "twistLimit" || name == "limitX")
+				dest.twistSpan = std::max(m_reader->readFloat(), 0.f);
+			else if (name == "limitSoftness")
+				dest.limitSoftness = btClamped(m_reader->readFloat(), 0.f, 1.f);
+			else if (name == "biasFactor")
+				dest.biasFactor = btClamped(m_reader->readFloat(), 0.f, 1.f);
+			else if (name == "relaxationFactor")
+				dest.relaxationFactor = btClamped(m_reader->readFloat(), 0.f, 1.f);
+			else {
+				warn("unknown element - " + name);
+				m_reader->skipCurrentElement();
+			}
+		}
+		else if (m_reader->GetInspected() == hdt::XMLReader::Inspected::EndTag)
+			break;
+	}
+}
+
+const PhysicsSystemBuilder::BoneTemplate& PhysicsSystemBuilder::getBoneTemplate(const IDStr& name) {
+	auto iter = m_boneTemplates.find(name);
+	if (iter == m_boneTemplates.end())
+		return m_boneTemplates[IDStr()];
+	return iter->second;
+}
+
+const PhysicsSystemBuilder::GenericConstraintTemplate& PhysicsSystemBuilder::getGenericConstraintTemplate(const IDStr& name) {
+	auto iter = m_genericConstraintTemplates.find(name);
+	if (iter == m_genericConstraintTemplates.end())
+		return m_genericConstraintTemplates[IDStr()];
+	return iter->second;
+}
+
+const PhysicsSystemBuilder::StiffSpringConstraintTemplate& PhysicsSystemBuilder::getStiffSpringConstraintTemplate(const IDStr& name) {
+	auto iter = m_stiffSpringConstraintTemplates.find(name);
+	if (iter == m_stiffSpringConstraintTemplates.end())
+		return m_stiffSpringConstraintTemplates[IDStr()];
+	return iter->second;
+}
+
+const PhysicsSystemBuilder::ConeTwistConstraintTemplate& PhysicsSystemBuilder::getConeTwistConstraintTemplate(const IDStr& name) {
+	auto iter = m_coneTwistConstraintTemplates.find(name);
+	if (iter == m_coneTwistConstraintTemplates.end())
+		return m_coneTwistConstraintTemplates[IDStr()];
+	return iter->second;
+}
+
+hdt::Ref<hdt::StiffSpringConstraint> PhysicsSystemBuilder::readStiffSpringConstraint() {
+	auto bodyAName = IDStr(m_reader->getAttribute("bodyA"));
+	auto bodyBName = IDStr(m_reader->getAttribute("bodyB"));
+	auto clsname = IDStr(m_reader->getAttribute("template", ""));
+
+	BSOSBone *bodyA, *bodyB;
+	if (!findBones(bodyAName, bodyBName, bodyA, bodyB))
+		return nullptr;
+
+	StiffSpringConstraintTemplate cinfo = getStiffSpringConstraintTemplate(clsname);
+	readStiffSpringConstraintTemplate(cinfo);
+
+	hdt::Ref<hdt::StiffSpringConstraint> constraint = hdt::make_ref(new hdt::StiffSpringConstraint(bodyA, bodyB));
+	constraint->m_minDistance *= cinfo.minDistanceFactor;
+	constraint->m_maxDistance *= cinfo.maxDistanceFactor;
+	constraint->m_stiffness = cinfo.stiffness;
+	constraint->m_damping = cinfo.damping;
+	constraint->m_equilibriumPoint = constraint->m_minDistance * cinfo.equilibriumFactor + constraint->m_maxDistance * (1 - cinfo.equilibriumFactor);
+	return constraint;
+}
+
+hdt::Ref<hdt::ConeTwistConstraint> PhysicsSystemBuilder::readConeTwistConstraint() {
+	auto bodyAName = IDStr(m_reader->getAttribute("bodyA"));
+	auto bodyBName = IDStr(m_reader->getAttribute("bodyB"));
+	auto clsname = IDStr(m_reader->getAttribute("template", ""));
+
+	BSOSBone *bodyA = nullptr, *bodyB = nullptr;
+	if (!findBones(bodyAName, bodyBName, bodyA, bodyB)) {
+		return nullptr;
+	}
+
+	auto trA = bodyA->m_currentTransform;
+	auto trB = bodyB->m_currentTransform;
+
+	auto cinfo = getConeTwistConstraintTemplate(clsname);
+	readConeTwistConstraintTemplate(cinfo);
+	btTransform frameA, frameB;
+	calcFrame(cinfo.frameType, cinfo.frame, trA, trB, frameA, frameB);
+
+	hdt::Ref<hdt::ConeTwistConstraint> constraint = hdt::make_ref(new hdt::ConeTwistConstraint(bodyA, bodyB, frameA, frameB));
+	constraint->setLimit(cinfo.swingSpan1, cinfo.swingSpan2, cinfo.twistSpan, cinfo.limitSoftness, cinfo.biasFactor, cinfo.relaxationFactor);
+
+	return constraint;
+}
+}
+
+#endif	// USE_BULLET

--- a/src/physics/PhysicsSystemBuilder.h
+++ b/src/physics/PhysicsSystemBuilder.h
@@ -1,0 +1,288 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#pragma once
+
+#ifdef USE_BULLET
+
+#include "PhysicsController.h"
+
+#include "hdt/hdtConeTwistConstraint.h"
+#include "hdt/hdtGeneric6DofConstraint.h"
+#include "hdt/hdtSkinnedMeshBody.h"
+#include "hdt/hdtSkinnedMeshBone.h"
+#include "hdt/hdtSkinnedMeshSystem.h"
+#include "hdt/hdtStiffSpringConstraint.h"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+class AnimBone;
+class AnimInfo;
+
+namespace nifly {
+class NifFile;
+class NiShape;
+}
+
+namespace hdt {
+class XMLReader;
+class PerVertexShape;
+}
+
+namespace bsos {
+class BSOSSystem;
+
+// Port of hdtSMP64's SkyrimBone: a physics bone bound to an AnimBone of the
+// application skeleton instead of a NiNode of the game scene graph.
+class BSOSBone : public hdt::SkinnedMeshBone {
+public:
+	BSOSBone(const hdt::IDStr& name, AnimBone* animBone, BSOSSystem* system, btRigidBody::btRigidBodyConstructionInfo& ci);
+
+	void readTransform(float timeStep) override;
+	void writeTransform() override;
+
+	int m_depth = 0;
+	AnimBone* m_animBone = nullptr;
+	BSOSSystem* m_system = nullptr;
+};
+
+// Port of hdtSMP64's SkyrimBody. The game's runtime disable machinery
+// (updateActiveState) is not ported, but the XML attributes feeding it are
+// still parsed into the members below.
+class BSOSBody : public hdt::SkinnedMeshBody {
+public:
+	enum class SharedType {
+		SHARED_PUBLIC,
+		SHARED_INTERNAL,
+		SHARED_EXTERNAL,
+		SHARED_PRIVATE,
+	};
+
+	BSOSSystem* m_mesh = nullptr;
+	SharedType m_shared = SharedType::SHARED_PUBLIC;
+	bool m_disabled = false;
+	int m_disablePriority = 0;
+	hdt::IDStr m_disableTag;
+
+	bool canCollideWith(const hdt::SkinnedMeshBody* body) const override;
+	void internalUpdate() override;
+};
+
+// Port of hdtSMP64's SkyrimSystem minus the game skeleton members. Root
+// motion (camera turntable yaw) takes the role of the skeleton root
+// transform the game watched.
+class BSOSSystem : public hdt::SkinnedMeshSystem {
+	friend class PhysicsSystemBuilder;
+
+public:
+	hdt::SkinnedMeshBone* findBone(const hdt::IDStr& name);
+	hdt::SkinnedMeshBody* findBody(const hdt::IDStr& name);
+	int findBoneIdx(const hdt::IDStr& name);
+
+	float prepareForRead(float timeStep) override;
+
+	const std::vector<hdt::Ref<hdt::SkinnedMeshBody>>& meshes() const { return m_meshes; }
+	const std::vector<hdt::Ref<hdt::BoneScaleConstraint>>& constraints() const { return m_constraints; }
+	const std::vector<hdt::Ref<hdt::ConstraintGroup>>& constraintGroups() const { return m_constraintGroups; }
+
+	// Set by the controller before each step; readTransform composes it in
+	// front of every kinematic pose, writeTransform removes it again.
+	btTransform m_rootMotion = btTransform::getIdentity();
+
+	// Simulated replacement pose transforms, owned by the controller.
+	PoseOverrideMap* m_poseOverrides = nullptr;
+
+	bool m_initialized = false;
+
+	// angular velocity damper (upstream: SkyrimPhysicsWorld config values)
+	bool m_clampRotations = true;
+	float m_rotationSpeedLimit = 10.0f;
+	bool m_unclampedResets = true;
+	float m_unclampedResetAngle = 120.0f;
+	btQuaternion m_lastRootRotation = btQuaternion::getIdentity();
+};
+
+// Inputs for building one physics system from one XML file. Vertices,
+// triangles, bone weights and skin transforms come from the NIF/AnimInfo
+// instead of the game's NiSkinInstance.
+struct PhysicsBuildInput {
+	const std::string* xmlData = nullptr; // whole XML file contents
+	std::string xmlName;				  // diagnostics prefix
+	nifly::NifFile* nif = nullptr;
+	AnimInfo* anim = nullptr;
+	std::vector<nifly::NiShape*> shapes;  // shapes this XML applies to
+};
+
+/*
+Port of hdtSMP64's SkyrimSystemCreator: parses a physics XML and builds the
+bone rigid bodies, constraints and collision meshes of one BSOSSystem, bound
+to AnimSkeleton bones. Mesh data (vertices, triangles, weights, skin-to-bone
+transforms) is sourced from nifly/AnimInfo. Diagnostics go to the warning
+list passed to Build.
+*/
+class PhysicsSystemBuilder {
+public:
+	hdt::Ref<BSOSSystem> Build(const PhysicsBuildInput& input, std::vector<std::string>& outWarnings);
+
+protected:
+	std::unordered_map<hdt::IDStr, BSOSBone*> m_boneIndex;
+
+	void indexBone(BSOSBone* bone);
+	BSOSBone* findBoneFromIndex(const hdt::IDStr& name) const;
+
+	struct DeferredBuild {
+		hdt::SkinnedMeshBody* body;
+		hdt::PerVertexShape* vertexShape;
+	};
+
+	std::vector<DeferredBuild> m_deferredBuilds;
+
+	struct BoneTemplate : public btRigidBody::btRigidBodyConstructionInfo {
+		static btEmptyShape emptyShape[1];
+
+		BoneTemplate()
+			: btRigidBodyConstructionInfo(0, nullptr, emptyShape) {
+			m_centerOfMassTransform = btTransform::getIdentity();
+			m_marginMultipler = 1.f;
+		}
+
+		std::shared_ptr<btCollisionShape> m_shape;
+		std::vector<hdt::IDStr> m_canCollideWithBone;
+		std::vector<hdt::IDStr> m_noCollideWithBone;
+		btTransform m_centerOfMassTransform;
+		float m_marginMultipler;
+		float m_gravityFactor = 1.0f;
+		float m_windFactor = 1.0f;
+		hdt::U32 m_collisionFilter = 0;
+	};
+
+	enum FrameType {
+		FrameInA,
+		FrameInB,
+		FrameInLerp,
+		AWithXPointToB,
+		AWithYPointToB,
+		AWithZPointToB
+	};
+
+	struct GenericConstraintTemplate {
+		FrameType frameType = FrameInB;
+		bool useLinearReferenceFrameA = false;
+		btTransform frame = btTransform::getIdentity();
+		btVector3 linearLowerLimit = btVector3(1, 1, 1);
+		btVector3 linearUpperLimit = btVector3(-1, -1, -1);
+		btVector3 angularLowerLimit = btVector3(1, 1, 1);
+		btVector3 angularUpperLimit = btVector3(-1, -1, -1);
+		btVector3 linearStiffness = btVector3(0, 0, 0);
+		btVector3 angularStiffness = btVector3(0, 0, 0);
+		btVector3 linearDamping = btVector3(0, 0, 0);
+		btVector3 angularDamping = btVector3(0, 0, 0);
+		btVector3 linearEquilibrium = btVector3(0, 0, 0);
+		btVector3 angularEquilibrium = btVector3(0, 0, 0);
+		btVector3 linearBounce = btVector3(0, 0, 0);
+		btVector3 angularBounce = btVector3(0, 0, 0);
+		bool enableLinearSprings = true;
+		bool enableAngularSprings = true;
+		bool linearStiffnessLimited = true;
+		bool angularStiffnessLimited = true;
+		bool springDampingLimited = true;
+		bool linearMotors = false;
+		bool angularMotors = false;
+		// TODO: Test if servo motors go to [0, 0, 0], or whatever equilibrium is. Provide option to set servo motor target. Hard coded to equilibrium right now.
+		bool linearServoMotors = false;
+		bool angularServoMotors = false;
+		btVector3 linearNonHookeanDamping = btVector3(0, 0, 0);
+		btVector3 angularNonHookeanDamping = btVector3(0, 0, 0);
+		btVector3 linearNonHookeanStiffness = btVector3(0, 0, 0);
+		btVector3 angularNonHookeanStiffness = btVector3(0, 0, 0);
+		btVector3 linearTargetVelocity = btVector3(0, 0, 0);
+		btVector3 angularTargetVelocity = btVector3(0, 0, 0);
+		btVector3 linearMaxMotorForce = btVector3(0, 0, 0);
+		btVector3 angularMaxMotorForce = btVector3(0, 0, 0);
+		btScalar motorERP = 0.9f;
+		btScalar motorCFM = 0;
+		btScalar stopERP = 0.2f;
+		btScalar stopCFM = 0;
+	};
+
+	struct StiffSpringConstraintTemplate {
+		float minDistanceFactor = 1;
+		float maxDistanceFactor = 1;
+		float stiffness = 0;
+		float damping = 0;
+		float equilibriumFactor = 0.5;
+	};
+
+	struct ConeTwistConstraintTemplate {
+		btTransform frame = btTransform::getIdentity();
+		FrameType frameType = FrameInB;
+		float swingSpan1 = 0;
+		float swingSpan2 = 0;
+		float twistSpan = 0;
+		float limitSoftness = 1.0f;
+		float biasFactor = 0.3f;
+		float relaxationFactor = 1.0f;
+	};
+
+	// NIF shape -> offset of its first vertex within the merged body
+	using VertexOffsetMap = std::vector<std::pair<nifly::NiShape*, int>>;
+
+	hdt::Ref<BSOSSystem> m_mesh;
+	nifly::NifFile* m_nif = nullptr;
+	AnimInfo* m_anim = nullptr;
+	const std::vector<nifly::NiShape*>* m_nifShapes = nullptr;
+	hdt::XMLReader* m_reader = nullptr;
+
+	std::string m_filePath;
+	std::vector<std::string>* m_warnings = nullptr;
+
+	void warn(const std::string& msg);
+
+	// Body of Build once the reader is set up
+	hdt::Ref<BSOSSystem> readSystem();
+
+	AnimBone* findAnimBone(const hdt::IDStr& name);
+	BSOSBone* getOrCreateBone(const hdt::IDStr& name);
+
+	std::unordered_map<hdt::IDStr, BoneTemplate> m_boneTemplates;
+	std::unordered_map<hdt::IDStr, GenericConstraintTemplate> m_genericConstraintTemplates;
+	std::unordered_map<hdt::IDStr, StiffSpringConstraintTemplate> m_stiffSpringConstraintTemplates;
+	std::unordered_map<hdt::IDStr, ConeTwistConstraintTemplate> m_coneTwistConstraintTemplates;
+	std::unordered_map<hdt::IDStr, std::shared_ptr<btCollisionShape>> m_shapes;
+	std::vector<std::shared_ptr<btCollisionShape>> m_shapeRefs;
+
+	std::pair<hdt::Ref<BSOSBody>, VertexOffsetMap> generateMeshBody(const std::string& name);
+
+	bool findBones(const hdt::IDStr& bodyAName, const hdt::IDStr& bodyBName, BSOSBone*& bodyA, BSOSBone*& bodyB);
+	bool parseFrameType(const std::string& name, FrameType& type, btTransform& frame);
+	static void calcFrame(FrameType type, const btTransform& frame, const hdt::btQsTransform& trA, const hdt::btQsTransform& trB, btTransform& frameA, btTransform& frameB);
+	void readFrameLerp(btTransform& tr);
+	void readBoneTemplate(BoneTemplate& dest);
+	void readGenericConstraintTemplate(GenericConstraintTemplate& dest);
+	void readStiffSpringConstraintTemplate(StiffSpringConstraintTemplate& dest);
+	void readConeTwistConstraintTemplate(ConeTwistConstraintTemplate& dest);
+
+	const BoneTemplate& getBoneTemplate(const hdt::IDStr& name);
+	const GenericConstraintTemplate& getGenericConstraintTemplate(const hdt::IDStr& name);
+	const StiffSpringConstraintTemplate& getStiffSpringConstraintTemplate(const hdt::IDStr& name);
+	const ConeTwistConstraintTemplate& getConeTwistConstraintTemplate(const hdt::IDStr& name);
+
+	BSOSBone* createBoneFromNodeName(const hdt::IDStr& bodyName, const hdt::IDStr& templateName = hdt::IDStr(""), const bool readTemplate = false);
+	void readOrUpdateBone();
+	hdt::Ref<BSOSBody> readPerVertexShape();
+	hdt::Ref<BSOSBody> readPerTriangleShape();
+	hdt::Ref<hdt::Generic6DofConstraint> readGenericConstraint();
+	hdt::Ref<hdt::StiffSpringConstraint> readStiffSpringConstraint();
+	hdt::Ref<hdt::ConeTwistConstraint> readConeTwistConstraint();
+	hdt::Ref<hdt::ConstraintGroup> readConstraintGroup();
+	std::shared_ptr<btCollisionShape> readShape();
+};
+}
+
+#endif	// USE_BULLET

--- a/src/physics/PumpClock.h
+++ b/src/physics/PumpClock.h
@@ -1,0 +1,71 @@
+/*
+BodySlide and Outfit Studio
+See the included LICENSE file
+*/
+
+#pragma once
+
+#include <algorithm>
+
+#include <wx/stopwatch.h>
+
+namespace Physics {
+// Timer interval driving the physics pump. Well below the frame period, so the
+// clock below - not the timer resolution - decides the frame rate.
+constexpr int PumpTimerIntervalMS = 15;
+
+/*
+Frame pacing for the physics preview, shared by both applications.
+
+Ticks arrive from idle events, a timer and (in Outfit Studio) mouse motion, at
+wildly varying rates - mouse movement floods the message queue and starves both
+idle events and WM_TIMER, so the pump has to be called from there as well. This
+decides which of those calls actually draws a frame and how much wall-clock time
+the simulation has to advance by, so the source and rate of the calls do not
+matter.
+*/
+class PumpClock {
+public:
+	// Begins (or restarts) timing. Call whenever the simulation starts or is
+	// re-seated, so a pause does not turn into one huge step.
+	void Reset(int targetFps = 60) {
+		fps = std::max(targetFps, 1);
+		watch.Start();
+		lastStepMicro = 0;
+		lastDrawMicro = 0;
+	}
+
+	// True when the next frame is due, with the seconds since the previous one
+	// in "outSeconds". False means this call should do nothing.
+	bool StepDue(float& outSeconds) {
+		const wxLongLong now = watch.TimeInMicro();
+		if (now - lastDrawMicro < Period())
+			return false;
+
+		outSeconds = static_cast<float>((now - lastStepMicro).ToDouble() / 1000000.0);
+		lastStepMicro = now;
+		lastDrawMicro = now;
+		return true;
+	}
+
+	// Seconds since the last step, for callers driven by something else that
+	// already paces itself (Outfit Studio's animation playback).
+	float TakeElapsed() {
+		const wxLongLong now = watch.TimeInMicro();
+		const float seconds = static_cast<float>((now - lastStepMicro).ToDouble() / 1000000.0);
+		lastStepMicro = now;
+		return seconds;
+	}
+
+	// Microseconds until the next frame is due; negative when it is overdue.
+	wxLongLong UntilDue() const { return Period() - (watch.TimeInMicro() - lastDrawMicro); }
+
+private:
+	wxLongLong Period() const { return 1000000 / fps; }
+
+	wxStopWatch watch;
+	wxLongLong lastStepMicro = 0;
+	wxLongLong lastDrawMicro = 0;
+	int fps = 60;
+};
+}

--- a/src/physics/SystemBuilder.cpp
+++ b/src/physics/SystemBuilder.cpp
@@ -11,7 +11,7 @@ The XML parsing semantics are kept identical to upstream.
 
 #ifdef USE_BULLET
 
-#include "PhysicsSystemBuilder.h"
+#include "SystemBuilder.h"
 
 #include "NiflyBullet.h"
 #include "hdt/XmlReader.h"
@@ -24,7 +24,7 @@ The XML parsing semantics are kept identical to upstream.
 #include <algorithm>
 #include <cfloat>
 
-namespace bsos {
+namespace Physics {
 using hdt::btQsTransform;
 using hdt::IDStr;
 using hdt::RESET_PHYSICS;
@@ -44,11 +44,11 @@ static btQsTransform ToBtQs(const nifly::MatTransform& t, float scaleOverride) {
 	return btQsTransform(ToBtQuaternion(t.rotation), ToBt(t.translation), scaleOverride);
 }
 
-btEmptyShape PhysicsSystemBuilder::BoneTemplate::emptyShape[1];
+btEmptyShape SystemBuilder::BoneTemplate::emptyShape[1];
 
-// ---------------------------------------------------------------- BSOSBone
+// ---------------------------------------------------------------- PreviewBone
 
-BSOSBone::BSOSBone(const IDStr& name, AnimBone* animBone, BSOSSystem* system, btRigidBody::btRigidBodyConstructionInfo& ci)
+PreviewBone::PreviewBone(const IDStr& name, AnimBone* animBone, PreviewSystem* system, btRigidBody::btRigidBodyConstructionInfo& ci)
 	: hdt::SkinnedMeshBone(name, ci)
 	, m_animBone(animBone)
 	, m_system(system) {
@@ -62,7 +62,7 @@ BSOSBone::BSOSBone(const IDStr& name, AnimBone* animBone, BSOSSystem* system, bt
 		++m_depth;
 }
 
-void BSOSBone::readTransform(float timeStep) {
+void PreviewBone::readTransform(float timeStep) {
 	// Upstream read the NiNode's world transform here. The kinematic input is
 	// now the pose-to-global transform of the AnimBone, shifted by the
 	// controller's root motion. Scale is treated as a constant 1 (poseScale
@@ -93,7 +93,7 @@ void BSOSBone::readTransform(float timeStep) {
 	}
 }
 
-void BSOSBone::writeTransform() {
+void PreviewBone::writeTransform() {
 	auto transform = m_rig.getWorldTransform() * m_rigToLocal;
 
 	m_currentTransform.setBasis(transform.getBasis());
@@ -111,10 +111,10 @@ void BSOSBone::writeTransform() {
 		(*overrides)[m_animBone->boneName] = FromBt(m_system->m_rootMotion.inverseTimes(transform));
 }
 
-// ---------------------------------------------------------------- BSOSBody
+// ---------------------------------------------------------------- PreviewBody
 
-bool BSOSBody::canCollideWith(const hdt::SkinnedMeshBody* rhs) const {
-	auto body = (BSOSBody*)rhs;
+bool PreviewBody::canCollideWith(const hdt::SkinnedMeshBody* rhs) const {
+	auto body = (PreviewBody*)rhs;
 	if (m_disabled || body->m_disabled)
 		return false;
 
@@ -134,15 +134,15 @@ bool BSOSBody::canCollideWith(const hdt::SkinnedMeshBody* rhs) const {
 	return hdt::SkinnedMeshBody::canCollideWith(rhs);
 }
 
-void BSOSBody::internalUpdate() {
+void PreviewBody::internalUpdate() {
 	if (m_disabled)
 		return;
 	hdt::SkinnedMeshBody::internalUpdate();
 }
 
-// -------------------------------------------------------------- BSOSSystem
+// -------------------------------------------------------------- PreviewSystem
 
-hdt::SkinnedMeshBone* BSOSSystem::findBone(const IDStr& name) {
+hdt::SkinnedMeshBone* PreviewSystem::findBone(const IDStr& name) {
 	for (auto i : m_bones) {
 		if (i->m_name == name)
 			return i.get();
@@ -151,7 +151,7 @@ hdt::SkinnedMeshBone* BSOSSystem::findBone(const IDStr& name) {
 	return nullptr;
 }
 
-hdt::SkinnedMeshBody* BSOSSystem::findBody(const IDStr& name) {
+hdt::SkinnedMeshBody* PreviewSystem::findBody(const IDStr& name) {
 	for (auto i : m_meshes) {
 		if (i->m_name == name)
 			return i.get();
@@ -160,7 +160,7 @@ hdt::SkinnedMeshBody* BSOSSystem::findBody(const IDStr& name) {
 	return nullptr;
 }
 
-int BSOSSystem::findBoneIdx(const IDStr& name) {
+int PreviewSystem::findBoneIdx(const IDStr& name) {
 	for (size_t i = 0; i < m_bones.size(); ++i) {
 		if (m_bones[i]->m_name == name)
 			return static_cast<int>(i);
@@ -169,7 +169,7 @@ int BSOSSystem::findBoneIdx(const IDStr& name) {
 	return -1;
 }
 
-float BSOSSystem::prepareForRead(float timeStep) {
+float PreviewSystem::prepareForRead(float timeStep) {
 	// Port of SkyrimSystem::prepareForRead. The game watched the skeleton
 	// root's world rotation and damped fast rotation to keep the simulation
 	// from exploding; here m_rootMotion (the camera turntable yaw) is the only
@@ -218,18 +218,18 @@ float BSOSSystem::prepareForRead(float timeStep) {
 	return timeStep;
 }
 
-// ---------------------------------------------------- PhysicsSystemBuilder
+// ---------------------------------------------------- SystemBuilder
 
-void PhysicsSystemBuilder::warn(const std::string& msg) {
+void SystemBuilder::warn(const std::string& msg) {
 	if (m_warnings)
 		m_warnings->push_back(m_filePath + ": " + msg);
 }
 
-void PhysicsSystemBuilder::indexBone(BSOSBone* bone) {
+void SystemBuilder::indexBone(PreviewBone* bone) {
 	m_boneIndex.emplace(bone->m_name, bone);
 }
 
-BSOSBone* PhysicsSystemBuilder::findBoneFromIndex(const IDStr& name) const {
+PreviewBone* SystemBuilder::findBoneFromIndex(const IDStr& name) const {
 	auto it = m_boneIndex.find(name);
 	return it != m_boneIndex.end() ? it->second : nullptr;
 }
@@ -239,7 +239,7 @@ BSOSBone* PhysicsSystemBuilder::findBoneFromIndex(const IDStr& name) const {
 // the NIF as a custom bone; the initial lookup retries with the NIF node's
 // exact spelling because AnimSkeleton is case-sensitive while SMP names
 // (BSFixedString upstream, IDStr here) are not.
-AnimBone* PhysicsSystemBuilder::findAnimBone(const IDStr& name) {
+AnimBone* SystemBuilder::findAnimBone(const IDStr& name) {
 	auto& skel = AnimSkeleton::getInstance();
 
 	AnimBone* bone = skel.GetBonePtr(name.str(), true);
@@ -263,7 +263,7 @@ AnimBone* PhysicsSystemBuilder::findAnimBone(const IDStr& name) {
 	return bone;
 }
 
-BSOSBone* PhysicsSystemBuilder::getOrCreateBone(const IDStr& name) {
+PreviewBone* SystemBuilder::getOrCreateBone(const IDStr& name) {
 	auto bone = findBoneFromIndex(name);
 	if (bone)
 		return bone;
@@ -272,7 +272,7 @@ BSOSBone* PhysicsSystemBuilder::getOrCreateBone(const IDStr& name) {
 	return createBoneFromNodeName(name);
 }
 
-hdt::Ref<BSOSSystem> PhysicsSystemBuilder::Build(const PhysicsBuildInput& input, std::vector<std::string>& outWarnings) {
+hdt::Ref<PreviewSystem> SystemBuilder::Build(const BuildInput& input, std::vector<std::string>& outWarnings) {
 	m_warnings = &outWarnings;
 	m_filePath = input.xmlName;
 
@@ -293,7 +293,7 @@ hdt::Ref<BSOSSystem> PhysicsSystemBuilder::Build(const PhysicsBuildInput& input,
 	return system;
 }
 
-hdt::Ref<BSOSSystem> PhysicsSystemBuilder::readSystem() {
+hdt::Ref<PreviewSystem> SystemBuilder::readSystem() {
 	// The whole document is parsed up front, so a malformed file is reported
 	// as such instead of as a missing <system> element.
 	if (m_reader->HasError()) {
@@ -307,7 +307,7 @@ hdt::Ref<BSOSSystem> PhysicsSystemBuilder::readSystem() {
 		return nullptr;
 	}
 
-	m_mesh = hdt::make_ref(new BSOSSystem);
+	m_mesh = hdt::make_ref(new PreviewSystem);
 	m_boneIndex.clear();
 
 	try {
@@ -413,13 +413,13 @@ hdt::Ref<BSOSSystem> PhysicsSystemBuilder::readSystem() {
 
 	m_mesh->m_shapeRefs.swap(m_shapeRefs);
 	std::sort(m_mesh->m_bones.begin(), m_mesh->m_bones.end(), [](const auto& a, const auto& b) {
-		return static_cast<BSOSBone*>(a.get())->m_depth < static_cast<BSOSBone*>(b.get())->m_depth;
+		return static_cast<PreviewBone*>(a.get())->m_depth < static_cast<PreviewBone*>(b.get())->m_depth;
 	});
 
 	return m_mesh->valid() ? m_mesh : nullptr;
 }
 
-hdt::Ref<hdt::ConstraintGroup> PhysicsSystemBuilder::readConstraintGroup() {
+hdt::Ref<hdt::ConstraintGroup> SystemBuilder::readConstraintGroup() {
 	hdt::Ref<hdt::ConstraintGroup> ret = hdt::make_ref(new hdt::ConstraintGroup);
 
 	while (m_reader->Inspect()) {
@@ -473,7 +473,7 @@ hdt::Ref<hdt::ConstraintGroup> PhysicsSystemBuilder::readConstraintGroup() {
 	return ret;
 }
 
-void PhysicsSystemBuilder::readBoneTemplate(BoneTemplate& cinfo) {
+void SystemBuilder::readBoneTemplate(BoneTemplate& cinfo) {
 	bool clearCollide = true;
 	while (m_reader->Inspect()) {
 		if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
@@ -539,7 +539,7 @@ void PhysicsSystemBuilder::readBoneTemplate(BoneTemplate& cinfo) {
 	}
 }
 
-std::shared_ptr<btCollisionShape> PhysicsSystemBuilder::readShape() {
+std::shared_ptr<btCollisionShape> SystemBuilder::readShape() {
 	auto typeStr = m_reader->getAttribute("type");
 	if (typeStr == "ref") {
 		auto shapeName = m_reader->getAttribute("name");
@@ -700,7 +700,7 @@ std::shared_ptr<btCollisionShape> PhysicsSystemBuilder::readShape() {
 	return nullptr;
 }
 
-void PhysicsSystemBuilder::readOrUpdateBone() {
+void SystemBuilder::readOrUpdateBone() {
 	IDStr name = m_reader->getAttribute("name");
 	if (findBoneFromIndex(name)) {
 		warn("Bone " + name.str() + " already exists, skipped");
@@ -713,13 +713,13 @@ void PhysicsSystemBuilder::readOrUpdateBone() {
 		m_reader->skipCurrentElement();
 }
 
-BSOSBone* PhysicsSystemBuilder::createBoneFromNodeName(const IDStr& bodyName, const IDStr& templateName, const bool readTemplate) {
+PreviewBone* SystemBuilder::createBoneFromNodeName(const IDStr& bodyName, const IDStr& templateName, const bool readTemplate) {
 	auto animBone = findAnimBone(bodyName);
 	if (animBone) {
 		auto boneTemplate = getBoneTemplate(templateName);
 		if (readTemplate)
 			readBoneTemplate(boneTemplate);
-		auto bone = new BSOSBone(animBone->boneName, animBone, m_mesh.get(), boneTemplate);
+		auto bone = new PreviewBone(animBone->boneName, animBone, m_mesh.get(), boneTemplate);
 		bone->m_localToRig = boneTemplate.m_centerOfMassTransform;
 		bone->m_rigToLocal = boneTemplate.m_centerOfMassTransform.inverse();
 		bone->m_marginMultipler = boneTemplate.m_marginMultipler;
@@ -736,8 +736,8 @@ BSOSBone* PhysicsSystemBuilder::createBoneFromNodeName(const IDStr& bodyName, co
 	return nullptr;
 }
 
-std::pair<hdt::Ref<BSOSBody>, PhysicsSystemBuilder::VertexOffsetMap> PhysicsSystemBuilder::generateMeshBody(const std::string& name) {
-	hdt::Ref<BSOSBody> body = hdt::make_ref(new BSOSBody);
+std::pair<hdt::Ref<PreviewBody>, SystemBuilder::VertexOffsetMap> SystemBuilder::generateMeshBody(const std::string& name) {
+	hdt::Ref<PreviewBody> body = hdt::make_ref(new PreviewBody);
 	body->m_name = name;
 
 	int vertexStart = 0;
@@ -793,7 +793,7 @@ std::pair<hdt::Ref<BSOSBody>, PhysicsSystemBuilder::VertexOffsetMap> PhysicsSyst
 					boneFailed = true;
 					break;
 				}
-				auto newBone = new BSOSBone(animBone->boneName, animBone, m_mesh.get(), defaultBoneInfo);
+				auto newBone = new PreviewBone(animBone->boneName, animBone, m_mesh.get(), defaultBoneInfo);
 				// Upstream left the rig at identity here; seating it on the
 				// pose keeps constraint frames correct for skin-created bones.
 				newBone->readTransform(RESET_PHYSICS);
@@ -866,7 +866,7 @@ std::pair<hdt::Ref<BSOSBody>, PhysicsSystemBuilder::VertexOffsetMap> PhysicsSyst
 	return {body, vertexOffsetMap};
 }
 
-hdt::Ref<BSOSBody> PhysicsSystemBuilder::readPerVertexShape() {
+hdt::Ref<PreviewBody> SystemBuilder::readPerVertexShape() {
 	auto name = m_reader->getAttribute("name");
 
 	auto body = generateMeshBody(name).first;
@@ -888,20 +888,20 @@ hdt::Ref<BSOSBody> PhysicsSystemBuilder::readPerVertexShape() {
 			else if (nodeName == "shared") {
 				auto str = m_reader->readText();
 				if (str == "public") {
-					body->m_shared = BSOSBody::SharedType::SHARED_PUBLIC;
+					body->m_shared = PreviewBody::SharedType::SHARED_PUBLIC;
 				}
 				else if (str == "internal") {
-					body->m_shared = BSOSBody::SharedType::SHARED_INTERNAL;
+					body->m_shared = PreviewBody::SharedType::SHARED_INTERNAL;
 				}
 				else if (str == "external") {
-					body->m_shared = BSOSBody::SharedType::SHARED_EXTERNAL;
+					body->m_shared = PreviewBody::SharedType::SHARED_EXTERNAL;
 				}
 				else if (str == "private") {
-					body->m_shared = BSOSBody::SharedType::SHARED_PRIVATE;
+					body->m_shared = PreviewBody::SharedType::SHARED_PRIVATE;
 				}
 				else {
 					warn("unknown shared value, use default value \"public\"");
-					body->m_shared = BSOSBody::SharedType::SHARED_PUBLIC;
+					body->m_shared = PreviewBody::SharedType::SHARED_PUBLIC;
 				}
 			}
 			else if (nodeName == "tag") {
@@ -954,7 +954,7 @@ hdt::Ref<BSOSBody> PhysicsSystemBuilder::readPerVertexShape() {
 	return body;
 }
 
-hdt::Ref<BSOSBody> PhysicsSystemBuilder::readPerTriangleShape() {
+hdt::Ref<PreviewBody> SystemBuilder::readPerTriangleShape() {
 	auto name = m_reader->getAttribute("name");
 
 	auto bodyData = generateMeshBody(name);
@@ -991,20 +991,20 @@ hdt::Ref<BSOSBody> PhysicsSystemBuilder::readPerTriangleShape() {
 			else if (nodeName == "shared") {
 				auto str = m_reader->readText();
 				if (str == "public") {
-					body->m_shared = BSOSBody::SharedType::SHARED_PUBLIC;
+					body->m_shared = PreviewBody::SharedType::SHARED_PUBLIC;
 				}
 				else if (str == "internal") {
-					body->m_shared = BSOSBody::SharedType::SHARED_INTERNAL;
+					body->m_shared = PreviewBody::SharedType::SHARED_INTERNAL;
 				}
 				else if (str == "external") {
-					body->m_shared = BSOSBody::SharedType::SHARED_EXTERNAL;
+					body->m_shared = PreviewBody::SharedType::SHARED_EXTERNAL;
 				}
 				else if (str == "private") {
-					body->m_shared = BSOSBody::SharedType::SHARED_PRIVATE;
+					body->m_shared = PreviewBody::SharedType::SHARED_PRIVATE;
 				}
 				else {
 					warn("unknown shared value, use default value \"public\"");
-					body->m_shared = BSOSBody::SharedType::SHARED_PUBLIC;
+					body->m_shared = PreviewBody::SharedType::SHARED_PUBLIC;
 				}
 			}
 			else if (nodeName == "prenetration" || nodeName == "penetration") {
@@ -1059,7 +1059,7 @@ hdt::Ref<BSOSBody> PhysicsSystemBuilder::readPerTriangleShape() {
 	return body;
 }
 
-void PhysicsSystemBuilder::readFrameLerp(btTransform& tr) {
+void SystemBuilder::readFrameLerp(btTransform& tr) {
 	tr.setIdentity();
 	while (m_reader->Inspect()) {
 		if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
@@ -1078,7 +1078,7 @@ void PhysicsSystemBuilder::readFrameLerp(btTransform& tr) {
 	}
 }
 
-bool PhysicsSystemBuilder::parseFrameType(const std::string& name, FrameType& frameType, btTransform& frame) {
+bool SystemBuilder::parseFrameType(const std::string& name, FrameType& frameType, btTransform& frame) {
 	if (name == "frameInA") {
 		frameType = FrameInA;
 		frame = m_reader->readTransform();
@@ -1096,7 +1096,7 @@ bool PhysicsSystemBuilder::parseFrameType(const std::string& name, FrameType& fr
 	return true;
 }
 
-void PhysicsSystemBuilder::readGenericConstraintTemplate(GenericConstraintTemplate& dest) {
+void SystemBuilder::readGenericConstraintTemplate(GenericConstraintTemplate& dest) {
 	while (m_reader->Inspect()) {
 		if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
 			auto name = m_reader->GetName();
@@ -1184,7 +1184,7 @@ void PhysicsSystemBuilder::readGenericConstraintTemplate(GenericConstraintTempla
 	}
 }
 
-bool PhysicsSystemBuilder::findBones(const IDStr& bodyAName, const IDStr& bodyBName, BSOSBone*& bodyA, BSOSBone*& bodyB) {
+bool SystemBuilder::findBones(const IDStr& bodyAName, const IDStr& bodyBName, PreviewBone*& bodyA, PreviewBone*& bodyB) {
 	bodyA = findBoneFromIndex(bodyAName);
 	bodyB = findBoneFromIndex(bodyBName);
 
@@ -1229,7 +1229,7 @@ static btQuaternion rotFromAtoB(const btVector3& a, const btVector3& b) {
 	return btQuaternion(axis, angle);
 }
 
-void PhysicsSystemBuilder::calcFrame(FrameType type, const btTransform& frame, const btQsTransform& trA, const btQsTransform& trB, btTransform& frameA, btTransform& frameB) {
+void SystemBuilder::calcFrame(FrameType type, const btTransform& frame, const btQsTransform& trA, const btQsTransform& trB, btTransform& frameA, btTransform& frameB) {
 	btQsTransform frameInWorld;
 	switch (type) {
 		case FrameInA:
@@ -1286,12 +1286,12 @@ void PhysicsSystemBuilder::calcFrame(FrameType type, const btTransform& frame, c
 	}
 }
 
-hdt::Ref<hdt::Generic6DofConstraint> PhysicsSystemBuilder::readGenericConstraint() {
+hdt::Ref<hdt::Generic6DofConstraint> SystemBuilder::readGenericConstraint() {
 	auto bodyAName = IDStr(m_reader->getAttribute("bodyA"));
 	auto bodyBName = IDStr(m_reader->getAttribute("bodyB"));
 	auto clsname = IDStr(m_reader->getAttribute("template", ""));
 
-	BSOSBone *bodyA, *bodyB;
+	PreviewBone *bodyA, *bodyB;
 	if (!findBones(bodyAName, bodyBName, bodyA, bodyB))
 		return nullptr;
 
@@ -1368,7 +1368,7 @@ hdt::Ref<hdt::Generic6DofConstraint> PhysicsSystemBuilder::readGenericConstraint
 	return constraint;
 }
 
-void PhysicsSystemBuilder::readStiffSpringConstraintTemplate(StiffSpringConstraintTemplate& dest) {
+void SystemBuilder::readStiffSpringConstraintTemplate(StiffSpringConstraintTemplate& dest) {
 	while (m_reader->Inspect()) {
 		if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
 			auto name = m_reader->GetName();
@@ -1392,7 +1392,7 @@ void PhysicsSystemBuilder::readStiffSpringConstraintTemplate(StiffSpringConstrai
 	}
 }
 
-void PhysicsSystemBuilder::readConeTwistConstraintTemplate(ConeTwistConstraintTemplate& dest) {
+void SystemBuilder::readConeTwistConstraintTemplate(ConeTwistConstraintTemplate& dest) {
 	while (m_reader->Inspect()) {
 		if (m_reader->GetInspected() == hdt::XMLReader::Inspected::StartTag) {
 			auto name = m_reader->GetName();
@@ -1420,40 +1420,40 @@ void PhysicsSystemBuilder::readConeTwistConstraintTemplate(ConeTwistConstraintTe
 	}
 }
 
-const PhysicsSystemBuilder::BoneTemplate& PhysicsSystemBuilder::getBoneTemplate(const IDStr& name) {
+const SystemBuilder::BoneTemplate& SystemBuilder::getBoneTemplate(const IDStr& name) {
 	auto iter = m_boneTemplates.find(name);
 	if (iter == m_boneTemplates.end())
 		return m_boneTemplates[IDStr()];
 	return iter->second;
 }
 
-const PhysicsSystemBuilder::GenericConstraintTemplate& PhysicsSystemBuilder::getGenericConstraintTemplate(const IDStr& name) {
+const SystemBuilder::GenericConstraintTemplate& SystemBuilder::getGenericConstraintTemplate(const IDStr& name) {
 	auto iter = m_genericConstraintTemplates.find(name);
 	if (iter == m_genericConstraintTemplates.end())
 		return m_genericConstraintTemplates[IDStr()];
 	return iter->second;
 }
 
-const PhysicsSystemBuilder::StiffSpringConstraintTemplate& PhysicsSystemBuilder::getStiffSpringConstraintTemplate(const IDStr& name) {
+const SystemBuilder::StiffSpringConstraintTemplate& SystemBuilder::getStiffSpringConstraintTemplate(const IDStr& name) {
 	auto iter = m_stiffSpringConstraintTemplates.find(name);
 	if (iter == m_stiffSpringConstraintTemplates.end())
 		return m_stiffSpringConstraintTemplates[IDStr()];
 	return iter->second;
 }
 
-const PhysicsSystemBuilder::ConeTwistConstraintTemplate& PhysicsSystemBuilder::getConeTwistConstraintTemplate(const IDStr& name) {
+const SystemBuilder::ConeTwistConstraintTemplate& SystemBuilder::getConeTwistConstraintTemplate(const IDStr& name) {
 	auto iter = m_coneTwistConstraintTemplates.find(name);
 	if (iter == m_coneTwistConstraintTemplates.end())
 		return m_coneTwistConstraintTemplates[IDStr()];
 	return iter->second;
 }
 
-hdt::Ref<hdt::StiffSpringConstraint> PhysicsSystemBuilder::readStiffSpringConstraint() {
+hdt::Ref<hdt::StiffSpringConstraint> SystemBuilder::readStiffSpringConstraint() {
 	auto bodyAName = IDStr(m_reader->getAttribute("bodyA"));
 	auto bodyBName = IDStr(m_reader->getAttribute("bodyB"));
 	auto clsname = IDStr(m_reader->getAttribute("template", ""));
 
-	BSOSBone *bodyA, *bodyB;
+	PreviewBone *bodyA, *bodyB;
 	if (!findBones(bodyAName, bodyBName, bodyA, bodyB))
 		return nullptr;
 
@@ -1469,12 +1469,12 @@ hdt::Ref<hdt::StiffSpringConstraint> PhysicsSystemBuilder::readStiffSpringConstr
 	return constraint;
 }
 
-hdt::Ref<hdt::ConeTwistConstraint> PhysicsSystemBuilder::readConeTwistConstraint() {
+hdt::Ref<hdt::ConeTwistConstraint> SystemBuilder::readConeTwistConstraint() {
 	auto bodyAName = IDStr(m_reader->getAttribute("bodyA"));
 	auto bodyBName = IDStr(m_reader->getAttribute("bodyB"));
 	auto clsname = IDStr(m_reader->getAttribute("template", ""));
 
-	BSOSBone *bodyA = nullptr, *bodyB = nullptr;
+	PreviewBone *bodyA = nullptr, *bodyB = nullptr;
 	if (!findBones(bodyAName, bodyBName, bodyA, bodyB)) {
 		return nullptr;
 	}

--- a/src/physics/SystemBuilder.h
+++ b/src/physics/SystemBuilder.h
@@ -7,7 +7,7 @@ See the included LICENSE file
 
 #ifdef USE_BULLET
 
-#include "PhysicsController.h"
+#include "Controller.h"
 
 #include "hdt/hdtConeTwistConstraint.h"
 #include "hdt/hdtGeneric6DofConstraint.h"
@@ -35,27 +35,27 @@ class XMLReader;
 class PerVertexShape;
 }
 
-namespace bsos {
-class BSOSSystem;
+namespace Physics {
+class PreviewSystem;
 
 // Port of hdtSMP64's SkyrimBone: a physics bone bound to an AnimBone of the
 // application skeleton instead of a NiNode of the game scene graph.
-class BSOSBone : public hdt::SkinnedMeshBone {
+class PreviewBone : public hdt::SkinnedMeshBone {
 public:
-	BSOSBone(const hdt::IDStr& name, AnimBone* animBone, BSOSSystem* system, btRigidBody::btRigidBodyConstructionInfo& ci);
+	PreviewBone(const hdt::IDStr& name, AnimBone* animBone, PreviewSystem* system, btRigidBody::btRigidBodyConstructionInfo& ci);
 
 	void readTransform(float timeStep) override;
 	void writeTransform() override;
 
 	int m_depth = 0;
 	AnimBone* m_animBone = nullptr;
-	BSOSSystem* m_system = nullptr;
+	PreviewSystem* m_system = nullptr;
 };
 
 // Port of hdtSMP64's SkyrimBody. The game's runtime disable machinery
 // (updateActiveState) is not ported, but the XML attributes feeding it are
 // still parsed into the members below.
-class BSOSBody : public hdt::SkinnedMeshBody {
+class PreviewBody : public hdt::SkinnedMeshBody {
 public:
 	enum class SharedType {
 		SHARED_PUBLIC,
@@ -64,7 +64,7 @@ public:
 		SHARED_PRIVATE,
 	};
 
-	BSOSSystem* m_mesh = nullptr;
+	PreviewSystem* m_mesh = nullptr;
 	SharedType m_shared = SharedType::SHARED_PUBLIC;
 	bool m_disabled = false;
 	int m_disablePriority = 0;
@@ -77,8 +77,8 @@ public:
 // Port of hdtSMP64's SkyrimSystem minus the game skeleton members. Root
 // motion (camera turntable yaw) takes the role of the skeleton root
 // transform the game watched.
-class BSOSSystem : public hdt::SkinnedMeshSystem {
-	friend class PhysicsSystemBuilder;
+class PreviewSystem : public hdt::SkinnedMeshSystem {
+	friend class SystemBuilder;
 
 public:
 	hdt::SkinnedMeshBone* findBone(const hdt::IDStr& name);
@@ -111,7 +111,7 @@ public:
 // Inputs for building one physics system from one XML file. Vertices,
 // triangles, bone weights and skin transforms come from the NIF/AnimInfo
 // instead of the game's NiSkinInstance.
-struct PhysicsBuildInput {
+struct BuildInput {
 	const std::string* xmlData = nullptr; // whole XML file contents
 	std::string xmlName;				  // diagnostics prefix
 	nifly::NifFile* nif = nullptr;
@@ -121,20 +121,20 @@ struct PhysicsBuildInput {
 
 /*
 Port of hdtSMP64's SkyrimSystemCreator: parses a physics XML and builds the
-bone rigid bodies, constraints and collision meshes of one BSOSSystem, bound
+bone rigid bodies, constraints and collision meshes of one PreviewSystem, bound
 to AnimSkeleton bones. Mesh data (vertices, triangles, weights, skin-to-bone
 transforms) is sourced from nifly/AnimInfo. Diagnostics go to the warning
 list passed to Build.
 */
-class PhysicsSystemBuilder {
+class SystemBuilder {
 public:
-	hdt::Ref<BSOSSystem> Build(const PhysicsBuildInput& input, std::vector<std::string>& outWarnings);
+	hdt::Ref<PreviewSystem> Build(const BuildInput& input, std::vector<std::string>& outWarnings);
 
 protected:
-	std::unordered_map<hdt::IDStr, BSOSBone*> m_boneIndex;
+	std::unordered_map<hdt::IDStr, PreviewBone*> m_boneIndex;
 
-	void indexBone(BSOSBone* bone);
-	BSOSBone* findBoneFromIndex(const hdt::IDStr& name) const;
+	void indexBone(PreviewBone* bone);
+	PreviewBone* findBoneFromIndex(const hdt::IDStr& name) const;
 
 	struct DeferredBuild {
 		hdt::SkinnedMeshBody* body;
@@ -233,7 +233,7 @@ protected:
 	// NIF shape -> offset of its first vertex within the merged body
 	using VertexOffsetMap = std::vector<std::pair<nifly::NiShape*, int>>;
 
-	hdt::Ref<BSOSSystem> m_mesh;
+	hdt::Ref<PreviewSystem> m_mesh;
 	nifly::NifFile* m_nif = nullptr;
 	AnimInfo* m_anim = nullptr;
 	const std::vector<nifly::NiShape*>* m_nifShapes = nullptr;
@@ -245,10 +245,10 @@ protected:
 	void warn(const std::string& msg);
 
 	// Body of Build once the reader is set up
-	hdt::Ref<BSOSSystem> readSystem();
+	hdt::Ref<PreviewSystem> readSystem();
 
 	AnimBone* findAnimBone(const hdt::IDStr& name);
-	BSOSBone* getOrCreateBone(const hdt::IDStr& name);
+	PreviewBone* getOrCreateBone(const hdt::IDStr& name);
 
 	std::unordered_map<hdt::IDStr, BoneTemplate> m_boneTemplates;
 	std::unordered_map<hdt::IDStr, GenericConstraintTemplate> m_genericConstraintTemplates;
@@ -257,9 +257,9 @@ protected:
 	std::unordered_map<hdt::IDStr, std::shared_ptr<btCollisionShape>> m_shapes;
 	std::vector<std::shared_ptr<btCollisionShape>> m_shapeRefs;
 
-	std::pair<hdt::Ref<BSOSBody>, VertexOffsetMap> generateMeshBody(const std::string& name);
+	std::pair<hdt::Ref<PreviewBody>, VertexOffsetMap> generateMeshBody(const std::string& name);
 
-	bool findBones(const hdt::IDStr& bodyAName, const hdt::IDStr& bodyBName, BSOSBone*& bodyA, BSOSBone*& bodyB);
+	bool findBones(const hdt::IDStr& bodyAName, const hdt::IDStr& bodyBName, PreviewBone*& bodyA, PreviewBone*& bodyB);
 	bool parseFrameType(const std::string& name, FrameType& type, btTransform& frame);
 	static void calcFrame(FrameType type, const btTransform& frame, const hdt::btQsTransform& trA, const hdt::btQsTransform& trB, btTransform& frameA, btTransform& frameB);
 	void readFrameLerp(btTransform& tr);
@@ -273,10 +273,10 @@ protected:
 	const StiffSpringConstraintTemplate& getStiffSpringConstraintTemplate(const hdt::IDStr& name);
 	const ConeTwistConstraintTemplate& getConeTwistConstraintTemplate(const hdt::IDStr& name);
 
-	BSOSBone* createBoneFromNodeName(const hdt::IDStr& bodyName, const hdt::IDStr& templateName = hdt::IDStr(""), const bool readTemplate = false);
+	PreviewBone* createBoneFromNodeName(const hdt::IDStr& bodyName, const hdt::IDStr& templateName = hdt::IDStr(""), const bool readTemplate = false);
 	void readOrUpdateBone();
-	hdt::Ref<BSOSBody> readPerVertexShape();
-	hdt::Ref<BSOSBody> readPerTriangleShape();
+	hdt::Ref<PreviewBody> readPerVertexShape();
+	hdt::Ref<PreviewBody> readPerTriangleShape();
 	hdt::Ref<hdt::Generic6DofConstraint> readGenericConstraint();
 	hdt::Ref<hdt::StiffSpringConstraint> readStiffSpringConstraint();
 	hdt::Ref<hdt::ConeTwistConstraint> readConeTwistConstraint();

--- a/src/physics/hdt/README.md
+++ b/src/physics/hdt/README.md
@@ -1,0 +1,66 @@
+# Ported HDT-SMP physics core
+
+The files in this directory are a port of the `hdtSkinnedMesh` core of
+**Faster HDT-SMP (FSMP)**, the skinned-mesh physics plugin for Skyrim SE/AE/VR:
+
+* Source: <https://github.com/DaymareOn/hdtSMP64> (`dev` branch, ported August 2026)
+* Maintained by DaydreamingDay / DaymareOn, a fork of
+  [Karonar1/hdtSMP64](https://github.com/Karonar1/hdtSMP64), itself a fork of
+  [aers/hdtSMP64](https://github.com/aers/hdtSMP64), from the original
+  [hdt-skyrimse-mods](https://github.com/HydrogensaysHDT/hdt-skyrimse-mods) by
+  HydrogensaysHDT
+* License: GPL-3.0, the same license as BodySlide and Outfit Studio
+
+They exist so Outfit Studio can preview the physics of the very same XML files
+the game plugin consumes, with the same behavior. Please keep them close to
+upstream so the two stay diffable: fix bugs upstream where possible, and do not
+restructure or "improve" the simulation code here.
+
+`XmlReader` keeps the pull-style interface of its upstream counterpart, so the
+parsing code in `PhysicsSystemBuilder` stays comparable with upstream, but it
+is implemented on the tinyxml2 this project already ships rather than on the
+XmlInspector parser vendored by FSMP. The physics XML format is ordinary
+well-formed XML - FSMP's own validator reads the same files with pugixml and
+validates them against XSD and Schematron schemas - so no behavior depends on
+which conformant parser reads them. What does matter for compatibility is the
+value conversion in `XmlReader.cpp` (decimal commas, hexadecimal and octal
+integers, leading `+`, `true`/`1`), and that is ported as-is.
+
+## Changes made during the port
+
+The simulation, collision and constraint code is ported as-is. Only the
+dependencies on the game and its engine were replaced:
+
+* `RE::` / CommonLibSSE types (`BSTSmartPointer`, `BSIntrusiveRefCounted`,
+  `BSFixedString`) and Intel TBB parallel loops are replaced by the standard
+  C++ equivalents in `hdtRefUtils.h`, which is the only file here without an
+  upstream counterpart. `IDStr` keeps the case-insensitive comparison and
+  hashing that bone and tag matching depends on.
+* The skeleton is read from and written to Outfit Studio's `AnimSkeleton` and
+  `AnimInfo` instead of the game's `NiNode` tree. That glue lives one directory
+  up, in `PhysicsSystemBuilder` (the port of `hdtSkyrimSystem`) and
+  `PhysicsController`.
+* Bullet's multithreaded classes (`btDiscreteDynamicsWorldMt`,
+  `btCollisionDispatcherMt`, `btParallelFor`) are replaced by their
+  single-threaded equivalents. They require a Bullet built with
+  `BT_THREADSAFE` plus a task scheduler, which stock Bullet packages do not
+  provide.
+* MSVC-only and Windows-only constructs are replaced by portable ones, since
+  this code also builds on Linux.
+* `XmlReader` is reimplemented on tinyxml2, as described above, which drops the
+  vendored XmlInspector parser (about 14000 lines) without changing the
+  interface the parsing code uses.
+* Game-side pieces that have no meaning in a mesh editor are not ported:
+  game hooks, `defaultBBPs.xml` name mapping (physics files are found through
+  the `"HDT Skinned Mesh Physics Object"` extra data only), and the actor and
+  weather queries that drive wind, which the preview replaces with its own
+  wind controls.
+
+## Known differences from the game
+
+* Non-Hookean spring parameters are parsed but not applied. Upstream needs a
+  patched Bullet for them; the preview warns and uses the ordinary springs.
+* Bone pose scaling other than 1 is treated as 1.
+* Wind is a preview control (strength and direction) rather than the weather
+  and actor state the game derives it from, and it is stronger at maximum than
+  the strongest vanilla weather.

--- a/src/physics/hdt/README.md
+++ b/src/physics/hdt/README.md
@@ -17,7 +17,7 @@ upstream so the two stay diffable: fix bugs upstream where possible, and do not
 restructure or "improve" the simulation code here.
 
 `XmlReader` keeps the pull-style interface of its upstream counterpart, so the
-parsing code in `PhysicsSystemBuilder` stays comparable with upstream, but it
+parsing code in `Physics::SystemBuilder` stays comparable with upstream, but it
 is implemented on the tinyxml2 this project already ships rather than on the
 XmlInspector parser vendored by FSMP. The physics XML format is ordinary
 well-formed XML - FSMP's own validator reads the same files with pugixml and
@@ -38,8 +38,8 @@ dependencies on the game and its engine were replaced:
   hashing that bone and tag matching depends on.
 * The skeleton is read from and written to Outfit Studio's `AnimSkeleton` and
   `AnimInfo` instead of the game's `NiNode` tree. That glue lives one directory
-  up, in `PhysicsSystemBuilder` (the port of `hdtSkyrimSystem`) and
-  `PhysicsController`.
+  up, in `Physics::SystemBuilder` (the port of `hdtSkyrimSystem`) and
+  `Physics::Controller`.
 * Bullet's multithreaded classes (`btDiscreteDynamicsWorldMt`,
   `btCollisionDispatcherMt`, `btParallelFor`) are replaced by their
   single-threaded equivalents. They require a Bullet built with

--- a/src/physics/hdt/XmlReader.cpp
+++ b/src/physics/hdt/XmlReader.cpp
@@ -1,0 +1,377 @@
+#ifdef USE_BULLET
+
+#include "XmlReader.h"
+#include "hdtStringUtils.h"
+#include <charconv>
+
+namespace hdt
+{
+	static inline float convertFloat(const std::string& str)
+	{
+		// Trim first (from_chars rejects surrounding spaces), then turn a decimal
+		// comma into a point so locale-independent parsing still accepts it.
+		std::string s = TrimAsciiWhitespace(str);
+		size_t start_pos = s.find(",");
+		if (start_pos != std::string::npos)
+			s.replace(start_pos, 1, ".");
+
+		float ret{};
+		const char* begin = s.data();
+		const char* end = begin + s.size();
+		// strtof accepted a leading '+'; from_chars doesn't, so skip it.
+		if (begin != end && *begin == '+')
+			++begin;
+		auto [ptr, ec] = std::from_chars(begin, end, ret);
+		if (ec != std::errc() || ptr != end)
+			throw std::string("not a float value");
+		return ret;
+	}
+
+	static inline int convertInt(const std::string& str)
+	{
+		// Trim first: from_chars rejects surrounding spaces and a leading '+'.
+		std::string s = TrimAsciiWhitespace(str);
+		const char* begin = s.data();
+		const char* end = begin + s.size();
+		if (begin != end && *begin == '+')
+			++begin;
+
+		int radix = 10;
+		if (!s.compare(0, 2, "0x")) {
+			radix = 16;
+			begin += 2;
+		} else if (s.length() > 1 && s[0] == '0') {
+			begin += 1;
+			radix = 8;
+		}
+
+		int ret{};
+		auto [ptr, ec] = std::from_chars(begin, end, ret, radix);
+		if (ec != std::errc() || ptr != end)
+			throw std::string("not a int value");
+		return ret;
+	}
+
+	static inline bool convertBool(const std::string& str)
+	{
+		const std::string s = TrimAsciiWhitespace(str);
+		if (s == "true" || s == "1")
+			return true;
+		if (s == "false" || s == "0")
+			return false;
+		throw std::string("not a boolean");
+	}
+
+	namespace
+	{
+		// tinyxml2 only reads UTF-8. Physics XMLs saved as UTF-16 (which some
+		// editors do by default) are converted so they keep working; anything
+		// else is handed over untouched, BOM included, which tinyxml2 skips.
+		bool ConvertUtf16ToUtf8(const uint8_t* data, size_t count, std::string& out)
+		{
+			const bool littleEndian = count >= 2 && data[0] == 0xFF && data[1] == 0xFE;
+			const bool bigEndian = count >= 2 && data[0] == 0xFE && data[1] == 0xFF;
+			if (!littleEndian && !bigEndian)
+				return false;
+
+			out.clear();
+			out.reserve(count / 2);
+
+			for (size_t i = 2; i + 1 < count; i += 2) {
+				uint32_t cp = littleEndian ? static_cast<uint32_t>(data[i]) | (static_cast<uint32_t>(data[i + 1]) << 8)
+										   : (static_cast<uint32_t>(data[i]) << 8) | static_cast<uint32_t>(data[i + 1]);
+
+				// Combine a surrogate pair into one code point
+				if (cp >= 0xD800 && cp <= 0xDBFF && i + 3 < count) {
+					const uint32_t low = littleEndian
+						? static_cast<uint32_t>(data[i + 2]) | (static_cast<uint32_t>(data[i + 3]) << 8)
+						: (static_cast<uint32_t>(data[i + 2]) << 8) | static_cast<uint32_t>(data[i + 3]);
+
+					if (low >= 0xDC00 && low <= 0xDFFF) {
+						cp = 0x10000 + ((cp - 0xD800) << 10) + (low - 0xDC00);
+						i += 2;
+					}
+				}
+
+				if (cp < 0x80) {
+					out.push_back(static_cast<char>(cp));
+				} else if (cp < 0x800) {
+					out.push_back(static_cast<char>(0xC0 | (cp >> 6)));
+					out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+				} else if (cp < 0x10000) {
+					out.push_back(static_cast<char>(0xE0 | (cp >> 12)));
+					out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+					out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+				} else {
+					out.push_back(static_cast<char>(0xF0 | (cp >> 18)));
+					out.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
+					out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+					out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+				}
+			}
+
+			return true;
+		}
+
+		// Only elements and character data are reported; everything else
+		// (comments, declarations, processing instructions) is stepped over.
+		tinyxml2::XMLNode* NextReportable(tinyxml2::XMLNode* node)
+		{
+			for (; node; node = node->NextSibling()) {
+				if (node->ToElement() || node->ToText())
+					return node;
+			}
+			return nullptr;
+		}
+	}
+
+	XMLReader::XMLReader(const uint8_t* data, size_t count)
+	{
+		if (ConvertUtf16ToUtf8(data, count, m_converted))
+			m_doc.Parse(m_converted.data(), m_converted.size());
+		else
+			m_doc.Parse(reinterpret_cast<const char*>(data), count);
+	}
+
+	bool XMLReader::moveTo(tinyxml2::XMLNode* node)
+	{
+		if (!node) {
+			m_inspected = Inspected::None;
+			return false;
+		}
+
+		m_node = node;
+		m_inspected = node->ToElement() ? Inspected::StartTag : Inspected::Text;
+		return true;
+	}
+
+	bool XMLReader::Inspect()
+	{
+		if (!m_started) {
+			m_started = true;
+			return moveTo(NextReportable(m_doc.FirstChild()));
+		}
+
+		if (!m_node) {
+			m_inspected = Inspected::None;
+			return false;
+		}
+
+		// Entering an element: its content comes next, or it ends right away
+		if (m_inspected == Inspected::StartTag) {
+			if (auto* child = NextReportable(m_node->FirstChild()))
+				return moveTo(child);
+
+			m_inspected = Inspected::EndTag;
+			return true;
+		}
+
+		// Done with this item: on to the next one, or out of the parent
+		if (auto* sibling = NextReportable(m_node->NextSibling()))
+			return moveTo(sibling);
+
+		auto* parent = m_node->Parent();
+		if (!parent || parent->ToDocument()) {
+			m_node = nullptr;
+			m_inspected = Inspected::None;
+			return false;
+		}
+
+		m_node = parent;
+		m_inspected = Inspected::EndTag;
+		return true;
+	}
+
+	std::string XMLReader::GetName() const
+	{
+		auto* element = m_node ? m_node->ToElement() : nullptr;
+		if (!element || m_inspected == Inspected::None)
+			return std::string();
+
+		const char* name = element->Name();
+		return name ? name : std::string();
+	}
+
+	std::string XMLReader::GetValue() const
+	{
+		if (m_inspected != Inspected::Text || !m_node)
+			return std::string();
+
+		const char* value = m_node->Value();
+		return value ? value : std::string();
+	}
+
+	bool XMLReader::HasError() const
+	{
+		return m_doc.Error();
+	}
+
+	std::string XMLReader::GetErrorMessage() const
+	{
+		if (!m_doc.Error())
+			return std::string();
+
+		std::string message = m_doc.ErrorStr() ? m_doc.ErrorStr() : "unknown error";
+		if (m_doc.ErrorLineNum() > 0)
+			message += " (line " + std::to_string(m_doc.ErrorLineNum()) + ")";
+
+		return message;
+	}
+
+	void XMLReader::skipCurrentElement()
+	{
+		if (GetInspected() == Inspected::EndTag)
+			return;
+
+		int currentDepth = 1;
+		while (currentDepth && Inspect()) {
+			switch (GetInspected()) {
+			case Inspected::StartTag:
+				++currentDepth;
+				break;
+			case Inspected::EndTag:
+				--currentDepth;
+				break;
+			}
+		}
+	}
+
+	void XMLReader::nextStartElement()
+	{
+		while (Inspect() && GetInspected() != Inspected::StartTag);
+	}
+
+	bool XMLReader::hasAttribute(const std::string& a_name)
+	{
+		auto* element = m_node ? m_node->ToElement() : nullptr;
+		return element && element->Attribute(a_name.c_str());
+	}
+
+	std::string XMLReader::getAttribute(const std::string& a_name)
+	{
+		auto* element = m_node ? m_node->ToElement() : nullptr;
+		const char* value = element ? element->Attribute(a_name.c_str()) : nullptr;
+		if (!value)
+			throw std::string("missing attribute : " + a_name);
+
+		return value;
+	}
+
+	std::string XMLReader::getAttribute(const std::string& a_name, const std::string& def)
+	{
+		auto* element = m_node ? m_node->ToElement() : nullptr;
+		const char* value = element ? element->Attribute(a_name.c_str()) : nullptr;
+		return value ? value : def;
+	}
+
+	float XMLReader::getAttributeAsFloat(const std::string& a_name)
+	{
+		return convertFloat(getAttribute(a_name));
+	}
+
+	int XMLReader::getAttributeAsInt(const std::string& a_name)
+	{
+		return convertInt(getAttribute(a_name));
+	}
+
+	bool XMLReader::getAttributeAsBool(const std::string& a_name)
+	{
+		return convertBool(getAttribute(a_name));
+	}
+
+	std::string XMLReader::readText()
+	{
+		Inspect();
+		auto ret = GetValue();
+		skipCurrentElement();
+		return ret;
+	}
+
+	float XMLReader::readFloat()
+	{
+		Inspect();
+		auto ret = convertFloat(GetValue());
+		skipCurrentElement();
+		return ret;
+	}
+
+	int XMLReader::readInt()
+	{
+		Inspect();
+		auto ret = convertInt(GetValue());
+		skipCurrentElement();
+		return ret;
+	}
+
+	bool XMLReader::readBool()
+	{
+		Inspect();
+		auto ret = convertBool(GetValue());
+		skipCurrentElement();
+		return ret;
+	}
+
+	btVector3 XMLReader::readVector3()
+	{
+		float x = getAttributeAsFloat("x");
+		float y = getAttributeAsFloat("y");
+		float z = getAttributeAsFloat("z");
+		skipCurrentElement();
+		return btVector3(x, y, z);
+	}
+
+	btQuaternion XMLReader::readQuaternion()
+	{
+		float x = getAttributeAsFloat("x");
+		float y = getAttributeAsFloat("y");
+		float z = getAttributeAsFloat("z");
+		float w = getAttributeAsFloat("w");
+		skipCurrentElement();
+		btQuaternion q(x, y, z, w);
+		if (btFuzzyZero(q.length2()))
+			q = btQuaternion::getIdentity();
+		else
+			q.normalize();
+		return q;
+	}
+
+	btQuaternion XMLReader::readAxisAngle()
+	{
+		float x = getAttributeAsFloat("x");
+		float y = getAttributeAsFloat("y");
+		float z = getAttributeAsFloat("z");
+		float w = getAttributeAsFloat("angle");
+		skipCurrentElement();
+		btQuaternion q;
+		btVector3 axis(x, y, z);
+		if (axis.fuzzyZero()) {
+			axis.setX(1);
+			w = 0;
+		} else
+			axis.normalize();
+		q.setRotation(axis, w);
+		return q;
+	}
+
+	btTransform XMLReader::readTransform()
+	{
+		btTransform ret(btTransform::getIdentity());
+		while (Inspect()) {
+			switch (GetInspected()) {
+			case Inspected::StartTag:
+				if (GetName() == "basis")
+					ret.setRotation(readQuaternion());
+				else if (GetName() == "basis-axis-angle")
+					ret.setRotation(readAxisAngle());
+				else if (GetName() == "origin")
+					ret.setOrigin(readVector3());
+				break;
+			case Inspected::EndTag:
+				return ret;
+			}
+		}
+		return ret;
+	}
+}
+
+#endif  // USE_BULLET

--- a/src/physics/hdt/XmlReader.h
+++ b/src/physics/hdt/XmlReader.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "hdtBulletHelper.h"
+
+#include <tinyxml2.h>
+
+#include <cstdint>
+#include <string>
+
+namespace hdt
+{
+	// Pull-style reader over a parsed XML document, with the interface the
+	// physics XML parsing was written against upstream (where it was a thin
+	// wrapper around the XmlInspector streaming parser). Keeping the interface
+	// means the parsing code stays comparable with upstream; the document
+	// itself is parsed by the tinyxml2 the rest of the project already uses.
+	//
+	// Elements are reported as a StartTag, then their content, then an EndTag,
+	// including empty elements such as <foo/>. Comments, declarations and
+	// processing instructions are skipped.
+	class XMLReader
+	{
+	public:
+		enum class Inspected
+		{
+			None,
+			StartTag,
+			EndTag,
+			Text
+		};
+
+		XMLReader(const uint8_t* data, size_t count);
+
+		// Advances to the next item, false at the end of the document
+		bool Inspect();
+		Inspected GetInspected() const { return m_inspected; }
+
+		// Element name at a StartTag or EndTag, empty otherwise
+		std::string GetName() const;
+		// Character data at Text, empty otherwise
+		std::string GetValue() const;
+
+		bool HasError() const;
+		std::string GetErrorMessage() const;
+
+		void skipCurrentElement();
+		void nextStartElement();
+
+		bool hasAttribute(const std::string& name);
+		std::string getAttribute(const std::string& name);
+		std::string getAttribute(const std::string& name, const std::string& def);
+
+		float getAttributeAsFloat(const std::string& name);
+		int getAttributeAsInt(const std::string& name);
+		bool getAttributeAsBool(const std::string& name);
+
+		std::string readText();
+		float readFloat();
+		int readInt();
+		bool readBool();
+
+		btVector3 readVector3();
+		btQuaternion readQuaternion();
+		btQuaternion readAxisAngle();
+		btTransform readTransform();
+
+	private:
+		bool moveTo(tinyxml2::XMLNode* node);
+
+		tinyxml2::XMLDocument m_doc;
+		// Owns the text when the input had to be converted to UTF-8, since
+		// tinyxml2 parses in place
+		std::string m_converted;
+		tinyxml2::XMLNode* m_node = nullptr;
+		Inspected m_inspected = Inspected::None;
+		bool m_started = false;
+	};
+}

--- a/src/physics/hdt/hdtAABB.h
+++ b/src/physics/hdt/hdtAABB.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "hdtBulletHelper.h"
+
+namespace hdt
+{
+	struct Aabb
+	{
+		Aabb() { invalidate(); }
+
+		Aabb(__m128 mmin, __m128 mmax) :
+			m_min(mmin), m_max(mmax)
+		{
+		}
+
+		__m128 m_min;
+		__m128 m_max;
+
+		bool collideWith(const Aabb& rhs) const
+		{
+			auto flag0 = _mm_cmplt_ps(rhs.m_max, m_min);
+			auto flag1 = _mm_cmplt_ps(m_max, rhs.m_min);
+			auto flag = _mm_movemask_ps(_mm_or_ps(flag0, flag1));
+			return !(flag & 0x7);
+		}
+
+		void invalidate()
+		{
+			m_min = setAll(FLT_MAX);
+			m_max = setAll(-FLT_MAX);
+		}
+
+		void merge(const btVector3& p)
+		{
+			m_min = _mm_min_ps(m_min, p.get128());
+			m_max = _mm_max_ps(m_max, p.get128());
+		}
+
+		void merge(const Aabb& rhs)
+		{
+			m_min = _mm_min_ps(m_min, rhs.m_min);
+			m_max = _mm_max_ps(m_max, rhs.m_max);
+		}
+	};
+
+	struct BoundingSphere
+	{
+		BoundingSphere()
+		{
+		}
+
+		BoundingSphere(const btVector3& center, float radius) :
+			m_centerRadius(center)
+		{
+			m_centerRadius[3] = radius;
+		}
+
+		btVector3 center() const { return m_centerRadius; }
+
+		float radius() const { return m_centerRadius.w(); }
+
+		// SIMD stuff: splat radius from W into all lanes, then build AABB as center +/- radius
+		Aabb getAabb() const
+		{
+			__m128 c = m_centerRadius.get128();
+			__m128 r = _mm_shuffle_ps(c, c, _MM_SHUFFLE(3, 3, 3, 3));
+			return Aabb(_mm_sub_ps(c, r), _mm_add_ps(c, r));
+		}
+
+		btVector4 m_centerRadius;
+	};
+}

--- a/src/physics/hdt/hdtAABB.h
+++ b/src/physics/hdt/hdtAABB.h
@@ -32,8 +32,8 @@ namespace hdt
 
 		void merge(const btVector3& p)
 		{
-			m_min = _mm_min_ps(m_min, p.get128());
-			m_max = _mm_max_ps(m_max, p.get128());
+			m_min = _mm_min_ps(m_min, toSimd(p));
+			m_max = _mm_max_ps(m_max, toSimd(p));
 		}
 
 		void merge(const Aabb& rhs)
@@ -50,9 +50,8 @@ namespace hdt
 		}
 
 		BoundingSphere(const btVector3& center, float radius) :
-			m_centerRadius(center)
+			m_centerRadius(center.x(), center.y(), center.z(), radius)
 		{
-			m_centerRadius[3] = radius;
 		}
 
 		btVector3 center() const { return m_centerRadius; }
@@ -62,7 +61,7 @@ namespace hdt
 		// SIMD stuff: splat radius from W into all lanes, then build AABB as center +/- radius
 		Aabb getAabb() const
 		{
-			__m128 c = m_centerRadius.get128();
+			__m128 c = toSimd(m_centerRadius);
 			__m128 r = _mm_shuffle_ps(c, c, _MM_SHUFFLE(3, 3, 3, 3));
 			return Aabb(_mm_sub_ps(c, r), _mm_add_ps(c, r));
 		}

--- a/src/physics/hdt/hdtBone.h
+++ b/src/physics/hdt/hdtBone.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "hdtBulletHelper.h"
+
+namespace hdt
+{
+	struct HDT_ALIGN16 Bone
+	{
+		Bone() { _mm_store_ps(m_reserved, _mm_setzero_ps()); }
+
+		// cache from rigidbody
+		btMatrix4x3T m_vertexToWorld;
+
+		float m_reserved[3];     // reserved for float4 aligned
+		float m_maginMultipler;  // scaled margin
+	};
+}

--- a/src/physics/hdt/hdtBoneScaleConstraint.cpp
+++ b/src/physics/hdt/hdtBoneScaleConstraint.cpp
@@ -1,0 +1,17 @@
+#ifdef USE_BULLET
+
+#include "hdtBoneScaleConstraint.h"
+
+namespace hdt
+{
+	BoneScaleConstraint::BoneScaleConstraint(SkinnedMeshBone* a, SkinnedMeshBone* b, btTypedConstraint* constraint) :
+		m_boneA(a), m_boneB(b), m_constraint(constraint), m_scaleA(1), m_scaleB(1)
+	{
+	}
+
+	BoneScaleConstraint::~BoneScaleConstraint()
+	{
+	}
+}
+
+#endif  // USE_BULLET

--- a/src/physics/hdt/hdtBoneScaleConstraint.h
+++ b/src/physics/hdt/hdtBoneScaleConstraint.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "hdtBulletHelper.h"
+#include "hdtSkinnedMeshBody.h"
+
+namespace hdt
+{
+	class alignas(16) BoneScaleConstraint : public RefObject
+	{
+	public:
+		BoneScaleConstraint(SkinnedMeshBone* a, SkinnedMeshBone* b, btTypedConstraint* constraint);
+		virtual ~BoneScaleConstraint();
+
+		virtual void scaleConstraint() = 0;
+
+		btTypedConstraint* getConstraint() const { return m_constraint; }
+
+		float m_scaleA, m_scaleB;
+
+		SkinnedMeshBone* m_boneA;
+		SkinnedMeshBone* m_boneB;
+		btTypedConstraint* m_constraint;
+	};
+}

--- a/src/physics/hdt/hdtBulletHelper.h
+++ b/src/physics/hdt/hdtBulletHelper.h
@@ -1,0 +1,452 @@
+#pragma once
+
+#include "hdtRefUtils.h"
+
+#include <btBulletCollisionCommon.h>
+#include <btBulletDynamicsCommon.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cfloat>
+
+#if defined(_MSC_VER)
+#include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
+
+#undef min
+#undef max
+
+#define HDT_LOCK_GUARD(name, lock) std::lock_guard<decltype(lock)> name(lock)
+
+namespace hdt
+{
+	typedef int8_t I8;
+	typedef int16_t I16;
+	typedef int32_t I32;
+	typedef int64_t I64;
+
+	typedef uint8_t U8;
+	typedef uint16_t U16;
+	typedef uint32_t U32;
+	typedef uint64_t U64;
+
+	template <int imm>
+	__m128 pshufd(__m128 m)
+	{
+		return _mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(m), imm));
+	}
+
+	inline __m128 setAll(float f) { return pshufd<0>(_mm_load_ss(&f)); }
+	inline __m128 setAll0(__m128 m) { return pshufd<0>(m); }
+	inline __m128 setAll1(__m128 m) { return pshufd<0x55>(m); }
+	inline __m128 setAll2(__m128 m) { return pshufd<0xAA>(m); }
+	inline __m128 setAll3(__m128 m) { return pshufd<0xFF>(m); }
+
+	// portable replacements for MSVC's __m128::m128_f32[3] accessor
+	inline __m128 setLane3(__m128 v, float w)
+	{
+		__m128 t = _mm_shuffle_ps(v, _mm_set_ss(w), _MM_SHUFFLE(0, 0, 2, 2));  // z z w w
+		return _mm_shuffle_ps(v, t, _MM_SHUFFLE(2, 0, 1, 0));                  // x y z w
+	}
+
+	inline float getLane3(__m128 v) { return _mm_cvtss_f32(pshufd<0xFF>(v)); }
+
+	inline __m128& operator+=(__m128& l, __m128 r)
+	{
+		l = _mm_add_ps(l, r);
+		return l;
+	}
+
+	inline __m128& operator-=(__m128& l, __m128 r)
+	{
+		l = _mm_sub_ps(l, r);
+		return l;
+	}
+
+	inline __m128& operator*=(__m128& l, __m128 r)
+	{
+		l = _mm_mul_ps(l, r);
+		return l;
+	}
+
+	inline __m128& operator+=(__m128& l, float r)
+	{
+		l = _mm_add_ps(l, setAll(r));
+		return l;
+	}
+
+	inline __m128& operator-=(__m128& l, float r)
+	{
+		l = _mm_sub_ps(l, setAll(r));
+		return l;
+	}
+
+	inline __m128& operator*=(__m128& l, float r)
+	{
+		l = _mm_mul_ps(l, setAll(r));
+		return l;
+	}
+
+	inline __m128 cross(__m128 a, __m128 b)
+	{
+		__m128 T, V;
+
+		T = pshufd<_MM_SHUFFLE(3, 0, 2, 1)>(a);
+		V = pshufd<_MM_SHUFFLE(3, 0, 2, 1)>(b);
+
+		V = _mm_mul_ps(V, a);
+		T = _mm_mul_ps(T, b);
+		V = _mm_sub_ps(V, T);
+
+		V = pshufd<_MM_SHUFFLE(3, 0, 2, 1)>(V);
+		return V;
+	}
+
+	inline float rsqrt(float number)
+	{
+		__m128 n = _mm_set_ss(number);
+		__m128 est = _mm_rsqrt_ss(n);
+
+		__m128 muls = _mm_mul_ss(_mm_mul_ss(n, est), est);
+
+		__m128 half_est = _mm_mul_ss(est, _mm_set_ss(0.5f));
+		__m128 three_minus_muls = _mm_sub_ss(_mm_set_ss(3.0f), muls);
+
+		return _mm_cvtss_f32(_mm_mul_ss(half_est, three_minus_muls));
+	}
+
+	template <class T>
+	T abs(T rhs)
+	{
+		return rhs < 0 ? -rhs : rhs;
+	}
+
+	template <>
+	inline float abs(float rhs)
+	{
+		return _mm_cvtss_f32(_mm_andnot_ps(_mm_set_ss(-0.f), _mm_set_ss(rhs)));
+	}
+
+	template <class T>
+	T min(const T& a, const T& b)
+	{
+		return a < b ? a : b;
+	}
+
+	template <class T>
+	T max(const T& a, const T& b)
+	{
+		return a < b ? b : a;
+	}
+
+	inline int aligned(int x, int a) { return (x + a - 1) & -a; }
+
+	template <int a>
+	int aligned(int x)
+	{
+		return (x + a - 1) & -a;
+	}
+
+	inline U32 aligned2Pow(U32 lim)
+	{
+		// std::bit_floor is C++20; the project is C++17
+		if (!lim)
+			return 0;
+		lim |= lim >> 1;
+		lim |= lim >> 2;
+		lim |= lim >> 4;
+		lim |= lim >> 8;
+		lim |= lim >> 16;
+		return lim - (lim >> 1);
+	}
+
+	inline btScalar clampScalar(btScalar value, btScalar low, btScalar high)
+	{
+		return std::clamp(value, low, high);
+	}
+
+	ATTRIBUTE_ALIGNED16(class)
+	btQsTransform
+	{
+		btQuaternion m_basis;
+		btVector4 m_originScale;
+
+	public:
+		BT_DECLARE_ALIGNED_ALLOCATOR();
+
+		btQsTransform() :
+			m_basis(btQuaternion::getIdentity()), m_originScale(0, 0, 0, 1)
+		{
+		}
+
+		btQsTransform(const btQuaternion& r, const btVector3& t, float s = 1.0f) :
+			m_basis(r)
+		{
+#ifdef BT_ALLOW_SSE4
+			//0x30 inserts the 0th element of _mm_set_ss into the 3rd (W) element of t
+			m_originScale.mVec128 = _mm_insert_ps(t.get128(), _mm_set_ss(s), 0x30);
+#else
+			m_originScale = t;
+			m_originScale[3] = s;
+#endif
+		}
+
+		btQsTransform(const btTransform& t, float s = 1.0f) :
+			m_basis(t.getRotation())
+		{
+#ifdef BT_ALLOW_SSE4
+			m_originScale.mVec128 = _mm_insert_ps(t.getOrigin().get128(), _mm_set_ss(s), 0x30);
+#else
+			m_originScale = t.getOrigin();
+			m_originScale[3] = s;
+#endif
+		}
+
+		btQsTransform(const btQsTransform&) = default;
+		btQsTransform(btQsTransform&&) = default;
+		btQsTransform& operator=(const btQsTransform&) = default;
+		btQsTransform& operator=(btQsTransform&&) = default;
+
+		[[nodiscard]] bool isValid() const { return getScale() > 0; }
+
+		[[nodiscard]] btQuaternion getBasis() const { return m_basis; }
+		btQuaternion& getBasis() { return m_basis; }
+
+		void setBasis(const btQuaternion& q) { m_basis = q; }
+		void setBasis(const btMatrix3x3& m) { m.getRotation(m_basis); }
+
+		[[nodiscard]] float getScale() const { return m_originScale[3]; }
+		float& getScale() { return m_originScale[3]; }
+
+		// Deprecated: just use getScale(), the compiler will automatically optimize register extraction..
+		[[nodiscard]] float getScaleReg() const { return getScale(); }
+
+		void setScale(float s)
+		{
+			assert(s > 0);
+			m_originScale[3] = s;
+		}
+
+		[[nodiscard]] btVector3 getOrigin() const { return m_originScale; }
+
+		void setOrigin(const btVector3& vec)
+		{
+#ifdef BT_ALLOW_SSE4
+			m_originScale.mVec128 = _mm_blend_ps(vec.get128(), m_originScale.get128(), 0b1000);
+#else
+			float s = getScale();
+			m_originScale = vec;
+			m_originScale[3] = s;
+#endif
+		}
+
+		void setOrigin(float x, float y, float z)
+		{
+			m_originScale[0] = x;
+			m_originScale[1] = y;
+			m_originScale[2] = z;
+		}
+
+		[[nodiscard]] btQsTransform operator*(const btQsTransform& rhs) const
+		{
+			return btQsTransform(
+				m_basis * rhs.m_basis,
+				getOrigin() + quatRotate(m_basis, rhs.getOrigin() * getScale()),
+				getScale() * rhs.getScale());
+		}
+
+		[[nodiscard]] btVector3 operator*(const btVector3& rhs) const
+		{
+			return getOrigin() + quatRotate(m_basis, rhs * getScale());
+		}
+
+		void operator*=(const btQsTransform& rhs)
+		{
+			float s = getScale();
+			float newScale = s * rhs.getScale();
+			btVector3 newOrigin = getOrigin() + quatRotate(m_basis, rhs.getOrigin() * s);
+			m_basis *= rhs.m_basis;
+
+#ifdef BT_ALLOW_SSE4
+			m_originScale.mVec128 = _mm_insert_ps(newOrigin.get128(), _mm_set_ss(newScale), 0x30);
+#else
+			m_originScale = newOrigin;
+			m_originScale[3] = newScale;
+#endif
+		}
+
+		[[nodiscard]] btQsTransform inverse() const
+		{
+			btQuaternion r = m_basis.inverse();
+			float s = 1.0f / getScale();
+			return btQsTransform(r, quatRotate(r, -getOrigin() * s), s);
+		}
+
+		[[nodiscard]] btTransform asTransform() const
+		{
+			return btTransform(m_basis, m_originScale);
+		}
+
+		[[nodiscard]] static btQsTransform getIdentity()
+		{
+			return btQsTransform();  // Returns value utilizing XMM registers directly, skipping threadsafe static guards
+		}
+	};
+
+	ATTRIBUTE_ALIGNED16(class)
+	btMatrix4x3
+	{
+	public:
+		btMatrix4x3()
+		{
+		}
+
+		btMatrix4x3(const btQsTransform& t)
+		{
+			reinterpret_cast<btMatrix3x3*>(this)->setRotation(t.getBasis());
+			__m128 scale = pshufd<0xFF>(t.getOrigin().get128());
+			m_row[0] = _mm_mul_ps(m_row[0], scale);
+			m_row[1] = _mm_mul_ps(m_row[1], scale);
+			m_row[2] = _mm_mul_ps(m_row[2], scale);
+			m_row[0] = setLane3(m_row[0], t.getOrigin()[0]);
+			m_row[1] = setLane3(m_row[1], t.getOrigin()[1]);
+			m_row[2] = setLane3(m_row[2], t.getOrigin()[2]);
+		}
+
+		btVector3 operator*(const btVector3& rhs) const
+		{
+#ifdef BT_ALLOW_SSE4
+			auto v = _mm_blend_ps(rhs.get128(), _mm_set_ps1(1), 0x8);
+			__m128 xmm0 = _mm_dp_ps(m_row[0], v, 0xF1);
+			__m128 xmm1 = _mm_dp_ps(m_row[1], v, 0xF2);
+			__m128 xmm2 = _mm_dp_ps(m_row[2], v, 0xF4);
+			xmm0 = _mm_or_ps(xmm0, xmm1);
+			xmm0 = _mm_or_ps(xmm0, xmm2);
+#else
+			auto v = rhs.get128();
+			v = setLane3(v, 1.0f);
+
+			__m128 xmm0 = _mm_mul_ps(m_row[0], v);
+			__m128 xmm1 = _mm_mul_ps(m_row[1], v);
+			__m128 xmm2 = _mm_mul_ps(m_row[2], v);
+
+			xmm0 = _mm_hadd_ps(xmm0, xmm1);
+			xmm2 = _mm_hadd_ps(xmm2, xmm2);
+			xmm0 = _mm_hadd_ps(xmm0, xmm2);
+#endif
+			return xmm0;
+		}
+
+		__m128 mulPack(const btVector3& rhs, float packW) const
+		{
+#ifdef BT_ALLOW_SSE4
+			auto v = _mm_blend_ps(rhs.get128(), _mm_set_ps1(1), 0x8);
+			__m128 xmm0 = _mm_dp_ps(m_row[0], v, 0xF1);       // x, 0, 0, 0
+			__m128 xmm1 = _mm_dp_ps(m_row[1], v, 0xF2);       // 0, y, 0, 0
+			xmm0 = _mm_or_ps(xmm0, xmm1);                     // x, y, 0, 0
+			xmm1 = _mm_dp_ps(m_row[2], v, 0xF1);              // z, 0, 0, 0
+			xmm1 = _mm_unpacklo_ps(xmm1, _mm_set_ss(packW));  // z, w, 0, 0
+			xmm0 = _mm_movelh_ps(xmm0, xmm1);                 // x, y, z, w
+#else
+			auto v = rhs.get128();
+			v = setLane3(v, 1.0f);
+			auto w = _mm_load_ss(&packW);
+
+			__m128 xmm0 = _mm_mul_ps(m_row[0], v);
+			__m128 xmm1 = _mm_mul_ps(m_row[1], v);
+			__m128 xmm2 = _mm_mul_ps(m_row[2], v);
+
+			xmm0 = _mm_hadd_ps(xmm0, xmm1);
+			xmm2 = _mm_hadd_ps(xmm2, w);
+			xmm0 = _mm_hadd_ps(xmm0, xmm2);
+#endif
+			return xmm0;
+		}
+
+		__m128 m_row[3];
+	};
+
+	ATTRIBUTE_ALIGNED16(class)
+	btMatrix4x3T
+	{
+	public:
+		btMatrix4x3T()
+		{
+		}
+
+		btMatrix4x3T(const btQsTransform& t)
+		{
+			btMatrix3x3 rot;
+			rot.setRotation(t.getBasis());
+			rot = rot.transpose();
+			__m128 scale = pshufd<0xFF>(t.getOrigin().get128());
+			m_col[0] = rot[0].get128() * scale;
+			m_col[1] = rot[1].get128() * scale;
+			m_col[2] = rot[2].get128() * scale;
+			m_col[3] = t.getOrigin().get128();
+		}
+
+		btVector3 operator*(const btVector3& rhs) const
+		{
+			return m_col[0] * rhs[0] + m_col[1] * rhs[1] + m_col[2] * rhs[2] + m_col[3];
+		}
+
+		btMatrix4x3T operator*(const btMatrix4x3T& r)
+		{
+			btMatrix4x3T ret;
+			ret.m_col[0] = m_col[0] * r.m_col[0][0] + m_col[1] * r.m_col[0][1] + m_col[2] * r.m_col[0][2];
+			ret.m_col[1] = m_col[0] * r.m_col[1][0] + m_col[1] * r.m_col[1][1] + m_col[2] * r.m_col[1][2];
+			ret.m_col[2] = m_col[0] * r.m_col[2][0] + m_col[1] * r.m_col[2][1] + m_col[2] * r.m_col[2][2];
+			ret.m_col[3] = *this * r.m_col[3];
+			return ret;
+		}
+
+		btMatrix3x3 basis() const { return reinterpret_cast<const btMatrix3x3*>(this)->transpose(); }
+		btTransform toTransform() const { return btTransform(reinterpret_cast<const btMatrix3x3*>(this)->transpose(), m_col[3]); }
+
+		btVector3 m_col[4];
+	};
+
+	// The original had a second ref-counted base for objects that could not
+	// inherit RE::BSIntrusiveRefCounted; with the port both roles are served
+	// by hdt::RefCounted.
+	using RefObject = RefCounted;
+
+	template <>
+	inline btVector3 abs(btVector3 rhs)
+	{
+		return _mm_andnot_ps(_mm_set_ps1(-0.f), rhs.get128());
+	}
+
+	template <class T>
+	using vectorA16 = std::vector<T>;
+
+	class SpinLock
+	{
+		std::atomic<bool> m_flag{ false };
+
+	public:
+		void lock() noexcept
+		{
+			for (;;) {
+				if (!m_flag.exchange(true, std::memory_order_acquire))
+					return;
+				// spin on cachelocal read until it looks free
+				while (m_flag.load(std::memory_order_relaxed))
+					_mm_pause();
+			}
+		}
+
+		void unlock() noexcept
+		{
+			m_flag.store(false, std::memory_order_release);
+		}
+
+		bool try_lock() noexcept
+		{
+			return !m_flag.exchange(true, std::memory_order_acquire);
+		}
+	};
+}

--- a/src/physics/hdt/hdtBulletHelper.h
+++ b/src/physics/hdt/hdtBulletHelper.h
@@ -32,6 +32,39 @@ namespace hdt
 	typedef uint32_t U32;
 	typedef uint64_t U64;
 
+	// Bullet only exposes its SSE-backed vector API (get128/set128 and the
+	// implicit __m128 conversions) when its headers configure BT_USE_SSE, which
+	// they do on Windows and macOS but not on Linux (see LinearMath/btScalar.h),
+	// no matter what BT_USE_SSE_IN_API says. btVector3 and btVector4 are four
+	// 16-byte aligned floats either way, so convert here instead of depending on
+	// how the Bullet package was built.
+	static_assert(sizeof(btScalar) == sizeof(float),
+		"the physics preview needs a single precision Bullet (built without BT_USE_DOUBLE_PRECISION)");
+
+#if defined(BT_USE_SSE) && defined(BT_USE_SSE_IN_API)
+	inline __m128 toSimd(const btVector3& v) { return v.get128(); }
+	inline void setSimd(btVector3& v, __m128 m) { v.set128(m); }
+	inline btVector3 fromSimd(__m128 m) { return btVector3(m); }
+	inline btVector4 fromSimd4(__m128 m) { return btVector4(m); }
+#else
+	inline __m128 toSimd(const btVector3& v) { return _mm_loadu_ps(v.m_floats); }
+	inline void setSimd(btVector3& v, __m128 m) { _mm_storeu_ps(v.m_floats, m); }
+
+	inline btVector3 fromSimd(__m128 m)
+	{
+		btVector3 v;
+		setSimd(v, m);
+		return v;
+	}
+
+	inline btVector4 fromSimd4(__m128 m)
+	{
+		btVector4 v;
+		setSimd(v, m);
+		return v;
+	}
+#endif
+
 	template <int imm>
 	__m128 pshufd(__m128 m)
 	{
@@ -53,6 +86,10 @@ namespace hdt
 
 	inline float getLane3(__m128 v) { return _mm_cvtss_f32(pshufd<0xFF>(v)); }
 
+	// MSVC models __m128 as a class without arithmetic operators; GCC and Clang
+	// model it as a native vector type that already has them (scalar operands
+	// included), and reject operator overloads for non-class types.
+#if defined(_MSC_VER) && !defined(__clang__)
 	inline __m128& operator+=(__m128& l, __m128 r)
 	{
 		l = _mm_add_ps(l, r);
@@ -88,6 +125,7 @@ namespace hdt
 		l = _mm_mul_ps(l, setAll(r));
 		return l;
 	}
+#endif
 
 	inline __m128 cross(__m128 a, __m128 b)
 	{
@@ -188,8 +226,7 @@ namespace hdt
 			//0x30 inserts the 0th element of _mm_set_ss into the 3rd (W) element of t
 			m_originScale.mVec128 = _mm_insert_ps(t.get128(), _mm_set_ss(s), 0x30);
 #else
-			m_originScale = t;
-			m_originScale[3] = s;
+			m_originScale = btVector4(t.x(), t.y(), t.z(), s);
 #endif
 		}
 
@@ -199,8 +236,8 @@ namespace hdt
 #ifdef BT_ALLOW_SSE4
 			m_originScale.mVec128 = _mm_insert_ps(t.getOrigin().get128(), _mm_set_ss(s), 0x30);
 #else
-			m_originScale = t.getOrigin();
-			m_originScale[3] = s;
+			const btVector3& o = t.getOrigin();
+			m_originScale = btVector4(o.x(), o.y(), o.z(), s);
 #endif
 		}
 
@@ -236,9 +273,7 @@ namespace hdt
 #ifdef BT_ALLOW_SSE4
 			m_originScale.mVec128 = _mm_blend_ps(vec.get128(), m_originScale.get128(), 0b1000);
 #else
-			float s = getScale();
-			m_originScale = vec;
-			m_originScale[3] = s;
+			m_originScale = btVector4(vec.x(), vec.y(), vec.z(), getScale());
 #endif
 		}
 
@@ -272,8 +307,7 @@ namespace hdt
 #ifdef BT_ALLOW_SSE4
 			m_originScale.mVec128 = _mm_insert_ps(newOrigin.get128(), _mm_set_ss(newScale), 0x30);
 #else
-			m_originScale = newOrigin;
-			m_originScale[3] = newScale;
+			m_originScale = btVector4(newOrigin.x(), newOrigin.y(), newOrigin.z(), newScale);
 #endif
 		}
 
@@ -306,7 +340,7 @@ namespace hdt
 		btMatrix4x3(const btQsTransform& t)
 		{
 			reinterpret_cast<btMatrix3x3*>(this)->setRotation(t.getBasis());
-			__m128 scale = pshufd<0xFF>(t.getOrigin().get128());
+			__m128 scale = pshufd<0xFF>(toSimd(t.getOrigin()));
 			m_row[0] = _mm_mul_ps(m_row[0], scale);
 			m_row[1] = _mm_mul_ps(m_row[1], scale);
 			m_row[2] = _mm_mul_ps(m_row[2], scale);
@@ -318,14 +352,14 @@ namespace hdt
 		btVector3 operator*(const btVector3& rhs) const
 		{
 #ifdef BT_ALLOW_SSE4
-			auto v = _mm_blend_ps(rhs.get128(), _mm_set_ps1(1), 0x8);
+			auto v = _mm_blend_ps(toSimd(rhs), _mm_set_ps1(1), 0x8);
 			__m128 xmm0 = _mm_dp_ps(m_row[0], v, 0xF1);
 			__m128 xmm1 = _mm_dp_ps(m_row[1], v, 0xF2);
 			__m128 xmm2 = _mm_dp_ps(m_row[2], v, 0xF4);
 			xmm0 = _mm_or_ps(xmm0, xmm1);
 			xmm0 = _mm_or_ps(xmm0, xmm2);
 #else
-			auto v = rhs.get128();
+			auto v = toSimd(rhs);
 			v = setLane3(v, 1.0f);
 
 			__m128 xmm0 = _mm_mul_ps(m_row[0], v);
@@ -336,13 +370,13 @@ namespace hdt
 			xmm2 = _mm_hadd_ps(xmm2, xmm2);
 			xmm0 = _mm_hadd_ps(xmm0, xmm2);
 #endif
-			return xmm0;
+			return fromSimd(xmm0);
 		}
 
 		__m128 mulPack(const btVector3& rhs, float packW) const
 		{
 #ifdef BT_ALLOW_SSE4
-			auto v = _mm_blend_ps(rhs.get128(), _mm_set_ps1(1), 0x8);
+			auto v = _mm_blend_ps(toSimd(rhs), _mm_set_ps1(1), 0x8);
 			__m128 xmm0 = _mm_dp_ps(m_row[0], v, 0xF1);       // x, 0, 0, 0
 			__m128 xmm1 = _mm_dp_ps(m_row[1], v, 0xF2);       // 0, y, 0, 0
 			xmm0 = _mm_or_ps(xmm0, xmm1);                     // x, y, 0, 0
@@ -350,7 +384,7 @@ namespace hdt
 			xmm1 = _mm_unpacklo_ps(xmm1, _mm_set_ss(packW));  // z, w, 0, 0
 			xmm0 = _mm_movelh_ps(xmm0, xmm1);                 // x, y, z, w
 #else
-			auto v = rhs.get128();
+			auto v = toSimd(rhs);
 			v = setLane3(v, 1.0f);
 			auto w = _mm_load_ss(&packW);
 
@@ -381,11 +415,11 @@ namespace hdt
 			btMatrix3x3 rot;
 			rot.setRotation(t.getBasis());
 			rot = rot.transpose();
-			__m128 scale = pshufd<0xFF>(t.getOrigin().get128());
-			m_col[0] = rot[0].get128() * scale;
-			m_col[1] = rot[1].get128() * scale;
-			m_col[2] = rot[2].get128() * scale;
-			m_col[3] = t.getOrigin().get128();
+			__m128 scale = pshufd<0xFF>(toSimd(t.getOrigin()));
+			m_col[0] = fromSimd(_mm_mul_ps(toSimd(rot[0]), scale));
+			m_col[1] = fromSimd(_mm_mul_ps(toSimd(rot[1]), scale));
+			m_col[2] = fromSimd(_mm_mul_ps(toSimd(rot[2]), scale));
+			m_col[3] = t.getOrigin();
 		}
 
 		btVector3 operator*(const btVector3& rhs) const
@@ -417,7 +451,7 @@ namespace hdt
 	template <>
 	inline btVector3 abs(btVector3 rhs)
 	{
-		return _mm_andnot_ps(_mm_set_ps1(-0.f), rhs.get128());
+		return fromSimd(_mm_andnot_ps(_mm_set_ps1(-0.f), toSimd(rhs)));
 	}
 
 	template <class T>

--- a/src/physics/hdt/hdtCollider.cpp
+++ b/src/physics/hdt/hdtCollider.cpp
@@ -1,0 +1,350 @@
+#ifdef USE_BULLET
+
+#include "hdtCollider.h"
+#include <algorithm>
+
+namespace hdt
+{
+
+	void ColliderTree::insertCollider(const U32* keys, size_t keyCount, const Collider& c)
+	{
+		ColliderTree* p = this;
+		for (size_t i = 0; i < keyCount && i < 4; ++i) {
+			auto f = std::find_if(p->children.begin(), p->children.end(), [=](const ColliderTree& n) { return n.key == keys[i]; });
+			if (f == p->children.end()) {
+				p->children.push_back(ColliderTree(keys[i]));
+				p = &p->children.back();
+			} else
+				p = &*f;
+		}
+		p->colliders.push_back(c);
+	}
+
+	// finds overlapping pairs between two collider trees
+	void ColliderTree::checkCollisionL(ColliderTree* r, std::vector<std::pair<ColliderTree*, ColliderTree*>>& ret)
+	{
+		enum Mode : uint8_t
+		{
+			L,  // still splitting a, b is along for the ride
+			R   // a is a leaf, now drilling into b's subtree
+		};
+		struct Entry
+		{
+			ColliderTree* a;
+			ColliderTree* b;
+			Mode mode;
+		};
+		// thread_local: stack is .clear()-ed on each call, so worker thread
+		// recreation is harmless (fresh thread sees empty vector). The port
+		// runs collision dispatch serially, so no re-entry aliasing is
+		// possible; keep this in mind if parallelism is ever reintroduced.
+		thread_local std::vector<Entry> stack;
+		stack.clear();
+		stack.push_back({ this, r, L });
+		while (!stack.empty()) {
+			if (ret.size() > MaxCollisionPairs) {
+				break;
+			}
+
+			auto e = stack.back();
+			stack.pop_back();
+
+			if (e.a->isKinematic && e.b->isKinematic)
+				continue;
+
+			if (e.mode == L) {
+				if (!e.a->aabbAll.collideWith(e.b->aabbAll))
+					continue;
+
+				// a is a leaf — switch to R-mode and walk down b
+				if (e.a->numCollider && e.a->aabbMe.collideWith(e.b->aabbAll)) {
+					if (e.a->aabbMe.collideWith(e.b->aabbMe))
+						ret.push_back(std::make_pair(e.a, e.b));
+
+					auto begin = e.b->children.data();
+					// skip b's kinematic children if a is kinematic (would get culled above anyway)
+					auto end = begin + (e.a->isKinematic ? e.b->dynChild : e.b->children.size());
+					for (auto i = begin; i < end; ++i)
+						stack.push_back({ e.a, i, R });
+				}
+
+				// keep splitting a — same kinematic shortcut
+				auto begin = e.a->children.data();
+				auto end = begin + (e.b->isKinematic ? e.a->dynChild : e.a->children.size());
+				for (auto i = begin; i < end; ++i)
+					stack.push_back({ i, e.b, L });
+			} else {
+				// a is always a leaf here (L only pushes R when numCollider is set)
+				// numCollider check is technically redundant but whatever, it's cheap
+				if (!e.a->numCollider)
+					continue;
+				if (!e.a->aabbMe.collideWith(e.b->aabbAll))
+					continue;
+				if (e.a->aabbMe.collideWith(e.b->aabbMe))
+					ret.push_back(std::make_pair(e.a, e.b));
+
+				auto begin = e.b->children.data();
+				auto end = begin + (e.a->isKinematic ? e.b->dynChild : e.b->children.size());
+				for (auto i = begin; i < end; ++i)
+					stack.push_back({ e.a, i, R });
+			}
+		}
+	}
+
+	// dead code. checkCollisionL inlines R logic now. kept for API
+	void ColliderTree::checkCollisionR(ColliderTree* r, std::vector<std::pair<ColliderTree*, ColliderTree*>>& ret)
+	{
+		if (isKinematic && r->isKinematic)
+			return;
+
+		if (numCollider) {
+			if (!aabbMe.collideWith(r->aabbAll))
+				return;
+
+			if (aabbMe.collideWith(r->aabbMe))
+				ret.push_back(std::make_pair(this, r));
+
+			auto begin = r->children.data();
+			auto end = begin + (isKinematic ? r->dynChild : r->children.size());
+			for (auto i = begin; i < end; ++i)
+				checkCollisionR(i, ret);
+		}
+	}
+
+	void ColliderTree::clipCollider(const std::function<bool(const Collider&)>& func)
+	{
+		for (auto& i : children)
+			i.clipCollider(func);
+
+		colliders.erase(std::remove_if(colliders.begin(), colliders.end(), func), colliders.end());
+		children.erase(std::remove_if(children.begin(), children.end(),
+						   [](const ColliderTree& n) -> bool { return n.empty(); }),
+			children.end());
+	}
+
+	void ColliderTree::updateKinematic(const std::function<float(const Collider*)>& func)
+	{
+		U32 k = true;
+		for (auto& i : colliders) {
+			i.flexible = func(&i);
+			k &= i.flexible < FLT_EPSILON;
+		}
+
+		for (auto& i : children) {
+			i.updateKinematic(func);
+			k &= i.isKinematic;
+		}
+
+		std::sort(colliders.begin(), colliders.end(), [](const Collider& a, const Collider& b) {
+			return a.flexible > b.flexible;
+		});
+		std::sort(children.begin(), children.end(), [](const ColliderTree& a, const ColliderTree& b) {
+			return a.isKinematic < b.isKinematic;
+		});
+
+		isKinematic = k;
+
+		if (k) {
+			dynChild = dynCollider = 0;
+		} else {
+			for (dynChild = 0; dynChild < children.size(); ++dynChild)
+				if (children[dynChild].isKinematic)
+					break;
+
+			for (dynCollider = 0; dynCollider < colliders.size(); ++dynCollider)
+				if (colliders[dynCollider].flexible < FLT_EPSILON)
+					break;
+		}
+	}
+
+	void ColliderTree::updateAabb()
+	{
+		struct Frame
+		{
+			ColliderTree* node;
+			size_t childIdx;
+		};
+		thread_local std::vector<Frame> stack;
+		stack.clear();
+		stack.push_back({ this, 0 });
+
+		while (!stack.empty()) {
+			auto& f = stack.back();
+			if (f.childIdx < f.node->children.size()) {
+				auto* child = &f.node->children[f.childIdx++];
+				stack.push_back({ child, 0 });
+				continue;
+			}
+
+			auto* node = f.node;
+			stack.pop_back();
+
+			// old code merged into aabb[0] directly which nuked collider 0's actual bbox,
+			// making it always pass narrow-phase checks. accumulate in registers instead
+			if (node->numCollider) {
+				__m128 mn = node->aabb[0].m_min;
+				__m128 mx = node->aabb[0].m_max;
+				auto* aabbPtr = node->aabb + 1;
+				auto* aabbEnd = node->aabb + node->numCollider;
+				for (; aabbPtr < aabbEnd; ++aabbPtr) {
+					mn = _mm_min_ps(mn, aabbPtr->m_min);
+					mx = _mm_max_ps(mx, aabbPtr->m_max);
+				}
+				node->aabbMe.m_min = mn;
+				node->aabbMe.m_max = mx;
+			}
+
+			__m128 allMin = node->aabbMe.m_min;
+			__m128 allMax = node->aabbMe.m_max;
+			for (auto& child : node->children) {
+				allMin = _mm_min_ps(allMin, child.aabbAll.m_min);
+				allMax = _mm_max_ps(allMax, child.aabbAll.m_max);
+			}
+			node->aabbAll.m_min = allMin;
+			node->aabbAll.m_max = allMax;
+		}
+	}
+
+	void ColliderTree::visitColliders(const std::function<void(Collider*)>& func)
+	{
+		for (auto& i : colliders)
+			func(&i);
+
+		for (auto& i : children)
+			i.visitColliders(func);
+	}
+
+	void ColliderTree::optimize()
+	{
+		for (auto& i : children)
+			i.optimize();
+
+		children.erase(
+			std::remove_if(children.begin(), children.end(), [](const ColliderTree& n) { return n.empty(); }),
+			children.end());
+
+		while (children.size() == 1 && children[0].colliders.empty()) {
+			vectorA16<ColliderTree> temp;
+			temp.swap(children.front().children);
+			children.swap(temp);
+		}
+
+		if (children.size() == 1 && colliders.empty()) {
+			colliders = children[0].colliders;
+
+			vectorA16<ColliderTree> temp;
+			temp.swap(children[0].children);
+			children.swap(temp);
+		}
+	}
+
+	// same deal as checkCollisionL - iterative, early return still works since we just bail out of the loop
+	bool ColliderTree::collapseCollideL(ColliderTree* r)
+	{
+		enum Mode : uint8_t
+		{
+			L,
+			R
+		};
+		struct Entry
+		{
+			ColliderTree* a;
+			ColliderTree* b;
+			Mode mode;
+		};
+		thread_local std::vector<Entry> stack;
+		stack.clear();
+		stack.push_back({ this, r, L });
+
+		while (!stack.empty()) {
+			auto e = stack.back();
+			stack.pop_back();
+
+			if (e.a->isKinematic && e.b->isKinematic)
+				continue;
+
+			if (e.mode == L) {
+				if (!e.a->aabbAll.collideWith(e.b->aabbAll))
+					continue;
+
+				if (e.a->numCollider && e.a->aabbMe.collideWith(e.b->aabbAll)) {
+					if (e.a->aabbMe.collideWith(e.b->aabbMe))
+						return true;
+
+					auto begin = e.b->children.data();
+					auto end = begin + (e.a->isKinematic ? e.b->dynChild : e.b->children.size());
+					for (auto i = begin; i < end; ++i)
+						stack.push_back({ e.a, i, R });
+				}
+
+				auto begin = e.a->children.data();
+				auto end = begin + (e.b->isKinematic ? e.a->dynChild : e.a->children.size());
+				for (auto i = begin; i < end; ++i)
+					stack.push_back({ i, e.b, L });
+			} else {
+				if (!e.a->numCollider)
+					continue;
+				if (!e.a->aabbMe.collideWith(e.b->aabbAll))
+					continue;
+
+				if (e.a->aabbMe.collideWith(e.b->aabbMe))
+					return true;
+
+				auto begin = e.b->children.data();
+				auto end = begin + (e.a->isKinematic ? e.b->dynChild : e.b->children.size());
+				for (auto i = begin; i < end; ++i)
+					stack.push_back({ e.a, i, R });
+			}
+		}
+		return false;
+	}
+
+	// dead code.. collapseCollideL inlines R logic now. kept for API
+	bool ColliderTree::collapseCollideR(ColliderTree* r)
+	{
+		if (isKinematic && r->isKinematic)
+			return false;
+
+		if (numCollider) {
+			if (!aabbMe.collideWith(r->aabbAll))
+				return false;
+
+			if (aabbMe.collideWith(r->aabbMe))
+				return true;
+
+			auto begin = r->children.data();
+			auto end = begin + (isKinematic ? r->dynChild : r->children.size());
+			for (auto i = begin; i < end; ++i)
+				if (collapseCollideR(i))
+					return true;
+		}
+
+		return false;
+	}
+
+	void ColliderTree::exportColliders(vectorA16<Collider>& exportTo)
+	{
+		numCollider = static_cast<hdt::U32>(colliders.size());
+		cbuf = (Collider*)exportTo.size();
+		for (auto& i : colliders) {
+			exportTo.push_back(i);
+		}
+
+		for (auto& i : children)
+			i.exportColliders(exportTo);
+	}
+
+	void ColliderTree::remapColliders(Collider* start, Aabb* startAabb)
+	{
+		vectorA16<Collider> tmp;
+		colliders.swap(tmp);
+		auto offset = (size_t)cbuf;
+		cbuf = start + offset;
+		aabb = startAabb + offset;
+
+		for (auto& i : children)
+			i.remapColliders(start, startAabb);
+	}
+}
+
+#endif  // USE_BULLET

--- a/src/physics/hdt/hdtCollider.h
+++ b/src/physics/hdt/hdtCollider.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "hdtAABB.h"
+#include <functional>
+
+namespace hdt
+{
+	static const int MaxCollisionPairs = 6024;
+
+	struct alignas(16) Collider
+	{
+		Collider()
+		{
+		}
+
+		Collider(int i0) { vertex = i0; }
+		Collider(int i0, int i1, int i2) { vertices[0] = i0, vertices[1] = i1, vertices[2] = i2; }
+		Collider(const Collider& rhs) { operator=(rhs); }
+
+		Collider& operator=(const Collider& rhs)
+		{
+			__m128i* dst = (__m128i*)this;
+			__m128i* src = (__m128i*)&rhs;
+			auto xmm0 = _mm_load_si128(src + 0);
+			_mm_store_si128(dst, xmm0);
+			return *this;
+		}
+
+		union
+		{
+			U32 vertex;       // vertexshape
+			U32 vertices[3];  // triangleshape
+		};
+
+		float flexible;
+		//		inline bool operator <(const Collider& rhs){ return aligned < rhs.aligned; }
+	};
+
+	struct alignas(16) ColliderTree
+	{
+		ColliderTree()
+		{
+			aabbAll.invalidate();
+			aabbMe.invalidate();
+		}
+
+		ColliderTree(U32 k) :
+			key(k)
+		{
+			aabbAll.invalidate();
+			aabbMe.invalidate();
+		}
+
+		Aabb aabbAll;
+		Aabb aabbMe;
+
+		U32 isKinematic;
+
+		Collider* cbuf = nullptr;
+		Aabb* aabb;
+		U32 numCollider;
+		U32 dynCollider;
+
+		U32 dynChild;
+		vectorA16<ColliderTree> children;
+
+		vectorA16<Collider> colliders;
+		U32 key;
+
+		void insertCollider(const U32* keys, size_t keyCount, const Collider& c);
+		void exportColliders(vectorA16<Collider>& exportTo);
+		void remapColliders(Collider* start, Aabb* startAabb);
+
+		void checkCollisionL(ColliderTree* r, std::vector<std::pair<ColliderTree*, ColliderTree*>>& ret);
+		void checkCollisionR(ColliderTree* r, std::vector<std::pair<ColliderTree*, ColliderTree*>>& ret);
+		void clipCollider(const std::function<bool(const Collider&)>& func);
+		void updateKinematic(const std::function<float(const Collider*)>& func);
+		void visitColliders(const std::function<void(Collider*)>& func);
+		void updateAabb();
+		void optimize();
+
+		bool empty() const { return children.empty() && colliders.empty(); }
+
+		bool collapseCollideL(ColliderTree* r);
+		bool collapseCollideR(ColliderTree* r);
+	};
+}

--- a/src/physics/hdt/hdtConeTwistConstraint.cpp
+++ b/src/physics/hdt/hdtConeTwistConstraint.cpp
@@ -1,0 +1,36 @@
+#ifdef USE_BULLET
+
+#include "hdtConeTwistConstraint.h"
+
+namespace hdt
+{
+	ConeTwistConstraint::ConeTwistConstraint(SkinnedMeshBone* a, SkinnedMeshBone* b, const btTransform& frameInA, const btTransform& frameInB) :
+		BoneScaleConstraint(a, b, static_cast<btConeTwistConstraint*>(this)),
+		btConeTwistConstraint(a->m_rig, b->m_rig, btTransform::getIdentity(), btTransform::getIdentity())
+	{
+		auto fa = a->m_rigToLocal * frameInA;
+		auto fb = b->m_rigToLocal * frameInB;
+		setFrames(fa, fb);
+
+		enableMotor(false);  // motor temporary not support
+	}
+
+	void ConeTwistConstraint::scaleConstraint()
+	{
+		auto newScaleA = m_boneA->m_currentTransform.getScale();
+		auto newScaleB = m_boneB->m_currentTransform.getScale();
+
+		if (btFuzzyZero(newScaleA - m_scaleA) && btFuzzyZero(newScaleB - m_scaleB))
+			return;
+
+		auto frameA = getFrameOffsetA();
+		auto frameB = getFrameOffsetB();
+		frameA.setOrigin(frameA.getOrigin() * (newScaleA / m_scaleA));
+		frameB.setOrigin(frameB.getOrigin() * (newScaleB / m_scaleB));
+		setFrames(frameA, frameB);
+		m_scaleA = newScaleA;
+		m_scaleB = newScaleB;
+	}
+}
+
+#endif  // USE_BULLET

--- a/src/physics/hdt/hdtConeTwistConstraint.h
+++ b/src/physics/hdt/hdtConeTwistConstraint.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "hdtBoneScaleConstraint.h"
+
+namespace hdt
+{
+	class ConeTwistConstraint :
+		public BoneScaleConstraint,
+		public btConeTwistConstraint
+	{
+	public:
+		BT_DECLARE_ALIGNED_ALLOCATOR();
+
+		ConeTwistConstraint(SkinnedMeshBone* a, SkinnedMeshBone* b, const btTransform& frameInA, const btTransform& frameInB);
+		virtual ~ConeTwistConstraint() override = default;
+
+		void scaleConstraint() override;
+	};
+}

--- a/src/physics/hdt/hdtConstraintGroup.h
+++ b/src/physics/hdt/hdtConstraintGroup.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "hdtBoneScaleConstraint.h"
+
+namespace hdt
+{
+	class ConstraintGroup : public RefObject
+	{
+	public:
+		void scaleConstraint()
+		{
+			for (auto& i : m_constraints)
+				i->scaleConstraint();
+		}
+		std::vector<Ref<BoneScaleConstraint>> m_constraints;
+	};
+}

--- a/src/physics/hdt/hdtDispatcher.cpp
+++ b/src/physics/hdt/hdtDispatcher.cpp
@@ -1,0 +1,174 @@
+#ifdef USE_BULLET
+
+#include "hdtDispatcher.h"
+#include "hdtSkinnedMeshAlgorithm.h"
+#include "hdtSkinnedMeshBody.h"
+
+#include <LinearMath/btPoolAllocator.h>
+#include <algorithm>
+
+namespace hdt
+{
+	void CollisionDispatcher::clearAllManifold()
+	{
+		std::lock_guard<decltype(m_lock)> l(m_lock);
+		for (int i = 0; i < m_manifoldsPtr.size(); ++i) {
+			auto manifold = m_manifoldsPtr[i];
+			manifold->~btPersistentManifold();
+			if (m_persistentManifoldPoolAllocator->validPtr(manifold))
+				m_persistentManifoldPoolAllocator->freeMemory(manifold);
+			else
+				btAlignedFree(manifold);
+		}
+		m_manifoldsPtr.clear();
+	}
+
+	bool needsCollision(const SkinnedMeshBody* shape0, const SkinnedMeshBody* shape1)
+	{
+		if (!shape0 || !shape1 || shape0 == shape1)
+			return false;
+
+		if (shape0->m_isKinematic && shape1->m_isKinematic)
+			return false;
+
+		return shape0->canCollideWith(shape1) && shape1->canCollideWith(shape0);
+	}
+
+	static inline bool isSkinnedMesh(const btCollisionObject* obj)
+	{
+		return obj->getCollisionShape()->getShapeType() == CUSTOM_CONCAVE_SHAPE_TYPE;
+	}
+
+	bool CollisionDispatcher::needsCollision(const btCollisionObject* body0, const btCollisionObject* body1)
+	{
+		bool skinned0 = isSkinnedMesh(body0);
+		bool skinned1 = isSkinnedMesh(body1);
+
+		if (skinned0 || skinned1) {
+			auto shape0 = skinned0 ? static_cast<const SkinnedMeshBody*>(body0) : nullptr;
+			auto shape1 = skinned1 ? static_cast<const SkinnedMeshBody*>(body1) : nullptr;
+			return hdt::needsCollision(shape0, shape1);
+		}
+
+		if (body0->isStaticOrKinematicObject() && body1->isStaticOrKinematicObject())
+			return false;
+
+		// Todo: This is likely dead code as only skinned objects can collide as of right now (3/20/2026)
+		if (body0->checkCollideWith(body1) || body1->checkCollideWith(body0)) {
+			auto rb0 = static_cast<SkinnedMeshBone*>(body0->getUserPointer());
+			auto rb1 = static_cast<SkinnedMeshBone*>(body1->getUserPointer());
+
+			return rb0->canCollideWith(rb1) && rb1->canCollideWith(rb0);
+		} else
+			return false;
+	}
+
+	// Docs: This is called by Bullet's broad phase, which finds pairs that may be colliding. We built these aabb's inside SkinnedMeshBody::updateBoundingSphereAabb() using Skyrim's bone
+	// spheres. This function checks if those pairs are even allowed to collide, updates the skinned shapes, then passes it to the next few phases of collision checks.
+	// Collision phases are: Bullet's broadphase, our BVH midphase, then finally our narrowphase
+	void CollisionDispatcher::dispatchAllCollisionPairs(btOverlappingPairCache* pairCache, [[maybe_unused]] const btDispatcherInfo& dispatchInfo, [[maybe_unused]] btDispatcher* dispatcher)
+	{
+		BT_PROFILE("HDTSMP_dispatchAllCollisionPairs");
+
+		auto size = pairCache->getNumOverlappingPairs();
+		if (!size)
+			return;
+
+		m_pairs.reserve(size);
+		auto pairs = pairCache->getOverlappingPairArrayPtr();
+		std::vector<SkinnedMeshBody*> bodies;
+
+		// SkinnedMeshBody:internalUpdate() already calls m_shape->internalUpdate() for both
+		// PerVertexShape and PerTriangleShape, so separate vertex/triangle shape update lists are
+		// unnecessary. The only shapes not covered are the m_verticesCollision companions
+		// that PerTriangleShape creates for triangle-vs-triangle collision pairs.
+		// Tldr: Triangle shapes ARE still updated because body->internalUpdate() handles them
+		std::vector<PerVertexShape*> extra_vertex_shapes;
+
+		bodies.reserve(size * 2);
+		extra_vertex_shapes.reserve(size);
+
+		for (int i = 0; i < size; ++i) {
+			auto& pair = pairs[i];
+			auto obj0 = static_cast<btCollisionObject*>(pair.m_pProxy0->m_clientObject);
+			auto obj1 = static_cast<btCollisionObject*>(pair.m_pProxy1->m_clientObject);
+
+			bool skinned0 = isSkinnedMesh(obj0);
+			bool skinned1 = isSkinnedMesh(obj1);
+
+			if (skinned0 || skinned1) {
+				auto shape0 = skinned0 ? static_cast<SkinnedMeshBody*>(obj0) : nullptr;
+				auto shape1 = skinned1 ? static_cast<SkinnedMeshBody*>(obj1) : nullptr;
+
+				if (hdt::needsCollision(shape0, shape1)) {
+					bodies.push_back(shape0);
+					bodies.push_back(shape1);
+					m_pairs.push_back(std::make_pair(shape0, shape1));
+
+					auto a = shape0->m_shape->asPerTriangleShape();
+					auto b = shape1->m_shape->asPerTriangleShape();
+
+					if (a && b) {
+						extra_vertex_shapes.push_back(a->m_verticesCollision.get());
+						extra_vertex_shapes.push_back(b->m_verticesCollision.get());
+					}
+				}
+			} else {
+				// [3/13/2026]
+				// This should never be called. We do addRigidBody(&system->m_bones[i]->m_rig, 0, 0) which means it's invisible
+				// to bullet's collision detector entirely. Why is this here? Likely in preparation for non-skinned objects..?
+				getNearCallback()(pair, *this, dispatchInfo);
+			}
+		}
+
+		// Wipe duplicates, since we don't want to reskin anything!
+		std::sort(bodies.begin(), bodies.end());
+		bodies.erase(std::unique(bodies.begin(), bodies.end()), bodies.end());
+
+		std::sort(extra_vertex_shapes.begin(), extra_vertex_shapes.end());
+		extra_vertex_shapes.erase(std::unique(extra_vertex_shapes.begin(), extra_vertex_shapes.end()), extra_vertex_shapes.end());
+
+		par::for_each(bodies.begin(), bodies.end(), [](SkinnedMeshBody* shape) {
+			if (shape->m_useBoundingSphere)
+				shape->internalUpdate();
+		});
+
+		if (!extra_vertex_shapes.empty()) {
+			par::for_each(extra_vertex_shapes.begin(), extra_vertex_shapes.end(), [](PerVertexShape* shape) {
+				shape->internalUpdate();
+			});
+		}
+
+		{
+			BT_PROFILE("HDTSMP_collision_pair_checks");
+
+			par::for_each(m_pairs.begin(), m_pairs.end(), [&, this](const std::pair<SkinnedMeshBody*, SkinnedMeshBody*>& i) {
+				// collapseCollideL is a candidate for optimizations since we'll re-traverse the tree in checkCollisionL. However,
+				// it's a bit tricky since collapse has an early-exit, and avoiding boilerplate is ideal. A traversal resume maybe?
+				if (i.first->m_shape->m_tree.collapseCollideL(&i.second->m_shape->m_tree)) {
+					BT_PROFILE("HDTSMP_processCollision");
+					SkinnedMeshAlgorithm::processCollision(i.first, i.second, this);
+				}
+			});
+		}
+
+		m_pairs.clear();
+	}
+
+	int CollisionDispatcher::getNumManifolds() const
+	{
+		return m_manifoldsPtr.size();
+	}
+
+	btPersistentManifold* CollisionDispatcher::getManifoldByIndexInternal(int index)
+	{
+		return m_manifoldsPtr[index];
+	}
+
+	btPersistentManifold** CollisionDispatcher::getInternalManifoldPointer()
+	{
+		return btCollisionDispatcher::getInternalManifoldPointer();
+	}
+}
+
+#endif  // USE_BULLET

--- a/src/physics/hdt/hdtDispatcher.h
+++ b/src/physics/hdt/hdtDispatcher.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "BulletCollision/CollisionDispatch/btCollisionDispatcher.h"
+#include "hdtBulletHelper.h"
+#include <mutex>
+#include <vector>
+
+namespace hdt
+{
+	class SkinnedMeshBody;
+
+	// Upstream derives from btCollisionDispatcherMt, which requires a global
+	// Bullet task scheduler and a BT_THREADSAFE build of Bullet (stock
+	// vcpkg/distro packages have neither). This port dispatches serially, so
+	// the plain btCollisionDispatcher base provides identical behavior.
+	class CollisionDispatcher : public btCollisionDispatcher
+	{
+	public:
+		CollisionDispatcher(btCollisionConfiguration* collisionConfiguration) :
+			btCollisionDispatcher(
+				collisionConfiguration)
+		{
+		}
+
+		btPersistentManifold* getNewManifold(const btCollisionObject* b0, const btCollisionObject* b1) override
+		{
+			std::lock_guard<decltype(m_lock)> l(m_lock);
+			auto ret = btCollisionDispatcher::getNewManifold(b0, b1);
+			return ret;
+		}
+
+		void releaseManifold(btPersistentManifold* manifold) override
+		{
+			std::lock_guard<decltype(m_lock)> l(m_lock);
+			btCollisionDispatcher::releaseManifold(manifold);
+		}
+
+		bool needsCollision(const btCollisionObject* body0, const btCollisionObject* body1) override;
+		void dispatchAllCollisionPairs(btOverlappingPairCache* pairCache, const btDispatcherInfo& dispatchInfo,
+			btDispatcher* dispatcher) override;
+
+		int getNumManifolds() const override;
+		btPersistentManifold** getInternalManifoldPointer() override;
+		btPersistentManifold* getManifoldByIndexInternal(int index) override;
+
+		void clearAllManifold();
+
+		hdt::SpinLock m_lock;
+		std::vector<std::pair<SkinnedMeshBody*, SkinnedMeshBody*>> m_pairs;
+	};
+}

--- a/src/physics/hdt/hdtGeneric6DofConstraint.cpp
+++ b/src/physics/hdt/hdtGeneric6DofConstraint.cpp
@@ -1,0 +1,58 @@
+#ifdef USE_BULLET
+
+#include "hdtGeneric6DofConstraint.h"
+
+namespace hdt
+{
+	Generic6DofConstraint::Generic6DofConstraint(SkinnedMeshBone* a, SkinnedMeshBone* b, const btTransform& frameInA, const btTransform& frameInB) :
+		BoneScaleConstraint(a, b, static_cast<btTypedConstraint*>(this)),
+		btGeneric6DofSpring2Constraint(a->m_rig, b->m_rig, btTransform::getIdentity(), btTransform::getIdentity(), RO_XYZ)
+	{
+		auto fa = a->m_rigToLocal * frameInA;
+		auto fb = b->m_rigToLocal * frameInB;
+		setFrames(fa, fb);
+
+		for (int i = 0; i < 6; ++i)
+			enableSpring(i, true);
+
+		//m_linearLimits.m_stopERP.setValue(0.1f, 0.1f, 0.1f);
+
+		//m_oldLinearDiff.setZero();
+		//m_oldAngularDiff.setZero();
+		//m_linearBounce.setZero();
+	}
+
+	void Generic6DofConstraint::scaleConstraint()
+	{
+		auto newScaleA = m_boneA->m_currentTransform.getScale();
+		auto newScaleB = m_boneB->m_currentTransform.getScale();
+
+		if (btFuzzyZero(newScaleA - m_scaleA) && btFuzzyZero(newScaleB - m_scaleB))
+			return;
+
+		float w0 = m_boneA->m_rig.getInvMass();
+		float w1 = m_boneB->m_rig.getInvMass();
+		auto factorA = newScaleA / m_scaleA;
+		auto factorB = newScaleB / m_scaleB;
+		auto factor = (factorA * w0 + factorB * w1) / (w0 + w1);
+		auto factor2 = factor * factor;
+		auto factor3 = factor2 * factor;
+		auto factor5 = factor3 * factor2;
+
+		getFrameOffsetA().setOrigin(getFrameOffsetA().getOrigin() * factorA);
+		getFrameOffsetB().setOrigin(getFrameOffsetB().getOrigin() * factorB);
+		m_linearLimits.m_equilibriumPoint *= factor;
+		// target k = ma / x(kg/s^2)
+		m_linearLimits.m_springStiffness *= factor3;
+		m_linearLimits.m_upperLimit *= factor;
+		m_linearLimits.m_lowerLimit *= factor;
+		for (int i = 0; i < 3; ++i) {
+			m_angularLimits[i].m_springStiffness *= factor5;
+		}
+
+		m_scaleA = newScaleA;
+		m_scaleB = newScaleB;
+	}
+}
+
+#endif  // USE_BULLET

--- a/src/physics/hdt/hdtGeneric6DofConstraint.h
+++ b/src/physics/hdt/hdtGeneric6DofConstraint.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "hdtBoneScaleConstraint.h"
+#include "hdtBulletHelper.h"
+
+namespace hdt
+{
+	class Generic6DofConstraint :
+		public BoneScaleConstraint,
+		public btGeneric6DofSpring2Constraint
+	{
+	public:
+		BT_DECLARE_ALIGNED_ALLOCATOR();
+
+		Generic6DofConstraint(SkinnedMeshBone* a, SkinnedMeshBone* b, const btTransform& frameInA, const btTransform& frameInB);
+		virtual ~Generic6DofConstraint() override = default;
+
+		void scaleConstraint() override;
+
+	private:
+	};
+}

--- a/src/physics/hdt/hdtRefUtils.h
+++ b/src/physics/hdt/hdtRefUtils.h
@@ -1,0 +1,164 @@
+#pragma once
+
+// Standard C++ replacements for the game-engine facilities the original
+// hdtSMP64 code relied on (CommonLibSSE smart pointers and interned strings,
+// Intel TBB parallel loops). Simulation code is otherwise ported unchanged.
+//
+// The only file in this directory without an upstream counterpart; see
+// README.md for where the rest comes from and under which license.
+
+#include <atomic>
+#include <cctype>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+
+#if defined(_MSC_VER)
+#define HDT_FORCEINLINE __forceinline
+#else
+#define HDT_FORCEINLINE inline __attribute__((always_inline))
+#endif
+
+// used between the struct/class keyword and the type name
+#define HDT_ALIGN16 alignas(16)
+
+namespace hdt {
+// Intrusive ref-count base replacing RE::BSIntrusiveRefCounted. Ref<T> deletes
+// the object when the count returns to zero.
+class RefCounted {
+public:
+	RefCounted() = default;
+	RefCounted(const RefCounted&) {}
+	RefCounted& operator=(const RefCounted&) { return *this; }
+	virtual ~RefCounted() = default;
+
+	uint32_t IncRef() const { return ++m_refCount; }
+	uint32_t DecRef() const { return --m_refCount; }
+	long getRefCount() const { return m_refCount; }
+
+private:
+	mutable std::atomic<uint32_t> m_refCount{0};
+};
+
+// Intrusive smart pointer replacing RE::BSTSmartPointer.
+template<class T>
+class Ref {
+public:
+	Ref() = default;
+	Ref(std::nullptr_t) {}
+	Ref(T* p)
+		: m_ptr(p) {
+		if (m_ptr)
+			m_ptr->IncRef();
+	}
+	Ref(const Ref& o)
+		: Ref(o.m_ptr) {}
+	Ref(Ref&& o) noexcept
+		: m_ptr(o.m_ptr) {
+		o.m_ptr = nullptr;
+	}
+	template<class U>
+	Ref(const Ref<U>& o)
+		: Ref(static_cast<T*>(o.get())) {}
+	~Ref() { reset(); }
+
+	Ref& operator=(const Ref& o) {
+		Ref(o).swap(*this);
+		return *this;
+	}
+	Ref& operator=(Ref&& o) noexcept {
+		Ref(std::move(o)).swap(*this);
+		return *this;
+	}
+	Ref& operator=(T* p) {
+		Ref(p).swap(*this);
+		return *this;
+	}
+
+	void reset() {
+		if (m_ptr) {
+			if (m_ptr->DecRef() == 0)
+				delete m_ptr;
+			m_ptr = nullptr;
+		}
+	}
+	void swap(Ref& o) noexcept { std::swap(m_ptr, o.m_ptr); }
+
+	T* get() const { return m_ptr; }
+	T* operator->() const { return m_ptr; }
+	T& operator*() const { return *m_ptr; }
+	explicit operator bool() const { return m_ptr != nullptr; }
+	bool operator==(const Ref& o) const { return m_ptr == o.m_ptr; }
+	bool operator!=(const Ref& o) const { return m_ptr != o.m_ptr; }
+	bool operator==(const T* p) const { return m_ptr == p; }
+	bool operator!=(const T* p) const { return m_ptr != p; }
+
+private:
+	T* m_ptr = nullptr;
+};
+
+template<class T>
+Ref<T> make_ref(T* p) {
+	return Ref<T>(p);
+}
+
+// Case-insensitive string replacing RE::BSFixedString. Skyrim bone and tag
+// names match case-insensitively; SMP XMLs in the wild depend on that.
+class IDStr {
+public:
+	IDStr() = default;
+	IDStr(const char* s)
+		: m_str(s ? s : "") {}
+	IDStr(std::string s)
+		: m_str(std::move(s)) {}
+
+	const char* c_str() const { return m_str.c_str(); }
+	const std::string& str() const { return m_str; }
+	bool empty() const { return m_str.empty(); }
+
+	bool operator==(const IDStr& o) const {
+		if (m_str.size() != o.m_str.size())
+			return false;
+		for (size_t i = 0; i < m_str.size(); ++i)
+			if (std::tolower(static_cast<unsigned char>(m_str[i])) != std::tolower(static_cast<unsigned char>(o.m_str[i])))
+				return false;
+		return true;
+	}
+	bool operator!=(const IDStr& o) const { return !(*this == o); }
+
+private:
+	std::string m_str;
+};
+
+// Serial replacements for the TBB parallel loops of the original. The preview
+// simulates a single actor, so parallelism is a contained future optimization.
+namespace par {
+	template<class It, class Fn>
+	void for_each(It begin, It end, Fn fn) {
+		for (; begin != end; ++begin)
+			fn(*begin);
+	}
+	template<class Index, class Fn>
+	void for_range(Index begin, Index end, Fn fn) {
+		for (Index i = begin; i != end; ++i)
+			fn(i);
+	}
+}
+}
+
+namespace std {
+template<>
+struct hash<hdt::IDStr> {
+	size_t operator()(const hdt::IDStr& s) const {
+		// FNV-1a over lowercased bytes so hashing matches the
+		// case-insensitive equality.
+		size_t h = 14695981039346656037ull;
+		for (const char c : s.str()) {
+			h ^= static_cast<size_t>(std::tolower(static_cast<unsigned char>(c)));
+			h *= 1099511628211ull;
+		}
+		return h;
+	}
+};
+}

--- a/src/physics/hdt/hdtSkinnedMeshAlgorithm.cpp
+++ b/src/physics/hdt/hdtSkinnedMeshAlgorithm.cpp
@@ -165,8 +165,8 @@ namespace hdt
 				penetration = 0;
 			}
 
-			auto ab = (p1.pos() - p0.pos()).get128();
-			auto ac = (p2.pos() - p0.pos()).get128();
+			auto ab = toSimd(p1.pos() - p0.pos());
+			auto ac = toSimd(p2.pos() - p0.pos());
 			auto raw_normal = cross_product(ab, ac);
 			auto len = _mm_sqrt_ps(_mm_dp_ps(raw_normal, raw_normal, 0x77));
 			if (_mm_cvtss_f32(len) < FLT_EPSILON) {
@@ -178,10 +178,10 @@ namespace hdt
 				penetration = -penetration;
 			}
 
-			auto ap = (s.pos() - p0.pos()).get128();
+			auto ap = toSimd(s.pos() - p0.pos());
 			auto distance = _mm_dp_ps(ap, normal, 0x77);
 			float distanceFromPlane = _mm_cvtss_f32(distance);
-			auto projection = _mm_sub_ps(s.pos().get128(), _mm_mul_ps(normal, distance));
+			auto projection = _mm_sub_ps(toSimd(s.pos()), _mm_mul_ps(normal, distance));
 			float radiusWithMargin = r + margin;
 			bool isInsideContactPlane;
 			if (penetration >= FLT_EPSILON)
@@ -200,9 +200,9 @@ namespace hdt
 			}
 
 			// Compute (twice) area of each triangle between projection and two triangle points
-			ap = _mm_sub_ps(projection, p0.pos().get128());
-			auto bp = _mm_sub_ps(projection, p1.pos().get128());
-			auto cp = _mm_sub_ps(projection, p2.pos().get128());
+			ap = _mm_sub_ps(projection, toSimd(p0.pos()));
+			auto bp = _mm_sub_ps(projection, toSimd(p1.pos()));
+			auto cp = _mm_sub_ps(projection, toSimd(p2.pos()));
 			auto aa = cross_product(bp, cp);
 			ab = cross_product(cp, ap);
 			ac = cross_product(ap, bp);
@@ -220,9 +220,9 @@ namespace hdt
 			res.colliderA = a;
 			res.colliderB = b;
 			if (pointInTriangle) {
-				res.normOnB.set128(normal);
+				setSimd(res.normOnB, normal);
 				res.posA = s.pos() - res.normOnB * r;
-				res.posB.set128(projection);
+				setSimd(res.posB, projection);
 				res.depth = distanceFromPlane - radiusWithMargin;
 				return res.depth < -FLT_EPSILON;
 			}

--- a/src/physics/hdt/hdtSkinnedMeshAlgorithm.cpp
+++ b/src/physics/hdt/hdtSkinnedMeshAlgorithm.cpp
@@ -1,0 +1,530 @@
+#ifdef USE_BULLET
+
+#include "hdtSkinnedMeshAlgorithm.h"
+#include "hdtCollider.h"
+
+namespace hdt
+{
+
+	// CollisionCheckBase1 provides data members and the basic constructor for the target types. Note that we
+	// always collide a vertex shape against something else, so only the second type is templated.
+	template <typename T>
+	struct CollisionCheckBase1
+	{
+		typedef typename PerVertexShape::ShapeProp SP0;
+		typedef typename T::ShapeProp SP1;
+
+		CollisionCheckBase1(PerVertexShape* a, T* b, CollisionResult* r)
+		{
+			v0 = a->m_owner->m_vpos.data();
+			v1 = b->m_owner->m_vpos.data();
+			c0 = &a->m_tree;
+			c1 = &b->m_tree;
+			sp0 = &a->m_shapeProp;
+			sp1 = &b->m_shapeProp;
+			results = r;
+			numResults = 0;
+		}
+
+		VertexPos* v0;
+		VertexPos* v1;
+		ColliderTree* c0;
+		ColliderTree* c1;
+		SP0* sp0;
+		SP1* sp1;
+
+		std::atomic_long numResults;
+		CollisionResult* results;
+	};
+
+	// CollisionCheckBase2 provides the method to add results, swapping the colliders if necessary. This
+	// means we can support triangle-sphere collisions by reversing the input shapes and setting SwapResults
+	// to true, instead of having two almost identical versions of the same lower-level algorithm.
+	template <typename T, bool SwapResults>
+	struct CollisionCheckBase2;
+
+	template <typename T>
+	struct CollisionCheckBase2<T, false> : public CollisionCheckBase1<T>
+	{
+		template <typename... Ts>
+		CollisionCheckBase2(Ts&&... ts) :
+			CollisionCheckBase1<T>(std::forward<Ts>(ts)...)
+		{}
+
+		bool addResult(const CollisionResult& res)
+		{
+			int p = this->numResults.fetch_add(1);
+			if (p < SkinnedMeshAlgorithm::MaxCollisionCount) {
+				this->results[p] = res;
+				return true;
+			}
+			return false;
+		}
+	};
+
+	template <typename T>
+	struct CollisionCheckBase2<T, true> : public CollisionCheckBase1<T>
+	{
+		template <typename... Ts>
+		CollisionCheckBase2(Ts&&... ts) :
+			CollisionCheckBase1<T>(std::forward<Ts>(ts)...)
+		{}
+
+		bool addResult(const CollisionResult& res)
+		{
+			int p = this->numResults.fetch_add(1);
+			if (p < SkinnedMeshAlgorithm::MaxCollisionCount) {
+				this->results[p].posA = res.posB;
+				this->results[p].posB = res.posA;
+				this->results[p].colliderA = res.colliderB;
+				this->results[p].colliderB = res.colliderA;
+				this->results[p].normOnB = -res.normOnB;
+				this->results[p].depth = res.depth;
+				return true;
+			}
+			return false;
+		}
+	};
+
+	// CollisionChecker provides the checkCollide method, which handles a single pair of colliders. This does
+	// the accurate collision check for the CPU algorithms. GPU algorithms will provide their own methods for
+	// this, and should derive directly from CollisionCheckBase2.
+	template <typename T, bool SwapResults>
+	struct CollisionChecker;
+
+	template <bool SwapResults>
+	struct CollisionChecker<PerVertexShape, SwapResults> : public CollisionCheckBase2<PerVertexShape, SwapResults>
+	{
+		template <typename... Ts>
+		CollisionChecker(Ts&&... ts) :
+			CollisionCheckBase2<PerVertexShape, SwapResults>(std::forward<Ts>(ts)...)
+		{}
+
+		bool checkCollide(Collider* a, Collider* b, CollisionResult& res)
+		{
+			auto s0 = this->v0[a->vertex];
+			auto r0 = s0.marginMultiplier() * this->sp0->margin;
+			auto s1 = this->v1[b->vertex];
+			auto r1 = s1.marginMultiplier() * this->sp1->margin;
+
+			auto pos0 = s0.pos();
+			auto pos1 = s1.pos();
+			auto diff = pos0 - pos1;
+			auto dist2 = diff.length2();
+			auto radiusSum = r0 + r1;
+			if (dist2 > radiusSum * radiusSum)
+				return false;
+
+			auto len = btSqrt(dist2);
+			auto normal = btVector3(1, 0, 0);
+			if (len > FLT_EPSILON)
+				normal = diff / len;
+
+			res.normOnB = normal;
+			res.depth = len - radiusSum;
+			res.posA = pos0 - normal * r0;
+			res.posB = pos1 + normal * r1;
+			res.colliderA = a;
+			res.colliderB = b;
+			return true;
+		}
+	};
+
+	namespace
+	{
+		inline __m128 cross_product(__m128 const& vec0, __m128 const& vec1)
+		{
+			__m128 tmp0 = _mm_shuffle_ps(vec0, vec0, _MM_SHUFFLE(3, 0, 2, 1));
+			__m128 tmp1 = _mm_shuffle_ps(vec1, vec1, _MM_SHUFFLE(3, 1, 0, 2));
+			__m128 tmp2 = _mm_mul_ps(tmp0, vec1);
+			__m128 tmp3 = _mm_mul_ps(tmp0, tmp1);
+			__m128 tmp4 = _mm_shuffle_ps(tmp2, tmp2, _MM_SHUFFLE(3, 0, 2, 1));
+			return _mm_sub_ps(tmp3, tmp4);
+		}
+	}
+
+	template <bool SwapResults>
+	struct CollisionChecker<PerTriangleShape, SwapResults> : public CollisionCheckBase2<PerTriangleShape, SwapResults>
+	{
+		template <typename... Ts>
+		CollisionChecker(Ts&&... ts) :
+			CollisionCheckBase2<PerTriangleShape, SwapResults>(std::forward<Ts>(ts)...)
+		{}
+
+		bool checkCollide(Collider* a, Collider* b, CollisionResult& res)
+		{
+			auto s = this->v0[a->vertex];
+			auto r = s.marginMultiplier() * this->sp0->margin;
+			auto p0 = this->v1[b->vertices[0]];
+			auto p1 = this->v1[b->vertices[1]];
+			auto p2 = this->v1[b->vertices[2]];
+			auto margin = (p0.marginMultiplier() + p1.marginMultiplier() + p2.marginMultiplier()) * (1.0f / 3.0f);
+			auto penetration = this->sp1->penetration * margin;
+			margin *= this->sp1->margin;
+			if (penetration > -FLT_EPSILON && penetration < FLT_EPSILON) {
+				penetration = 0;
+			}
+
+			auto ab = (p1.pos() - p0.pos()).get128();
+			auto ac = (p2.pos() - p0.pos()).get128();
+			auto raw_normal = cross_product(ab, ac);
+			auto len = _mm_sqrt_ps(_mm_dp_ps(raw_normal, raw_normal, 0x77));
+			if (_mm_cvtss_f32(len) < FLT_EPSILON) {
+				return false;
+			}
+			auto normal = _mm_div_ps(raw_normal, len);
+			if (penetration < 0) {
+				normal = _mm_sub_ps(_mm_setzero_ps(), normal);
+				penetration = -penetration;
+			}
+
+			auto ap = (s.pos() - p0.pos()).get128();
+			auto distance = _mm_dp_ps(ap, normal, 0x77);
+			float distanceFromPlane = _mm_cvtss_f32(distance);
+			auto projection = _mm_sub_ps(s.pos().get128(), _mm_mul_ps(normal, distance));
+			float radiusWithMargin = r + margin;
+			bool isInsideContactPlane;
+			if (penetration >= FLT_EPSILON)
+				isInsideContactPlane = distanceFromPlane < radiusWithMargin && distanceFromPlane >= -penetration;
+			else {
+				if (distanceFromPlane < 0) {
+					distanceFromPlane = -distanceFromPlane;
+					normal = _mm_sub_ps(_mm_setzero_ps(), normal);
+				}
+				isInsideContactPlane = distanceFromPlane < radiusWithMargin;
+			}
+
+			// This has a very high early rejection rate, up to ~60% average
+			if (!isInsideContactPlane) {
+				return false;
+			}
+
+			// Compute (twice) area of each triangle between projection and two triangle points
+			ap = _mm_sub_ps(projection, p0.pos().get128());
+			auto bp = _mm_sub_ps(projection, p1.pos().get128());
+			auto cp = _mm_sub_ps(projection, p2.pos().get128());
+			auto aa = cross_product(bp, cp);
+			ab = cross_product(cp, ap);
+			ac = cross_product(ap, bp);
+			aa = _mm_dp_ps(aa, aa, 0x74);
+			ab = _mm_dp_ps(ab, ab, 0x72);
+			ac = _mm_dp_ps(ac, ac, 0x71);
+			aa = _mm_or_ps(aa, ab);
+			aa = _mm_or_ps(aa, ac);
+			aa = _mm_sqrt_ps(aa);
+			// Now if every pair of elements in aa sums to no more than area, then the point is inside the triangle
+			aa = _mm_add_ps(aa, _mm_shuffle_ps(aa, aa, _MM_SHUFFLE(3, 0, 2, 1)));
+			aa = _mm_cmpgt_ps(aa, len);
+			auto pointInTriangle = _mm_test_all_zeros(_mm_set_epi32(0, -1, -1, -1), _mm_castps_si128(aa));
+
+			res.colliderA = a;
+			res.colliderB = b;
+			if (pointInTriangle) {
+				res.normOnB.set128(normal);
+				res.posA = s.pos() - res.normOnB * r;
+				res.posB.set128(projection);
+				res.depth = distanceFromPlane - radiusWithMargin;
+				return res.depth < -FLT_EPSILON;
+			}
+			return false;
+		}
+	};
+
+	template <typename T, bool SwapResults>
+	struct CollisionCheckDispatcher : public CollisionChecker<T, SwapResults>
+	{
+		template <typename... Ts>
+		CollisionCheckDispatcher(Ts&&... ts) :
+			CollisionChecker<T, SwapResults>(std::forward<Ts>(ts)...)
+		{}
+
+		// We intentionally don't use a 'Dynamic 1D Sweep and Prune Algorithm' here.
+		// O(N*M) is nearly always faster or within a margin of error. Not worth the extra boilerplate code
+		void dispatch(ColliderTree* a, ColliderTree* b, std::vector<Aabb*>& listA, std::vector<Aabb*>& listB, const Aabb& refinedBForPruningA)
+		{
+			CollisionResult result;
+			CollisionResult temp;
+			bool hasResult = false;
+
+			auto abeg = a->aabb;
+			auto bbeg = b->aabb;
+
+			if (listA.size() && listB.size()) {
+				for (auto i : listA) {
+					if (!i->collideWith(refinedBForPruningA))
+						continue;
+					for (auto j : listB) {
+						if (!i->collideWith(*j))
+							continue;
+						if (this->checkCollide(&a->cbuf[i - abeg], &b->cbuf[j - bbeg], temp)) {
+							if (!hasResult || result.depth > temp.depth) {
+								hasResult = true;
+								result = temp;
+							}
+						}
+					}
+				}
+			}
+
+			if (hasResult) {
+				this->addResult(result);
+			}
+		}
+	};
+
+	template <typename T, bool SwapResults = false>
+	struct CollisionCheckAlgorithm : public CollisionCheckDispatcher<T, SwapResults>
+	{
+		template <typename... Ts>
+		CollisionCheckAlgorithm(Ts&&... ts) :
+			CollisionCheckDispatcher<T, SwapResults>(std::forward<Ts>(ts)...)
+		{}
+
+		int operator()()
+		{
+			thread_local std::vector<std::pair<ColliderTree*, ColliderTree*>> pairs;
+			pairs.clear();
+
+			if (pairs.capacity() < 256)
+				pairs.reserve(256);
+
+			this->c0->checkCollisionL(this->c1, pairs);
+
+			if (pairs.empty())
+				return 0;
+
+			// The collision is just too complex to solve. We must quit before we explode the user's computer
+			// If this DOES solve, it seems to only cause the collision to become significantly more tangles up
+			if (pairs.size() > MaxCollisionPairs) {
+				return 0;
+			}
+
+			decltype(auto) func = [this](const std::pair<ColliderTree*, ColliderTree*>& pair) {
+				if (this->numResults >= SkinnedMeshAlgorithm::MaxCollisionCount)
+					return;
+
+				auto a = pair.first, b = pair.second;
+
+				auto abeg = a->aabb;
+				auto bbeg = b->aabb;
+				auto asize = b->isKinematic ? a->dynCollider : a->numCollider;
+				auto bsize = a->isKinematic ? b->dynCollider : b->numCollider;
+				auto aend = abeg + asize;
+				auto bend = bbeg + bsize;
+
+				Aabb aabbA;
+				auto aabbB = b->aabbMe;
+
+				thread_local std::vector<Aabb*> listA;
+				thread_local std::vector<Aabb*> listB;
+
+				listA.clear();
+				listB.clear();
+				listA.reserve(asize);
+				listB.reserve(bsize);
+
+				// Colliders in A that intersect full bounding box of B. Compute a new bounding box for just those - this
+				// can be MUCH smaller than the original bounding box for A (consider the case where we have two spheres
+				// colliding, offset by an equal amount in all three axes).
+				for (auto i = abeg; i < aend; ++i) {
+					if (i->collideWith(aabbB)) {
+						listA.push_back(i);
+						aabbA.merge(*i);
+					}
+				}
+
+				// Colliders in B that intersect the new bounding box for A. Compute a new bounding box for those too.
+				if (listA.size()) {
+					aabbB.invalidate();
+					for (auto i = bbeg; i < bend; ++i) {
+						if (i->collideWith(aabbA)) {
+							listB.push_back(i);
+							aabbB.merge(*i);
+						}
+					}
+				}
+
+				// Now go through both lists and do the real collision (if needed).
+				this->dispatch(a, b, listA, listB, aabbB);
+			};
+
+			if (pairs.size() >= 32)
+				par::for_each(pairs.begin(), pairs.end(), func);
+			else
+				for (auto& i : pairs) func(i);
+
+			return this->numResults;
+		}
+	};
+
+	template <class T1>
+	int checkCollide(PerVertexShape* a, T1* b, CollisionResult* results)
+	{
+		return CollisionCheckAlgorithm<T1>(a, b, results)();
+	}
+
+	int checkCollide(PerTriangleShape* a, PerVertexShape* b, CollisionResult* results)
+	{
+		return CollisionCheckAlgorithm<PerTriangleShape, true>(b, a, results)();
+	}
+
+	template <class T0, class T1>
+	void SkinnedMeshAlgorithm::MergeBuffer::doMerge(T0* a, T1* b, CollisionResult* collision, int count)
+	{
+		for (int i = 0; i < count; ++i) {
+			auto& res = collision[i];
+			if (res.depth >= -FLT_EPSILON)
+				break;
+
+			auto flexible = std::max(res.colliderA->flexible, res.colliderB->flexible);
+			// [3/13/2026]
+			// Note: This was using a break before, but logically that doesn't make sense?
+			// if we hit a stiffer collider earlier than our depth target, it'd early exit..
+			if (flexible < FLT_EPSILON)
+				continue;
+
+			float w = flexible * res.depth;
+			float w2 = w * w;
+
+			// pre-scale outside the bone loop, these don't depend on bone indices and the inner
+			// loop runs bonePerCollider^2 times, so this matters
+			auto normScaled = res.normOnB * w * w2;  // cubic weight: bakes depth into normal magnitude
+			auto posAScaled = res.posA * w2;
+			auto posBScaled = res.posB * w2;
+
+			for (int ib = 0; ib < a->getBonePerCollider(); ++ib) {
+				auto w0 = a->getColliderBoneWeight(res.colliderA, ib);
+				int boneIdx0 = a->getColliderBoneIndex(res.colliderA, ib);
+				if (w0 <= a->m_owner->m_skinnedBones[boneIdx0].weightThreshold)
+					continue;
+
+				for (int jb = 0; jb < b->getBonePerCollider(); ++jb) {
+					auto w1 = b->getColliderBoneWeight(res.colliderB, jb);
+					int boneIdx1 = b->getColliderBoneIndex(res.colliderB, jb);
+					if (w1 <= b->m_owner->m_skinnedBones[boneIdx1].weightThreshold)
+						continue;
+
+					if (a->m_owner->m_skinnedBones[boneIdx0].isKinematic && b->m_owner->m_skinnedBones[boneIdx1].isKinematic)
+						continue;
+
+					auto c = getAndTrack(boneIdx0, boneIdx1);
+
+					// If we already have a primary direction (weight > 0),
+					// and this new contact pushes in the opposite direction (dot < 0),
+					// reject it entirely. This prevents the vector cancellation that creates
+					// unpredictable movement, and preserves the depth/weight ratio
+					// [If we get jitter, try removing this]
+					if (c->weight > FLT_EPSILON && c->normal.dot(normScaled) < 0) {
+						continue;
+					}
+
+					c->weight += w2;
+					c->normal += normScaled;
+					c->pos[0] += posAScaled;
+					c->pos[1] += posBScaled;
+				}
+			}
+		}
+	}
+
+	void SkinnedMeshAlgorithm::MergeBuffer::apply(SkinnedMeshBody* body0, SkinnedMeshBody* body1,
+		CollisionDispatcher* dispatcher)
+	{
+		// only visit cells that were actually written to this frame,
+		// instead of looping all bones0 * bones1 (far fewer iterations)
+		for (int flatIdx : activeCells) {
+			int i = flatIdx / mergeStride;
+			int j = flatIdx % mergeStride;
+
+			auto* c = &buffer[flatIdx];
+			if (c->weight < FLT_EPSILON)
+				continue;
+
+			if (!body1->canCollideWith(body0->m_skinnedBones[i].ptr))
+				continue;
+			if (!body0->canCollideWith(body1->m_skinnedBones[j].ptr))
+				continue;
+			if (body0->m_skinnedBones[i].isKinematic && body1->m_skinnedBones[j].isKinematic)
+				continue;
+
+			auto rb0 = body0->m_skinnedBones[i].ptr;
+			auto rb1 = body1->m_skinnedBones[j].ptr;
+			if (rb0 == rb1)
+				continue;
+
+			float invWeight = 1.0f / c->weight;
+
+			auto worldA = c->pos[0] * invWeight;
+			auto worldB = c->pos[1] * invWeight;
+			auto localA = rb0->m_rig.getWorldTransform().invXform(worldA);
+			auto localB = rb1->m_rig.getWorldTransform().invXform(worldB);
+			auto normal = c->normal * invWeight;
+			if (normal.fuzzyZero())
+				continue;
+
+			// depth was baked into normal magnitude during doMerge (weighted cubically instead of storing a separate depth field)
+			auto depth = -normal.length();
+			normal = -normal.normalized();
+
+			if (depth >= -FLT_EPSILON)
+				continue;
+			btManifoldPoint newPt(localA, localB, normal, depth);
+			newPt.m_positionWorldOnA = worldA;
+			newPt.m_positionWorldOnB = worldB;
+			newPt.m_combinedFriction = rb0->m_rig.getFriction() * rb1->m_rig.getFriction();
+			newPt.m_combinedRestitution = rb0->m_rig.getRestitution() * rb1->m_rig.getRestitution();
+			newPt.m_combinedRollingFriction = rb0->m_rig.getRollingFriction() * rb1->m_rig.getRollingFriction();
+
+			auto maniford = dispatcher->getNewManifold(&rb0->m_rig, &rb1->m_rig);
+			maniford->addManifoldPoint(newPt);
+		}
+	}
+
+	template <class T0, class T1>
+	void SkinnedMeshAlgorithm::processCollision(T0* shape0, T1* shape1, MergeBuffer& merge, CollisionResult* collision)
+	{
+		int count = std::min(checkCollide(shape0, shape1, collision), MaxCollisionCount);
+		if (count > 0) {
+			// results come back in random order from parallel workers, sort so doMerge's
+			// early break actually bails on shallow contacts instead of random ones
+			std::sort(collision, collision + count, [](const CollisionResult& a, const CollisionResult& b) {
+				return a.depth < b.depth;
+			});
+			merge.doMerge(shape0, shape1, collision, count);
+		}
+	}
+
+	void SkinnedMeshAlgorithm::processCollision(SkinnedMeshBody* body0, SkinnedMeshBody* body1,
+		CollisionDispatcher* dispatcher)
+	{
+		// thread_local so we don't heap-alloc these 200+ times per frame.
+		// MergeBuffer::resize() is O(1) after first call (generation counter, no zeroing).
+		// The port runs collision dispatch serially, so there is no
+		// work-stealing re-entrancy to guard against; review this if
+		// parallelism is ever reintroduced.
+		thread_local MergeBuffer merge;
+		thread_local auto collision = std::make_unique<CollisionResult[]>(MaxCollisionCount);
+
+		merge.resize(static_cast<int>(body0->m_skinnedBones.size()), static_cast<int>(body1->m_skinnedBones.size()));
+
+		if (body0->m_shape->asPerTriangleShape() && body1->m_shape->asPerTriangleShape()) {
+			// Todo: This can actually be further optimized, but would need a re-factor.. However, would the performance increase be worth
+			// the extra boilerplate code..?
+			processCollision(body0->m_shape->asPerTriangleShape(), body1->m_shape->asPerVertexShape(), merge,
+				collision.get());
+			processCollision(body0->m_shape->asPerVertexShape(), body1->m_shape->asPerTriangleShape(), merge,
+				collision.get());
+		} else if (body0->m_shape->asPerTriangleShape())
+			processCollision(body0->m_shape->asPerTriangleShape(), body1->m_shape->asPerVertexShape(), merge,
+				collision.get());
+		else if (body1->m_shape->asPerTriangleShape())
+			processCollision(body0->m_shape->asPerVertexShape(), body1->m_shape->asPerTriangleShape(), merge,
+				collision.get());
+		else
+			processCollision(body0->m_shape->asPerVertexShape(), body1->m_shape->asPerVertexShape(), merge, collision.get());
+
+		merge.apply(body0, body1, dispatcher);
+	}
+}
+
+#endif  // USE_BULLET

--- a/src/physics/hdt/hdtSkinnedMeshAlgorithm.h
+++ b/src/physics/hdt/hdtSkinnedMeshAlgorithm.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include "hdtDispatcher.h"
+#include "hdtSkinnedMeshShape.h"
+
+namespace hdt
+{
+	struct CollisionResult
+	{
+		btVector3 posA;
+		btVector3 posB;
+		btVector3 normOnB;
+		Collider* colliderA;
+		Collider* colliderB;
+		float depth;
+	};
+
+	class SkinnedMeshAlgorithm
+	{
+	public:
+		// Note: It's possible to exceed this with complex outfits, which is why we cap it.
+		// We don't want to stress a simulation island too much!
+		static const int MaxCollisionCount = 512;
+
+		static void processCollision(SkinnedMeshBody* body0Wrap, SkinnedMeshBody* body1Wrap,
+			CollisionDispatcher* dispatcher);
+
+	protected:
+		struct CollisionMerge
+		{
+			btVector3 normal;  // accumulated weighted normal: length encodes depth, direction encodes contact normal
+			btVector3 pos[2];
+			float weight;
+
+			CollisionMerge()
+			{
+				_mm_store_ps(((float*)this), _mm_setzero_ps());
+				_mm_store_ps(((float*)this) + 4, _mm_setzero_ps());
+				_mm_store_ps(((float*)this) + 8, _mm_setzero_ps());
+				_mm_store_ps(((float*)this) + 12, _mm_setzero_ps());
+			}
+
+			void reset()
+			{
+				_mm_store_ps(((float*)this), _mm_setzero_ps());
+				_mm_store_ps(((float*)this) + 4, _mm_setzero_ps());
+				_mm_store_ps(((float*)this) + 8, _mm_setzero_ps());
+				_mm_store_ps(((float*)this) + 12, _mm_setzero_ps());
+			}
+		};
+
+		struct MergeBuffer
+		{
+			MergeBuffer() :
+				mergeStride(0), mergeSize(0), currentGen(0)
+			{
+				activeCells.reserve(256);
+			}
+
+			~MergeBuffer()
+			{
+				std::free(buffer);
+				std::free(generations);
+			}
+
+			MergeBuffer(const MergeBuffer&) = delete;
+			MergeBuffer& operator=(const MergeBuffer&) = delete;
+
+			// Just in case!
+			MergeBuffer(MergeBuffer&&) = delete;
+			MergeBuffer& operator=(MergeBuffer&&) = delete;
+
+			// Buffer is ~2-10% occupied in basic scenes, so instead of zeroing old cells every resize() call we just bump a generation counter.
+			// cells get lazily reset on first touch in getAndTrack(). Makes resize() O(1).
+			void resize(int x, int y)
+			{
+				mergeStride = y;
+				int needed = x * y;
+				if (needed > mergeSize) {
+					std::free(buffer);
+					std::free(generations);
+					mergeSize = needed;
+					buffer = static_cast<CollisionMerge*>(std::malloc(needed * sizeof(CollisionMerge)));
+					generations = static_cast<uint32_t*>(std::calloc(needed, sizeof(uint32_t)));
+				}
+				if (++currentGen == 0) {
+					// wrap around, shouldn't realistically happen (~4 billion frames lol)
+					// This is virtually skipped entirely by the cpu, 0 cost. Just in case since it would
+					// create difficult to track down inconsistencies..
+					std::memset(generations, 0, mergeSize * sizeof(uint32_t));
+					currentGen = 1;
+				}
+				activeCells.clear();
+			}
+
+			CollisionMerge* get(int x, int y) { return &buffer[x * mergeStride + y]; }
+
+			CollisionMerge* getAndTrack(int x, int y)
+			{
+				int idx = x * mergeStride + y;
+				auto* c = &buffer[idx];
+				if (generations[idx] != currentGen) {
+					c->reset();
+					generations[idx] = currentGen;
+					activeCells.push_back(idx);
+				}
+				return c;
+			}
+
+			template <class T0, class T1>
+			void doMerge(T0* shape0, T1* shape1, CollisionResult* collisions, int count);
+
+			void apply(SkinnedMeshBody* body0, SkinnedMeshBody* body1, CollisionDispatcher* dispatcher);
+
+			int mergeStride;
+			int mergeSize;
+			uint32_t currentGen;
+			CollisionMerge* buffer = nullptr;
+			uint32_t* generations = nullptr;
+			std::vector<int> activeCells;
+		};
+
+		template <class T0, class T1>
+		static void processCollision(T0* shape0, T1* shape1, MergeBuffer& merge, CollisionResult* collision);
+	};
+}

--- a/src/physics/hdt/hdtSkinnedMeshBody.cpp
+++ b/src/physics/hdt/hdtSkinnedMeshBody.cpp
@@ -1,0 +1,278 @@
+#ifdef USE_BULLET
+
+#include "hdtSkinnedMeshBody.h"
+#include "hdtSkinnedMeshShape.h"
+
+
+namespace hdt
+{
+
+	SkinnedMeshBody::SkinnedMeshBody()
+	{
+		m_collisionShape = &m_bulletShape;
+	}
+
+	SkinnedMeshBody::~SkinnedMeshBody()
+	{
+		//m_bonesGPU.discard_data();
+		//m_verticesGPU.discard_data();
+	}
+
+	HDT_FORCEINLINE __m128 calcVertexState(__m128 skinPos, const Bone& bone, __m128 w)
+	{
+		auto p = bone.m_vertexToWorld * skinPos;
+		p = _mm_blend_ps(p.get128(), _mm_load_ps(bone.m_reserved), 0x8);
+		return _mm_mul_ps(w, p.get128());
+	}
+
+#if defined(__AVX2__)
+	HDT_FORCEINLINE __m128 calcVertexStateFMA(__m128 skinPos, const Bone& bone, __m128 w)
+	{
+		__m128 px = pshufd<0x00>(skinPos);
+		__m128 py = pshufd<0x55>(skinPos);
+		__m128 pz = pshufd<0xAA>(skinPos);
+		__m128 r = _mm_fmadd_ps(bone.m_vertexToWorld.m_col[2].get128(), pz, bone.m_vertexToWorld.m_col[3].get128());
+		r = _mm_fmadd_ps(bone.m_vertexToWorld.m_col[1].get128(), py, r);
+		r = _mm_fmadd_ps(bone.m_vertexToWorld.m_col[0].get128(), px, r);
+		r = _mm_blend_ps(r, _mm_load_ps(bone.m_reserved), 0x8);
+		return _mm_mul_ps(w, r);
+	}
+#endif
+
+	void SkinnedMeshBody::internalUpdate()
+	{
+		const size_t numBones = m_skinnedBones.size();
+		const auto* __restrict skinnedBones = m_skinnedBones.data();
+		auto* __restrict bonesDst = m_bones.data();
+
+		for (size_t i = 0; i < numBones; ++i) {
+			if (i + 8 < numBones)
+				_mm_prefetch((const char*)&skinnedBones[i + 8], _MM_HINT_T1);
+			if (i + 4 < numBones)
+				_mm_prefetch((const char*)skinnedBones[i + 4].ptr, _MM_HINT_T0);
+			auto& v = skinnedBones[i];
+			auto boneT = v.ptr->m_currentTransform;
+			bonesDst[i].m_vertexToWorld = btMatrix4x3T(boneT) * v.vertexToBone;
+			bonesDst[i].m_maginMultipler = v.ptr->m_marginMultipler * boneT.getScale();
+		}
+
+		const int size = static_cast<int>(m_vpos.size());
+		const Vertex* __restrict verts = m_vertices.data();
+		VertexPos* __restrict vpos = m_vpos.data();
+		const Bone* __restrict bones = bonesDst;
+
+		// We can use AVX2 here due to sequential memory reads..
+#if defined(__AVX2__)
+
+		constexpr int PF = 6;
+		int idx = 0;
+		for (; idx + 1 < size; idx += 2) {
+			if (idx + PF < size) {
+				_mm_prefetch((const char*)&verts[idx + PF], _MM_HINT_T0);
+				_mm_prefetch((const char*)&verts[idx + PF + 1], _MM_HINT_T0);
+			}
+
+			{
+				auto& v = verts[idx];
+				auto p = v.m_skinPos.get128();
+				auto w = _mm_load_ps(v.m_weight);
+				auto pm = calcVertexStateFMA(p, bones[v.getBoneIdx(0)], setAll0(w));
+				pm += calcVertexStateFMA(p, bones[v.getBoneIdx(1)], setAll1(w));
+				pm += calcVertexStateFMA(p, bones[v.getBoneIdx(2)], setAll2(w));
+				pm += calcVertexStateFMA(p, bones[v.getBoneIdx(3)], setAll3(w));
+				vpos[idx].set(pm);
+			}
+			{
+				auto& v = verts[idx + 1];
+				auto p = v.m_skinPos.get128();
+				auto w = _mm_load_ps(v.m_weight);
+				auto pm = calcVertexStateFMA(p, bones[v.getBoneIdx(0)], setAll0(w));
+				pm += calcVertexStateFMA(p, bones[v.getBoneIdx(1)], setAll1(w));
+				pm += calcVertexStateFMA(p, bones[v.getBoneIdx(2)], setAll2(w));
+				pm += calcVertexStateFMA(p, bones[v.getBoneIdx(3)], setAll3(w));
+				vpos[idx + 1].set(pm);
+			}
+		}
+		for (; idx < size; ++idx) {
+			auto& v = verts[idx];
+			auto p = v.m_skinPos.get128();
+			auto w = _mm_load_ps(v.m_weight);
+			auto pm = calcVertexStateFMA(p, bones[v.getBoneIdx(0)], setAll0(w));
+			pm += calcVertexStateFMA(p, bones[v.getBoneIdx(1)], setAll1(w));
+			pm += calcVertexStateFMA(p, bones[v.getBoneIdx(2)], setAll2(w));
+			pm += calcVertexStateFMA(p, bones[v.getBoneIdx(3)], setAll3(w));
+			vpos[idx].set(pm);
+		}
+
+#else
+
+		constexpr int PF = 8;
+		int idx = 0;
+		for (; idx + 3 < size; idx += 4) {
+			if (idx + PF + 3 < size) {
+				_mm_prefetch((const char*)&verts[idx + PF], _MM_HINT_T0);
+				_mm_prefetch((const char*)&verts[idx + PF + 1], _MM_HINT_T0);
+				_mm_prefetch((const char*)&verts[idx + PF + 2], _MM_HINT_T0);
+				_mm_prefetch((const char*)&verts[idx + PF + 3], _MM_HINT_T0);
+			}
+
+			{
+				auto& v = verts[idx];
+				auto p = v.m_skinPos.get128();
+				auto w = _mm_load_ps(v.m_weight);
+				auto pm = calcVertexState(p, bones[v.getBoneIdx(0)], setAll0(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(1)], setAll1(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(2)], setAll2(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(3)], setAll3(w));
+				vpos[idx].set(pm);
+			}
+			{
+				auto& v = verts[idx + 1];
+				auto p = v.m_skinPos.get128();
+				auto w = _mm_load_ps(v.m_weight);
+				auto pm = calcVertexState(p, bones[v.getBoneIdx(0)], setAll0(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(1)], setAll1(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(2)], setAll2(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(3)], setAll3(w));
+				vpos[idx + 1].set(pm);
+			}
+			{
+				auto& v = verts[idx + 2];
+				auto p = v.m_skinPos.get128();
+				auto w = _mm_load_ps(v.m_weight);
+				auto pm = calcVertexState(p, bones[v.getBoneIdx(0)], setAll0(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(1)], setAll1(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(2)], setAll2(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(3)], setAll3(w));
+				vpos[idx + 2].set(pm);
+			}
+			{
+				auto& v = verts[idx + 3];
+				auto p = v.m_skinPos.get128();
+				auto w = _mm_load_ps(v.m_weight);
+				auto pm = calcVertexState(p, bones[v.getBoneIdx(0)], setAll0(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(1)], setAll1(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(2)], setAll2(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(3)], setAll3(w));
+				vpos[idx + 3].set(pm);
+			}
+		}
+		for (; idx < size; ++idx) {
+			auto& v = verts[idx];
+			auto p = v.m_skinPos.get128();
+			auto w = _mm_load_ps(v.m_weight);
+			auto pm = calcVertexState(p, bones[v.getBoneIdx(0)], setAll0(w));
+			pm += calcVertexState(p, bones[v.getBoneIdx(1)], setAll1(w));
+			pm += calcVertexState(p, bones[v.getBoneIdx(2)], setAll2(w));
+			pm += calcVertexState(p, bones[v.getBoneIdx(3)], setAll3(w));
+			vpos[idx].set(pm);
+		}
+
+#endif
+
+		m_shape->internalUpdate();
+		m_bulletShape.m_aabb = m_shape->m_tree.aabbAll;
+	}
+
+	float SkinnedMeshBody::flexible(const Vertex& v)
+	{
+		float ret = 0.f;
+		for (int i = 0; i < 4; ++i) {
+			if (v.m_weight[i] < FLT_EPSILON)
+				break;
+			int boneIdx = v.getBoneIdx(i);
+			if (!m_skinnedBones[boneIdx].isKinematic)
+				ret += v.m_weight[i];
+		}
+		return ret;
+	}
+
+	int SkinnedMeshBody::addBone(SkinnedMeshBone* bone, const btQsTransform& verticesToBone,
+		const BoundingSphere& boundingSphere)
+	{
+		m_skinnedBones.push_back(SkinnedBone());
+		auto& v = m_skinnedBones.back();
+		v.ptr = bone;
+		v.vertexToBone = verticesToBone;
+		v.localBoundingSphere = boundingSphere;
+		v.isKinematic = bone->m_rig.isStaticOrKinematicObject();
+		return static_cast<int>(m_skinnedBones.size() - 1);
+	}
+
+	void SkinnedMeshBody::finishBuild()
+	{
+		m_bones.resize(m_skinnedBones.size());
+		m_shape->clipColliders();
+		m_vpos.resize(m_vertices.size());
+
+		m_isKinematic = true;
+		for (auto& i : m_skinnedBones) {
+			i.isKinematic = i.ptr->m_rig.isStaticOrKinematicObject();
+			if (!i.isKinematic)
+				m_isKinematic = false;
+		}
+
+		m_shape->finishBuild();
+
+		bool* flags = new bool[m_vertices.size()];
+		memset(flags, 0, m_vertices.size());
+		m_shape->markUsedVertices(flags);
+
+		uint32_t numUsed = 0;
+		std::vector<uint32_t> map(m_vertices.size());
+		for (int i = 0; i < m_vertices.size(); ++i) {
+			if (flags[i]) {
+				m_vertices[numUsed] = m_vertices[i];
+				m_vpos[numUsed] = m_vpos[i];
+				map[i] = numUsed++;
+			}
+		}
+		delete[] flags;
+		m_shape->remapVertices(map.data());
+		m_vertices.resize(numUsed);
+		m_vpos.resize(numUsed);
+
+		m_useBoundingSphere = m_shape->m_colliders.size() > 10;
+	}
+
+	bool SkinnedMeshBody::canCollideWith(const SkinnedMeshBody* body) const
+	{
+		if (m_isKinematic && body->m_isKinematic)
+			return false;
+
+		if (m_canCollideWithTags.empty()) {
+			for (auto& i : body->m_tags)
+				if (m_noCollideWithTags.find(i) != m_noCollideWithTags.end())
+					return false;
+			return true;
+		}
+		for (auto& i : body->m_tags)
+			if (m_canCollideWithTags.find(i) != m_canCollideWithTags.end())
+				return true;
+		return false;
+	}
+
+	void SkinnedMeshBody::updateBoundingSphereAabb()
+	{
+		m_bulletShape.m_aabb.invalidate();
+		for (auto& i : m_skinnedBones) {
+			auto sp = i.localBoundingSphere;
+			auto tr = i.ptr->m_currentTransform;
+			i.worldBoundingSphere = BoundingSphere(tr * sp.center(), tr.getScale() * sp.radius());
+			m_bulletShape.m_aabb.merge(i.worldBoundingSphere.getAabb());
+		}
+
+		if (!m_useBoundingSphere)
+			internalUpdate();
+	}
+
+	bool SkinnedMeshBody::isBoundingSphereCollided(SkinnedMeshBody* rhs)
+	{
+		if (canCollideWith(rhs) && rhs->canCollideWith(this)) {
+			return true;
+		}
+		return false;
+	}
+}
+
+#endif  // USE_BULLET

--- a/src/physics/hdt/hdtSkinnedMeshBody.cpp
+++ b/src/physics/hdt/hdtSkinnedMeshBody.cpp
@@ -20,9 +20,9 @@ namespace hdt
 
 	HDT_FORCEINLINE __m128 calcVertexState(__m128 skinPos, const Bone& bone, __m128 w)
 	{
-		auto p = bone.m_vertexToWorld * skinPos;
-		p = _mm_blend_ps(p.get128(), _mm_load_ps(bone.m_reserved), 0x8);
-		return _mm_mul_ps(w, p.get128());
+		auto p = bone.m_vertexToWorld * fromSimd(skinPos);
+		auto pm = _mm_blend_ps(toSimd(p), _mm_load_ps(bone.m_reserved), 0x8);
+		return _mm_mul_ps(w, pm);
 	}
 
 #if defined(__AVX2__)
@@ -31,9 +31,9 @@ namespace hdt
 		__m128 px = pshufd<0x00>(skinPos);
 		__m128 py = pshufd<0x55>(skinPos);
 		__m128 pz = pshufd<0xAA>(skinPos);
-		__m128 r = _mm_fmadd_ps(bone.m_vertexToWorld.m_col[2].get128(), pz, bone.m_vertexToWorld.m_col[3].get128());
-		r = _mm_fmadd_ps(bone.m_vertexToWorld.m_col[1].get128(), py, r);
-		r = _mm_fmadd_ps(bone.m_vertexToWorld.m_col[0].get128(), px, r);
+		__m128 r = _mm_fmadd_ps(toSimd(bone.m_vertexToWorld.m_col[2]), pz, toSimd(bone.m_vertexToWorld.m_col[3]));
+		r = _mm_fmadd_ps(toSimd(bone.m_vertexToWorld.m_col[1]), py, r);
+		r = _mm_fmadd_ps(toSimd(bone.m_vertexToWorld.m_col[0]), px, r);
 		r = _mm_blend_ps(r, _mm_load_ps(bone.m_reserved), 0x8);
 		return _mm_mul_ps(w, r);
 	}
@@ -74,7 +74,7 @@ namespace hdt
 
 			{
 				auto& v = verts[idx];
-				auto p = v.m_skinPos.get128();
+				auto p = toSimd(v.m_skinPos);
 				auto w = _mm_load_ps(v.m_weight);
 				auto pm = calcVertexStateFMA(p, bones[v.getBoneIdx(0)], setAll0(w));
 				pm += calcVertexStateFMA(p, bones[v.getBoneIdx(1)], setAll1(w));
@@ -84,7 +84,7 @@ namespace hdt
 			}
 			{
 				auto& v = verts[idx + 1];
-				auto p = v.m_skinPos.get128();
+				auto p = toSimd(v.m_skinPos);
 				auto w = _mm_load_ps(v.m_weight);
 				auto pm = calcVertexStateFMA(p, bones[v.getBoneIdx(0)], setAll0(w));
 				pm += calcVertexStateFMA(p, bones[v.getBoneIdx(1)], setAll1(w));
@@ -95,7 +95,7 @@ namespace hdt
 		}
 		for (; idx < size; ++idx) {
 			auto& v = verts[idx];
-			auto p = v.m_skinPos.get128();
+			auto p = toSimd(v.m_skinPos);
 			auto w = _mm_load_ps(v.m_weight);
 			auto pm = calcVertexStateFMA(p, bones[v.getBoneIdx(0)], setAll0(w));
 			pm += calcVertexStateFMA(p, bones[v.getBoneIdx(1)], setAll1(w));
@@ -118,7 +118,7 @@ namespace hdt
 
 			{
 				auto& v = verts[idx];
-				auto p = v.m_skinPos.get128();
+				auto p = toSimd(v.m_skinPos);
 				auto w = _mm_load_ps(v.m_weight);
 				auto pm = calcVertexState(p, bones[v.getBoneIdx(0)], setAll0(w));
 				pm += calcVertexState(p, bones[v.getBoneIdx(1)], setAll1(w));
@@ -128,7 +128,7 @@ namespace hdt
 			}
 			{
 				auto& v = verts[idx + 1];
-				auto p = v.m_skinPos.get128();
+				auto p = toSimd(v.m_skinPos);
 				auto w = _mm_load_ps(v.m_weight);
 				auto pm = calcVertexState(p, bones[v.getBoneIdx(0)], setAll0(w));
 				pm += calcVertexState(p, bones[v.getBoneIdx(1)], setAll1(w));
@@ -138,7 +138,7 @@ namespace hdt
 			}
 			{
 				auto& v = verts[idx + 2];
-				auto p = v.m_skinPos.get128();
+				auto p = toSimd(v.m_skinPos);
 				auto w = _mm_load_ps(v.m_weight);
 				auto pm = calcVertexState(p, bones[v.getBoneIdx(0)], setAll0(w));
 				pm += calcVertexState(p, bones[v.getBoneIdx(1)], setAll1(w));
@@ -148,7 +148,7 @@ namespace hdt
 			}
 			{
 				auto& v = verts[idx + 3];
-				auto p = v.m_skinPos.get128();
+				auto p = toSimd(v.m_skinPos);
 				auto w = _mm_load_ps(v.m_weight);
 				auto pm = calcVertexState(p, bones[v.getBoneIdx(0)], setAll0(w));
 				pm += calcVertexState(p, bones[v.getBoneIdx(1)], setAll1(w));
@@ -159,7 +159,7 @@ namespace hdt
 		}
 		for (; idx < size; ++idx) {
 			auto& v = verts[idx];
-			auto p = v.m_skinPos.get128();
+			auto p = toSimd(v.m_skinPos);
 			auto w = _mm_load_ps(v.m_weight);
 			auto pm = calcVertexState(p, bones[v.getBoneIdx(0)], setAll0(w));
 			pm += calcVertexState(p, bones[v.getBoneIdx(1)], setAll1(w));

--- a/src/physics/hdt/hdtSkinnedMeshBody.h
+++ b/src/physics/hdt/hdtSkinnedMeshBody.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include "hdtAABB.h"
+#include "hdtBulletHelper.h"
+#include "hdtSkinnedMeshBone.h"
+#include "hdtVertex.h"
+
+#include <BulletCollision/Gimpact/btBoxCollision.h>
+
+#include <unordered_set>
+
+namespace hdt
+{
+	class SkinnedMeshShape;
+
+	class SkinnedMeshBody :
+		public btCollisionObject,
+		public RefCounted
+	{
+	public:
+		using btCollisionObject::operator new;
+		using btCollisionObject::operator delete;
+		using btCollisionObject::operator new[];
+		using btCollisionObject::operator delete[];
+
+	public:
+		SkinnedMeshBody();
+		virtual ~SkinnedMeshBody();
+
+		struct CollisionShape : public btCollisionShape  // a shape only used for markout
+		{
+			CollisionShape() :
+				m_aabb(_mm_setzero_ps(), _mm_setzero_ps()) { m_shapeType = CUSTOM_CONCAVE_SHAPE_TYPE; }
+
+			Aabb m_aabb;
+
+			void getAabb([[maybe_unused]] const btTransform& t, btVector3& aabbMin, btVector3& aabbMax) const override
+			{
+				aabbMin = m_aabb.m_min;
+				aabbMax = m_aabb.m_max;
+			}
+
+			void setLocalScaling([[maybe_unused]] const btVector3& scaling) override
+			{
+			}
+
+			const btVector3& getLocalScaling() const override
+			{
+				static const btVector3 ret(1, 1, 1);
+				return ret;
+			}
+
+			void calculateLocalInertia([[maybe_unused]] btScalar mass, [[maybe_unused]] btVector3& inertia) const override
+			{
+			}
+
+			const char* getName() const override { return "btSkinnedMeshBody"; }
+			btScalar getMargin() const override { return 0; }
+
+			void setMargin([[maybe_unused]] btScalar m) override
+			{
+			}
+		} m_bulletShape;
+
+		struct SkinnedBone
+		{
+			btMatrix4x3T vertexToBone;
+			BoundingSphere localBoundingSphere;
+			BoundingSphere worldBoundingSphere;
+			SkinnedMeshBone* ptr = nullptr;
+			float weightThreshold;
+			bool isKinematic;
+		};
+
+		IDStr m_name;
+
+		//		int m_priority;
+		bool m_isKinematic;
+		bool m_useBoundingSphere;
+		Ref<SkinnedMeshShape> m_shape;
+
+		int addBone(SkinnedMeshBone* bone, const btQsTransform& verticesToBone, const BoundingSphere& boundingSphere);
+
+		void finishBuild();
+		virtual void internalUpdate();
+
+		std::vector<SkinnedBone> m_skinnedBones;
+		std::vector<Bone> m_bones;
+
+		std::vector<Vertex> m_vertices;
+		std::vector<VertexPos> m_vpos;
+
+		std::vector<IDStr> m_tags;
+		std::unordered_set<IDStr> m_canCollideWithTags;
+		std::unordered_set<IDStr> m_noCollideWithTags;
+		std::unordered_set<SkinnedMeshBone*> m_canCollideWithBones;
+		std::unordered_set<SkinnedMeshBone*> m_noCollideWithBones;
+
+		float flexible(const Vertex& v);
+
+		bool canCollideWith(const SkinnedMeshBone* bone) const
+		{
+			if (!m_canCollideWithBones.empty()) {
+				return m_canCollideWithBones.count(const_cast<SkinnedMeshBone*>(bone)) != 0;
+			}
+			return m_noCollideWithBones.count(const_cast<SkinnedMeshBone*>(bone)) == 0;
+		}
+
+		virtual bool canCollideWith(const SkinnedMeshBody* body) const;
+
+		void updateBoundingSphereAabb();
+		bool isBoundingSphereCollided(SkinnedMeshBody* rhs);
+	};
+}

--- a/src/physics/hdt/hdtSkinnedMeshBody.h
+++ b/src/physics/hdt/hdtSkinnedMeshBody.h
@@ -36,8 +36,8 @@ namespace hdt
 
 			void getAabb([[maybe_unused]] const btTransform& t, btVector3& aabbMin, btVector3& aabbMax) const override
 			{
-				aabbMin = m_aabb.m_min;
-				aabbMax = m_aabb.m_max;
+				aabbMin = fromSimd(m_aabb.m_min);
+				aabbMax = fromSimd(m_aabb.m_max);
 			}
 
 			void setLocalScaling([[maybe_unused]] const btVector3& scaling) override

--- a/src/physics/hdt/hdtSkinnedMeshBone.cpp
+++ b/src/physics/hdt/hdtSkinnedMeshBone.cpp
@@ -1,0 +1,40 @@
+#ifdef USE_BULLET
+
+#include "hdtSkinnedMeshBone.h"
+
+namespace hdt
+{
+	SkinnedMeshBone::SkinnedMeshBone(const IDStr& name, btRigidBody::btRigidBodyConstructionInfo& ci) :
+		m_name(name), m_rig(ci)
+	{
+		m_rigToLocal.setIdentity();
+		m_localToRig.setIdentity();
+		m_currentTransform.setScale(1);
+
+		m_marginMultipler = 1.0f;
+
+		m_rig.setUserPointer(this);
+	}
+
+	SkinnedMeshBone::~SkinnedMeshBone()
+	{
+	}
+
+	void SkinnedMeshBone::internalUpdate()
+	{
+		auto t = m_rigToLocal * m_rig.getInterpolationWorldTransform();
+		m_currentTransform.setBasis(t.getBasis());
+		m_currentTransform.setOrigin(t.getOrigin());
+	}
+
+	bool SkinnedMeshBone::canCollideWith(SkinnedMeshBone* rhs)
+	{
+		if (m_canCollideWithBone.size()) {
+			return std::find(m_canCollideWithBone.begin(), m_canCollideWithBone.end(), rhs->m_name) !=
+			       m_canCollideWithBone.end();
+		}
+		return std::find(m_noCollideWithBone.begin(), m_noCollideWithBone.end(), rhs->m_name) == m_noCollideWithBone.end();
+	}
+}
+
+#endif  // USE_BULLET

--- a/src/physics/hdt/hdtSkinnedMeshBone.h
+++ b/src/physics/hdt/hdtSkinnedMeshBone.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "hdtAABB.h"
+#include "hdtBulletHelper.h"
+#include <memory>
+
+namespace hdt
+{
+	class SkinnedMeshBody;
+
+	// Sentinel time step: bone readTransform implementations treat any step
+	// <= this as "teleport to the kinematic pose without dynamics". Upstream
+	// this lived in hdtSkyrimPhysicsWorld.h.
+	constexpr float RESET_PHYSICS = -10.0f;
+	struct HDT_ALIGN16 SkinnedMeshBone :
+		public RefCounted
+	{
+		BT_DECLARE_ALIGNED_ALLOCATOR();
+
+		SkinnedMeshBone(const IDStr& name, btRigidBody::btRigidBodyConstructionInfo& ci);
+		virtual ~SkinnedMeshBone();
+
+		IDStr m_name;
+		float m_marginMultipler;
+		float m_boudingSphereMultipler = 1.0f;
+		float m_gravityFactor = 1.0f;
+		float m_windFactor = 1.0f;  // Mapped to <wind-factor> in the XML. Acts as a multiplier for the global wind force applied to this bone (0.0 = no wind, 2.0 = double wind)
+
+		btRigidBody m_rig;
+		btTransform m_localToRig;
+		btTransform m_rigToLocal;
+		btQsTransform m_currentTransform;
+
+		std::vector<IDStr> m_canCollideWithBone;
+		std::vector<IDStr> m_noCollideWithBone;
+
+		virtual void readTransform(float timeStep) = 0;
+		virtual void writeTransform() = 0;
+
+		void internalUpdate();
+
+		bool canCollideWith(SkinnedMeshBone* rhs);
+	};
+}

--- a/src/physics/hdt/hdtSkinnedMeshShape.cpp
+++ b/src/physics/hdt/hdtSkinnedMeshShape.cpp
@@ -126,7 +126,7 @@ namespace hdt
 			auto p0 = vertices[c->vertices[0]].m_data;
 			auto p1 = vertices[c->vertices[1]].m_data;
 			auto p2 = vertices[c->vertices[2]].m_data;
-			auto margin4 = p0 + p1 + p2;
+			auto margin4 = _mm_add_ps(_mm_add_ps(p0, p1), p2);
 
 			auto aabbMin = _mm_min_ps(_mm_min_ps(p0, p1), p2);
 			auto aabbMax = _mm_max_ps(_mm_max_ps(p0, p1), p2);
@@ -134,8 +134,8 @@ namespace hdt
 			prenetration = _mm_andnot_ps(_mm_set_ss(-0.0f), prenetration);  // abs
 			margin4 = _mm_max_ss(_mm_set_ss(getLane3(margin4) * m_shapeProp.margin / 3), prenetration);
 			margin4 = _mm_shuffle_ps(margin4, margin4, 0);
-			aabbMin = aabbMin - margin4;
-			aabbMax = aabbMax + margin4;
+			aabbMin = _mm_sub_ps(aabbMin, margin4);
+			aabbMax = _mm_add_ps(aabbMax, margin4);
 
 			m_aabb[i].m_min = aabbMin;
 			m_aabb[i].m_max = aabbMax;

--- a/src/physics/hdt/hdtSkinnedMeshShape.cpp
+++ b/src/physics/hdt/hdtSkinnedMeshShape.cpp
@@ -1,0 +1,253 @@
+#ifdef USE_BULLET
+
+#include "hdtSkinnedMeshShape.h"
+
+
+namespace hdt
+{
+	SkinnedMeshShape::SkinnedMeshShape(SkinnedMeshBody* body)
+	{
+		m_owner = body;
+		m_owner->m_shape = hdt::make_ref(this);
+	}
+
+	SkinnedMeshShape::~SkinnedMeshShape()
+	{
+		//m_aabbGridLink.discard_data();
+		//m_aabbGridBuffer.discard_data();
+	}
+
+	void SkinnedMeshShape::clipColliders()
+	{
+		m_tree.clipCollider([&, this](const Collider& n) -> bool {
+			bool flg = false;
+			for (int i = 0; i < getBonePerCollider() && !flg; ++i) {
+				float weight = getColliderBoneWeight(&n, i);
+				if (weight > FLT_EPSILON && weight > m_owner->m_skinnedBones[getColliderBoneIndex(&n, i)].weightThreshold)
+					flg = true;
+			}
+			return !flg;
+		});
+	}
+
+	PerVertexShape::PerVertexShape(SkinnedMeshBody* body) :
+		SkinnedMeshShape(body)
+	{
+	}
+
+	PerVertexShape::~PerVertexShape()
+	{
+	}
+
+	void PerVertexShape::finishBuild()
+	{
+		m_tree.optimize();
+		m_tree.updateKinematic([this](const Collider* n) {
+			return m_owner->flexible(m_owner->m_vertices[n->vertex]);
+		});
+
+		m_owner->setCollisionFlags(m_tree.isKinematic ? btCollisionObject::CF_KINEMATIC_OBJECT : 0);
+
+		m_tree.exportColliders(m_colliders);
+		m_aabb.resize(m_colliders.size());
+		m_tree.remapColliders(m_colliders.data(), m_aabb.data());
+	}
+
+	void PerVertexShape::internalUpdate()
+	{
+		const VertexPos* __restrict vertices = m_owner->m_vpos.data();
+		const Collider* __restrict colliders = m_colliders.data();
+		Aabb* __restrict aabbs = m_aabb.data();
+		const size_t size = m_colliders.size();
+
+		const __m128 marginFactor = _mm_set1_ps(m_shapeProp.margin);
+
+		for (size_t i = 0; i < size; ++i) {
+			__m128 p0 = vertices[colliders[i].vertex].m_data;
+
+			// Broadcast the W component and multiply by margin factor
+			__m128 bcast = _mm_shuffle_ps(p0, p0, _MM_SHUFFLE(3, 3, 3, 3));
+			__m128 margin = _mm_mul_ps(bcast, marginFactor);
+
+			// Force 16-byte aligned vector stores to prevent MSVC scalar assignment fallback
+			_mm_store_ps(reinterpret_cast<float*>(&aabbs[i].m_min), _mm_sub_ps(p0, margin));
+			_mm_store_ps(reinterpret_cast<float*>(&aabbs[i].m_max), _mm_add_ps(p0, margin));
+		}
+
+		m_tree.updateAabb();
+	}
+
+	void PerVertexShape::autoGen()
+	{
+		m_tree.children.clear();
+		std::vector<U32> keys;
+		for (U32 i = 0; i < m_owner->m_vertices.size(); ++i) {
+			keys.clear();
+			for (int j = 0; j < 4; ++j) {
+				if (m_owner->m_vertices[i].m_weight[j] > FLT_EPSILON)
+					keys.push_back(m_owner->m_vertices[i].getBoneIdx(j));
+			}
+			m_tree.insertCollider(keys.data(), keys.size(), Collider(i));
+		}
+	}
+
+	void PerVertexShape::markUsedVertices(bool* flags)
+	{
+		for (auto& i : m_colliders)
+			flags[i.vertex] = true;
+	}
+
+	void PerVertexShape::remapVertices(uint32_t* map)
+	{
+		for (auto& i : m_colliders)
+			i.vertex = map[i.vertex];
+	}
+
+	PerTriangleShape::PerTriangleShape(SkinnedMeshBody* body) :
+		SkinnedMeshShape(body)
+	{
+	}
+
+	PerTriangleShape::~PerTriangleShape()
+	{
+	}
+
+	// Note: Don't waste your time trying to optimize this...
+	// 1: The compiler auto-vertorizes, unrolls, and broadcasts W already (Very sensitive to changes)
+	// 2: Memory wall is the main issue
+	// 3: AVX2 would just have overhead
+	void PerTriangleShape::internalUpdate()
+	{
+		auto& vertices = m_owner->m_vpos;
+
+		size_t size = m_colliders.size();
+		for (size_t i = 0; i < size; ++i) {
+			auto c = &m_colliders[i];
+			auto p0 = vertices[c->vertices[0]].m_data;
+			auto p1 = vertices[c->vertices[1]].m_data;
+			auto p2 = vertices[c->vertices[2]].m_data;
+			auto margin4 = p0 + p1 + p2;
+
+			auto aabbMin = _mm_min_ps(_mm_min_ps(p0, p1), p2);
+			auto aabbMax = _mm_max_ps(_mm_max_ps(p0, p1), p2);
+			auto prenetration = _mm_set_ss(m_shapeProp.penetration);
+			prenetration = _mm_andnot_ps(_mm_set_ss(-0.0f), prenetration);  // abs
+			margin4 = _mm_max_ss(_mm_set_ss(getLane3(margin4) * m_shapeProp.margin / 3), prenetration);
+			margin4 = _mm_shuffle_ps(margin4, margin4, 0);
+			aabbMin = aabbMin - margin4;
+			aabbMax = aabbMax + margin4;
+
+			m_aabb[i].m_min = aabbMin;
+			m_aabb[i].m_max = aabbMax;
+		}
+
+		m_tree.updateAabb();
+	}
+
+	void PerTriangleShape::finishBuild()
+	{
+		m_tree.optimize();
+		m_tree.updateKinematic([=](const Collider* c) {
+			float k = m_owner->flexible(m_owner->m_vertices[c->vertices[0]]);
+			k += m_owner->flexible(m_owner->m_vertices[c->vertices[1]]);
+			k += m_owner->flexible(m_owner->m_vertices[c->vertices[2]]);
+			return k / 3;
+		});
+
+		m_owner->setCollisionFlags(m_tree.isKinematic ? btCollisionObject::CF_KINEMATIC_OBJECT : 0);
+
+		m_tree.exportColliders(m_colliders);
+		m_aabb.resize(m_colliders.size());
+		m_tree.remapColliders(m_colliders.data(), m_aabb.data());
+
+		Ref<PerTriangleShape> holder = hdt::make_ref(this);
+		m_verticesCollision = make_ref(new PerVertexShape(m_owner));
+		m_verticesCollision->m_shapeProp.margin = m_shapeProp.margin;
+		m_owner->m_shape = hdt::make_ref(this);
+
+		m_verticesCollision->autoGen();
+		m_verticesCollision->clipColliders();
+		m_verticesCollision->finishBuild();
+	}
+
+	void PerTriangleShape::markUsedVertices(bool* flags)
+	{
+		for (auto& i : m_colliders) {
+			flags[i.vertices[0]] = true;
+			flags[i.vertices[1]] = true;
+			flags[i.vertices[2]] = true;
+		}
+
+		m_verticesCollision->markUsedVertices(flags);
+	}
+
+	void PerTriangleShape::remapVertices(uint32_t* map)
+	{
+		for (auto& i : m_colliders) {
+			i.vertices[0] = map[i.vertices[0]];
+			i.vertices[1] = map[i.vertices[1]];
+			i.vertices[2] = map[i.vertices[2]];
+		}
+
+		m_verticesCollision->remapVertices(map);
+	}
+
+	void PerTriangleShape::addTriangle(int a, int b, int c)
+	{
+		assert(a < m_owner->m_vertices.size());
+		assert(b < m_owner->m_vertices.size());
+		assert(c < m_owner->m_vertices.size());
+		Collider collider(a, b, c);
+
+		// Stacklocal fixed arrays, max 12 unique bones (3 verts * 4 weights)
+		U32 keys[12];
+		float w[12];
+		int count = 0;
+
+		const auto& v0 = m_owner->m_vertices[a];
+		const auto& v1 = m_owner->m_vertices[b];
+		const auto& v2 = m_owner->m_vertices[c];
+		const Vertex* verts[3] = { &v0, &v1, &v2 };
+
+		for (int vi = 0; vi < 3; ++vi) {
+			for (int wi = 0; wi < 4; ++wi) {
+				float weight = verts[vi]->m_weight[wi];
+				if (weight < FLT_EPSILON)
+					continue;
+				U32 bone = verts[vi]->getBoneIdx(wi);
+
+				int found = -1;
+				for (int k = 0; k < count; ++k) {
+					if (keys[k] == bone) {
+						found = k;
+						break;
+					}
+				}
+				if (found >= 0) {
+					w[found] += weight;
+				} else {
+					keys[count] = bone;
+					w[count] = weight;
+					++count;
+				}
+			}
+		}
+
+		for (int i = 1; i < count; ++i) {
+			float wTemp = w[i];
+			U32 kTemp = keys[i];
+			int j = i;
+			while (j > 0 && (w[j - 1] < wTemp || (w[j - 1] == wTemp && keys[j - 1] > kTemp))) {
+				w[j] = w[j - 1];
+				keys[j] = keys[j - 1];
+				--j;
+			}
+			w[j] = wTemp;
+			keys[j] = kTemp;
+		}
+
+		m_tree.insertCollider(keys, count, collider);
+	}
+}
+
+#endif  // USE_BULLET

--- a/src/physics/hdt/hdtSkinnedMeshShape.h
+++ b/src/physics/hdt/hdtSkinnedMeshShape.h
@@ -87,9 +87,9 @@ namespace hdt
 			auto side0 = point0 - p;
 			auto side1 = point1 - p;
 			auto side2 = point2 - p;
-			auto area0 = btCross(side0, side1).get128();
-			auto area1 = btCross(side1, side2).get128();
-			auto area2 = btCross(side2, side0).get128();
+			auto area0 = toSimd(btCross(side0, side1));
+			auto area1 = toSimd(btCross(side1, side2));
+			auto area2 = toSimd(btCross(side2, side0));
 			area0 = _mm_dp_ps(area0, area0, 0x74);
 			area1 = _mm_dp_ps(area1, area1, 0x71);
 			area2 = _mm_dp_ps(area2, area2, 0x72);
@@ -98,7 +98,7 @@ namespace hdt
 			area0 = _mm_sqrt_ps(area0);
 			area1 = _mm_set_ps1(1);
 			area1 = _mm_dp_ps(area1, area0, 0x77);
-			return _mm_div_ps(area0, area1);
+			return fromSimd(_mm_div_ps(area0, area1));
 		}
 		inline float baryWeight(const btVector3& w, int boneIdx) override final { return w[boneIdx / 4]; }
 

--- a/src/physics/hdt/hdtSkinnedMeshShape.h
+++ b/src/physics/hdt/hdtSkinnedMeshShape.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include "hdtCollider.h"
+#include "hdtSkinnedMeshBody.h"
+
+namespace hdt
+{
+	class PerVertexShape;
+	class PerTriangleShape;
+
+	class SkinnedMeshShape :
+		public RefCounted
+	{
+	public:
+		BT_DECLARE_ALIGNED_ALLOCATOR();
+
+		SkinnedMeshShape(SkinnedMeshBody* body);
+		virtual ~SkinnedMeshShape();
+
+		virtual PerVertexShape* asPerVertexShape() { return nullptr; }
+		virtual PerTriangleShape* asPerTriangleShape() { return nullptr; }
+
+		const Aabb& getAabb() const { return m_tree.aabbAll; }
+
+		virtual void clipColliders();
+		virtual void finishBuild() = 0;
+		virtual void internalUpdate() = 0;
+		virtual void markUsedVertices(bool* flags) = 0;
+		virtual void remapVertices(uint32_t* map) = 0;
+
+		virtual float getColliderBoneWeight(const Collider* c, int boneIdx) = 0;
+		virtual int getColliderBoneIndex(const Collider* c, int boneIdx) = 0;
+		virtual btVector3 baryCoord(const Collider* c, const btVector3& p) = 0;
+		virtual float baryWeight(const btVector3& w, int boneIdx) = 0;
+		virtual int getBonePerCollider() = 0;
+
+		SkinnedMeshBody* m_owner;
+		vectorA16<Aabb> m_aabb;
+		vectorA16<Collider> m_colliders;
+		ColliderTree m_tree;
+	};
+
+	class PerVertexShape : public SkinnedMeshShape
+	{
+	public:
+		PerVertexShape(SkinnedMeshBody* body);
+		virtual ~PerVertexShape();
+
+		PerVertexShape* asPerVertexShape() override { return this; }
+		void internalUpdate() override;
+
+		inline int getBonePerCollider() override final { return 4; }
+		inline float getColliderBoneWeight(const Collider* c, int boneIdx) override final { return m_owner->m_vertices[c->vertex].m_weight[boneIdx]; }
+		inline int getColliderBoneIndex(const Collider* c, int boneIdx) override final { return m_owner->m_vertices[c->vertex].getBoneIdx(boneIdx); }
+		inline btVector3 baryCoord([[maybe_unused]] const Collider* c, [[maybe_unused]] const btVector3& p) override final { return btVector3(1, 1, 1); }
+		inline float baryWeight([[maybe_unused]] const btVector3& w, [[maybe_unused]] int boneIdx) override final { return 1; }
+
+		void finishBuild() override;
+		void markUsedVertices(bool* flags) override;
+		void remapVertices(uint32_t* map) override;
+		void autoGen();
+
+		struct ShapeProp
+		{
+			float margin = 1.0f;
+		} m_shapeProp;
+	};
+
+	class PerTriangleShape : public SkinnedMeshShape
+	{
+	public:
+		PerTriangleShape(SkinnedMeshBody* body);
+		virtual ~PerTriangleShape();
+
+		PerVertexShape* asPerVertexShape() override { return m_verticesCollision.get(); }
+		PerTriangleShape* asPerTriangleShape() override { return this; }
+		void internalUpdate() override;
+
+		inline int getBonePerCollider() override final { return 12; }
+		inline float getColliderBoneWeight(const Collider* c, int boneIdx) override final { return m_owner->m_vertices[c->vertices[boneIdx / 4]].m_weight[boneIdx % 4]; }
+		inline int getColliderBoneIndex(const Collider* c, int boneIdx) override final { return m_owner->m_vertices[c->vertices[boneIdx / 4]].getBoneIdx(boneIdx % 4); }
+		inline btVector3 baryCoord(const Collider* c, const btVector3& p) override final
+		{
+			auto point0 = m_owner->m_vpos[c->vertices[0]].pos();
+			auto point1 = m_owner->m_vpos[c->vertices[1]].pos();
+			auto point2 = m_owner->m_vpos[c->vertices[2]].pos();
+			auto side0 = point0 - p;
+			auto side1 = point1 - p;
+			auto side2 = point2 - p;
+			auto area0 = btCross(side0, side1).get128();
+			auto area1 = btCross(side1, side2).get128();
+			auto area2 = btCross(side2, side0).get128();
+			area0 = _mm_dp_ps(area0, area0, 0x74);
+			area1 = _mm_dp_ps(area1, area1, 0x71);
+			area2 = _mm_dp_ps(area2, area2, 0x72);
+			area0 = _mm_or_ps(area0, area1);
+			area0 = _mm_or_ps(area0, area2);
+			area0 = _mm_sqrt_ps(area0);
+			area1 = _mm_set_ps1(1);
+			area1 = _mm_dp_ps(area1, area0, 0x77);
+			return _mm_div_ps(area0, area1);
+		}
+		inline float baryWeight(const btVector3& w, int boneIdx) override final { return w[boneIdx / 4]; }
+
+		void finishBuild() override;
+		void markUsedVertices(bool* flags) override;
+		void remapVertices(uint32_t* map) override;
+
+		void addTriangle(int p0, int p1, int p2);
+
+		struct ShapeProp
+		{
+			float margin = 1.0f;
+			float penetration = 1.f;
+		} m_shapeProp;
+
+		Ref<PerVertexShape> m_verticesCollision;
+	};
+}

--- a/src/physics/hdt/hdtSkinnedMeshSystem.cpp
+++ b/src/physics/hdt/hdtSkinnedMeshSystem.cpp
@@ -1,0 +1,63 @@
+#ifdef USE_BULLET
+
+#include "hdtSkinnedMeshSystem.h"
+
+#include "hdtBoneScaleConstraint.h"
+#include "hdtSkinnedMeshBody.h"
+#include "hdtSkinnedMeshShape.h"
+
+namespace hdt
+{
+	void SkinnedMeshSystem::readTransform(float timeStep)
+	{
+		if (this->block_resetting)
+			return;
+
+		for (const auto& bone : m_bones) {
+			bone->readTransform(timeStep);
+		}
+
+		for (auto i : m_constraints) {
+			i->scaleConstraint();
+		}
+
+		for (auto i : m_constraintGroups) {
+			i->scaleConstraint();
+		}
+	}
+
+	void SkinnedMeshSystem::writeTransform()
+	{
+		for (int i = 0; i < m_bones.size(); ++i) {
+			if (m_bones[i]->m_rig.isKinematicObject()) {
+				continue;
+			}
+
+			m_bones[i]->writeTransform();
+		}
+	}
+
+	void SkinnedMeshSystem::internalUpdate()
+	{
+		for (auto& i : m_bones)
+			i->internalUpdate();
+
+		for (auto& i : m_meshes)
+			i->updateBoundingSphereAabb();
+	}
+
+	void SkinnedMeshSystem::gather(std::vector<SkinnedMeshBody*>& bodies, std::vector<SkinnedMeshShape*>& shapes)
+	{
+		for (auto& i : m_meshes) {
+			bodies.push_back(i.get());
+			shapes.push_back(i->m_shape.get());
+			auto triShape = dynamic_cast<PerTriangleShape*>(i->m_shape.get());
+
+			if (triShape) {
+				shapes.push_back(triShape->m_verticesCollision.get());
+			}
+		}
+	}
+}
+
+#endif  // USE_BULLET

--- a/src/physics/hdt/hdtSkinnedMeshSystem.h
+++ b/src/physics/hdt/hdtSkinnedMeshSystem.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "hdtBulletHelper.h"
+#include "hdtConstraintGroup.h"
+
+namespace hdt
+{
+	struct SkinnedMeshBone;
+	class SkinnedMeshBody;
+	class SkinnedMeshShape;
+	class SkinnedMeshWorld;
+	class BoneScaleConstraint;
+
+	class SkinnedMeshSystem :
+		public RefCounted
+	{
+		friend class hdt::SkinnedMeshWorld;
+
+	public:
+		virtual ~SkinnedMeshSystem() = default;
+
+		virtual float prepareForRead(float timeStep) { return timeStep; }
+		virtual void readTransform(float timeStep);
+		virtual void writeTransform();
+
+		void internalUpdate();
+
+		void gather(std::vector<SkinnedMeshBody*>& bodies, std::vector<SkinnedMeshShape*>& shapes);
+
+		bool valid() const { return !m_bones.empty(); }
+
+		std::vector<std::shared_ptr<btCollisionShape>> m_shapeRefs;
+		SkinnedMeshWorld* m_world = nullptr;
+
+		// wind factor for the whole system; lived on the game-side subclass
+		// (SkyrimSystem) upstream, but applyWind reads it generically
+		float m_windFactor = 1.f;
+
+		bool block_resetting = false;
+		std::vector<Ref<SkinnedMeshBone>>& getBones() { return m_bones; };
+
+	protected:
+		std::vector<Ref<SkinnedMeshBone>> m_bones;
+		std::vector<Ref<SkinnedMeshBody>> m_meshes;
+		std::vector<Ref<BoneScaleConstraint>> m_constraints;
+		std::vector<Ref<ConstraintGroup>> m_constraintGroups;
+
+	private:
+	};
+}

--- a/src/physics/hdt/hdtSkinnedMeshWorld.cpp
+++ b/src/physics/hdt/hdtSkinnedMeshWorld.cpp
@@ -1,0 +1,427 @@
+#ifdef USE_BULLET
+
+#include "hdtSkinnedMeshWorld.h"
+#include "hdtBoneScaleConstraint.h"
+#include "hdtDispatcher.h"
+#include "hdtSkinnedMeshAlgorithm.h"
+#include <algorithm>
+#include <cmath>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace hdt
+{
+	SkinnedMeshWorld::SkinnedMeshWorld() :
+		btDiscreteDynamicsWorld(
+			nullptr,
+			nullptr,
+			new btSequentialImpulseConstraintSolver,
+			nullptr)
+	{
+		m_windSpeed = _mm_setzero_ps();
+
+		auto collisionConfiguration = new btDefaultCollisionConfiguration;
+		auto collisionDispatcher = new CollisionDispatcher(collisionConfiguration);
+
+		m_dispatcher1 = collisionDispatcher;
+		m_broadphasePairCache = new btDbvtBroadphase();
+	}
+
+	SkinnedMeshWorld::~SkinnedMeshWorld()
+	{
+		for (auto system : m_systems) {
+			for (int i = 0; i < system->m_meshes.size(); ++i)
+				removeCollisionObject(system->m_meshes[i].get());
+
+			for (int i = 0; i < system->m_constraints.size(); ++i)
+				if (system->m_constraints[i]->m_constraint)
+					removeConstraint(system->m_constraints[i]->m_constraint);
+
+			for (int i = 0; i < system->m_bones.size(); ++i)
+				removeRigidBody(&system->m_bones[i]->m_rig);
+
+			for (auto i : system->m_constraintGroups)
+				for (auto j : i->m_constraints)
+					if (j->m_constraint)
+						removeConstraint(j->m_constraint);
+		}
+
+		m_systems.clear();
+
+		auto solver = m_constraintSolver;
+		m_constraintSolver = nullptr;
+		delete solver;
+	}
+
+	void SkinnedMeshWorld::addSkinnedMeshSystem(SkinnedMeshSystem* system)
+	{
+		if (std::find(m_systems.begin(), m_systems.end(), system) != m_systems.end()) {
+			return;
+		}
+
+		m_systems.push_back(hdt::make_ref(system));
+		for (int i = 0; i < system->m_meshes.size(); ++i) {
+			addCollisionObject(system->m_meshes[i].get(), 1, 1);
+		}
+
+		for (int i = 0; i < system->m_bones.size(); ++i) {
+			system->m_bones[i]->m_rig.setActivationState(DISABLE_DEACTIVATION);
+			// 0,0 mask disables the collision of this object on Bullet.
+			addRigidBody(&system->m_bones[i]->m_rig, 0, 0);
+		}
+
+		for (auto i : system->m_constraintGroups)
+			for (auto j : i->m_constraints)
+				addConstraint(j->m_constraint, true);
+
+		for (int i = 0; i < system->m_constraints.size(); ++i)
+			addConstraint(system->m_constraints[i]->m_constraint, true);
+
+		// -10 allows RESET_PHYSICS down the calls. But equality with a float?...
+		system->readTransform(system->prepareForRead(RESET_PHYSICS));
+
+		system->m_world = this;
+	}
+
+	void SkinnedMeshWorld::removeSkinnedMeshSystem(SkinnedMeshSystem* system)
+	{
+		auto idx = std::find(m_systems.begin(), m_systems.end(), system);
+		if (idx == m_systems.end())
+			return;
+
+		for (auto i : system->m_constraintGroups)
+			for (auto j : i->m_constraints)
+				if (j->m_constraint)
+					removeConstraint(j->m_constraint);
+
+		for (int i = 0; i < system->m_meshes.size(); ++i)
+			removeCollisionObject(system->m_meshes[i].get());
+		for (int i = 0; i < system->m_constraints.size(); ++i)
+			if (system->m_constraints[i]->m_constraint)
+				removeConstraint(system->m_constraints[i]->m_constraint);
+		for (int i = 0; i < system->m_bones.size(); ++i)
+			removeRigidBody(&system->m_bones[i]->m_rig);
+
+		std::swap(*idx, m_systems.back());
+		m_systems.pop_back();
+
+		system->m_world = nullptr;
+	}
+
+	void SkinnedMeshWorld::updateConstraintsForBone(SkinnedMeshBone* bone)
+	{
+		if (!bone)
+			return;
+
+		int numConstraints = int(m_constraints.size());
+		for (int i = 0; i < numConstraints; i++) {
+			btTypedConstraint* constraint = m_constraints[i];
+
+			if (&constraint->getRigidBodyA() == &bone->m_rig ||
+				&constraint->getRigidBodyB() == &bone->m_rig) {
+				bool bothKinematic = constraint->getRigidBodyA().isStaticOrKinematicObject() &&
+				                     constraint->getRigidBodyB().isStaticOrKinematicObject();
+
+				constraint->setEnabled(!bothKinematic);
+			}
+		}
+	}
+
+	int SkinnedMeshWorld::stepSimulation(btScalar remainingTimeStep, int, btScalar fixedTimeStep)
+	{
+		applyGravity();
+		if (m_enableWind)
+			applyWind(remainingTimeStep);
+
+		while (remainingTimeStep > fixedTimeStep) {
+			internalSingleStepSimulation(fixedTimeStep);
+			remainingTimeStep -= fixedTimeStep;
+		}
+
+		// For the sake of the bullet library, we don't manage a step that would be lower than a 300Hz frame.
+		// Review this when (screens / Skyrim) will allow 300Hz+.
+		// Note: We are taking a final variable-sized step for the remaining time.
+		// Because Bullet's constraint solvers (ERP/CFM) are sensitive to delta-time,
+		// this variable tick can cause constraints to behave a bit differently
+		// (appearing more stiff or damping differently at various framerates).
+		constexpr auto minPossiblePeriod = 1.0f / 300.0f;
+		if (remainingTimeStep > minPossiblePeriod)
+			internalSingleStepSimulation(remainingTimeStep);
+		clearForces();
+
+		_bodies.clear();
+		_shapes.clear();
+
+		return 0;
+	}
+
+	// --Todo: This, and the systems related to it, can be optimized a bit more. I WILL BE BACK...
+	// This optimizes Bullet's broadphase by removing tons of redudent work. We don't use persistent manifolds,
+	// we don't have static objects, etc..
+	// HOWEVER: If we ever add non-skinned Bullet collision objects, or make (0,0) bodies participate in
+	// broadphase queries/collision, this optimization must be revisited.
+	void SkinnedMeshWorld::performDiscreteCollisionDetection()
+	{
+		BT_PROFILE("performDiscreteCollisionDetection");
+
+		for (auto& system : m_systems) {
+			system->internalUpdate();
+		}
+
+		btDispatcherInfo& dispatchInfo = getDispatchInfo();
+
+		for (int i = 0; i < m_collisionObjects.size(); i++) {
+			btCollisionObject* colObj = m_collisionObjects[i];
+			btBroadphaseProxy* proxy = colObj->getBroadphaseHandle();
+
+			if (proxy->m_collisionFilterGroup == 0 && proxy->m_collisionFilterMask == 0)
+				continue;
+
+			btVector3 minAabb, maxAabb;
+			colObj->getCollisionShape()->getAabb(colObj->getWorldTransform(), minAabb, maxAabb);
+
+			m_broadphasePairCache->setAabb(proxy, minAabb, maxAabb, m_dispatcher1);
+		}
+
+		m_broadphasePairCache->calculateOverlappingPairs(m_dispatcher1);
+
+		if (m_dispatcher1) {
+			m_dispatcher1->dispatchAllCollisionPairs(m_broadphasePairCache->getOverlappingPairCache(), dispatchInfo, m_dispatcher1);
+		}
+	}
+
+	void SkinnedMeshWorld::applyGravity()
+	{
+		for (auto& i : m_systems) {
+			for (auto& j : i->m_bones) {
+				auto body = &j->m_rig;
+				if (!body->isStaticOrKinematicObject() && !(body->getFlags() & BT_DISABLE_WORLD_GRAVITY)) {
+					body->setGravity(m_gravity * j->m_gravityFactor);
+				}
+			}
+		}
+
+		btDiscreteDynamicsWorld::applyGravity();
+	}
+
+	void SkinnedMeshWorld::applyWind(btScalar timeStep)
+	{
+		constexpr btScalar kMaxFrameStep = 0.1f;
+		constexpr btScalar kTimeWrap = 4096.0f;
+		constexpr btScalar kResponseToBodyVelocity = 0.08f;
+		constexpr btScalar kGustSpeedPerForce = 7.0f;
+		constexpr btScalar kMinGustSpeed = 180.0f;
+		constexpr btScalar kMaxGustSpeed = 1200.0f;
+		constexpr btScalar kCrosswindTimeScale = 0.004f;
+		constexpr btScalar kVerticalPhaseScale = 0.006f;
+		constexpr btScalar kPressureCenterOffset = 0.8f;
+
+		BT_PROFILE("HDTSMP_applyWind");
+
+		const btScalar windMagnitude = m_windSpeed.length();
+		if (btFuzzyZero(windMagnitude))
+			return;
+
+		m_windTime += clampScalar(timeStep, 0.0f, kMaxFrameStep);
+		if (m_windTime > kTimeWrap)
+			m_windTime -= kTimeWrap;
+
+		const btVector3 windDirection = m_windSpeed / windMagnitude;
+		const btVector3 up(0.0f, 0.0f, 1.0f);
+		btVector3 side = windDirection.cross(up);
+		if (btFuzzyZero(side.length2())) {
+			side = btVector3(1.0f, 0.0f, 0.0f);
+		} else {
+			side.normalize();
+		}
+
+		const btScalar gustSpeed = clampScalar(windMagnitude * kGustSpeedPerForce, kMinGustSpeed, kMaxGustSpeed);
+
+		for (auto& i : m_systems) {
+			auto system = i.get();
+			if (btFuzzyZero(system->m_windFactor))  // skip any systems that aren't affected by wind
+				continue;
+			for (auto& j : i->m_bones) {
+				auto body = &j->m_rig;
+				if (body->isStaticOrKinematicObject() || btFuzzyZero(j->m_windFactor))
+					continue;
+
+				const btScalar windFactor = j->m_windFactor * system->m_windFactor;
+				const btVector3 origin = body->getWorldTransform().getOrigin();
+				// Move gust phases downwind so stronger wind carries the same gust across bones faster
+				const btScalar advectedTime = m_windTime - origin.dot(windDirection) / gustSpeed - origin.dot(side) * kCrosswindTimeScale;
+				const btScalar verticalPhase = origin.getZ() * kVerticalPhaseScale;
+
+				const btScalar longGust = std::sin(advectedTime * 0.55f + verticalPhase * 0.35f);
+				const btScalar midGust = std::sin(advectedTime * 1.35f + verticalPhase + longGust * 0.5f);
+				const btScalar flutter = std::sin(advectedTime * 4.15f + verticalPhase * 2.2f + midGust);
+				const btScalar gustPulse = 0.5f + 0.5f * std::sin(advectedTime * 0.85f + verticalPhase * 0.6f);
+				const btScalar gustBurst = gustPulse * gustPulse;
+				const btScalar gustScale = clampScalar(0.68f + longGust * 0.18f + midGust * 0.12f + flutter * 0.06f + gustBurst * 0.45f, 0.35f, 1.55f);
+
+				const btScalar relativeScale = clampScalar((m_windSpeed - body->getLinearVelocity() * kResponseToBodyVelocity).dot(windDirection) / windMagnitude,
+					0.0f,
+					1.4f);
+
+				const btScalar baseMagnitude = windMagnitude * windFactor;
+				const btScalar sidewaysFlutter = (midGust * 0.13f + flutter * 0.06f + gustBurst * 0.04f) * baseMagnitude;
+				const btScalar verticalFlutter = (std::sin(advectedTime * 1.9f + verticalPhase * 1.4f) * 0.018f + flutter * 0.01f) * baseMagnitude;
+
+				const btVector3 windForce =
+					m_windSpeed * windFactor * gustScale * relativeScale +
+					side * sidewaysFlutter +
+					up * verticalFlutter;
+
+				const btVector3 pressureOffset = (side * midGust + up * (0.35f + flutter * 0.25f)) * kPressureCenterOffset;
+				body->applyForce(windForce, pressureOffset);
+			}
+		}
+	}
+
+	void SkinnedMeshWorld::predictUnconstraintMotion(btScalar timeStep)
+	{
+		struct UpdaterPredictUnconstraintMotion : public btIParallelForBody
+		{
+			btScalar timeStep;
+			btRigidBody** rigidBodies;
+
+			void forLoop(int iBegin, int iEnd) const BT_OVERRIDE
+			{
+				for (int i = iBegin; i < iEnd; ++i) {
+					btRigidBody* body = rigidBodies[i];
+
+					// not realistic, just an approximate
+					if (!body->isStaticOrKinematicObject())
+						body->applyDamping(timeStep);
+
+					body->predictIntegratedTransform(timeStep, body->getInterpolationWorldTransform());
+				}
+			}
+		};
+
+		if (m_nonStaticRigidBodies.size() > 0) {
+			UpdaterPredictUnconstraintMotion update;
+			update.timeStep = timeStep;
+			update.rigidBodies = &m_nonStaticRigidBodies[0];
+
+			// Upstream uses btParallelFor here, which asserts on stock
+			// (non-BT_THREADSAFE) Bullet builds; run the loop body directly.
+			update.forLoop(0, m_nonStaticRigidBodies.size());
+		}
+	}
+
+	void SkinnedMeshWorld::integrateTransforms(btScalar timeStep)
+	{
+		for (int i = 0; i < m_collisionObjects.size(); ++i) {
+			auto body = m_collisionObjects[i];
+			if (body->isKinematicObject()) {
+				btTransformUtil::integrateTransform(
+					body->getWorldTransform(),
+					body->getInterpolationLinearVelocity(),
+					body->getInterpolationAngularVelocity(),
+					timeStep,
+					body->getInterpolationWorldTransform());
+				body->setWorldTransform(body->getInterpolationWorldTransform());
+			}
+		}
+
+		btVector3 limitMin(-1e+9f, -1e+9f, -1e+9f);
+		btVector3 limitMax(1e+9f, 1e+9f, 1e+9f);
+		for (int i = 0; i < m_nonStaticRigidBodies.size(); i++) {
+			btRigidBody* body = m_nonStaticRigidBodies[i];
+			auto lv = body->getLinearVelocity();
+			lv.setMax(limitMin);
+			lv.setMin(limitMax);
+			body->setLinearVelocity(lv);
+
+			auto av = body->getAngularVelocity();
+			av.setMax(limitMin);
+			av.setMin(limitMax);
+			body->setAngularVelocity(av);
+		}
+
+		btDiscreteDynamicsWorld::integrateTransforms(timeStep);
+	}
+
+	void SkinnedMeshWorld::calculateSimulationIslands()
+	{
+		BT_PROFILE("calculateSimulationIslands");
+		getSimulationIslandManager()->updateActivationState(getCollisionWorld(), getCollisionWorld()->getDispatcher());
+
+		auto unionFind = &getSimulationIslandManager()->getUnionFind();
+
+		for (int i = 0; i < m_predictiveManifolds.size(); i++) {
+			btPersistentManifold* manifold = m_predictiveManifolds[i];
+			const btCollisionObject* colObj0 = manifold->getBody0();
+			const btCollisionObject* colObj1 = manifold->getBody1();
+			if (((colObj0) && (!(colObj0)->isStaticOrKinematicObject())) &&
+				((colObj1) && (!(colObj1)->isStaticOrKinematicObject()))) {
+				unionFind->unite((colObj0)->getIslandTag(), (colObj1)->getIslandTag());
+			}
+		}
+
+		int numConstraints = int(m_constraints.size());
+		for (int i = 0; i < numConstraints; i++) {
+			btTypedConstraint* constraint = m_constraints[i];
+			if (constraint->isEnabled()) {
+				const btRigidBody* colObj0 = &constraint->getRigidBodyA();
+				const btRigidBody* colObj1 = &constraint->getRigidBodyB();
+				if (((colObj0) && (!(colObj0)->isStaticOrKinematicObject())) &&
+					((colObj1) && (!(colObj1)->isStaticOrKinematicObject()))) {
+					unionFind->unite((colObj0)->getIslandTag(), (colObj1)->getIslandTag());
+				}
+			}
+		}
+
+		// If two dynamic bones are colliding, they MUST be processed by the same island! Without this the solver will cause an
+		// EXCEPTION_ACCESS_VIOLATION reading m_tmpSolverBodyPool :(
+		btDispatcher* dispatcher = getCollisionWorld()->getDispatcher();
+		int numManifolds = dispatcher->getNumManifolds();
+		for (int i = 0; i < numManifolds; i++) {
+			btPersistentManifold* manifold = dispatcher->getManifoldByIndexInternal(i);
+
+			// Only unite if they are actively generating contact points
+			if (manifold->getNumContacts() > 0) {
+				const btCollisionObject* colObj0 = static_cast<const btCollisionObject*>(manifold->getBody0());
+				const btCollisionObject* colObj1 = static_cast<const btCollisionObject*>(manifold->getBody1());
+
+				if (((colObj0) && (!(colObj0)->isStaticOrKinematicObject())) &&
+					((colObj1) && (!(colObj1)->isStaticOrKinematicObject()))) {
+					unionFind->unite((colObj0)->getIslandTag(), (colObj1)->getIslandTag());
+				}
+			}
+		}
+
+		getSimulationIslandManager()->storeIslandActivationState(getCollisionWorld());
+	}
+
+	// Island-based constraint solving...
+	// btDiscreteDynamicsWorld::solveConstraints decomposes the world into independent
+	// simulation islands and dispatches each to a solver from the pool on separate threads.
+	void SkinnedMeshWorld::solveConstraints(btContactSolverInfo& solverInfo)
+	{
+		BT_PROFILE("solveConstraints");
+		if (!m_collisionObjects.size())
+			return;
+
+		// Kinematic objects should never be able to collide, or move. Because: They're kinematic?
+		// This avoids broken configs, API misuse - etc. Better to check it every cycle for safety
+		for (int i = 0; i < m_constraints.size(); i++) {
+			btTypedConstraint* constraint = m_constraints[i];
+			if (constraint->isEnabled()) {
+				if (constraint->getRigidBodyA().isStaticOrKinematicObject() &&
+					constraint->getRigidBodyB().isStaticOrKinematicObject()) {
+					constraint->setEnabled(false);
+				}
+			}
+		}
+
+		btDiscreteDynamicsWorld::solveConstraints(solverInfo);
+
+		// the HDT manifolds are still recreated every frame, clear to prevent stale data.
+		static_cast<CollisionDispatcher*>(m_dispatcher1)->clearAllManifold();
+	}
+}
+
+#endif  // USE_BULLET

--- a/src/physics/hdt/hdtSkinnedMeshWorld.cpp
+++ b/src/physics/hdt/hdtSkinnedMeshWorld.cpp
@@ -19,7 +19,7 @@ namespace hdt
 			new btSequentialImpulseConstraintSolver,
 			nullptr)
 	{
-		m_windSpeed = _mm_setzero_ps();
+		m_windSpeed.setZero();
 
 		auto collisionConfiguration = new btDefaultCollisionConfiguration;
 		auto collisionDispatcher = new CollisionDispatcher(collisionConfiguration);

--- a/src/physics/hdt/hdtSkinnedMeshWorld.h
+++ b/src/physics/hdt/hdtSkinnedMeshWorld.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "hdtSkinnedMeshSystem.h"
+#include <BulletCollision/CollisionDispatch/btSimulationIslandManager.h>
+#include <BulletDynamics/Dynamics/btDiscreteDynamicsWorld.h>
+
+namespace hdt
+{
+	class SkinnedMeshWorld : protected btDiscreteDynamicsWorld
+	{
+	public:
+		SkinnedMeshWorld();
+		~SkinnedMeshWorld();
+
+		virtual void addSkinnedMeshSystem(SkinnedMeshSystem* system);
+		virtual void removeSkinnedMeshSystem(SkinnedMeshSystem* system);
+
+		void updateConstraintsForBone(SkinnedMeshBone* bone);
+
+		int stepSimulation(btScalar remainingTimeStep, int maxSubSteps = 1,
+			btScalar fixedTimeStep = btScalar(1.) / btScalar(60.)) override;
+
+		btVector3& getWind() { return m_windSpeed; }
+		const btVector3& getWind() const { return m_windSpeed; }
+
+		// wind is off in the preview by default; upstream this flag lived on
+		// the game-side world singleton
+		bool m_enableWind = false;
+
+	protected:
+		std::vector<float> m_timeSteps;
+
+		void readTransform(float timeStep)
+		{
+			const size_t n = m_systems.size();
+			if (n == 0)
+				return;
+
+			m_timeSteps.resize(n);
+
+			// processSkeletonRoot must be ran synchronously to avoid race issues
+			for (size_t i = 0; i < n; ++i)
+				m_timeSteps[i] = m_systems[i]->prepareForRead(timeStep);
+
+			par::for_range(size_t{ 0 }, n, [this](size_t i) {
+				m_systems[i]->readTransform(m_timeSteps[i]);
+			});
+		}
+
+		void writeTransform()
+		{
+			for (int i = 0; i < m_systems.size(); ++i) m_systems[i]->writeTransform();
+		}
+
+		void applyGravity() override;
+		void applyWind(btScalar timeStep);
+
+		void predictUnconstraintMotion(btScalar timeStep) override;
+		void integrateTransforms(btScalar timeStep) override;
+		void performDiscreteCollisionDetection() override;
+		void calculateSimulationIslands() override;
+		void solveConstraints(btContactSolverInfo& solverInfo) override;
+
+		std::vector<Ref<SkinnedMeshSystem>> m_systems;
+
+		btVector3 m_windSpeed;       // world windspeed
+		btScalar m_windTime = 0.0f;  // wind simulation clock
+
+	private:
+		std::vector<SkinnedMeshBody*> _bodies;
+		std::vector<SkinnedMeshShape*> _shapes;
+	};
+}

--- a/src/physics/hdt/hdtStiffSpringConstraint.cpp
+++ b/src/physics/hdt/hdtStiffSpringConstraint.cpp
@@ -1,0 +1,121 @@
+#ifdef USE_BULLET
+
+#include "hdtStiffSpringConstraint.h"
+
+namespace hdt
+{
+	StiffSpringConstraint::StiffSpringConstraint(SkinnedMeshBone* a, SkinnedMeshBone* b) :
+		BoneScaleConstraint(a, b, this), btTypedConstraint(MAX_CONSTRAINT_TYPE, a->m_rig, b->m_rig)
+	{
+		auto distance = a->m_currentTransform.getOrigin().distance(b->m_currentTransform.getOrigin());
+		m_equilibriumPoint = m_minDistance = m_maxDistance = distance;
+		m_oldDiff = 0;
+		m_stiffness = 0;
+		m_damping = 0;
+		// m_minDistance *= 0.8;
+		// m_maxDistance /= 0.8;
+	}
+
+	void StiffSpringConstraint::scaleConstraint()
+	{
+		auto newScaleA = m_boneA->m_currentTransform.getScale();
+		auto newScaleB = m_boneB->m_currentTransform.getScale();
+
+		if (btFuzzyZero(newScaleA - m_scaleA) && btFuzzyZero(newScaleB - m_scaleB))
+			return;
+
+		float w0 = m_boneA->m_rig.getInvMass();
+		float w1 = m_boneB->m_rig.getInvMass();
+		auto factor = (newScaleA / m_scaleA * w0 + newScaleB / m_scaleB * w1) / (w0 + w1);
+		auto factor3 = factor * factor * factor;
+
+		m_minDistance *= factor;
+		m_maxDistance *= factor;
+		m_equilibriumPoint *= factor;
+		m_stiffness *= factor3;
+		m_damping *= factor3;
+
+		m_scaleA = newScaleA;
+		m_scaleB = newScaleB;
+	}
+
+	void StiffSpringConstraint::getInfo1(btConstraintInfo1* info)
+	{
+		auto a = m_boneA->m_rigToLocal * m_rbA.getWorldTransform();
+		auto b = m_boneB->m_rigToLocal * m_rbB.getWorldTransform();
+		auto a2b = a.getOrigin() - b.getOrigin();
+		auto distance = a2b.length();
+
+		info->m_numConstraintRows = !btFuzzyZero(distance);
+		info->nub = 0;
+	}
+
+	void StiffSpringConstraint::getInfo2(btConstraintInfo2* info)
+	{
+		auto a = m_boneA->m_rigToLocal * m_rbA.getWorldTransform();
+		auto b = m_boneB->m_rigToLocal * m_rbB.getWorldTransform();
+		auto a2b = a.getOrigin() - b.getOrigin();
+		auto distance = a2b.length();
+		auto dir = a2b.normalized();
+
+		info->m_J1linearAxis[0] = dir[0];
+		info->m_J1linearAxis[1] = dir[1];
+		info->m_J1linearAxis[2] = dir[2];
+		info->m_J2linearAxis[0] = -dir[0];
+		info->m_J2linearAxis[1] = -dir[1];
+		info->m_J2linearAxis[2] = -dir[2];
+
+		int currentLimit;
+		float currentLimitError;
+		if (distance < m_minDistance) {
+			currentLimit = 2;
+			currentLimitError = distance - m_minDistance;
+		} else if (distance > m_maxDistance) {
+			currentLimit = 1;
+			currentLimitError = distance - m_maxDistance;
+		} else {
+			currentLimit = 0;
+			currentLimitError = 0;
+		}
+
+		if (!currentLimit) {
+			// get current position of constraint
+			auto delta = distance - m_equilibriumPoint;
+			auto vel = (delta - m_oldDiff) * info->fps;
+
+			// spring force is (delta * m_stiffness) according to Hooke's Law
+			btScalar force = (delta + m_oldDiff) * 0.5f * m_stiffness;
+			btScalar friction = m_damping * vel;
+			force += force * friction < 0 ? btClamped(friction, -abs(force), abs(force)) : friction;
+			btScalar velFactor = info->fps / btScalar(info->m_numIterations);
+			auto m_targetVelocity = velFactor * force;
+			auto m_maxMotorForce = btFabs(force) / info->fps;
+
+			btScalar mot_fact = getMotorFactor(distance, m_minDistance, m_maxDistance, m_targetVelocity,
+				info->fps * info->erp);
+			info->m_constraintError[0] = mot_fact * m_targetVelocity * (m_rbA.getInvMass() + m_rbB.getInvMass());
+			info->m_lowerLimit[0] = -m_maxMotorForce;
+			info->m_upperLimit[0] = m_maxMotorForce;
+
+			m_oldDiff = delta;
+		} else {
+			btScalar k = info->fps * info->erp;
+			info->m_constraintError[0] = k * currentLimitError;
+			if (m_minDistance == m_maxDistance) {
+				// limited low and high simultaneously
+				info->m_lowerLimit[0] = -SIMD_INFINITY;
+				info->m_upperLimit[0] = SIMD_INFINITY;
+			} else {
+				if (currentLimit == 1) {
+					info->m_lowerLimit[0] = -SIMD_INFINITY;
+					info->m_upperLimit[0] = 0;
+				} else {
+					info->m_lowerLimit[0] = 0;
+					info->m_upperLimit[0] = SIMD_INFINITY;
+				}
+			}
+		}
+	}
+}
+
+#endif  // USE_BULLET

--- a/src/physics/hdt/hdtStiffSpringConstraint.h
+++ b/src/physics/hdt/hdtStiffSpringConstraint.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "hdtBoneScaleConstraint.h"
+#include "hdtBulletHelper.h"
+
+namespace hdt
+{
+	class StiffSpringConstraint :
+		public BoneScaleConstraint,
+		public btTypedConstraint
+	{
+	public:
+		BT_DECLARE_ALIGNED_ALLOCATOR();
+
+		StiffSpringConstraint(SkinnedMeshBone* a, SkinnedMeshBone* b);
+		virtual ~StiffSpringConstraint() override = default;
+
+		void scaleConstraint() override;
+
+		float m_minDistance;
+		float m_maxDistance;
+		float m_stiffness;
+		float m_damping;
+		float m_equilibriumPoint;
+
+	protected:
+		float m_oldDiff;
+
+		///internal method used by the constraint solver, don't use them directly
+		void getInfo1(btConstraintInfo1* info) override;
+		///internal method used by the constraint solver, don't use them directly
+		void getInfo2(btConstraintInfo2* info) override;
+
+		///override the default global value of a parameter (such as ERP or CFM), optionally provide the axis (0..5).
+		///If no axis is provided, it uses the default axis for this constraint.
+		void setParam([[maybe_unused]] int num, [[maybe_unused]] btScalar value, [[maybe_unused]] int axis = -1) override {
+		};
+
+		///return the local value of parameter
+		btScalar getParam([[maybe_unused]] int num, [[maybe_unused]] int axis = -1) const override { return 0; };
+	};
+}

--- a/src/physics/hdt/hdtStringUtils.h
+++ b/src/physics/hdt/hdtStringUtils.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+// Minimal subset of hdtSMP64's string helpers needed by the ported physics
+// code.
+namespace hdt
+{
+	// Trim ASCII whitespace from both ends of a string.
+	inline std::string TrimAsciiWhitespace(const std::string& s)
+	{
+		auto start = s.find_first_not_of(" \t\r\n");
+		if (start == std::string::npos)
+			return "";
+		auto end = s.find_last_not_of(" \t\r\n");
+		return s.substr(start, end - start + 1);
+	}
+
+	// ASCII lower-case copy. Name comparisons folded with this mirror the
+	// engine's case-insensitive BSFixedString matching.
+	inline std::string ToLowerAscii(std::string s)
+	{
+		std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+		return s;
+	}
+}

--- a/src/physics/hdt/hdtVertex.cpp
+++ b/src/physics/hdt/hdtVertex.cpp
@@ -1,0 +1,20 @@
+#ifdef USE_BULLET
+
+#include "hdtVertex.h"
+
+namespace hdt
+{
+	void Vertex::sortWeight()
+	{
+		for (int i = 0; i < 4; ++i) {
+			for (int j = 0; j < 3; ++j) {
+				if (m_weight[j] < m_weight[j + 1]) {
+					std::swap(m_weight[j], m_weight[j + 1]);
+					std::swap(m_boneIdx[j], m_boneIdx[j + 1]);
+				}
+			}
+		}
+	}
+}
+
+#endif  // USE_BULLET

--- a/src/physics/hdt/hdtVertex.h
+++ b/src/physics/hdt/hdtVertex.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "hdtBone.h"
+
+#include <cstring>
+
+namespace hdt
+{
+	struct alignas(16) Vertex
+	{
+		Vertex()
+		{
+			memset(this, 0, sizeof(*this));
+		}
+
+		Vertex(float x, float y, float z) :
+			Vertex() { m_skinPos.setValue(x, y, z); }
+
+		// skin info;
+		btVector3 m_skinPos;
+		float m_weight[4];
+		U32 m_boneIdx[4];
+
+		U32 getBoneIdx(int i) const { return m_boneIdx[i]; }
+
+		void setBoneIdx(int i, U32 idx)
+		{
+			m_boneIdx[i] = idx;
+		}
+
+		void sortWeight();
+	};
+
+	struct alignas(16) VertexPos
+	{
+		// position info
+
+		void set(const btVector3& p, float m)
+		{
+			m_data = setLane3(p.get128(), m);
+		}
+
+		void set(const btVector4& pm)
+		{
+			m_data = pm.get128();
+		}
+
+		btVector3 pos() const { return m_data; }
+		__m128 marginMultiplier4() const { return pshufd<0xFF>(m_data); }
+		float marginMultiplier() const { return _mm_cvtss_f32(marginMultiplier4()); }
+
+		__m128 m_data;
+	};
+}

--- a/src/physics/hdt/hdtVertex.h
+++ b/src/physics/hdt/hdtVertex.h
@@ -37,15 +37,22 @@ namespace hdt
 
 		void set(const btVector3& p, float m)
 		{
-			m_data = setLane3(p.get128(), m);
+			m_data = setLane3(toSimd(p), m);
 		}
 
 		void set(const btVector4& pm)
 		{
-			m_data = pm.get128();
+			m_data = toSimd(pm);
 		}
 
-		btVector3 pos() const { return m_data; }
+		// The original relied on btVector4's implicit __m128 conversion, which
+		// Bullet only provides when built with BT_USE_SSE.
+		void set(__m128 pm)
+		{
+			m_data = pm;
+		}
+
+		btVector3 pos() const { return fromSimd(m_data); }
 		__m128 marginMultiplier4() const { return pshufd<0xFF>(m_data); }
 		float marginMultiplier() const { return _mm_cvtss_f32(marginMultiplier4()); }
 

--- a/src/program/BodySlideApp.cpp
+++ b/src/program/BodySlideApp.cpp
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "BodySlideApp.h"
 #include "../components/ClippingFixer.h"
 #include "../components/Mesh.h"
+#include "../files/GameDataStream.h"
 #include "../files/SFMorphFile.h"
 #include "../files/wxDDSImage.h"
 #include "../utils/SettingsDialogShared.h"
@@ -2076,6 +2077,7 @@ void BodySlideApp::InitPreview() {
 
 			previewLoading = false;
 			UpdatePreview();
+			UpdatePreviewPhysicsAvailability();
 			preview->ShowLoadingIndicator(false);
 		});
 	});
@@ -2491,15 +2493,189 @@ void BodySlideApp::PostProcessPreview(std::vector<ShapePreviewData>& shapeData, 
 				sd.uvs.erase(sd.uvs.begin() + sd.zapIdx[z]);
 			}
 		}
+
+		if (previewPhysicsRunning) {
+			// Remember the morphed shape so a physics tick can skin it again
+			// without running all sliders, then show it simulated
+			previewMorphedVerts[sd.name] = sd.verts;
+			ApplyPreviewPhysicsSkinning(sd.name, sd.verts);
+		}
+
 		preview->UpdateMeshes(sd.name, &sd.verts, &sd.uvs);
 	}
 
 	preview->Render();
 }
 
+void BodySlideApp::UpdatePreviewPhysicsAvailability(bool keepRunning) {
+	// Whatever led here replaced the previewed meshes, so the simulation - which
+	// holds shapes of those meshes - has to go either way.
+	const bool wasRunning = previewPhysicsRunning;
+	EnablePreviewPhysics(false);
+
+	previewPhysicsAvailable = false;
+	for (auto& pp : projects) {
+		if (Physics::HasPhysicsLinks(&pp->modNif, {})) {
+			previewPhysicsAvailable = true;
+			break;
+		}
+	}
+
+	if (keepRunning && wasRunning && previewPhysicsAvailable)
+		EnablePreviewPhysics(true);
+
+	if (preview) {
+		preview->ShowPhysicsControls(previewPhysicsAvailable);
+		preview->SetPhysicsChecked(previewPhysicsRunning);
+	}
+}
+
+void BodySlideApp::EnablePreviewPhysics(bool enable) {
+	if (enable == previewPhysicsRunning)
+		return;
+
+	if (!enable) {
+		previewPhysicsRunning = false;
+		previewPhysics.clear();
+
+		// Put the meshes back to the plain morphed shape the sliders describe
+		if (IsPreviewRenderable()) {
+			for (auto& morphedVerts : previewMorphedVerts)
+				preview->UpdateMeshes(morphedVerts.first, &morphedVerts.second);
+
+			preview->Render();
+		}
+
+		previewMorphedVerts.clear();
+		return;
+	}
+
+	if (!IsPreviewRenderable() || projects.empty())
+		return;
+
+	// The simulation reads its kinematic input from the application skeleton,
+	// which BodySlide has no other use for and therefore never loaded.
+	if (AnimSkeleton::getInstance().GetActiveBoneCount() == 0 && LoadDefaultSkeletonReference() != 0) {
+		wxLogError("Physics preview needs the reference skeleton, which could not be loaded.");
+		return;
+	}
+
+	for (size_t i = 0; i < projects.size(); i++) {
+		auto& pp = projects[i];
+
+		auto anim = std::make_unique<AnimInfo>();
+		if (!anim->LoadFromNif(&pp->modNif))
+			continue;
+
+		// The mod's own folder is the fallback for physics XMLs that aren't
+		// installed under the game data path
+		const std::string& nifPath = pp->inputFileName;
+
+		std::vector<std::string> warnings;
+		auto controller = std::make_unique<Physics::Controller>();
+		size_t systemCount = controller->BuildFromNif(
+			&pp->modNif,
+			anim.get(),
+			[&nifPath](const std::string& xmlPath) { return GameDataStream::OpenPhysicsXml(xmlPath, nifPath); },
+			{},
+			warnings);
+
+		for (auto& warning : warnings)
+			wxLogWarning("Physics: %s", warning);
+
+		if (systemCount == 0)
+			continue;
+
+		controller->ResetDynamics();
+
+		PreviewPhysicsProject entry;
+		entry.controller = std::move(controller);
+		entry.anim = std::move(anim);
+		entry.projectIdx = i;
+		previewPhysics.push_back(std::move(entry));
+	}
+
+	if (previewPhysics.empty()) {
+		wxLogWarning("No physics XMLs could be loaded for the previewed meshes.");
+		return;
+	}
+
+	previewPhysicsRunning = true;
+	previewPhysicsClock.Reset();
+
+	// Fills the morphed vertex cache and shows the first simulated frame
+	UpdatePreview();
+}
+
+void BodySlideApp::ApplyPreviewPhysicsSkinning(const PreviewPhysicsProject& physics, const std::string& shapeName, std::vector<Vector3>& verts) {
+	auto& modNif = projects[physics.projectIdx]->modNif;
+	auto shape = modNif.FindBlockByName<NiShape>(shapeName);
+	if (!shape)
+		return;
+
+	ApplySkinningToVerts(*physics.anim, shape, modNif.GetHeader().GetVersion().IsSF(), &physics.controller->PoseOverrides(), verts);
+}
+
+void BodySlideApp::ApplyPreviewPhysicsSkinning(const std::string& shapeName, std::vector<Vector3>& verts) {
+	for (auto& physics : previewPhysics) {
+		if (physics.controller->AffectedShapes().count(shapeName) != 0) {
+			ApplyPreviewPhysicsSkinning(physics, shapeName, verts);
+			return;
+		}
+	}
+}
+
+void BodySlideApp::PumpPreviewPhysics() {
+	if (!previewPhysicsRunning)
+		return;
+
+	if (!IsPreviewRenderable()) {
+		EnablePreviewPhysics(false);
+		return;
+	}
+
+	float dtSeconds = 0.0f;
+	if (!previewPhysicsClock.StepDue(dtSeconds))
+		return;
+
+	for (auto& physics : previewPhysics)
+		physics.controller->Step(dtSeconds);
+
+	// Only the shapes the simulation actually drives have to be skinned again
+	std::vector<Vector3> verts;
+	for (auto& physics : previewPhysics) {
+		for (auto& shapeName : physics.controller->AffectedShapes()) {
+			auto morphedVerts = previewMorphedVerts.find(shapeName);
+			if (morphedVerts == previewMorphedVerts.end())
+				continue;
+
+			verts = morphedVerts->second;
+			ApplyPreviewPhysicsSkinning(physics, shapeName, verts);
+			preview->UpdateMeshes(shapeName, &verts);
+		}
+	}
+
+	preview->Render();
+}
+
+void BodySlideApp::InjectPreviewCameraYaw(float deltaDegrees) {
+	for (auto& physics : previewPhysics)
+		physics.controller->InjectCameraYaw(deltaDegrees);
+}
+
+void BodySlideApp::SetPreviewWind(int directionIndex, int strengthPercent) {
+	for (auto& physics : previewPhysics) {
+		physics.controller->SetWindDirection(Physics::WindDirectionFromIndex(directionIndex));
+		physics.controller->SetWindStrength(strengthPercent / 100.0f);
+	}
+}
+
 void BodySlideApp::CleanupPreview() {
 	if (!preview)
 		return;
+
+	EnablePreviewPhysics(false);
+	previewPhysicsAvailable = false;
 
 	// Cancel async load and wait for it to finish
 	++previewLoadGeneration;
@@ -2589,6 +2765,7 @@ void BodySlideApp::RebuildPreviewMeshes() {
 		}
 
 		PostProcessPreview(shapeData, weight);
+		UpdatePreviewPhysicsAvailability(true);
 		return;
 	}
 
@@ -2629,6 +2806,7 @@ void BodySlideApp::RebuildPreviewMeshes() {
 	}
 
 	PostProcessPreview(shapeData, weight);
+	UpdatePreviewPhysicsAvailability(true);
 }
 
 void BodySlideApp::UpdateExternalReferenceMesh(int weight, std::vector<Vector3>* outVerts) {

--- a/src/program/BodySlideApp.h
+++ b/src/program/BodySlideApp.h
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include "../components/Anim.h"
 #include "../components/BuildSelection.h"
 #include "../components/ClippingFixer.h"
 #include "../components/SliderCategories.h"
@@ -24,6 +25,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "../components/SliderGroup.h"
 #include "../components/SliderManager.h"
 #include "../files/TriFile.h"
+#include "../physics/Controller.h"
+#include "../physics/PumpClock.h"
 #include "../utils/ConfigurationManager.h"
 #include "../utils/Log.h"
 #include "GroupManager.h"
@@ -149,6 +152,29 @@ private:
 	};
 	std::vector<std::unique_ptr<ProjectData>> projects;
 	bool multiProjectMode = false;
+
+	/* Physics preview (HDT-SMP), one simulation per previewed project */
+	struct PreviewPhysicsProject {
+		std::unique_ptr<Physics::Controller> controller;
+		// Skinning of the previewed NIF. Held by pointer because the physics
+		// bones keep pointers into it for as long as they exist.
+		std::unique_ptr<AnimInfo> anim;
+		size_t projectIdx = 0;
+	};
+	std::vector<PreviewPhysicsProject> previewPhysics;
+	// At least one previewed project references a physics XML, so the preview
+	// shows its physics controls.
+	bool previewPhysicsAvailable = false;
+	bool previewPhysicsRunning = false;
+	// Morphed (but not simulated) preview vertices per shape, so a physics tick
+	// can re-skin without running every slider again.
+	std::unordered_map<std::string, std::vector<nifly::Vector3>> previewMorphedVerts;
+	Physics::PumpClock previewPhysicsClock;
+
+	// Applies the simulated bone transforms on top of the shape's morphed
+	// vertices. The lookup overload picks the simulation driving the shape.
+	void ApplyPreviewPhysicsSkinning(const PreviewPhysicsProject& physics, const std::string& shapeName, std::vector<nifly::Vector3>& verts);
+	void ApplyPreviewPhysicsSkinning(const std::string& shapeName, std::vector<nifly::Vector3>& verts);
 
 	int CreateSetSliders(const std::string& outfit);
 	std::string GetFavoriteConfigKey(const std::string& listName) const;
@@ -292,6 +318,27 @@ public:
 	void UpdateReferenceCheckboxState();
 	void UpdatePreview();
 	void RebuildPreviewMeshes();
+
+	/* Physics preview */
+	// Rescans the previewed meshes for physics XML links and shows or hides the
+	// preview's physics controls accordingly. Always tears the simulation down
+	// first, because whatever led here replaced the meshes it was built on; only
+	// a rebuild of an already running preview ("keepRunning") starts it again,
+	// so a newly opened preview always begins with physics off.
+	void UpdatePreviewPhysicsAvailability(bool keepRunning = false);
+	bool IsPreviewPhysicsAvailable() const { return previewPhysicsAvailable; }
+	// Builds or tears down the simulation for all previewed projects.
+	void EnablePreviewPhysics(bool enable);
+	bool IsPreviewPhysicsRunning() const { return previewPhysicsRunning; }
+	// One simulation tick plus the resulting re-skin and redraw. Internally
+	// paced, so it is safe to call from any event source at any rate.
+	void PumpPreviewPhysics();
+	// Feeds a horizontal camera rotation into the simulation so cloth and hair
+	// react as if the character turned under a fixed camera.
+	void InjectPreviewCameraYaw(float deltaDegrees);
+	// Wind direction as an index into Physics::WindDirectionNames(), strength in
+	// percent.
+	void SetPreviewWind(int directionIndex, int strengthPercent);
 	std::vector<ShapePreviewData> ComputeMorphedShapeData(int weight);
 	void PostProcessPreview(std::vector<ShapePreviewData>& shapeData, int weight);
 	void UpdateExternalReferenceMesh(int weight, std::vector<nifly::Vector3>* outVerts = nullptr);

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -8,6 +8,7 @@ See the included LICENSE file
 #include "../components/SliderDataFileUtil.h"
 #include "../components/WeightNorm.h"
 #include "../files/FBXWrangler.h"
+#include "../files/GameDataStream.h"
 #include "../files/ObjFile.h"
 #include "../files/TriFile.h"
 #include "../files/SFMorphFile.h"
@@ -300,11 +301,7 @@ OutfitProject::OutfitProject(OutfitStudioFrame* inOwner) {
 	owner = inOwner;
 	workAnim.SetRefNif(&workNif);
 
-	std::string defSkelFile = Config["Anim/DefaultSkeletonReference"];
-	if (wxFileName(wxString::FromUTF8(defSkelFile)).IsRelative())
-		LoadSkeletonReference(Config["AppDir"] + PathSepStr + defSkelFile);
-	else
-		LoadSkeletonReference(defSkelFile);
+	LoadDefaultSkeletonReference();
 
 	auto targetGame = (TargetGame)Config.GetIntValue("TargetGame");
 	if (targetGame == SKYRIM || targetGame == SKYRIMSE || targetGame == SKYRIMVR)
@@ -7048,39 +7045,6 @@ int OutfitProject::ExportFBX(const std::string& fileName, const std::vector<NiSh
 }
 #endif
 
-// Try opening a loose file at the given path
-static std::unique_ptr<std::istream> OpenLooseFileStream(const std::string& fullPath) {
-	if (!PlatformUtil::FileExists(fullPath))
-		return nullptr;
-
-	auto fs = std::make_unique<std::fstream>();
-	PlatformUtil::OpenFileStream(*fs, fullPath, std::ios::in | std::ios::binary);
-	if (!fs->fail())
-		return fs;
-
-	return nullptr;
-}
-
-// Try opening a data-folder relative path in one of the loaded archives
-static std::unique_ptr<std::istream> OpenArchiveFileStream(const std::string& relPath) {
-	for (FSArchiveFile* archive : FSManager::archiveList()) {
-		if (!archive || !archive->hasFile(relPath))
-			continue;
-
-		wxMemoryBuffer outData;
-		archive->fileContents(relPath, outData);
-		if (outData.IsEmpty())
-			continue;
-
-		auto contentStream = std::make_unique<std::istringstream>(
-			std::string(static_cast<char*>(outData.GetData()), outData.GetDataLen()), std::istringstream::binary);
-		if (!contentStream->fail())
-			return contentStream;
-	}
-
-	return nullptr;
-}
-
 std::unique_ptr<std::istream> OutfitProject::GetExternalGeometryStream(const std::string& dir, const std::string& path, const std::string& nifFilePath) const {
 	// Normalize path: replace backslashes, extract relative geometries path, ensure prefix and suffix
 	std::string meshPath = std::regex_replace(path, std::regex("\\\\+"), "/");
@@ -7092,7 +7056,7 @@ std::unique_ptr<std::istream> OutfitProject::GetExternalGeometryStream(const std
 		meshPath += ".mesh";
 
 	// 1) Loose file in GameDataPath
-	if (auto stream = OpenLooseFileStream(dir + meshPath))
+	if (auto stream = GameDataStream::OpenLoose(dir + meshPath))
 		return stream;
 
 	// 2) Beside the meshes folder (or NIF directory) of the loading NIF
@@ -7102,72 +7066,27 @@ std::unique_ptr<std::istream> OutfitProject::GetExternalGeometryStream(const std
 
 		auto meshesPos = nifDirLower.rfind("/meshes/");
 		if (meshesPos != std::string::npos) {
-			if (auto stream = OpenLooseFileStream(nifDir.substr(0, meshesPos + 1) + meshPath))
+			if (auto stream = GameDataStream::OpenLoose(nifDir.substr(0, meshesPos + 1) + meshPath))
 				return stream;
 		}
 		else {
 			auto lastSlash = nifDir.rfind('/');
 			if (lastSlash != std::string::npos) {
-				if (auto stream = OpenLooseFileStream(nifDir.substr(0, lastSlash + 1) + meshPath))
+				if (auto stream = GameDataStream::OpenLoose(nifDir.substr(0, lastSlash + 1) + meshPath))
 					return stream;
 			}
 		}
 	}
 
 	// 3) Search in archives
-	if (auto stream = OpenArchiveFileStream(meshPath))
+	if (auto stream = GameDataStream::OpenArchive(meshPath))
 		return stream;
 
 	return nullptr;
 }
 
 std::unique_ptr<std::istream> OutfitProject::GetPhysicsXmlStream(const std::string& xmlPath) {
-	// Physics XML paths from "HDT Skinned Mesh Physics Object" extra data are
-	// relative to the game data folder, e.g.
-	// "SKSE\Plugins\hdtSkinnedMeshConfigs\outfit.xml". The game's resource
-	// system also accepts a leading "Data\" prefix ("Data\meshes\...") and
-	// mods in the wild use both spellings, so strip it before resolving.
-	std::string relPath = std::regex_replace(xmlPath, std::regex("\\\\+"), "/");
-	relPath = std::regex_replace(relPath, std::regex("^/+"), "");
-	if (ToLower(relPath).rfind("data/", 0) == 0)
-		relPath = relPath.substr(5);
-	if (relPath.empty())
-		return nullptr;
-
-	// 1) Loose file in GameDataPath
-	if (auto stream = OpenLooseFileStream(Config["GameDataPath"] + relPath))
-		return stream;
-
-	// 2) Relative to the project's input NIF: its "meshes" anchor points at
-	// the mod's data root, where SKSE/Plugins/... lives for loose mod folders
-	std::string nifFilePath = activeSet.GetInputFileName();
-	if (!nifFilePath.empty()) {
-		std::string nifDir = std::regex_replace(nifFilePath, std::regex("\\\\+"), "/");
-		std::string nifDirLower = ToLower(nifDir);
-
-		auto meshesPos = nifDirLower.rfind("/meshes/");
-		if (meshesPos != std::string::npos) {
-			if (auto stream = OpenLooseFileStream(nifDir.substr(0, meshesPos + 1) + relPath))
-				return stream;
-		}
-
-		auto lastSlash = nifDir.rfind('/');
-		if (lastSlash != std::string::npos) {
-			// Also try directly beside the NIF (both the full relative path
-			// and just the file name), for standalone test setups
-			if (auto stream = OpenLooseFileStream(nifDir.substr(0, lastSlash + 1) + relPath))
-				return stream;
-
-			auto fileNamePos = relPath.rfind('/');
-			if (fileNamePos != std::string::npos) {
-				if (auto stream = OpenLooseFileStream(nifDir.substr(0, lastSlash + 1) + relPath.substr(fileNamePos + 1)))
-					return stream;
-			}
-		}
-	}
-
-	// 3) Search in archives
-	return OpenArchiveFileStream(relPath);
+	return GameDataStream::OpenPhysicsXml(xmlPath, activeSet.GetInputFileName());
 }
 
 SFMaterialDatabase* OutfitProject::GetSFMaterialDatabase() {

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -2147,51 +2147,8 @@ void OutfitProject::GetLiveVerts(NiShape* shape, std::vector<Vector3>& outVerts,
 	}
 
 	if (bPose) {
-		int nv = outVerts.size();
-		std::vector<Vector3> pv(nv);
-		std::vector<float> wv(nv, 0.0f);
-		AnimSkin& animSkin = workAnim.shapeSkinning[shape->name.get()];
-		MatTransform globalToSkin = workAnim.GetTransformGlobalToShape(shape);
 		bool isSF = workNif.GetHeader().GetVersion().IsSF();
-
-		for (auto& boneNamesIt : animSkin.boneNames) {
-			AnimBone* animB = AnimSkeleton::getInstance().GetBonePtr(boneNamesIt.first);
-			if (animB) {
-				AnimWeight& animW = animSkin.boneWeights[boneNamesIt.second];
-
-				// Compose transform: skin -> (posed) bone -> global -> skin
-				MatTransform transform = globalToSkin.ComposeTransforms(animB->xformPoseToGlobal.ComposeTransforms(animW.xformSkinToBone));
-
-				if (isSF)
-					transform.translation *= sfHavokScale;
-
-				if (transform.IsNearlyEqualTo(MatTransform()))
-					transform.Clear();
-
-				// Add weighted contributions to vertex for this bone
-				for (auto& wIt : animW.weights) {
-					int ind = wIt.first;
-					float w = wIt.second;
-					pv[ind] += w * transform.ApplyTransform(outVerts[ind]);
-					wv[ind] += w;
-				}
-			}
-		}
-
-		// Check if total weight for each vertex was 1
-		for (int ind = 0; ind < nv; ++ind) {
-			if (wv[ind] < EPSILON) // If weights are missing for this vertex
-				pv[ind] = outVerts[ind];
-			else if (std::fabs(wv[ind] - 1.0f) >= EPSILON) // If weights are bad for this vertex
-				pv[ind] /= wv[ind];
-			// else do nothing because weights totaled 1.
-
-			// New position is nearly equal to old position (reduce noise)
-			if (pv[ind].IsNearlyEqualTo(outVerts[ind]))
-				pv[ind] = outVerts[ind];
-		}
-
-		outVerts.swap(pv);
+		ApplySkinningToVerts(workAnim, shape, isSF, physicsPose, outVerts);
 	}
 }
 
@@ -3192,6 +3149,9 @@ int OutfitProject::LoadReference(const std::string& fileName, const std::string&
 		clothData[refFile] = cloth->Clone();
 
 	refNif.GetHeader().DeleteBlockByType("BSClothExtraData");
+
+	// Record physics XML links of the reference before it is merged in
+	CapturePhysicsFiles(refNif, {refShape});
 
 	if (workNif.IsValid()) {
 		// Copy only reference shape
@@ -5297,6 +5257,7 @@ void OutfitProject::DeleteShape(NiShape* shape) {
 	owner->glView->DeleteMesh(shapeName);
 	shapeTextures.erase(shapeName);
 	shapeMaterialFiles.erase(shapeName);
+	shapePhysicsFiles.erase(shapeName);
 
 	if (IsBaseShape(shape)) {
 		morpher.UnlinkRefDiffData();
@@ -5308,6 +5269,48 @@ void OutfitProject::DeleteShape(NiShape* shape) {
 
 	owner->ClearSelected(shape);
 	workNif.DeleteShape(shape);
+}
+
+void OutfitProject::CapturePhysicsFiles(NifFile& nif, const std::vector<NiShape*>& shapes) {
+	// HDT-SMP links a model to its physics XML with a NiStringExtraData named
+	// "HDT Skinned Mesh Physics Object". The game only reads it from the
+	// model's root node, so that is where it usually sits, but extra data
+	// further down the hierarchy is honored here as well.
+	static const std::string physicsExtraDataName = "hdt skinned mesh physics object";
+
+	auto collect = [&nif](NiObjectNET* obj, std::vector<std::string>& outFiles) {
+		for (auto& extraDataRef : obj->extraDataRefs) {
+			auto stringExtraData = nif.GetHeader().GetBlock<NiStringExtraData>(extraDataRef);
+			if (!stringExtraData)
+				continue;
+
+			if (ToLower(stringExtraData->name.get()) != physicsExtraDataName)
+				continue;
+
+			const std::string& xmlPath = stringExtraData->stringData.get();
+			if (!xmlPath.empty() && std::find(outFiles.begin(), outFiles.end(), xmlPath) == outFiles.end())
+				outFiles.push_back(xmlPath);
+		}
+	};
+
+	for (auto& shape : shapes) {
+		if (!shape)
+			continue;
+
+		std::vector<std::string> physicsFiles;
+		collect(shape, physicsFiles);
+
+		for (NiNode* node = nif.GetParentNode(shape); node; node = nif.GetParentNode(node))
+			collect(node, physicsFiles);
+
+		// Always overwrite: re-importing a file must not keep links of a shape
+		// of the same name that no longer has any.
+		std::string shapeName = shape->name.get();
+		if (physicsFiles.empty())
+			shapePhysicsFiles.erase(shapeName);
+		else
+			shapePhysicsFiles[shapeName] = std::move(physicsFiles);
+	}
 }
 
 void OutfitProject::CaptureShapeDeleteState(NiShape* shape, UndoStateShapeDelete& state) {
@@ -5359,6 +5362,10 @@ void OutfitProject::CaptureShapeDeleteState(NiShape* shape, UndoStateShapeDelete
 	auto mat = shapeMaterialFiles.find(state.shapeName);
 	if (mat != shapeMaterialFiles.end())
 		state.materialFile = mat->second;
+
+	auto physics = shapePhysicsFiles.find(state.shapeName);
+	if (physics != shapePhysicsFiles.end())
+		state.physicsFiles = physics->second;
 }
 
 NiShape* OutfitProject::RestoreDeletedShape(UndoStateShapeDelete& state) {
@@ -5409,6 +5416,9 @@ NiShape* OutfitProject::RestoreDeletedShape(UndoStateShapeDelete& state) {
 
 	if (state.materialFile.has_value())
 		shapeMaterialFiles[state.shapeName] = state.materialFile.value();
+
+	if (!state.physicsFiles.empty())
+		shapePhysicsFiles[state.shapeName] = state.physicsFiles;
 
 	// Restore base shape status if appropriate
 	if (restoreAsBase) {
@@ -5473,6 +5483,13 @@ void OutfitProject::RenameShape(NiShape* shape, const std::string& newShapeName)
 		auto value = mat->second;
 		shapeMaterialFiles.erase(mat);
 		shapeMaterialFiles[newShapeName] = value;
+	}
+
+	auto physics = shapePhysicsFiles.find(shapeName);
+	if (physics != shapePhysicsFiles.end()) {
+		auto value = physics->second;
+		shapePhysicsFiles.erase(physics);
+		shapePhysicsFiles[newShapeName] = value;
 	}
 
 	if (isBaseShape) {
@@ -6422,6 +6439,9 @@ int OutfitProject::ImportNIF(const std::string& fileName, bool clear, const std:
 
 	nif.GetHeader().DeleteBlockByType("BSClothExtraData");
 
+	// Record physics XML links of all shapes before they are merged in
+	CapturePhysicsFiles(nif, nif.GetShapes());
+
 	if (workNif.IsValid()) {
 		for (auto& s : nif.GetShapes()) {
 			std::string shapeName = s->name.get();
@@ -7028,6 +7048,39 @@ int OutfitProject::ExportFBX(const std::string& fileName, const std::vector<NiSh
 }
 #endif
 
+// Try opening a loose file at the given path
+static std::unique_ptr<std::istream> OpenLooseFileStream(const std::string& fullPath) {
+	if (!PlatformUtil::FileExists(fullPath))
+		return nullptr;
+
+	auto fs = std::make_unique<std::fstream>();
+	PlatformUtil::OpenFileStream(*fs, fullPath, std::ios::in | std::ios::binary);
+	if (!fs->fail())
+		return fs;
+
+	return nullptr;
+}
+
+// Try opening a data-folder relative path in one of the loaded archives
+static std::unique_ptr<std::istream> OpenArchiveFileStream(const std::string& relPath) {
+	for (FSArchiveFile* archive : FSManager::archiveList()) {
+		if (!archive || !archive->hasFile(relPath))
+			continue;
+
+		wxMemoryBuffer outData;
+		archive->fileContents(relPath, outData);
+		if (outData.IsEmpty())
+			continue;
+
+		auto contentStream = std::make_unique<std::istringstream>(
+			std::string(static_cast<char*>(outData.GetData()), outData.GetDataLen()), std::istringstream::binary);
+		if (!contentStream->fail())
+			return contentStream;
+	}
+
+	return nullptr;
+}
+
 std::unique_ptr<std::istream> OutfitProject::GetExternalGeometryStream(const std::string& dir, const std::string& path, const std::string& nifFilePath) const {
 	// Normalize path: replace backslashes, extract relative geometries path, ensure prefix and suffix
 	std::string meshPath = std::regex_replace(path, std::regex("\\\\+"), "/");
@@ -7038,21 +7091,8 @@ std::unique_ptr<std::istream> OutfitProject::GetExternalGeometryStream(const std
 	if (meshPath.size() < 5 || meshPath.compare(meshPath.size() - 5, 5, ".mesh") != 0)
 		meshPath += ".mesh";
 
-	// Try opening a loose file at the given path
-	auto tryOpenLoose = [](const std::string& fullPath) -> std::unique_ptr<std::istream> {
-		if (!PlatformUtil::FileExists(fullPath))
-			return nullptr;
-
-		auto fs = std::make_unique<std::fstream>();
-		PlatformUtil::OpenFileStream(*fs, fullPath, std::ios::in | std::ios::binary);
-		if (!fs->fail())
-			return fs;
-
-		return nullptr;
-	};
-
 	// 1) Loose file in GameDataPath
-	if (auto stream = tryOpenLoose(dir + meshPath))
+	if (auto stream = OpenLooseFileStream(dir + meshPath))
 		return stream;
 
 	// 2) Beside the meshes folder (or NIF directory) of the loading NIF
@@ -7062,34 +7102,72 @@ std::unique_ptr<std::istream> OutfitProject::GetExternalGeometryStream(const std
 
 		auto meshesPos = nifDirLower.rfind("/meshes/");
 		if (meshesPos != std::string::npos) {
-			if (auto stream = tryOpenLoose(nifDir.substr(0, meshesPos + 1) + meshPath))
+			if (auto stream = OpenLooseFileStream(nifDir.substr(0, meshesPos + 1) + meshPath))
 				return stream;
 		}
 		else {
 			auto lastSlash = nifDir.rfind('/');
 			if (lastSlash != std::string::npos) {
-				if (auto stream = tryOpenLoose(nifDir.substr(0, lastSlash + 1) + meshPath))
+				if (auto stream = OpenLooseFileStream(nifDir.substr(0, lastSlash + 1) + meshPath))
 					return stream;
 			}
 		}
 	}
 
 	// 3) Search in archives
-	for (FSArchiveFile* archive : FSManager::archiveList()) {
-		if (archive && archive->hasFile(meshPath)) {
-			wxMemoryBuffer outData;
-			archive->fileContents(meshPath, outData);
+	if (auto stream = OpenArchiveFileStream(meshPath))
+		return stream;
 
-			if (!outData.IsEmpty()) {
-				auto contentStream = std::make_unique<std::istringstream>(
-					std::string(static_cast<char*>(outData.GetData()), outData.GetDataLen()), std::istringstream::binary);
-				if (!contentStream->fail())
-					return contentStream;
+	return nullptr;
+}
+
+std::unique_ptr<std::istream> OutfitProject::GetPhysicsXmlStream(const std::string& xmlPath) {
+	// Physics XML paths from "HDT Skinned Mesh Physics Object" extra data are
+	// relative to the game data folder, e.g.
+	// "SKSE\Plugins\hdtSkinnedMeshConfigs\outfit.xml". The game's resource
+	// system also accepts a leading "Data\" prefix ("Data\meshes\...") and
+	// mods in the wild use both spellings, so strip it before resolving.
+	std::string relPath = std::regex_replace(xmlPath, std::regex("\\\\+"), "/");
+	relPath = std::regex_replace(relPath, std::regex("^/+"), "");
+	if (ToLower(relPath).rfind("data/", 0) == 0)
+		relPath = relPath.substr(5);
+	if (relPath.empty())
+		return nullptr;
+
+	// 1) Loose file in GameDataPath
+	if (auto stream = OpenLooseFileStream(Config["GameDataPath"] + relPath))
+		return stream;
+
+	// 2) Relative to the project's input NIF: its "meshes" anchor points at
+	// the mod's data root, where SKSE/Plugins/... lives for loose mod folders
+	std::string nifFilePath = activeSet.GetInputFileName();
+	if (!nifFilePath.empty()) {
+		std::string nifDir = std::regex_replace(nifFilePath, std::regex("\\\\+"), "/");
+		std::string nifDirLower = ToLower(nifDir);
+
+		auto meshesPos = nifDirLower.rfind("/meshes/");
+		if (meshesPos != std::string::npos) {
+			if (auto stream = OpenLooseFileStream(nifDir.substr(0, meshesPos + 1) + relPath))
+				return stream;
+		}
+
+		auto lastSlash = nifDir.rfind('/');
+		if (lastSlash != std::string::npos) {
+			// Also try directly beside the NIF (both the full relative path
+			// and just the file name), for standalone test setups
+			if (auto stream = OpenLooseFileStream(nifDir.substr(0, lastSlash + 1) + relPath))
+				return stream;
+
+			auto fileNamePos = relPath.rfind('/');
+			if (fileNamePos != std::string::npos) {
+				if (auto stream = OpenLooseFileStream(nifDir.substr(0, lastSlash + 1) + relPath.substr(fileNamePos + 1)))
+					return stream;
 			}
 		}
 	}
 
-	return nullptr;
+	// 3) Search in archives
+	return OpenArchiveFileStream(relPath);
 }
 
 SFMaterialDatabase* OutfitProject::GetSFMaterialDatabase() {

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -200,6 +200,17 @@ public:
 	std::unordered_map<std::string, std::vector<std::string>> shapeTextures;
 	std::unordered_map<std::string, MaterialFile> shapeMaterialFiles;
 
+	// Physics XML files ("HDT Skinned Mesh Physics Object" extra data) that
+	// were linked to each shape by the NIF it came from. Only the first NIF
+	// loaded keeps its node hierarchy in the work NIF; every later file
+	// contributes shapes alone, so the link - which the game stores on the
+	// root node - has to be captured before the merge or it is lost.
+	std::unordered_map<std::string, std::vector<std::string>> shapePhysicsFiles;
+
+	// Records the physics XML files linked to the given shapes of a NIF that
+	// is about to be merged into the work NIF, keyed by shape name.
+	void CapturePhysicsFiles(nifly::NifFile& nif, const std::vector<nifly::NiShape*>& shapes);
+
 	// inOwner is meant to provide access to OutfitStudio for the purposes of reporting process status only.
 	OutfitProject(OutfitStudioFrame* inOwner = nullptr);
 	~OutfitProject();
@@ -217,6 +228,11 @@ public:
 	wxString mSFMorphPath;
 	wxString mSFMorphTargetShape;
 	bool bPose = false;
+
+	// Physics preview: replacement pose-to-global transforms for bones driven
+	// by the simulation, or nullptr while physics is off. Owned by the
+	// physics controller; consumed by GetLiveVerts' skinning.
+	const AnimPoseOverrideMap* physicsPose = nullptr;
 
 	// Reference source info (remembered when reference is loaded from an OSP)
 	std::string mRefProjectFile;    // OSP file path relative to project dir
@@ -241,6 +257,11 @@ public:
 
 	nifly::NifFile* GetWorkNif() { return &workNif; }
 	AnimInfo* GetWorkAnim() { return &workAnim; }
+
+	// Resolves a physics XML path referenced by a "HDT Skinned Mesh Physics
+	// Object" extra data to a readable stream (loose game data folder file,
+	// relative to the project's input NIF, or from loaded archives).
+	std::unique_ptr<std::istream> GetPhysicsXmlStream(const std::string& xmlPath);
 	std::unordered_map<std::string, std::unique_ptr<nifly::BSClothExtraData>>& GetClothData() { return clothData; }
 
 	nifly::NiShape* GetBaseShape() { return baseShape; }

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -213,6 +213,11 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_BUTTON(XRCID("resetAllPose"), OutfitStudioFrame::OnResetAllPose)
 	EVT_BUTTON(XRCID("poseToMesh"), OutfitStudioFrame::OnPoseToMesh)
 	EVT_CHECKBOX(XRCID("cbPose"), OutfitStudioFrame::OnPoseCheckBox)
+	EVT_CHECKBOX(XRCID("cbPhysics"), OutfitStudioFrame::OnPhysicsCheckBox)
+	EVT_CHECKBOX(XRCID("cbPhysicsVis"), OutfitStudioFrame::OnPhysicsVisCheckBox)
+	EVT_COMMAND_SCROLL(XRCID("physicsWindSlider"), OutfitStudioFrame::OnPhysicsWindSlider)
+	EVT_CHOICE(XRCID("physicsWindDir"), OutfitStudioFrame::OnPhysicsWindDir)
+	EVT_TIMER(PHYSICS_TIMER, OutfitStudioFrame::OnPhysicsTimer)
 
 	EVT_COMBOBOX(XRCID("cPoseName"), OutfitStudioFrame::OnSelectPose)
 	EVT_BUTTON(XRCID("savePose"), OutfitStudioFrame::OnSavePose)
@@ -1494,7 +1499,20 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 	tzPoseText = (wxTextCtrl*)FindWindowByName("tzPoseText");
 	scPoseText = (wxTextCtrl*)FindWindowByName("scPoseText");
 	cbPose = (wxCheckBox*)FindWindowByName("cbPose");
+	cbPhysics = (wxCheckBox*)FindWindowByName("cbPhysics");
+	cbPhysicsVis = (wxCheckBox*)FindWindowByName("cbPhysicsVis");
+	physicsWindSlider = (wxSlider*)FindWindowByName("physicsWindSlider");
+	physicsWindDir = (wxChoice*)FindWindowByName("physicsWindDir");
 	poseToMesh = (wxButton*)FindWindowByName("poseToMesh");
+
+#ifndef USE_BULLET
+	// The physics preview needs a build with Bullet; without it the controls
+	// exist (the XRC is shared) but stay hidden.
+	for (wxWindow* physicsCtrl : {(wxWindow*)cbPhysics, (wxWindow*)cbPhysicsVis, (wxWindow*)physicsWindSlider, (wxWindow*)physicsWindDir, FindWindowByName("physicsWindLabel")}) {
+		if (physicsCtrl)
+			physicsCtrl->Hide();
+	}
+#endif
 
 	cAnimationName = (wxComboBox*)FindWindowByName("cAnimationName");
 	animPlayPauseButton = (wxButton*)FindWindowByName("animPlayPause");
@@ -1509,6 +1527,7 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 	}
 
 	animPlaybackTimer.SetOwner(this, ANIM_PLAYBACK_TIMER);
+	physicsTimer.SetOwner(this, PHYSICS_TIMER);
 
 	wxWindow* leftPanel = FindWindowByName("leftSplitPanel");
 	if (leftPanel) {
@@ -1625,6 +1644,7 @@ void OutfitStudioFrame::OnClose(wxCloseEvent& WXUNUSED(event)) {
 		editUV->Close();
 
 	if (project) {
+		ShutdownPhysics();
 		delete project;
 		project = nullptr;
 	}
@@ -2742,6 +2762,7 @@ bool OutfitStudioFrame::LoadProject(const std::string& fileName,
 		bEditSlider = false;
 		MenuExitSliderEdit();
 
+		ShutdownPhysics();
 		delete project;
 		project = new OutfitProject(this);
 	}
@@ -4143,6 +4164,7 @@ void OutfitStudioFrame::OnNewProject(wxCommandEvent& WXUNUSED(event)) {
 	bEditSlider = false;
 	MenuExitSliderEdit();
 
+	ShutdownPhysics();
 	delete project;
 	project = new OutfitProject(this);
 
@@ -4501,6 +4523,7 @@ void OutfitStudioFrame::OnUnloadProject(wxCommandEvent& WXUNUSED(event)) {
 
 	ResetProject();
 
+	ShutdownPhysics();
 	delete project;
 	project = new OutfitProject(this);
 
@@ -8042,6 +8065,7 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 
 		if (project->bPose) {
 			project->bPose = false;
+			UpdatePhysicsState();
 			ApplyPose();
 		}
 
@@ -13162,12 +13186,22 @@ void OutfitStudioFrame::OnPaneCollapse(wxCollapsiblePaneEvent& WXUNUSED(event)) 
 }
 
 void OutfitStudioFrame::ApplyPose() {
+	// While an animation plays there is no separate physics pump; the
+	// simulation advances in lockstep with each displayed frame, using the
+	// wall-clock time since the last step.
+	if (physicsRunning && animPlaying) {
+		const wxLongLong now = physicsWatch.TimeInMicro();
+		const float dt = static_cast<float>((now - physicsLastStepMicro).ToDouble() / 1000000.0);
+		physicsLastStepMicro = now;
+		physics->Step(dt);
+	}
+
 	// Asking for a BVH update queues the shape with wxGLPanel::OnIdle, which
 	// rebuilds a whole AABB tree over every triangle of it - far too expensive
 	// to pay once per displayed animation frame. The tree only serves picking
 	// and brush hit tests, both locked out during playback, so the rebuild is
 	// deferred to the single ApplyPose that PauseAnimationPlayback does.
-	const bool updateBVH = !animPlaying;
+	const bool updateBVH = !animPlaying && !physicsPumpActive;
 
 	for (auto& shape : project->GetWorkNif()->GetShapes()) {
 		std::vector<Vector3> verts;
@@ -13422,6 +13456,7 @@ void OutfitStudioFrame::ActivatePose(bool checked) {
 	project->bPose = checked;
 	poseToMesh->Enable(checked);
 
+	UpdatePhysicsState();
 	ApplyPose();
 }
 
@@ -13980,6 +14015,10 @@ void OutfitStudioFrame::StartAnimationPlayback() {
 	SetHighResolutionTimers(true);
 	Bind(wxEVT_IDLE, &OutfitStudioFrame::OnAnimIdle, this);
 	animPlaybackTimer.Start(AnimPlaybackTimerIntervalMS);
+
+	// Physics switches from its own pump to stepping in lockstep with the
+	// displayed animation frames (see ApplyPose)
+	UpdatePhysicsState();
 }
 
 void OutfitStudioFrame::PauseAnimationPlayback() {
@@ -14004,6 +14043,9 @@ void OutfitStudioFrame::PauseAnimationPlayback() {
 	// the pose sliders that were skipped while playing.
 	PoseToGUI();
 	UpdateAnimationPlayerUI();
+
+	// Back to the physics pump if physics stays enabled with pose mode on
+	UpdatePhysicsState();
 }
 
 void OutfitStudioFrame::ResetAnimationList() {
@@ -14158,6 +14200,11 @@ void OutfitStudioFrame::OnAnimFrameSlider(wxScrollEvent& event) {
 	if (!GetSelectedAnimation())
 		return;
 
+	// Seeking teleports the pose; re-seat the physics bodies on it instead of
+	// letting them interpret the jump as a huge velocity.
+	if (physicsRunning)
+		physics->ResetDynamics();
+
 	ApplyAnimationFrame(std::max(event.GetPosition(), 0), !animPlaying);
 
 	// Seeking moves the playhead, so playback has to continue from there.
@@ -14199,6 +14246,241 @@ void OutfitStudioFrame::OnAnimIdle(wxIdleEvent& event) {
 		wxMilliSleep(1);
 	else
 		PumpAnimationPlayback();
+
+	event.RequestMore();
+}
+
+void OutfitStudioFrame::InjectPhysicsCameraYaw(float deltaDegrees) {
+	if (physicsRunning)
+		physics->InjectCameraYaw(deltaDegrees);
+}
+
+void OutfitStudioFrame::OnPhysicsCheckBox(wxCommandEvent& e) {
+	// Physics only simulates while posing or playing; make checking the box
+	// take effect immediately by enabling pose mode along with it.
+	if (e.IsChecked() && !project->bPose && !animPlaying)
+		ActivatePose(true);
+	else
+		UpdatePhysicsState();
+}
+
+void OutfitStudioFrame::OnPhysicsVisCheckBox(wxCommandEvent& e) {
+	if (physics && physicsRunning) {
+		physics->UpdateDebugVis(glView->gls, e.IsChecked());
+		glView->Render();
+	}
+}
+
+void OutfitStudioFrame::OnPhysicsWindSlider(wxScrollEvent& WXUNUSED(e)) {
+	ApplyPhysicsWind();
+}
+
+void OutfitStudioFrame::OnPhysicsWindDir(wxCommandEvent& WXUNUSED(e)) {
+	ApplyPhysicsWind();
+}
+
+void OutfitStudioFrame::ApplyPhysicsWind() {
+	if (!physics)
+		return;
+
+	if (physicsWindDir) {
+		// Same order as the choice control in the XRC
+		static const bsos::WindDirection directions[] = {bsos::WindDirection::Up,
+														 bsos::WindDirection::Down,
+														 bsos::WindDirection::Forward,
+														 bsos::WindDirection::Backward,
+														 bsos::WindDirection::Left,
+														 bsos::WindDirection::Right};
+
+		const int selection = physicsWindDir->GetSelection();
+		if (selection >= 0 && selection < static_cast<int>(std::size(directions)))
+			physics->SetWindDirection(directions[selection]);
+	}
+
+	if (physicsWindSlider)
+		physics->SetWindStrength(physicsWindSlider->GetValue() / 100.0f);
+}
+
+void OutfitStudioFrame::ShutdownPhysics() {
+	StopPhysicsPump();
+	physicsRunning = false;
+
+	if (project)
+		project->physicsPose = nullptr;
+
+	if (physics) {
+		if (glView)
+			physics->UpdateDebugVis(glView->gls, false);
+		physics->Clear();
+	}
+
+	if (cbPhysics)
+		cbPhysics->SetValue(false);
+
+	if (cbPhysicsVis) {
+		cbPhysicsVis->SetValue(false);
+		cbPhysicsVis->Enable(false);
+	}
+}
+
+void OutfitStudioFrame::UpdatePhysicsState() {
+	const bool desired = cbPhysics && cbPhysics->IsChecked() && project && (project->bPose || animPlaying);
+
+	if (desired && !physicsRunning) {
+		if (!physics)
+			physics = std::make_unique<bsos::PhysicsController>();
+
+		std::vector<std::string> warnings;
+		OutfitProject* proj = project;
+		size_t systemCount = physics->BuildFromNif(
+			project->GetWorkNif(),
+			project->GetWorkAnim(),
+			[proj](const std::string& xmlPath) { return proj->GetPhysicsXmlStream(xmlPath); },
+			project->shapePhysicsFiles,
+			warnings);
+
+		for (auto& warning : warnings)
+			wxLogWarning("Physics: %s", warning);
+
+		if (systemCount == 0) {
+			statusBar->SetStatusText(_("No physics XMLs found in loaded meshes"));
+			physics->Clear();
+
+			// Nothing is simulating, so the box must not claim otherwise
+			cbPhysics->SetValue(false);
+			return;
+		}
+
+		statusBar->SetStatusText(wxString::Format(_("Physics active: %zu system(s)"), systemCount));
+		project->physicsPose = &physics->PoseOverrides();
+		physics->ResetDynamics();
+		physicsRunning = true;
+
+		// The step clock must be valid for the lockstep path too, where
+		// StartPhysicsPump never runs
+		physicsWatch.Start();
+		physicsLastStepMicro = 0;
+		physicsLastDrawMicro = 0;
+
+		// The controller is fresh; re-apply the current wind settings
+		ApplyPhysicsWind();
+
+		if (cbPhysicsVis)
+			cbPhysicsVis->Enable();
+
+		if (!animPlaying)
+			StartPhysicsPump();
+	}
+	else if (!desired && physicsRunning) {
+		// Drop the overrides before the pose is applied again, or the frame
+		// that is supposed to restore the user pose still shows the simulated
+		// one.
+		physicsRunning = false;
+		project->physicsPose = nullptr;
+		physics->UpdateDebugVis(glView->gls, false);
+		physics->Clear();
+		StopPhysicsPump();
+
+		if (cbPhysicsVis) {
+			cbPhysicsVis->SetValue(false);
+			cbPhysicsVis->Enable(false);
+		}
+
+		// Restore the clean user pose without the physics overrides. Also
+		// catches the BVH up with what is displayed: the pump skipped the
+		// rebuild on every tick.
+		ApplyPose();
+	}
+	else if (physicsRunning) {
+		// Animation playback took over or ended: while playing, ApplyPose
+		// steps the simulation in lockstep instead of the pump.
+		if (animPlaying && physicsPumpActive)
+			StopPhysicsPump();
+		else if (!animPlaying && !physicsPumpActive)
+			StartPhysicsPump();
+	}
+
+	// A checked box always means "simulating". Anything that stopped physics -
+	// leaving the bones tab, turning off pose mode, ending playback - clears
+	// it instead of leaving a checked box that does nothing.
+	if (cbPhysics && !physicsRunning)
+		cbPhysics->SetValue(false);
+}
+
+void OutfitStudioFrame::StartPhysicsPump() {
+	if (physicsPumpActive)
+		return;
+
+	physicsPumpActive = true;
+	physicsTargetFps = GetAnimTargetFps();
+	physicsWatch.Start();
+	physicsLastStepMicro = 0;
+	physicsLastDrawMicro = 0;
+	SetHighResolutionTimers(true);
+	Bind(wxEVT_IDLE, &OutfitStudioFrame::OnPhysicsIdle, this);
+	physicsTimer.Start(AnimPlaybackTimerIntervalMS);
+}
+
+void OutfitStudioFrame::StopPhysicsPump() {
+	if (!physicsPumpActive)
+		return;
+
+	physicsTimer.Stop();
+	Unbind(wxEVT_IDLE, &OutfitStudioFrame::OnPhysicsIdle, this);
+	SetHighResolutionTimers(false);
+	physicsPumpActive = false;
+}
+
+void OutfitStudioFrame::PumpPhysics() {
+	if (!physicsPumpActive || !physicsRunning)
+		return;
+
+	// Same pacing idea as PumpAnimationPlayback: ticks arrive from idle and
+	// the timer at wildly different rates, the drawing rate is decided here.
+	const wxLongLong period = 1000000 / std::max(physicsTargetFps, 1);
+	const wxLongLong now = physicsWatch.TimeInMicro();
+	if (now - physicsLastDrawMicro < period)
+		return;
+
+	const float dt = static_cast<float>((now - physicsLastStepMicro).ToDouble() / 1000000.0);
+	physicsLastStepMicro = now;
+	physicsLastDrawMicro = now;
+
+	physics->Step(dt);
+
+	const auto& affectedShapes = physics->AffectedShapes();
+	for (auto& shape : project->GetWorkNif()->GetShapes()) {
+		if (affectedShapes.count(shape->name.get()) == 0)
+			continue;
+
+		std::vector<Vector3> verts;
+		project->GetLiveVerts(shape, verts);
+
+		// BVH rebuilds only serve picking and brushes; way too expensive per
+		// frame. StopPhysicsPump does one full ApplyPose to catch up.
+		glView->UpdateMeshVertices(shape->name.get(), &verts, false, true, false);
+	}
+
+	if (cbPhysicsVis && cbPhysicsVis->IsChecked())
+		physics->UpdateDebugVis(glView->gls, true);
+
+	glView->Render();
+}
+
+void OutfitStudioFrame::OnPhysicsTimer(wxTimerEvent& WXUNUSED(event)) {
+	PumpPhysics();
+}
+
+void OutfitStudioFrame::OnPhysicsIdle(wxIdleEvent& event) {
+	if (!physicsPumpActive)
+		return;
+
+	const wxLongLong period = 1000000 / std::max(physicsTargetFps, 1);
+	const wxLongLong due = period - (physicsWatch.TimeInMicro() - physicsLastDrawMicro);
+	if (due > 1500)
+		wxMilliSleep(1);
+	else
+		PumpPhysics();
 
 	event.RequestMore();
 }
@@ -17293,8 +17575,10 @@ void wxGLPanel::OnMouseMove(wxMouseEvent& event) {
 		SetFocus();
 
 	// Mouse motion floods the message queue, which starves both the idle events
-	// and the WM_TIMER that drive playback, so tick it from here as well.
+	// and the WM_TIMER that drive playback and physics, so tick them from here
+	// as well.
 	os->PumpAnimationPlayback();
+	os->PumpPhysics();
 
 	bool cursorExists = false;
 	int x;
@@ -17331,8 +17615,9 @@ void wxGLPanel::OnMouseMove(wxMouseEvent& event) {
 			gls.PanCamera(x - lastX, y - lastY);
 		}
 		else {
-			gls.TurnTableCamera(x - lastX);
+			float yawDegrees = gls.TurnTableCamera(x - lastX);
 			gls.PitchCamera(y - lastY);
+			os->InjectPhysicsCameraYaw(yawDegrees);
 			ShowRotationCenter();
 		}
 

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -192,6 +192,7 @@ wxBEGIN_EVENT_TABLE(OutfitStudioFrame, wxFrame)
 	EVT_BUTTON(XRCID("importMask"), OutfitStudioFrame::OnImportMask)
 
 	EVT_COLLAPSIBLEPANE_CHANGED(XRCID("posePane"), OutfitStudioFrame::OnPaneCollapse)
+	EVT_COLLAPSIBLEPANE_CHANGED(XRCID("physicsPane"), OutfitStudioFrame::OnPaneCollapse)
 	EVT_COLLAPSIBLEPANE_CHANGED(XRCID("animationPane"), OutfitStudioFrame::OnPaneCollapse)
 	EVT_COLLAPSIBLEPANE_CHANGED(XRCID("notesPane"), OutfitStudioFrame::OnPaneCollapse)
 	EVT_CHOICE(XRCID("cPoseBone"), OutfitStudioFrame::OnPoseBoneChanged)
@@ -1360,8 +1361,10 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 	segmentTabButton = (wxStateButton*)FindWindowByName("segmentTabButton");
 	partitionTabButton = (wxStateButton*)FindWindowByName("partitionTabButton");
 	lightsTabButton = (wxStateButton*)FindWindowByName("lightsTabButton");
+	toolScroll = dynamic_cast<wxScrolledWindow*>(FindWindowByName("toolScroll"));
 	masksPane = dynamic_cast<wxCollapsiblePane*>(FindWindowByName("masksPane"));
 	posePane = dynamic_cast<wxCollapsiblePane*>(FindWindowByName("posePane"));
+	physicsPane = dynamic_cast<wxCollapsiblePane*>(FindWindowByName("physicsPane"));
 	animationPane = dynamic_cast<wxCollapsiblePane*>(FindWindowByName("animationPane"));
 	notesPane = dynamic_cast<wxCollapsiblePane*>(FindWindowByName("notesPane"));
 	projectNotes = (wxTextCtrl*)FindWindowByName("projectNotes");
@@ -1482,6 +1485,10 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 	if (editPanel)
 		editPanel->SetBackgroundColour(wxColour(112, 112, 112));
 
+	// Dragging the splitter sash changes how much of the tool area fits.
+	if (wxWindow* bottomSplitPanel = FindWindowByName("bottomSplitPanel"))
+		bottomSplitPanel->Bind(wxEVT_SIZE, &OutfitStudioFrame::OnBottomPanelResize, this);
+
 	cXMirrorBone = (wxChoice*)FindWindowByName("cXMirrorBone");
 	cPoseBone = (wxChoice*)FindWindowByName("cPoseBone");
 	rxPoseSlider = (wxSlider*)FindWindowByName("rxPoseSlider");
@@ -1506,14 +1513,10 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 	poseToMesh = (wxButton*)FindWindowByName("poseToMesh");
 
 	// Nothing is loaded yet, and only meshes that reference a physics XML can be
-	// simulated: UpdatePhysicsControlsVisibility reveals these again when one
+	// simulated: UpdatePhysicsControlsVisibility reveals the pane again when one
 	// shows up. In a build without Bullet that never happens.
-	for (wxWindow* physicsCtrl : {(wxWindow*)cbPhysics, (wxWindow*)cbPhysicsVis, (wxWindow*)physicsWindSlider, (wxWindow*)physicsWindDir, FindWindowByName("physicsWindLabel")}) {
-		if (physicsCtrl) {
-			physicsControls.push_back(physicsCtrl);
-			physicsCtrl->Hide();
-		}
-	}
+	if (physicsPane)
+		physicsPane->Hide();
 
 	cAnimationName = (wxComboBox*)FindWindowByName("cAnimationName");
 	animPlayPauseButton = (wxButton*)FindWindowByName("animPlayPause");
@@ -2829,9 +2832,7 @@ bool OutfitStudioFrame::LoadProject(const std::string& fileName,
 		projectNotes->SetValue(notesText);
 		notesPane->Collapse(notesText.empty());
 
-		wxWindow* parentPanel = FindWindowByName("bottomSplitPanel");
-		if (parentPanel)
-			parentPanel->Layout();
+		UpdateToolScrollLayout();
 	}
 
 	UpdateTitle();
@@ -4612,9 +4613,7 @@ void OutfitStudioFrame::ClearProject() {
 		projectNotes->Clear();
 		notesPane->Collapse();
 
-		wxWindow* parentPanel = FindWindowByName("bottomSplitPanel");
-		if (parentPanel)
-			parentPanel->Layout();
+		UpdateToolScrollLayout();
 	}
 
 	project->outfitName.clear();
@@ -8061,6 +8060,8 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 		cbNormalizeWeights->Show(false);
 		xMirrorBoneLabel->Show(false);
 		posePane->Show(false);
+		if (physicsPane)
+			physicsPane->Show(false);
 		if (animationPane)
 			animationPane->Show(false);
 		bonesFilter->GetParent()->Show(false);
@@ -8167,6 +8168,8 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 		cbNormalizeWeights->Show();
 		xMirrorBoneLabel->Show();
 		posePane->Show();
+		if (physicsPane)
+			physicsPane->Show(physicsAvailable);
 		if (animationPane)
 			animationPane->Show();
 		bonesFilter->GetParent()->Show();
@@ -8451,10 +8454,9 @@ void OutfitStudioFrame::OnTabButtonClick(wxCommandEvent& event) {
 	UpdateBrushSettings();
 
 	wxPanel* topSplitPanel = (wxPanel*)FindWindowByName("topSplitPanel");
-	wxPanel* bottomSplitPanel = (wxPanel*)FindWindowByName("bottomSplitPanel");
-
 	topSplitPanel->Layout();
-	bottomSplitPanel->Layout();
+
+	UpdateToolScrollLayout();
 
 	Refresh();
 }
@@ -13183,8 +13185,42 @@ void OutfitStudioFrame::OnImportMask(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void OutfitStudioFrame::OnPaneCollapse(wxCollapsiblePaneEvent& WXUNUSED(event)) {
-	wxWindow* parentPanel = FindWindowByName("bottomSplitPanel");
-	parentPanel->Layout();
+	UpdateToolScrollLayout();
+}
+
+void OutfitStudioFrame::OnBottomPanelResize(wxSizeEvent& event) {
+	event.Skip();
+	UpdateToolScrollLayout();
+}
+
+void OutfitStudioFrame::UpdateToolScrollLayout() {
+	wxWindow* container = FindWindowByName("bottomSplitPanel");
+	if (!container)
+		return;
+
+	wxSizer* contentSizer = toolScroll ? toolScroll->GetSizer() : nullptr;
+	if (contentSizer) {
+		// The panes stack up taller than the panel once a few of them are open.
+		// Letting the tool area claim its full height would squeeze the slider
+		// list to nothing and cut off whatever no longer fits, so cap it here
+		// and let the rest scroll.
+		int reserved = FromDIP(120);
+		if (notesPane && notesPane->IsShown())
+			reserved += notesPane->GetEffectiveMinSize().GetHeight();
+
+		const int room = std::max(container->GetClientSize().GetHeight() - reserved, FromDIP(80));
+		const int height = std::min(contentSizer->CalcMin().GetHeight(), room);
+
+		if (toolScroll->GetMinHeight() != height)
+			toolScroll->SetMinSize(wxSize(-1, height));
+	}
+
+	container->Layout();
+
+	// Scrollbars follow the virtual size, which the capped minimum above does
+	// not change.
+	if (toolScroll)
+		toolScroll->FitInside();
 }
 
 void OutfitStudioFrame::ApplyPose() {
@@ -14089,6 +14125,7 @@ void OutfitStudioFrame::SetAnimationPlaybackLock(bool locked) {
 															masksPane,
 															notesPane,
 															posePane,
+															physicsPane,
 															FindWindow(XRCID("cbFixedWeight")),
 															FindWindow(XRCID("cbNormalizeWeights")),
 															// The player itself stays usable; only the
@@ -14290,26 +14327,27 @@ void OutfitStudioFrame::ApplyPhysicsWind() {
 }
 
 void OutfitStudioFrame::UpdatePhysicsControlsVisibility() {
-	if (!cbPhysics)
+	if (!cbPhysics || !physicsPane)
 		return;
 
 	const bool available = project && Physics::HasPhysicsLinks(project->GetWorkNif(), project->shapePhysicsFiles);
-	if (available == cbPhysics->IsShown())
+	if (available == physicsAvailable)
 		return;
+
+	physicsAvailable = available;
 
 	// Deleting the last shape with physics while it simulates has to stop it,
 	// and UpdatePhysicsState only ever starts physics for a checked box
 	if (!available)
 		cbPhysics->SetValue(false);
 
-	for (wxWindow* physicsCtrl : physicsControls)
-		physicsCtrl->Show(available);
+	// The pane belongs to the bones tab; leaving it shows nothing regardless.
+	physicsPane->Show(available && currentTabButton == boneTabButton);
 
 	if (!available)
 		UpdatePhysicsState();
 
-	if (cbPhysics->GetParent())
-		cbPhysics->GetParent()->Layout();
+	UpdateToolScrollLayout();
 }
 
 void OutfitStudioFrame::ShutdownPhysics() {

--- a/src/program/OutfitStudio.cpp
+++ b/src/program/OutfitStudio.cpp
@@ -1505,14 +1505,15 @@ OutfitStudioFrame::OutfitStudioFrame(const wxPoint& pos, const wxSize& size) {
 	physicsWindDir = (wxChoice*)FindWindowByName("physicsWindDir");
 	poseToMesh = (wxButton*)FindWindowByName("poseToMesh");
 
-#ifndef USE_BULLET
-	// The physics preview needs a build with Bullet; without it the controls
-	// exist (the XRC is shared) but stay hidden.
+	// Nothing is loaded yet, and only meshes that reference a physics XML can be
+	// simulated: UpdatePhysicsControlsVisibility reveals these again when one
+	// shows up. In a build without Bullet that never happens.
 	for (wxWindow* physicsCtrl : {(wxWindow*)cbPhysics, (wxWindow*)cbPhysicsVis, (wxWindow*)physicsWindSlider, (wxWindow*)physicsWindDir, FindWindowByName("physicsWindLabel")}) {
-		if (physicsCtrl)
+		if (physicsCtrl) {
+			physicsControls.push_back(physicsCtrl);
 			physicsCtrl->Hide();
+		}
 	}
-#endif
 
 	cAnimationName = (wxComboBox*)FindWindowByName("cAnimationName");
 	animPlayPauseButton = (wxButton*)FindWindowByName("animPlayPause");
@@ -4885,6 +4886,7 @@ void OutfitStudioFrame::UpdateAnimationGUI() {
 
 	RefreshGUIWeightColors();
 	PoseToGUI();
+	UpdatePhysicsControlsVisibility();
 
 	glView->UpdateNodes();
 	glView->UpdateBones();
@@ -13189,12 +13191,8 @@ void OutfitStudioFrame::ApplyPose() {
 	// While an animation plays there is no separate physics pump; the
 	// simulation advances in lockstep with each displayed frame, using the
 	// wall-clock time since the last step.
-	if (physicsRunning && animPlaying) {
-		const wxLongLong now = physicsWatch.TimeInMicro();
-		const float dt = static_cast<float>((now - physicsLastStepMicro).ToDouble() / 1000000.0);
-		physicsLastStepMicro = now;
-		physics->Step(dt);
-	}
+	if (physicsRunning && animPlaying)
+		physics->Step(physicsClock.TakeElapsed());
 
 	// Asking for a BVH update queues the shape with wxGLPanel::OnIdle, which
 	// rebuilds a whole AABB tree over every triangle of it - far too expensive
@@ -14283,22 +14281,35 @@ void OutfitStudioFrame::ApplyPhysicsWind() {
 	if (!physics)
 		return;
 
-	if (physicsWindDir) {
-		// Same order as the choice control in the XRC
-		static const bsos::WindDirection directions[] = {bsos::WindDirection::Up,
-														 bsos::WindDirection::Down,
-														 bsos::WindDirection::Forward,
-														 bsos::WindDirection::Backward,
-														 bsos::WindDirection::Left,
-														 bsos::WindDirection::Right};
-
-		const int selection = physicsWindDir->GetSelection();
-		if (selection >= 0 && selection < static_cast<int>(std::size(directions)))
-			physics->SetWindDirection(directions[selection]);
-	}
+	// The choice control lists Physics::WindDirectionNames() in order
+	if (physicsWindDir)
+		physics->SetWindDirection(Physics::WindDirectionFromIndex(physicsWindDir->GetSelection()));
 
 	if (physicsWindSlider)
 		physics->SetWindStrength(physicsWindSlider->GetValue() / 100.0f);
+}
+
+void OutfitStudioFrame::UpdatePhysicsControlsVisibility() {
+	if (!cbPhysics)
+		return;
+
+	const bool available = project && Physics::HasPhysicsLinks(project->GetWorkNif(), project->shapePhysicsFiles);
+	if (available == cbPhysics->IsShown())
+		return;
+
+	// Deleting the last shape with physics while it simulates has to stop it,
+	// and UpdatePhysicsState only ever starts physics for a checked box
+	if (!available)
+		cbPhysics->SetValue(false);
+
+	for (wxWindow* physicsCtrl : physicsControls)
+		physicsCtrl->Show(available);
+
+	if (!available)
+		UpdatePhysicsState();
+
+	if (cbPhysics->GetParent())
+		cbPhysics->GetParent()->Layout();
 }
 
 void OutfitStudioFrame::ShutdownPhysics() {
@@ -14328,7 +14339,7 @@ void OutfitStudioFrame::UpdatePhysicsState() {
 
 	if (desired && !physicsRunning) {
 		if (!physics)
-			physics = std::make_unique<bsos::PhysicsController>();
+			physics = std::make_unique<Physics::Controller>();
 
 		std::vector<std::string> warnings;
 		OutfitProject* proj = project;
@@ -14358,9 +14369,7 @@ void OutfitStudioFrame::UpdatePhysicsState() {
 
 		// The step clock must be valid for the lockstep path too, where
 		// StartPhysicsPump never runs
-		physicsWatch.Start();
-		physicsLastStepMicro = 0;
-		physicsLastDrawMicro = 0;
+		physicsClock.Reset(GetAnimTargetFps());
 
 		// The controller is fresh; re-apply the current wind settings
 		ApplyPhysicsWind();
@@ -14412,13 +14421,10 @@ void OutfitStudioFrame::StartPhysicsPump() {
 		return;
 
 	physicsPumpActive = true;
-	physicsTargetFps = GetAnimTargetFps();
-	physicsWatch.Start();
-	physicsLastStepMicro = 0;
-	physicsLastDrawMicro = 0;
+	physicsClock.Reset(GetAnimTargetFps());
 	SetHighResolutionTimers(true);
 	Bind(wxEVT_IDLE, &OutfitStudioFrame::OnPhysicsIdle, this);
-	physicsTimer.Start(AnimPlaybackTimerIntervalMS);
+	physicsTimer.Start(Physics::PumpTimerIntervalMS);
 }
 
 void OutfitStudioFrame::StopPhysicsPump() {
@@ -14435,18 +14441,11 @@ void OutfitStudioFrame::PumpPhysics() {
 	if (!physicsPumpActive || !physicsRunning)
 		return;
 
-	// Same pacing idea as PumpAnimationPlayback: ticks arrive from idle and
-	// the timer at wildly different rates, the drawing rate is decided here.
-	const wxLongLong period = 1000000 / std::max(physicsTargetFps, 1);
-	const wxLongLong now = physicsWatch.TimeInMicro();
-	if (now - physicsLastDrawMicro < period)
+	float dtSeconds = 0.0f;
+	if (!physicsClock.StepDue(dtSeconds))
 		return;
 
-	const float dt = static_cast<float>((now - physicsLastStepMicro).ToDouble() / 1000000.0);
-	physicsLastStepMicro = now;
-	physicsLastDrawMicro = now;
-
-	physics->Step(dt);
+	physics->Step(dtSeconds);
 
 	const auto& affectedShapes = physics->AffectedShapes();
 	for (auto& shape : project->GetWorkNif()->GetShapes()) {
@@ -14475,9 +14474,7 @@ void OutfitStudioFrame::OnPhysicsIdle(wxIdleEvent& event) {
 	if (!physicsPumpActive)
 		return;
 
-	const wxLongLong period = 1000000 / std::max(physicsTargetFps, 1);
-	const wxLongLong due = period - (physicsWatch.TimeInMicro() - physicsLastDrawMicro);
-	if (due > 1500)
+	if (physicsClock.UntilDue() > 1500)
 		wxMilliSleep(1);
 	else
 		PumpPhysics();

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -1067,8 +1067,10 @@ public:
 	wxSlider* fovSlider = nullptr;
 	wxCheckBox* cbDepthClip = nullptr;
 	wxBrushSettingsPopupTransient* brushSettingsPopupTransient = nullptr;
+	wxScrolledWindow* toolScroll = nullptr;
 	wxCollapsiblePane* masksPane = nullptr;
 	wxCollapsiblePane* posePane = nullptr;
+	wxCollapsiblePane* physicsPane = nullptr;
 	wxCollapsiblePane* animationPane = nullptr;
 	wxCollapsiblePane* notesPane = nullptr;
 	wxTextCtrl* projectNotes = nullptr;
@@ -1796,6 +1798,10 @@ private:
 	void OnExportMask(wxCommandEvent& event);
 	void OnImportMask(wxCommandEvent& event);
 	void OnPaneCollapse(wxCollapsiblePaneEvent& event);
+	void OnBottomPanelResize(wxSizeEvent& event);
+	// Re-lays out the bottom panel, capping the scrolled tool area so the
+	// slider list below it keeps its room no matter how many panes are open.
+	void UpdateToolScrollLayout();
 	void ApplyPose();
 
 public:
@@ -1924,8 +1930,9 @@ private:
 	void OnPhysicsIdle(wxIdleEvent& event);
 
 	std::unique_ptr<Physics::Controller> physics;
-	// The pose pane's physics controls, shown and hidden as a block.
-	std::vector<wxWindow*> physicsControls;
+	// Whether any loaded mesh references a physics XML. The physics pane only
+	// exists on the bones tab, so showing it takes both this and the tab.
+	bool physicsAvailable = false;
 	wxTimer physicsTimer;
 	// Simulation built and active (either pump mode or animation lockstep).
 	bool physicsRunning = false;

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -22,7 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "../components/RefTemplates.h"
 #include "../components/TweakBrush.h"
 #include "../components/UndoHistory.h"
-#include "../physics/PhysicsController.h"
+#include "../physics/Controller.h"
+#include "../physics/PumpClock.h"
 #include "../render/GLSurface.h"
 #include "../ui/WeightCopyDialog.h"
 #include "../ui/wxSliderPanel.h"
@@ -1903,6 +1904,10 @@ private:
 	// Single authority over building/tearing down the simulation; call after
 	// anything that changes one of those conditions or the loaded meshes.
 	void UpdatePhysicsState();
+	// Shows the physics controls only while the loaded meshes reference a
+	// physics XML, since there is nothing to simulate otherwise. Stops a running
+	// simulation when the last of them goes away.
+	void UpdatePhysicsControlsVisibility();
 	// Hard teardown for project unload/close: stops the pump and drops all
 	// simulation state without touching the (possibly dying) project meshes.
 	void ShutdownPhysics();
@@ -1918,16 +1923,15 @@ private:
 	void OnPhysicsTimer(wxTimerEvent& event);
 	void OnPhysicsIdle(wxIdleEvent& event);
 
-	std::unique_ptr<bsos::PhysicsController> physics;
+	std::unique_ptr<Physics::Controller> physics;
+	// The pose pane's physics controls, shown and hidden as a block.
+	std::vector<wxWindow*> physicsControls;
 	wxTimer physicsTimer;
 	// Simulation built and active (either pump mode or animation lockstep).
 	bool physicsRunning = false;
 	// Own idle+timer pump bound (pose mode without animation playback).
 	bool physicsPumpActive = false;
-	wxStopWatch physicsWatch;
-	wxLongLong physicsLastStepMicro = 0;
-	wxLongLong physicsLastDrawMicro = 0;
-	int physicsTargetFps = 60;
+	Physics::PumpClock physicsClock;
 
 	wxDECLARE_EVENT_TABLE();
 };

--- a/src/program/OutfitStudio.h
+++ b/src/program/OutfitStudio.h
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "../components/RefTemplates.h"
 #include "../components/TweakBrush.h"
 #include "../components/UndoHistory.h"
+#include "../physics/PhysicsController.h"
 #include "../render/GLSurface.h"
 #include "../ui/WeightCopyDialog.h"
 #include "../ui/wxSliderPanel.h"
@@ -71,6 +72,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 enum TargetGame { FO3, FONV, SKYRIM, FO4, SKYRIMSE, FO4VR, SKYRIMVR, FO76, OB, SF };
 
 #define ANIM_PLAYBACK_TIMER 300
+#define PHYSICS_TIMER 301
 
 struct MergeCheckErrors;
 
@@ -978,6 +980,17 @@ public:
 	// a tick count, so the speed stays correct however often it arrives.
 	void PumpAnimationPlayback();
 
+	// Feeds a horizontal camera rotation into the physics preview so cloth
+	// and hair react as if the character turned under a fixed camera. No-op
+	// while physics is not simulating.
+	void InjectPhysicsCameraYaw(float deltaDegrees);
+
+	// The per-frame physics tick while physics runs without animation
+	// playback; while an animation plays, ApplyPose steps the simulation in
+	// lockstep instead. Internally paced, so like PumpAnimationPlayback it is
+	// safe to call from any event source at any rate.
+	void PumpPhysics();
+
 	wxGLPanel* glView = nullptr;
 	EditUV* editUV = nullptr;
 	OutfitProject* project = nullptr;
@@ -1020,6 +1033,10 @@ public:
 	wxTextCtrl* tzPoseText = nullptr;
 	wxTextCtrl* scPoseText = nullptr;
 	wxCheckBox* cbPose = nullptr;
+	wxCheckBox* cbPhysics = nullptr;
+	wxCheckBox* cbPhysicsVis = nullptr;
+	wxSlider* physicsWindSlider = nullptr;
+	wxChoice* physicsWindDir = nullptr;
 	wxButton* poseToMesh = nullptr;
 	wxComboBox* cAnimationName = nullptr;
 	wxButton* animPlayPauseButton = nullptr;
@@ -1880,6 +1897,37 @@ private:
 	// Scratch pose for interpolated frames, kept around so that playback does
 	// not reallocate the bone list every tick.
 	PoseData animBlendPose;
+
+	// Physics preview (HDT-SMP): simulation runs while the physics checkbox
+	// is set and either pose mode is active or an animation is playing.
+	// Single authority over building/tearing down the simulation; call after
+	// anything that changes one of those conditions or the loaded meshes.
+	void UpdatePhysicsState();
+	// Hard teardown for project unload/close: stops the pump and drops all
+	// simulation state without touching the (possibly dying) project meshes.
+	void ShutdownPhysics();
+	void StartPhysicsPump();
+	void StopPhysicsPump();
+	void OnPhysicsCheckBox(wxCommandEvent& event);
+	void OnPhysicsVisCheckBox(wxCommandEvent& event);
+	void OnPhysicsWindSlider(wxScrollEvent& event);
+	void OnPhysicsWindDir(wxCommandEvent& event);
+	// Pushes the wind controls into the simulation; the controller is built
+	// fresh every time physics starts, so it has no idea of either value.
+	void ApplyPhysicsWind();
+	void OnPhysicsTimer(wxTimerEvent& event);
+	void OnPhysicsIdle(wxIdleEvent& event);
+
+	std::unique_ptr<bsos::PhysicsController> physics;
+	wxTimer physicsTimer;
+	// Simulation built and active (either pump mode or animation lockstep).
+	bool physicsRunning = false;
+	// Own idle+timer pump bound (pose mode without animation playback).
+	bool physicsPumpActive = false;
+	wxStopWatch physicsWatch;
+	wxLongLong physicsLastStepMicro = 0;
+	wxLongLong physicsLastDrawMicro = 0;
+	int physicsTargetFps = 60;
 
 	wxDECLARE_EVENT_TABLE();
 };

--- a/src/render/GLSurface.cpp
+++ b/src/render/GLSurface.cpp
@@ -211,9 +211,11 @@ void GLSurface::SetStartingView(const Vector3& pos, const Vector3& rot, const ui
 	SetSize(vpWidth, vpHeight);
 }
 
-void GLSurface::TurnTableCamera(int dScreenX) {
+float GLSurface::TurnTableCamera(int dScreenX) {
 	float pct = (float)dScreenX / (float)vpW;
-	camRot.y += (pct * 500.0f);
+	float degrees = pct * 500.0f;
+	camRot.y += degrees;
+	return degrees;
 }
 
 void GLSurface::PitchCamera(int dScreenY) {

--- a/src/render/GLSurface.h
+++ b/src/render/GLSurface.h
@@ -258,7 +258,8 @@ public:
 
 	void RenderFullScreenQuad(GLMaterial* renderShader, unsigned int w, unsigned int h);
 
-	void TurnTableCamera(int dScreenX);
+	// Returns the applied rotation in degrees
+	float TurnTableCamera(int dScreenX);
 	void PitchCamera(int dScreenY);
 	void PanCamera(int dScreenX, int dScreenY);
 	void DollyCamera(int dAmount);

--- a/src/ui/PreviewPanel.cpp
+++ b/src/ui/PreviewPanel.cpp
@@ -6,11 +6,15 @@ See the included LICENSE file
 #include "PreviewPanel.h"
 #include "../files/SFMaterialDatabase.h"
 #include "../files/SFMaterialFile.h"
+#include "../physics/Controller.h"
+#include "../physics/PumpClock.h"
 #include "../program/BodySlideApp.h"
 #include "../utils/PlatformUtil.h"
 
 #include <regex>
 #include <sstream>
+
+#include <wx/statline.h>
 
 using namespace nifly;
 
@@ -23,7 +27,11 @@ wxBEGIN_EVENT_TABLE(PreviewPanel, wxPanel)
 	EVT_COMMAND_SCROLL(wxID_ANY, PreviewPanel::OnWeightSlider)
 wxEND_EVENT_TABLE()
 
-PreviewPanel::~PreviewPanel() {}
+PreviewPanel::~PreviewPanel() {
+	// The popup hangs off the frame, not off this panel, and its handlers point
+	// back here
+	DestroyPhysicsWindPopup();
+}
 
 PreviewPanel::PreviewPanel(wxWindow* parent, BodySlideApp* app)
 	: wxPanel(parent, wxID_ANY)
@@ -31,7 +39,7 @@ PreviewPanel::PreviewPanel(wxWindow* parent, BodySlideApp* app)
 	, refNormalGenLayers(emptyLayers) {
 
 	wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
-	wxBoxSizer* sizerPanel = new wxBoxSizer(wxHORIZONTAL);
+	wxBoxSizer* sizerToolBar = new wxBoxSizer(wxHORIZONTAL);
 	wxBoxSizer* sizerProjectSelect = new wxBoxSizer(wxHORIZONTAL);
 
 	wxPanel* projectSelectPanel = new wxPanel(this);
@@ -52,33 +60,50 @@ PreviewPanel::PreviewPanel(wxWindow* parent, BodySlideApp* app)
 	projectSelectPanel->SetSizer(sizerProjectSelect);
 	projectSelectPanel->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE));
 
-	wxPanel* uiPanel = new wxPanel(this);
-	weightSlider = new wxSlider(uiPanel, wxID_ANY, 100, 0, 100, wxDefaultPosition, wxDefaultSize, wxSL_LABELS, wxDefaultValidator, "weightSlider");
+	toolBarPanel = new wxPanel(this);
+	toolBarPanel->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE));
 
-	optButton = new wxButton(uiPanel, wxID_ANY, "N", wxDefaultPosition, FromDIP(wxSize(25, 25)));
+	weightSlider = new wxSlider(toolBarPanel, wxID_ANY, 100, 0, 100, wxDefaultPosition, wxDefaultSize, wxSL_LABELS, wxDefaultValidator, "weightSlider");
+
+	optButton = new wxButton(toolBarPanel, wxID_ANY, "N", wxDefaultPosition, FromDIP(wxSize(28, 28)));
 	optButton->SetToolTip(_("Show the Normal Map Generator dialog."));
 	optButton->Bind(wxEVT_BUTTON, &PreviewPanel::ShowNormalGenWindow, this);
 	optButton->Hide();
 
-	lockShapeButton = new wxButton(uiPanel, wxID_ANY, _("Lock Shape"), wxDefaultPosition, wxDefaultSize);
+	lockShapeButton = new wxButton(toolBarPanel, wxID_ANY, _("Lock Shape"), wxDefaultPosition, wxDefaultSize);
 	lockShapeButton->SetToolTip(_("Set the current preview shape to both low and high weight sliders."));
 	lockShapeButton->Bind(wxEVT_BUTTON, &PreviewPanel::OnLockShape, this);
 	lockShapeButton->Hide();
 
-	showReferenceCheckbox = new wxCheckBox(uiPanel, wxID_ANY, _("Show Reference"), wxDefaultPosition, wxDefaultSize);
+	showReferenceCheckbox = new wxCheckBox(toolBarPanel, wxID_ANY, _("Show Reference"), wxDefaultPosition, wxDefaultSize);
 	showReferenceCheckbox->SetToolTip(_("Show the reference shape from the source project for clipping preview."));
 	showReferenceCheckbox->Bind(wxEVT_CHECKBOX, &PreviewPanel::OnShowReference, this);
 	showReferenceCheckbox->Hide();
 
-	showHelperShapesCheckbox = new wxCheckBox(uiPanel, wxID_ANY, _("Show Helper Shapes"), wxDefaultPosition, wxDefaultSize);
+	showHelperShapesCheckbox = new wxCheckBox(toolBarPanel, wxID_ANY, _("Show Helper Shapes"), wxDefaultPosition, wxDefaultSize);
 	showHelperShapesCheckbox->SetToolTip(_("Show helper shapes (e.g. collisions) - shapes with no shader or with the hidden flag set."));
 	showHelperShapesCheckbox->Bind(wxEVT_CHECKBOX, &PreviewPanel::OnShowHelperShapes, this);
 
-	uiPanel->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE));
+	physicsCheckbox = new wxCheckBox(toolBarPanel, wxID_ANY, _("Physics"), wxDefaultPosition, wxDefaultSize);
+	physicsCheckbox->SetToolTip(_("Simulate HDT-SMP physics XMLs referenced by the previewed meshes"));
+	physicsCheckbox->Bind(wxEVT_CHECKBOX, &PreviewPanel::OnPhysics, this);
+	physicsCheckbox->Hide();
 
-	// Pop-out button (placed in uiPanel, below Lock Shape)
+	// The wind settings live in a drop-down so that turning physics on doesn't
+	// re-flow the tool bar around them. The label carries U+25BE as an escape
+	// because the sources are compiled without /utf-8.
+	physicsWindButton = new wxButton(toolBarPanel, wxID_ANY, _("Wind") + wxString(L" \u25BE"), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+	physicsWindButton->SetToolTip(_("Wind settings for the physics preview."));
+	physicsWindButton->Bind(wxEVT_BUTTON, &PreviewPanel::OnPhysicsWindButton, this);
+	physicsWindButton->Hide();
+
+	physicsWindDirIndex = static_cast<int>(Physics::WindDirectionNames().size()) - 1;
+
+	physicsTimer.SetOwner(this);
+	Bind(wxEVT_TIMER, &PreviewPanel::OnPhysicsTimer, this);
+
 	popoutButton = new wxBitmapButton(
-		uiPanel,
+		toolBarPanel,
 		wxID_ANY,
 		wxBitmap(wxString::FromUTF8(Config["AppDir"]) + "/res/images/PopOut.png", wxBITMAP_TYPE_PNG),
 		wxDefaultPosition,
@@ -90,21 +115,33 @@ PreviewPanel::PreviewPanel(wxWindow* parent, BodySlideApp* app)
 	canvas = new PreviewCanvas(this, GLSurface::GetGLAttribs());
 	context = std::make_unique<wxGLContext>(canvas, nullptr, &GLSurface::GetGLContextAttribs());
 
-	sizerPanel->Add(weightSlider, 1, wxTOP | wxLEFT | wxRIGHT, 10);
+	// Tool bar: weight slider on the left, view options in a left-aligned column
+	// next to it, buttons last. Everything is centered on one baseline so hiding
+	// a control doesn't shift the rest around. The slider gets its own
+	// stretching sizer, which keeps the gap when the slider itself is hidden.
+	wxBoxSizer* sizerWeight = new wxBoxSizer(wxHORIZONTAL);
+	sizerWeight->Add(weightSlider, 1, wxALIGN_CENTER_VERTICAL);
+	sizerToolBar->Add(sizerWeight, 1, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+	sizerToolBar->Add(new wxStaticLine(toolBarPanel, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_VERTICAL), 0, wxEXPAND | wxTOP | wxBOTTOM, 4);
 
-	wxBoxSizer* sizerRight = new wxBoxSizer(wxVERTICAL);
-	sizerRight->Add(showReferenceCheckbox, 0, wxALIGN_CENTER_HORIZONTAL);
+	wxBoxSizer* sizerOptions = new wxBoxSizer(wxVERTICAL);
+	sizerOptions->Add(showReferenceCheckbox, 0, wxBOTTOM, 2);
+	sizerOptions->Add(showHelperShapesCheckbox, 0, wxBOTTOM, 2);
+
+	wxBoxSizer* sizerPhysics = new wxBoxSizer(wxHORIZONTAL);
+	sizerPhysics->Add(physicsCheckbox, 0, wxALIGN_CENTER_VERTICAL);
+	sizerPhysics->Add(physicsWindButton, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 6);
+	sizerOptions->Add(sizerPhysics, 0);
+
+	sizerToolBar->Add(sizerOptions, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
 
 	wxBoxSizer* sizerButtons = new wxBoxSizer(wxHORIZONTAL);
 	sizerButtons->Add(lockShapeButton, 0, wxALIGN_CENTER_VERTICAL);
 	sizerButtons->Add(popoutButton, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 4);
-	sizerRight->Add(sizerButtons, 0, wxTOP | wxALIGN_CENTER_HORIZONTAL, 2);
-	sizerRight->Add(showHelperShapesCheckbox, 0, wxTOP | wxALIGN_CENTER_HORIZONTAL, 2);
+	sizerButtons->Add(optButton, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 4);
+	sizerToolBar->Add(sizerButtons, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
 
-	sizerPanel->Add(sizerRight, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-	sizerPanel->Add(optButton, 0, wxALL | wxALIGN_BOTTOM, 10);
-	uiPanel->SetSizer(sizerPanel);
+	toolBarPanel->SetSizer(sizerToolBar);
 
 	// Loading overlay (hidden by default, positioned over canvas)
 	loadingOverlay = new wxPanel(this, wxID_ANY);
@@ -121,7 +158,7 @@ PreviewPanel::PreviewPanel(wxWindow* parent, BodySlideApp* app)
 	loadingOverlay->Hide();
 
 	sizer->Add(projectSelectPanel, 0, wxEXPAND);
-	sizer->Add(uiPanel, 0, wxEXPAND);
+	sizer->Add(toolBarPanel, 0, wxEXPAND);
 	sizer->Add(canvas, 1, wxEXPAND);
 
 	SetSizer(sizer);
@@ -136,6 +173,65 @@ PreviewPanel::PreviewPanel(wxWindow* parent, BodySlideApp* app)
 
 	projectChoice->Bind(wxEVT_CHOICE, &PreviewPanel::OnProjectChoice, this);
 	presetChoice->Bind(wxEVT_CHOICE, &PreviewPanel::OnPresetChoice, this);
+}
+
+void PreviewPanel::CreatePhysicsWindPopup() {
+	// A popup is a window of its own, owned by the top level window it was
+	// created under. The preview panel moves between the main frame and its own
+	// frame when it's popped out, so the popup has to follow it there.
+	physicsWindPopup = new wxPopupTransientWindow(wxGetTopLevelParent(this), wxBORDER_SIMPLE | wxPU_CONTAINS_CONTROLS);
+
+	wxPanel* windPanel = new wxPanel(physicsWindPopup);
+	windPanel->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
+
+	physicsWindSlider = new wxSlider(windPanel, wxID_ANY, physicsWindStrength, 0, 100, wxDefaultPosition, FromDIP(wxSize(140, -1)), wxSL_VALUE_LABEL, wxDefaultValidator, "physicsWindSlider");
+	physicsWindSlider->SetToolTip(_("World wind strength for the physics preview (0 = off)."));
+	physicsWindSlider->Bind(wxEVT_SCROLL_CHANGED, &PreviewPanel::OnPhysicsWind, this);
+	physicsWindSlider->Bind(wxEVT_SCROLL_THUMBTRACK, &PreviewPanel::OnPhysicsWind, this);
+
+	wxArrayString windDirections;
+	for (auto& name : Physics::WindDirectionNames())
+		windDirections.Add(wxGetTranslation(wxString::FromUTF8(name)));
+
+	physicsWindDir = new wxChoice(windPanel, wxID_ANY, wxDefaultPosition, wxDefaultSize, windDirections, 0, wxDefaultValidator, "physicsWindDir");
+	physicsWindDir->SetSelection(physicsWindDirIndex);
+	physicsWindDir->SetToolTip(_("Direction the wind blows in, as seen in the viewport. It stays fixed to the mesh while the camera turns."));
+	physicsWindDir->Bind(wxEVT_CHOICE, &PreviewPanel::OnPhysicsWindDir, this);
+
+	wxFlexGridSizer* sizerWind = new wxFlexGridSizer(2, FromDIP(4), FromDIP(8));
+	sizerWind->AddGrowableCol(1);
+	sizerWind->Add(new wxStaticText(windPanel, wxID_ANY, _("Strength")), 0, wxALIGN_CENTER_VERTICAL);
+	sizerWind->Add(physicsWindSlider, 1, wxEXPAND);
+	sizerWind->Add(new wxStaticText(windPanel, wxID_ANY, _("Direction")), 0, wxALIGN_CENTER_VERTICAL);
+	sizerWind->Add(physicsWindDir, 1, wxEXPAND);
+
+	wxBoxSizer* sizerWindBorder = new wxBoxSizer(wxVERTICAL);
+	sizerWindBorder->Add(sizerWind, 1, wxEXPAND | wxALL, FromDIP(8));
+	windPanel->SetSizerAndFit(sizerWindBorder);
+
+	wxBoxSizer* sizerPopup = new wxBoxSizer(wxVERTICAL);
+	sizerPopup->Add(windPanel, 1, wxEXPAND);
+	physicsWindPopup->SetSizerAndFit(sizerPopup);
+}
+
+void PreviewPanel::DestroyPhysicsWindPopup() {
+	if (!physicsWindPopup)
+		return;
+
+	if (physicsWindPopup->IsShown())
+		physicsWindPopup->Dismiss();
+
+	physicsWindPopup->Destroy();
+	physicsWindPopup = nullptr;
+	physicsWindSlider = nullptr;
+	physicsWindDir = nullptr;
+}
+
+void PreviewPanel::LayoutToolBar() {
+	if (toolBarPanel)
+		toolBarPanel->Layout();
+
+	Layout();
 }
 
 void PreviewPanel::ShowLoadingIndicator(bool show) {
@@ -395,7 +491,7 @@ void PreviewPanel::SetNormalsGenerationLayers(std::vector<NormalGenLayer>& norma
 	if (normalsGenDlg)
 		normalsGenDlg->Hide();
 
-	Layout();
+	LayoutToolBar();
 }
 
 Mesh* PreviewPanel::GetMesh(const std::string& shapeName) {
@@ -710,8 +806,9 @@ void PreviewPanel::RenderNormalMap(const std::string& outfilename) {
 }
 
 void PreviewPanel::RightDrag(int dX, int dY) {
-	gls.TurnTableCamera(dX);
+	const float yawDegrees = gls.TurnTableCamera(dX);
 	gls.PitchCamera(dY);
+	app->InjectPreviewCameraYaw(yawDegrees);
 	gls.RenderOneFrame();
 }
 
@@ -731,6 +828,13 @@ void PreviewPanel::MouseWheel(int dW) {
 }
 
 void PreviewPanel::OnWeightSlider(wxScrollEvent& event) {
+	// The panel catches scroll events of any id, so make sure this is the weight
+	// slider and not one of the other sliders on it
+	if (event.GetEventObject() != weightSlider) {
+		event.Skip();
+		return;
+	}
+
 	weight = event.GetPosition();
 	app->UpdatePreview();
 }
@@ -752,14 +856,103 @@ void PreviewPanel::OnShowHelperShapes(wxCommandEvent& WXUNUSED(event)) {
 	gls.RenderOneFrame();
 }
 
+void PreviewPanel::ShowPhysicsControls(bool show) {
+	if (!physicsCheckbox)
+		return;
+
+	physicsCheckbox->Show(show);
+	if (!show)
+		SetPhysicsChecked(false);
+
+	LayoutToolBar();
+}
+
+void PreviewPanel::SetPhysicsChecked(bool checked) {
+	if (!physicsCheckbox)
+		return;
+
+	physicsCheckbox->SetValue(checked);
+
+	// Wind is meaningless without a running simulation
+	const bool showWind = checked && physicsCheckbox->IsShown();
+	if (physicsWindButton)
+		physicsWindButton->Show(showWind);
+
+	if (!showWind)
+		DestroyPhysicsWindPopup();
+
+	if (checked)
+		physicsTimer.Start(Physics::PumpTimerIntervalMS);
+	else
+		physicsTimer.Stop();
+
+	LayoutToolBar();
+}
+
+void PreviewPanel::ApplyPhysicsWind() {
+	app->SetPreviewWind(physicsWindDirIndex, physicsWindStrength);
+}
+
+void PreviewPanel::OnPhysics(wxCommandEvent& event) {
+	app->EnablePreviewPhysics(event.IsChecked());
+
+	// The simulation refuses to start without usable XMLs, so take the state
+	// from it instead of from the click
+	SetPhysicsChecked(app->IsPreviewPhysicsRunning());
+	ApplyPhysicsWind();
+}
+
+void PreviewPanel::OnPhysicsWindButton(wxCommandEvent& WXUNUSED(event)) {
+	if (!physicsWindButton)
+		return;
+
+	// Popping the preview out moves it to a different window, leaving the popup
+	// behind on the old one
+	if (physicsWindPopup && physicsWindPopup->GetParent() != wxGetTopLevelParent(this))
+		DestroyPhysicsWindPopup();
+
+	if (!physicsWindPopup)
+		CreatePhysicsWindPopup();
+
+	// Drop it down from the button, flipping to above it near the screen edge
+	physicsWindPopup->Position(physicsWindButton->GetScreenPosition(), physicsWindButton->GetSize());
+	physicsWindPopup->Popup();
+}
+
+void PreviewPanel::OnPhysicsWind(wxScrollEvent& WXUNUSED(event)) {
+	if (!physicsWindSlider)
+		return;
+
+	physicsWindStrength = physicsWindSlider->GetValue();
+	ApplyPhysicsWind();
+}
+
+void PreviewPanel::OnPhysicsWindDir(wxCommandEvent& WXUNUSED(event)) {
+	if (!physicsWindDir)
+		return;
+
+	physicsWindDirIndex = physicsWindDir->GetSelection();
+	ApplyPhysicsWind();
+}
+
+void PreviewPanel::PumpPhysics() {
+	app->PumpPreviewPhysics();
+}
+
+void PreviewPanel::OnPhysicsTimer(wxTimerEvent& WXUNUSED(event)) {
+	PumpPhysics();
+}
+
 void PreviewPanel::OnPopout(wxCommandEvent& WXUNUSED(event)) {
 	wxCommandEvent evt(EVT_PREVIEW_POPOUT);
 	wxPostEvent(GetParent(), evt);
 }
 
 void PreviewPanel::ShowPopoutButton(bool show) {
-	if (popoutButton)
+	if (popoutButton) {
 		popoutButton->Show(show);
+		LayoutToolBar();
+	}
 }
 
 void PreviewPanel::SetPopoutButtonDetachedState(bool detached) {
@@ -787,6 +980,9 @@ void PreviewPanel::ShowNormalGenWindow(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void PreviewPanel::Cleanup() {
+	physicsTimer.Stop();
+	DestroyPhysicsWindPopup();
+
 	if (canvas && context)
 		canvas->SetCurrent(*context);
 
@@ -833,6 +1029,10 @@ void PreviewCanvas::OnMotion(wxMouseEvent& event) {
 		if (topLevel && topLevel->IsActive())
 			SetFocus();
 	}
+
+	// Mouse motion floods the message queue and starves the WM_TIMER driving the
+	// physics, so tick it from here as well (the pump paces itself)
+	previewPanel->PumpPhysics();
 
 	auto delta = event.GetPosition() - lastMousePosition;
 

--- a/src/ui/PreviewPanel.h
+++ b/src/ui/PreviewPanel.h
@@ -21,6 +21,9 @@ See the included LICENSE file
 
 #include <wx/wx.h>
 #include <wx/activityindicator.h>
+#include <wx/popupwin.h>
+#include <wx/timer.h>
+#include <wx/weakref.h>
 
 class BodySlideApp;
 class PreviewCanvas;
@@ -39,10 +42,23 @@ class PreviewPanel : public wxPanel {
 	BodySlideApp* app = nullptr;
 	PreviewCanvas* canvas = nullptr;
 	std::unique_ptr<wxGLContext> context;
+	wxPanel* toolBarPanel = nullptr;
 	wxButton* optButton = nullptr;
 	wxButton* lockShapeButton = nullptr;
 	wxCheckBox* showReferenceCheckbox = nullptr;
 	wxCheckBox* showHelperShapesCheckbox = nullptr;
+	wxCheckBox* physicsCheckbox = nullptr;
+	wxButton* physicsWindButton = nullptr;
+	// Created on demand under the window the preview currently lives in, so the
+	// controls only exist while the drop-down is around. The values are kept
+	// here instead. Weak references: docking the preview back destroys the
+	// window the popup hangs off, and the popup with it.
+	wxWeakRef<wxPopupTransientWindow> physicsWindPopup;
+	wxWeakRef<wxSlider> physicsWindSlider;
+	wxWeakRef<wxChoice> physicsWindDir;
+	int physicsWindStrength = 0;
+	int physicsWindDirIndex = 0;
+	wxTimer physicsTimer;
 	wxStaticText* projectLabel = nullptr;
 	wxChoice* projectChoice = nullptr;
 	wxStaticText* presetLabel = nullptr;
@@ -65,6 +81,13 @@ class PreviewPanel : public wxPanel {
 	std::string sfMaterialDbContent;
 	std::unique_ptr<std::istringstream> sfMaterialDbStream;
 	SFMaterialDatabase* GetSFMaterialDatabase();
+	void CreatePhysicsWindPopup();
+	void DestroyPhysicsWindPopup();
+	void ApplyPhysicsWind();
+	// Re-flows the tool bar above the canvas after a control was shown or
+	// hidden. The panel itself keeps its size, so its sizer needs the explicit
+	// nudge.
+	void LayoutToolBar();
 	std::vector<std::string> extraNifPaths;
 	std::vector<PreviewProjectEntry> projectEntries;
 	std::string initialPresetName;
@@ -88,6 +111,24 @@ public:
 	void OnShowReference(wxCommandEvent& event);
 	void OnShowHelperShapes(wxCommandEvent& event);
 	void OnPopout(wxCommandEvent& event);
+
+	void OnPhysics(wxCommandEvent& event);
+	void OnPhysicsWindButton(wxCommandEvent& event);
+	void OnPhysicsWind(wxScrollEvent& event);
+	void OnPhysicsWindDir(wxCommandEvent& event);
+	void OnPhysicsTimer(wxTimerEvent& event);
+
+	// One physics tick. Internally paced, so any event source may call it at
+	// any rate; a no-op while physics is off.
+	void PumpPhysics();
+
+	// Shows or hides the whole physics block. Only meshes that reference a
+	// physics XML can be simulated, so the controls stay out of the way for
+	// everything else.
+	void ShowPhysicsControls(bool show);
+	// Reflects whether the simulation is actually running, and shows the wind
+	// controls only while it is.
+	void SetPhysicsChecked(bool checked);
 
 	void ShowPopoutButton(bool show);
 	void SetPopoutButtonDetachedState(bool detached);
@@ -113,19 +154,21 @@ public:
 		if (weightSlider) {
 			weightSlider->SetValue(weight);
 			weightSlider->Show(show);
-			Layout();
+			LayoutToolBar();
 		}
 	}
 
 	void ShowLockShapeButton(bool show = true) {
-		if (lockShapeButton)
+		if (lockShapeButton) {
 			lockShapeButton->Show(show);
+			LayoutToolBar();
+		}
 	}
 
 	void ShowReferenceCheckbox(bool show = true) {
 		if (showReferenceCheckbox) {
 			showReferenceCheckbox->Show(show);
-			Layout();
+			LayoutToolBar();
 		}
 	}
 


### PR DESCRIPTION
Simulates the physics XMLs referenced by the loaded meshes via NiStringExtraData in both Outfit Studio and BodySlide preview,
using a port of the hdtSkinnedMesh core of Faster HDT-SMP (GPL-3.0). Bullet is an optional dependency (BSOS_ENABLE_BULLET); without it the feature compiles out and its controls stay hidden.

Runs while posing or during animation playback, with collider visualization and wind controls.

Also cleaned up the posing and animation UI in Outfit Studio.