### PR TITLE
Add multi-CDB support for Starfield official creations material loading

### DIFF
--- a/lib/FSEngine/FSBSA.cpp
+++ b/lib/FSEngine/FSBSA.cpp
@@ -535,6 +535,22 @@ void BSA::fileTree(std::vector<std::string> &tree) const {
 		addFilesOfFolders(folder.first, tree);
 }
 
+void BSA::findFilesBySuffix(const std::string& prefix, const std::string& suffix, std::vector<std::string>& results) const {
+	std::string lowerPrefix = prefix;
+	SequenceToLowerCase(lowerPrefix.begin(), lowerPrefix.end());
+	std::string lowerSuffix = suffix;
+	SequenceToLowerCase(lowerSuffix.begin(), lowerSuffix.end());
+
+	for (const auto& entry : root.files) {
+		const std::string& key = entry.first;
+		if (key.size() >= lowerPrefix.size() + lowerSuffix.size()
+			&& key.compare(0, lowerPrefix.size(), lowerPrefix) == 0
+			&& key.compare(key.size() - lowerSuffix.size(), lowerSuffix.size(), lowerSuffix) == 0) {
+			results.push_back(key);
+		}
+	}
+}
+
 bool BSA::fileContents(const std::string &fn, wxMemoryBuffer &content) {
 	if (const BSAFile *file = getFile(fn)) {
 		wxMutexLocker lock(bsaMutex);

--- a/lib/FSEngine/FSBSA.h
+++ b/lib/FSEngine/FSBSA.h
@@ -218,6 +218,8 @@ public:
 	void addFilesOfFolders(const std::string&, std::vector<std::string>&) const override final;
 	//! Returns the entire file tree of the BSA
 	void fileTree(std::vector<std::string>&) const override final;
+	//! Find files matching a prefix and suffix (searches flat file map for BA2s)
+	void findFilesBySuffix(const std::string& prefix, const std::string& suffix, std::vector<std::string>& results) const override final;
 
 	//! Returns the contents of the specified file
 	/*!

--- a/lib/FSEngine/FSEngine.h
+++ b/lib/FSEngine/FSEngine.h
@@ -78,6 +78,7 @@ public:
 	virtual wxInt64 fileSize(const std::string&) const = 0;
 	virtual void addFilesOfFolders(const std::string&, std::vector<std::string>&) const = 0;
 	virtual void fileTree(std::vector<std::string>&) const = 0;
+	virtual void findFilesBySuffix(const std::string& prefix, const std::string& suffix, std::vector<std::string>& results) const = 0;
 	virtual bool fileContents(const std::string&, wxMemoryBuffer&) = 0;
 	virtual bool exportFile(const std::string&, const std::string&) = 0;
 	virtual std::string absoluteFilePath(const std::string&) const = 0;

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -114,6 +114,30 @@ public:
 		texFiles = sfMat.GetTextureFiles(numTextures);
 		return true;
 	}
+
+	static std::vector<std::string> FindAllCdbPaths() {
+		std::vector<std::string> cdbPaths;
+		std::set<std::string> seen;
+
+		for (FSArchiveFile* archive : FSManager::archiveList()) {
+			if (!archive)
+				continue;
+
+			if (archive->hasFile("materials/materialsbeta.cdb")) {
+				if (seen.insert("materials/materialsbeta.cdb").second)
+					cdbPaths.push_back("materials/materialsbeta.cdb");
+			}
+
+			std::vector<std::string> matches;
+			archive->findFilesBySuffix("materials/creations/", "materialsbeta.cdb", matches);
+			for (const auto& match : matches) {
+				if (seen.insert(match).second)
+					cdbPaths.push_back(match);
+			}
+		}
+
+		return cdbPaths;
+	}
 };
 
 int GetFirstSegmentPartID(const NifSegmentationInfo& inf) {
@@ -2294,8 +2318,7 @@ void OutfitProject::SetTextures(NiShape* shape, const std::vector<std::string>& 
 
 					if (!resolvedFromArchive) {
 						std::string materialJson;
-						SFMaterialDatabase* cdb = GetSFMaterialDatabase();
-						if (cdb && cdb->GetMaterialJSON(matFile, materialJson)) {
+						if (GetSFMaterialJSON(matFile, materialJson)) {
 							std::istringstream materialStream(materialJson);
 							SFMaterialFile cdbMat(materialStream);
 							if (!cdbMat.Failed()) {
@@ -7089,26 +7112,40 @@ std::unique_ptr<std::istream> OutfitProject::GetPhysicsXmlStream(const std::stri
 	return GameDataStream::OpenPhysicsXml(xmlPath, activeSet.GetInputFileName());
 }
 
-SFMaterialDatabase* OutfitProject::GetSFMaterialDatabase() {
-	if (sfMaterialDb)
-		return sfMaterialDb->Failed() ? nullptr : sfMaterialDb.get();
+bool OutfitProject::GetSFMaterialJSON(const std::string& matPath, std::string& jsonOutput) {
+	if ((TargetGame)Config.GetIntValue("TargetGame") != SF)
+		return false;
 
-	sfMaterialDb = std::make_unique<SFMaterialDatabase>();
+	if (!sfMaterialDbsLoaded) {
+		sfMaterialDbsLoaded = true;
 
-	wxMemoryBuffer data;
-	if (!ArchiveMaterialLoader::ReadFile("materials/materialsbeta.cdb", data) || data.IsEmpty())
-		return nullptr;
+		auto cdbPaths = ArchiveMaterialLoader::FindAllCdbPaths();
 
-	sfMaterialDbContent.assign(static_cast<const char*>(data.GetData()), data.GetDataLen());
-	sfMaterialDbStream = std::make_unique<std::istringstream>(sfMaterialDbContent, std::ios::in | std::ios::binary);
+		for (const auto& cdbPath : cdbPaths) {
+			wxMemoryBuffer data;
+			if (!ArchiveMaterialLoader::ReadFile(cdbPath, data) || data.IsEmpty())
+				continue;
 
-	if (!sfMaterialDb->Load(*sfMaterialDbStream) || sfMaterialDb->Failed()) {
-		sfMaterialDbContent.clear();
-		sfMaterialDbStream.reset();
-		return nullptr;
+			auto db = std::make_unique<SFMaterialDatabase>();
+			sfMaterialDbContents.emplace_back(static_cast<const char*>(data.GetData()), data.GetDataLen());
+			sfMaterialDbStreams.push_back(std::make_unique<std::istringstream>(sfMaterialDbContents.back(), std::ios::in | std::ios::binary));
+
+			if (db->Load(*sfMaterialDbStreams.back()) && !db->Failed()) {
+				sfMaterialDbs.push_back(std::move(db));
+			}
+			else {
+				sfMaterialDbContents.pop_back();
+				sfMaterialDbStreams.pop_back();
+			}
+		}
 	}
 
-	return sfMaterialDb.get();
+	for (auto& db : sfMaterialDbs) {
+		if (db->GetMaterialJSON(matPath, jsonOutput))
+			return true;
+	}
+
+	return false;
 }
 
 void OutfitProject::ValidateNIF(NifFile& nif, const std::string& nifFilePath) {

--- a/src/program/OutfitProject.cpp
+++ b/src/program/OutfitProject.cpp
@@ -123,13 +123,8 @@ public:
 			if (!archive)
 				continue;
 
-			if (archive->hasFile("materials/materialsbeta.cdb")) {
-				if (seen.insert("materials/materialsbeta.cdb").second)
-					cdbPaths.push_back("materials/materialsbeta.cdb");
-			}
-
 			std::vector<std::string> matches;
-			archive->findFilesBySuffix("materials/creations/", "materialsbeta.cdb", matches);
+			archive->findFilesBySuffix("materials/", ".cdb", matches);
 			for (const auto& match : matches) {
 				if (seen.insert(match).second)
 					cdbPaths.push_back(match);

--- a/src/program/OutfitProject.h
+++ b/src/program/OutfitProject.h
@@ -155,7 +155,7 @@ class OutfitProject {
 	std::unordered_map<std::string, std::unique_ptr<nifly::BSClothExtraData>> clothData;
 
 	std::unique_ptr<std::istream> GetExternalGeometryStream(const std::string& dir, const std::string& path, const std::string& nifFilePath = std::string()) const;
-	SFMaterialDatabase* GetSFMaterialDatabase();
+	bool GetSFMaterialJSON(const std::string& matPath, std::string& jsonOutput);
 	void ValidateNIF(nifly::NifFile& nif, const std::string& nifFilePath = std::string());
 	std::string SliderDataTargetForShape(nifly::NiShape* shape);
 	std::string ShapeTargetOrDefault(const std::string& shapeName);
@@ -166,9 +166,10 @@ class OutfitProject {
 	bool ResolveSliderDataEntry(const SliderDataKey& key, size_t& sliderIndex, size_t& dataIndex);
 	bool ShapeSliderDataIsLocalOnly(const std::string& shapeName);
 
-	std::unique_ptr<SFMaterialDatabase> sfMaterialDb;
-	std::string sfMaterialDbContent;
-	std::unique_ptr<std::istream> sfMaterialDbStream;
+	std::vector<std::unique_ptr<SFMaterialDatabase>> sfMaterialDbs;
+	std::vector<std::string> sfMaterialDbContents;
+	std::vector<std::unique_ptr<std::istringstream>> sfMaterialDbStreams;
+	bool sfMaterialDbsLoaded = false;
 
 	// Applies the inverse of the blended pose transform to a NIF-space diff
 	// vector for a single vertex, converting it from posed space to rest space.

--- a/src/ui/PreviewPanel.cpp
+++ b/src/ui/PreviewPanel.cpp
@@ -12,6 +12,7 @@ See the included LICENSE file
 #include "../utils/PlatformUtil.h"
 
 #include <regex>
+#include <set>
 #include <sstream>
 
 #include <wx/statline.h>
@@ -557,37 +558,56 @@ void PreviewPanel::RefreshMeshFromNif(const std::vector<NifFile*>& nifs) {
 	gls.RenderOneFrame();
 }
 
-SFMaterialDatabase* PreviewPanel::GetSFMaterialDatabase() {
-	if (sfMaterialDb)
-		return sfMaterialDb->Failed() ? nullptr : sfMaterialDb.get();
+bool PreviewPanel::GetSFMaterialJSON(const std::string& matPath, std::string& jsonOutput) {
+	if ((TargetGame)Config.GetIntValue("TargetGame") != SF)
+		return false;
 
-	sfMaterialDb = std::make_unique<SFMaterialDatabase>();
+	if (!sfMaterialDbsLoaded) {
+		sfMaterialDbsLoaded = true;
 
-	wxMemoryBuffer data;
-	for (FSArchiveFile* archive : FSManager::archiveList()) {
-		if (archive && archive->hasFile("materials/materialsbeta.cdb")) {
-			wxMemoryBuffer outData;
-			archive->fileContents("materials/materialsbeta.cdb", outData);
-			if (!outData.IsEmpty()) {
-				data = std::move(outData);
-				break;
-			}
+		std::set<std::string> seen;
+		for (FSArchiveFile* archive : FSManager::archiveList()) {
+			if (!archive)
+				continue;
+
+			auto tryLoad = [&](const std::string& cdbPath) {
+				if (!seen.insert(cdbPath).second)
+					return;
+
+				wxMemoryBuffer data;
+				archive->fileContents(cdbPath, data);
+				if (data.IsEmpty())
+					return;
+
+				auto db = std::make_unique<SFMaterialDatabase>();
+				sfMaterialDbContents.emplace_back(static_cast<const char*>(data.GetData()), data.GetDataLen());
+				sfMaterialDbStreams.push_back(std::make_unique<std::istringstream>(sfMaterialDbContents.back(), std::ios::in | std::ios::binary));
+
+				if (db->Load(*sfMaterialDbStreams.back()) && !db->Failed()) {
+					sfMaterialDbs.push_back(std::move(db));
+				}
+				else {
+					sfMaterialDbContents.pop_back();
+					sfMaterialDbStreams.pop_back();
+				}
+			};
+
+			if (archive->hasFile("materials/materialsbeta.cdb"))
+				tryLoad("materials/materialsbeta.cdb");
+
+			std::vector<std::string> matches;
+			archive->findFilesBySuffix("materials/creations/", "materialsbeta.cdb", matches);
+			for (const auto& match : matches)
+				tryLoad(match);
 		}
 	}
 
-	if (data.IsEmpty())
-		return nullptr;
-
-	sfMaterialDbContent.assign(static_cast<const char*>(data.GetData()), data.GetDataLen());
-	sfMaterialDbStream = std::make_unique<std::istringstream>(sfMaterialDbContent, std::ios::in | std::ios::binary);
-
-	if (!sfMaterialDb->Load(*sfMaterialDbStream) || sfMaterialDb->Failed()) {
-		sfMaterialDbContent.clear();
-		sfMaterialDbStream.reset();
-		return nullptr;
+	for (auto& db : sfMaterialDbs) {
+		if (db->GetMaterialJSON(matPath, jsonOutput))
+			return true;
 	}
 
-	return sfMaterialDb.get();
+	return false;
 }
 
 void PreviewPanel::AddNifShapeTextures(NifFile* fromNif, const std::string& shapeName) {
@@ -654,8 +674,7 @@ void PreviewPanel::AddNifShapeTextures(NifFile* fromNif, const std::string& shap
 
 				if (!resolvedFromArchive) {
 					std::string materialJson;
-					SFMaterialDatabase* cdb = GetSFMaterialDatabase();
-					if (cdb && cdb->GetMaterialJSON(matFile, materialJson)) {
+					if (GetSFMaterialJSON(matFile, materialJson)) {
 						std::istringstream materialStream(materialJson);
 						SFMaterialFile cdbMat(materialStream);
 						if (!cdbMat.Failed())

--- a/src/ui/PreviewPanel.cpp
+++ b/src/ui/PreviewPanel.cpp
@@ -592,11 +592,8 @@ bool PreviewPanel::GetSFMaterialJSON(const std::string& matPath, std::string& js
 				}
 			};
 
-			if (archive->hasFile("materials/materialsbeta.cdb"))
-				tryLoad("materials/materialsbeta.cdb");
-
 			std::vector<std::string> matches;
-			archive->findFilesBySuffix("materials/creations/", "materialsbeta.cdb", matches);
+			archive->findFilesBySuffix("materials/", ".cdb", matches);
 			for (const auto& match : matches)
 				tryLoad(match);
 		}

--- a/src/ui/PreviewPanel.h
+++ b/src/ui/PreviewPanel.h
@@ -77,10 +77,11 @@ class PreviewPanel : public wxPanel {
 	std::unordered_map<std::string, GLMaterial*> shapeMaterials;
 	std::string baseDataPath;
 
-	std::unique_ptr<SFMaterialDatabase> sfMaterialDb;
-	std::string sfMaterialDbContent;
-	std::unique_ptr<std::istringstream> sfMaterialDbStream;
-	SFMaterialDatabase* GetSFMaterialDatabase();
+	std::vector<std::unique_ptr<SFMaterialDatabase>> sfMaterialDbs;
+	std::vector<std::string> sfMaterialDbContents;
+	std::vector<std::unique_ptr<std::istringstream>> sfMaterialDbStreams;
+	bool sfMaterialDbsLoaded = false;
+	bool GetSFMaterialJSON(const std::string& matPath, std::string& jsonOutput);
 	void CreatePhysicsWindPopup();
 	void DestroyPhysicsWindPopup();
 	void ApplyPhysicsWind();


### PR DESCRIPTION
## Summary

- Starfield DLC/Creation content (e.g. Shattered Space) stores material definitions in DLC-specific CDB files at `materials/creations/<slug>/materialsbeta.cdb` inside BA2 archives. Previously only the base game `materials/materialsbeta.cdb` was searched, so DLC materials resolved empty with no textures.
- Adds `findFilesBySuffix()` virtual method to `FSArchiveFile`/`BSA` that searches the flat file map directly — the existing `hasFolder()`/`addFilesOfFolders()` don't work for BA2 archives since folder tree building is disabled in FSEngine.
- Replaces the single `SFMaterialDatabase` instance with a vector that lazily discovers and loads all CDB files from loaded archives, then searches each for material lookups.
- Multi-CDB discovery is gated behind a `TargetGame == SF` check so it only runs for Starfield projects.

## Test plan

- [x] Load a Shattered Space DLC NIF (e.g. `spacesuit_varuun_upperbody_02_f.nif`) — material path `materials/clothes/dlc001/...` resolves textures from the DLC CDB
- [x] Verify base game Starfield NIFs still resolve materials from the base `materialsbeta.cdb`
- [x] Verify non-Starfield projects (FO4, Skyrim, etc.) are unaffected — `GetSFMaterialJSON` early-returns false
- [x] Verify with `nif_inspect` that DLC NIF structure is intact
- [ ] Test with multiple DLC/Creation BA2s loaded simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)